### PR TITLE
Test reference script deployment

### DIFF
--- a/integration/src/main/scala/hydrozoa/sut/LocalFacade.scala
+++ b/integration/src/main/scala/hydrozoa/sut/LocalFacade.scala
@@ -143,7 +143,9 @@ object LocalFacade:
     def apply(
         peers: Set[TestPeer],
         autonomousBlocks: Boolean = false,
-        useYaci: Boolean = false
+        useYaci: Boolean = false,
+        mbTreasuryScriptRefUtxoId: Option[UtxoIdL1],
+        mbDisputeScriptRefUtxoId: Option[UtxoIdL1]
     ): HydrozoaFacade =
 
         InheritableMDC.init
@@ -165,6 +167,8 @@ object LocalFacade:
                               autonomousBlocks = autonomousBlocks,
                               useYaci = useYaci,
                               pp = Some(Utils.protocolParams),
+                              mbTreasuryScriptRefUtxoId = mbTreasuryScriptRefUtxoId,
+                              mbDisputeScriptRefUtxoId = mbDisputeScriptRefUtxoId,
                               nodeCallback = (p, n) => {
                                   synchronized(nodes.put(p, n))
                               }

--- a/integration/src/main/scala/hydrozoa/sut/LocalNode.scala
+++ b/integration/src/main/scala/hydrozoa/sut/LocalNode.scala
@@ -15,7 +15,7 @@ import hydrozoa.node.monitoring.NoopMetrics
 import hydrozoa.node.rest.NodeRestApi
 import hydrozoa.node.server.Node
 import hydrozoa.node.state.NodeState
-import hydrozoa.{mkCardanoL1, mkTxBuilders}
+import hydrozoa.{UtxoIdL1, mkCardanoL1, mkTxBuilders}
 import ox.*
 import ox.channels.Actor
 import ox.logback.InheritableMDC
@@ -65,6 +65,8 @@ object LocalNode:
         useYaci: Boolean = true,
         yaciBFApiUri: String = "http://localhost:8080/api/v1/",
         pp: Option[ProtocolParams] = None,
+        mbTreasuryScriptRefUtxoId: Option[UtxoIdL1] = None,
+        mbDisputeScriptRefUtxoId: Option[UtxoIdL1] = None,
         nodeCallback: ((TestPeer, Node) => Unit)
     ): Unit =
         InheritableMDC.supervisedWhere("node" -> ownPeer.toString) {
@@ -91,7 +93,7 @@ object LocalNode:
                   finalizationTxBuilder,
                   voteTxBuilder,
                   tallyTxBuilder
-                ) = mkTxBuilders(backendService, nodeState)
+                ) = mkTxBuilders(backendService, nodeState, mbTreasuryScriptRefUtxoId, mbDisputeScriptRefUtxoId)
 
                 nodeState.setVoteTxBuilder(voteTxBuilder)
                 nodeState.setTallyTxBuilder(tallyTxBuilder)

--- a/integration/src/test/scala/hydrozoa/DisputeSuite.scala
+++ b/integration/src/test/scala/hydrozoa/DisputeSuite.scala
@@ -1,7 +1,12 @@
 package hydrozoa
 
+import com.bloxbean.cardano.client.backend.api.BackendService
+import com.bloxbean.cardano.client.backend.blockfrost.service.BFBackendService
+import com.bloxbean.cardano.client.spec.Script
 import com.typesafe.scalalogging.Logger
-import hydrozoa.infra.txHash
+import hydrozoa.deploy.mkDeployTx
+import hydrozoa.infra.{serializeTxHex, toEither, txHash}
+import hydrozoa.l1.rulebased.onchain.{DisputeResolutionScript, TreasuryValidatorScript}
 import hydrozoa.l2.ledger.L2Transaction
 import hydrozoa.node.TestPeer
 import hydrozoa.node.TestPeer.*
@@ -57,7 +62,23 @@ class DisputeSuite extends FunSuite {
             // supervised { par(fs) }
             fs.foreach(_())
 
-        if (useYaci)
+        def deployHydrozoaScript(
+            backendService: BackendService,
+            peer: TestPeer,
+            script: Script
+        ): UtxoIdL1 = {
+            val tx = mkDeployTx(backendService, peer, script)
+            log.info(s"deployment tx is: ${serializeTxHex(tx)}")
+            backendService.getTransactionService.submitTransaction(tx.bytes).toEither match
+                case Right(txId) =>
+                    log.info(s"$txId")
+                    UtxoIdL1.apply(TxId(txId), TxIx(0))
+                case Left(err) =>
+                    log.error(s"Can't deploy reference scripts: $err")
+                    throw RuntimeException()
+        }
+
+        val (mbTreasuryScriptRefUtxoId, mbDisputeScriptRefUtxoId) = if (useYaci)
             // Reset Yaci DevKit
             log.info("Resetting Yaci...")
             val _: Response[String] = quickRequest
@@ -68,9 +89,25 @@ class DisputeSuite extends FunSuite {
             log.info("Topping up peers' wallets...")
             topupNodeWallets(testPeers, 10, 3)
 
+            // Deploy reference scripts
+            val backendService = BFBackendService("http://localhost:8080/api/v1/", "")
+
+            val treasuryScriptRefUtxoId =
+                deployHydrozoaScript(backendService, Julia, TreasuryValidatorScript.plutusScript)
+            val disputeScriptRefUtxoId =
+                deployHydrozoaScript(backendService, Isabel, DisputeResolutionScript.plutusScript)
+
+            (Some(treasuryScriptRefUtxoId), Some(disputeScriptRefUtxoId))
+        else (None, None)
+
         // Make SUT
         log.info("Making a Hydrozoa head uing a local network...")
-        sut = LocalFacade.apply(testPeers, useYaci = useYaci)
+        sut = LocalFacade.apply(
+          testPeers,
+          useYaci = useYaci,
+          mbTreasuryScriptRefUtxoId,
+          mbDisputeScriptRefUtxoId
+        )
 
     override def afterEach(context: AfterEach): Unit = sut.shutdownSut()
 
@@ -203,7 +240,7 @@ class DisputeSuite extends FunSuite {
                   )
                 )
               )
-            )   
+            )
             minor1_4 <- sut.produceBlock(false, true)
 
             _ = Thread.sleep(5000)

--- a/integration/src/test/scala/hydrozoa/DisputeSuite.scala
+++ b/integration/src/test/scala/hydrozoa/DisputeSuite.scala
@@ -75,7 +75,7 @@ class DisputeSuite extends FunSuite {
                     UtxoIdL1.apply(TxId(txId), TxIx(0))
                 case Left(err) =>
                     log.error(s"Can't deploy reference scripts: $err")
-                    throw RuntimeException()
+                    throw RuntimeException(err)
         }
 
         val (mbTreasuryScriptRefUtxoId, mbDisputeScriptRefUtxoId) = if (useYaci)

--- a/integration/src/test/scala/hydrozoa/HappyPathSuite.scala
+++ b/integration/src/test/scala/hydrozoa/HappyPathSuite.scala
@@ -35,7 +35,7 @@ class HappyPathSuite extends FunSuite {
                 .post(uri"http://localhost:10000/local-cluster/api/admin/devnet/reset")
                 .send()
 
-    sut = LocalFacade.apply(testPeers, useYaci = useYaci)
+    sut = LocalFacade.apply(testPeers, useYaci = useYaci, None, None)
 
     override def afterEach(context: AfterEach): Unit = sut.shutdownSut()
 

--- a/integration/src/test/scala/hydrozoa/deploy/Deploy.scala
+++ b/integration/src/test/scala/hydrozoa/deploy/Deploy.scala
@@ -1,0 +1,35 @@
+package hydrozoa.deploy
+
+import com.bloxbean.cardano.client.api.model.Amount
+import com.bloxbean.cardano.client.backend.api.BackendService
+import com.bloxbean.cardano.client.function.helper.SignerProviders
+import com.bloxbean.cardano.client.quicktx.{QuickTxBuilder, Tx}
+import com.bloxbean.cardano.client.spec.Script
+import hydrozoa.TxL1
+import hydrozoa.infra.Piper
+import hydrozoa.node.TestPeer
+
+def mkDeployTx(backendService: BackendService, peer: TestPeer, script: Script): TxL1 =
+
+    val account = TestPeer.account(peer)
+    val address = account.baseAddress()
+
+    val txPartial = Tx()
+        .payToAddress(
+          address,
+          Amount.ada(100),
+          script
+        )
+        .from(address)
+
+    val builder = QuickTxBuilder(backendService)
+
+    builder
+        .compose(txPartial)
+        .feePayer(address)
+        .withSigner(SignerProviders.signerFrom(account))
+        .buildAndSign
+        .serialize()
+        |> TxL1.apply
+
+end mkDeployTx

--- a/integration/src/test/scala/hydrozoa/model/MBTSuite.scala
+++ b/integration/src/test/scala/hydrozoa/model/MBTSuite.scala
@@ -65,7 +65,7 @@ object MBTSuite extends Commands:
             val response: Response[String] = quickRequest
                 .post(uri"http://localhost:10000/local-cluster/api/admin/devnet/reset")
                 .send()
-        LocalFacade.apply(state.knownPeers, false, useYaci)
+        LocalFacade.apply(state.knownPeers, false, useYaci, None, None)
 
     override def destroySut(sut: Sut): Unit =
         log.warn("<-------------------- destroy SUT")

--- a/src/main/scala/hydrozoa/Main.scala
+++ b/src/main/scala/hydrozoa/Main.scala
@@ -218,7 +218,9 @@ end mkCardanoL1
 
 def mkTxBuilders(
     backendService: BackendService,
-    nodeState: NodeState
+    nodeState: NodeState,
+    _mbTreasuryScriptRefUtxoId: Option[UtxoIdL1] = None,
+    _mbDisputeScriptRefUtxoId: Option[UtxoIdL1] = None
 ) =
 
     val nodeStateReader: HeadStateReader = nodeState.reader


### PR DESCRIPTION
This adds the ability to deploy Hydrozoa reference scripts and bring the references to `mkTxBuilders` function where they are likely needed.