### PR TITLE
Virtual withdrawals txs for visualization

### DIFF
--- a/src/main/scala/hydrozoa/l1/multisig/tx/settlement/Settlement.scala
+++ b/src/main/scala/hydrozoa/l1/multisig/tx/settlement/Settlement.scala
@@ -1,7 +1,7 @@
 package hydrozoa.l1.multisig.tx.settlement
 
 import hydrozoa.l1.multisig.tx.MultisigTxs.{DepositTx, PostDatedRefundTx, SettlementTx}
-import hydrozoa.l2.ledger.state.UtxosDiff
+import hydrozoa.l2.ledger.state.{OrderedUtxosDiff, UtxosDiff}
 import hydrozoa.{L1, OutputRef, ParticipantSecretKey, TxIx}
 
 trait SettlementTxBuilder {
@@ -12,6 +12,6 @@ trait SettlementTxBuilder {
 
 case class SettlementRecipe(
     deposits: Seq[OutputRef[L1]],
-    utxosWithdrawn: UtxosDiff,
+    utxosWithdrawn: OrderedUtxosDiff,
     majorVersion: Int
 )

--- a/src/main/scala/hydrozoa/l2/consensus/network/HydrozoaNetwork.scala
+++ b/src/main/scala/hydrozoa/l2/consensus/network/HydrozoaNetwork.scala
@@ -2,7 +2,7 @@ package hydrozoa.l2.consensus.network
 
 import hydrozoa.*
 import hydrozoa.l2.block.{Block, BlockHeader}
-import hydrozoa.l2.ledger.state.UtxosDiff
+import hydrozoa.l2.ledger.state.{OrderedUtxosDiff, UtxosDiff}
 
 trait HydrozoaNetwork {
 
@@ -18,7 +18,7 @@ trait HydrozoaNetwork {
     def reqMinor(block: Block): Set[AckMinor]
 
     // FIXME: remove utxosWithdrawn once we have block validation
-    def reqMajor(block: Block, utxosWithdrawn: UtxosDiff): Set[AckMajorCombined]
+    def reqMajor(block: Block, utxosWithdrawn: OrderedUtxosDiff): Set[AckMajorCombined]
 
     def reqFinal(block: Block): Set[AckFinalCombined]
 }

--- a/src/main/scala/hydrozoa/l2/consensus/network/MockHydrozoaNetwork.scala
+++ b/src/main/scala/hydrozoa/l2/consensus/network/MockHydrozoaNetwork.scala
@@ -9,7 +9,7 @@ import hydrozoa.l1.multisig.tx.initialization.{InitTxBuilder, InitTxRecipe}
 import hydrozoa.l1.multisig.tx.refund.{PostDatedRefundRecipe, RefundTxBuilder}
 import hydrozoa.l1.multisig.tx.settlement.{SettlementRecipe, SettlementTxBuilder}
 import hydrozoa.l2.block.Block
-import hydrozoa.l2.ledger.state.UtxosDiff
+import hydrozoa.l2.ledger.state.{OrderedUtxosDiff, UtxosDiff}
 import hydrozoa.node.server.HeadStateReader
 import hydrozoa.{L1Tx, ParticipantVerificationKey, TxKeyWitness}
 
@@ -67,7 +67,7 @@ class MockHydrozoaNetwork(
             AckMinor(block.blockHeader, (), false)
         )
 
-    override def reqMajor(block: Block, utxosWithdrawn: UtxosDiff): Set[AckMajorCombined] =
+    override def reqMajor(block: Block, utxosWithdrawn: OrderedUtxosDiff): Set[AckMajorCombined] =
         // TODO: check block type
         val recipe =
             SettlementRecipe(block.blockBody.depositsAbsorbed, utxosWithdrawn, block.blockHeader.versionMajor)

--- a/src/main/scala/hydrozoa/l2/ledger/AdaSimpleLedger.scala
+++ b/src/main/scala/hydrozoa/l2/ledger/AdaSimpleLedger.scala
@@ -66,9 +66,10 @@ case class AdaSimpleLedger[InstancePurpose <: TInstancePurpose] private (
                 Right(txId, Some(cardanoTx))
             case event: L2Withdrawal =>
                 val s = s"Simple withdrawing: ${event.withdrawal}"
-                val virtualOutputs = resolveInputs(event.withdrawal.inputs)
+//                val virtualOutputs = resolveInputs(event.withdrawal.inputs)
                 val cardanoTx =
-                    mkVirtualWithdrawalTx(event.withdrawal, virtualOutputs.map(unwrapTxOut(_)))
+                    // mkVirtualWithdrawalTx(event.withdrawal, virtualOutputs.map(unwrapTxOut(_)))
+                    mkVirtualWithdrawalTx(event.withdrawal)
                 val txId = txHash(cardanoTx)
                 println(s"L2 withdrawal event, txId: $txId, content: ${serializeTxHex(cardanoTx)}")
                 Right(txId, Some(cardanoTx))

--- a/src/main/scala/hydrozoa/l2/ledger/state/Types.scala
+++ b/src/main/scala/hydrozoa/l2/ledger/state/Types.scala
@@ -15,6 +15,8 @@ type Utxos = mutable.Map[TxIn, TxOut]
 
 type UtxosDiff = Set[(TxIn, TxOut)]
 type MutableUtxosDiff = mutable.Set[(TxIn, TxOut)]
+type MutableOrderedUtxosDiff = mutable.Buffer[(TxIn, TxOut)]
+type OrderedUtxosDiff = List[(TxIn, TxOut)]
 
 // FIXME: move to another package
 def mkTxIn(txId: hydrozoa.TxId, txIx: hydrozoa.TxIx): TxIn =


### PR DESCRIPTION
Saving this for later use.

The problem with this approach stems from the fact that it is very easy to add "virtual input" to a tx and impossible to add a "virtual output". Since an extra input just represents a link from a spent output to the tx, but once you add an additional output, it gets rendered as a separate node and a link to it due to a different tx hash. So, for combined L1/L2 diagrams, I decided to go back to "virtual settlement txs," which virtually consume L2 withdrawn inputs:
![image](https://github.com/user-attachments/assets/dfbc69b6-6188-435d-a5a0-7bdcb4fa3d8a)

For reference: alternative approach with virtual withdrawals breaks because of the way sc-tools work now:
![image](https://github.com/user-attachments/assets/de4294dd-c843-4d68-8053-b6863bb9eee5)
