### PR TITLE
Chore(flake): remove idea from flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,8 +22,6 @@
           buildInputs = [ pkgs.bashInteractive ];
           packages = with pkgs; [
             async-profiler
-            git
-            jetbrains.idea-community-bin
             openjdk21
             sbt
             scala-cli


### PR DESCRIPTION
While having IDEA that comes from nixpkgs might be convenient, it's too old for the recent version of the Scala plugin, which is totally necessary. So the current approach is to keep only JDK, Scala, and `sbt` along with some basic tools and use IDEA from JetBrains Toolboox. 