### PR TITLE
Remove the beaconTokenName from the InitTxRecipe

### DIFF
--- a/src/main/scala/hydrozoa/l1/multisig/tx/initialization/BloxBeanInitializationTxBuilder.scala
+++ b/src/main/scala/hydrozoa/l1/multisig/tx/initialization/BloxBeanInitializationTxBuilder.scala
@@ -7,6 +7,7 @@ import com.bloxbean.cardano.client.quicktx.Tx
 import com.bloxbean.cardano.client.transaction.spec.Asset
 import com.bloxbean.cardano.client.transaction.spec.script.{NativeScript, ScriptAll}
 import hydrozoa.infra.{mkBuilder, numberOfSignatories, toEither}
+import hydrozoa.l1.multisig.onchain.mkBeaconTokenName
 import hydrozoa.l1.multisig.state.mkInitMultisigTreasuryDatum
 import hydrozoa.l1.multisig.tx.{InitTx, MultisigTx}
 import hydrozoa.{AddressBech, AddressBechL1, L1, TxL1}
@@ -35,7 +36,7 @@ class BloxBeanInitializationTxBuilder(backendService: BackendService) extends In
             .toEither
 
         val beaconToken = Asset.builder
-            .name(recipe.beaconTokenName.tokenName)
+            .name(mkBeaconTokenName(recipe.seedOutput).toString)
             .value(BigInteger.valueOf(1))
             .build
 

--- a/src/main/scala/hydrozoa/l1/multisig/tx/initialization/InitializationTxBuilder.scala
+++ b/src/main/scala/hydrozoa/l1/multisig/tx/initialization/InitializationTxBuilder.scala
@@ -14,5 +14,4 @@ case class InitTxRecipe(
     seedOutput: UtxoIdL1,
     coins: BigInt,
     headNativeScript: NativeScript,
-    beaconTokenName: TokenName
 )

--- a/src/main/scala/hydrozoa/l1/rulebased/onchain/DisputeResolutionValidator.scala
+++ b/src/main/scala/hydrozoa/l1/rulebased/onchain/DisputeResolutionValidator.scala
@@ -122,7 +122,7 @@ object DisputeResolutionValidator extends ParameterizedValidator[ScriptHash]:
     private inline val VoteOnlyOneVoteUtxoIsSpent = "Only one vote utxo can be spent"
     private inline val VoteAlreadyCast = "Vote is already has been cast"
     private inline val VoteMustBeSignedByPeer = "Transaction must be signed by peer"
-    private inline val VoteOneRefInputTreasury = "Only one ref input (treasury) is reuired"
+    private inline val VoteOneRefInputTreasury = "Only one ref input (treasury) is required"
     private inline val VoteTreasuryBeacon = "Treasury should contain beacon token"
     private inline val VoteTreasuryDatum = "Treasury datum is missing"
     private inline val VoteTreasuryDatumHeadMp = "Treasury datum headMp mismatch"

--- a/src/main/scala/hydrozoa/l2/consensus/network/HeadPeerNetworkOneNode.scala
+++ b/src/main/scala/hydrozoa/l2/consensus/network/HeadPeerNetworkOneNode.scala
@@ -2,7 +2,7 @@ package hydrozoa.l2.consensus.network
 
 import hydrozoa.infra.txHash
 import hydrozoa.l1.CardanoL1
-import hydrozoa.l1.multisig.onchain.{mkBeaconTokenName, mkHeadNativeScriptAndAddress}
+import hydrozoa.l1.multisig.onchain.{mkHeadNativeScriptAndAddress}
 import hydrozoa.l1.multisig.tx.PostDatedRefundTx
 import hydrozoa.l1.multisig.tx.finalization.{FinalizationRecipe, FinalizationTxBuilder}
 import hydrozoa.l1.multisig.tx.initialization.{InitTxBuilder, InitTxRecipe}
@@ -47,7 +47,6 @@ class HeadPeerNetworkOneNode(
 
         // Native script, head address, and token
         val (headNativeScript, headAddress) = mkHeadNativeScriptAndAddress(vKeys, cardano.network)
-        val beaconTokenName = mkBeaconTokenName(req.seedUtxoId)
 
         // Recipe to build init tx
         val initTxRecipe = InitTxRecipe(
@@ -55,7 +54,6 @@ class HeadPeerNetworkOneNode(
           req.seedUtxoId,
           req.treasuryCoins,
           headNativeScript,
-          beaconTokenName
         )
 
         val Right(tx, _) = initTxBuilder.mkInitializationTxDraft(initTxRecipe)

--- a/src/main/scala/hydrozoa/l2/consensus/network/actor/InitHeadActor.scala
+++ b/src/main/scala/hydrozoa/l2/consensus/network/actor/InitHeadActor.scala
@@ -44,7 +44,6 @@ private class InitHeadActor(
         val Some(headVKeys) = stateActor.ask(_.getVerificationKeys(headPeers))
         val (headNativeScript, headAddress) =
             mkHeadNativeScriptAndAddress(headVKeys, cardanoActor.ask(_.network))
-        val beaconTokenName = mkBeaconTokenName(req.seedUtxoId)
 
         log.info(s"Head's address: $headAddress, beacon token name: $beaconTokenName")
 
@@ -53,7 +52,6 @@ private class InitHeadActor(
           req.seedUtxoId,
           req.treasuryCoins,
           headNativeScript,
-          beaconTokenName
         )
 
         log.info(s"initTxRecipe: $initTxRecipe")
@@ -73,7 +71,7 @@ private class InitHeadActor(
         this.txDraft = txDraft
         this.headNativeScript = headNativeScript
         this.headAddress = headAddress
-        this.beaconTokenName = beaconTokenName
+        this.beaconTokenName = mkBeaconTokenName(req.seedUtxoId)
         this.seedAddress = seedAddress
         deliver(ownAck)
         Seq(ownAck)


### PR DESCRIPTION
Small PR to remove the beaconTokenName from the InitTxRecipe and calculate it from the seed UTxO instead.

With some more work, we may be able to do the same for the head script and address -- but I think we'd need to carry around a network ID instead, which probably isn't worth refactoring until we switch tx builders.