### PR TITLE
Make actors' state truly private

### DIFF
--- a/src/main/scala/hydrozoa/multisig/consensus/CardanoLiaison.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/CardanoLiaison.scala
@@ -19,12 +19,12 @@ import hydrozoa.multisig.protocol.ConsensusProtocol.CardanoLiaison.*
   *   - Submits whichever L1 effects are not yet reflected in the Cardano blockchain.
   */
 object CardanoLiaison {
-    final case class Config()
-
-    final case class ConnectionsPending(
-        cardanoBackend: Deferred[IO, CardanoBackend.Ref],
-        persistence: Deferred[IO, Persistence.Ref]
+    final case class Config(
+        cardanoBackend: CardanoBackend.Ref,
+        persistence: Persistence.Ref
     )
+
+    final case class ConnectionsPending()
 
     def create(config: Config, connections: ConnectionsPending): IO[CardanoLiaison] = {
         IO(CardanoLiaison(config, connections))
@@ -36,20 +36,13 @@ final class CardanoLiaison private (config: Config, private val connections: Con
     private val subscribers = Ref.unsafe[IO, Option[Subscribers]](None)
     private val state = State()
 
-    private final case class Subscribers(
-        cardanoBackend: CardanoBackend.Ref,
-        persistence: Persistence.Ref
-    )
+    private final case class Subscribers()
 
     override def preStart: IO[Unit] =
         for {
-            cardanoBackend <- connections.cardanoBackend.get
-            persistence <- connections.persistence.get
             _ <- subscribers.set(
               Some(
                 Subscribers(
-                  cardanoBackend = cardanoBackend,
-                  persistence = persistence
                 )
               )
             )

--- a/src/main/scala/hydrozoa/multisig/consensus/CardanoLiaison.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/CardanoLiaison.scala
@@ -6,18 +6,41 @@ import cats.effect.Ref
 import cats.implicits.*
 import com.suprnation.actor.Actor.Actor
 import com.suprnation.actor.Actor.Receive
-import CardanoLiaison.{Config, ConnectionsPending, State, Subscribers}
+import CardanoLiaison.{Config, ConnectionsPending}
 import hydrozoa.multisig.protocol.CardanoBackendProtocol.*
 import hydrozoa.multisig.protocol.ConsensusProtocol.*
 import hydrozoa.multisig.protocol.PersistenceProtocol.*
 import hydrozoa.multisig.protocol.ConsensusProtocol.CardanoLiaison.*
 
-final case class CardanoLiaison(config: Config)(
-    private val connections: ConnectionsPending
-)(
-    private val subscribers: Ref[IO, Option[Subscribers]],
-    private val state: State
-) extends Actor[IO, Request] {
+/** Cardano actor:
+  *
+  *   - Keeps track of confirmed L1 effects of L2 blocks.
+  *   - Periodically polls the Cardano blockchain for the head's utxo state.
+  *   - Submits whichever L1 effects are not yet reflected in the Cardano blockchain.
+  */
+object CardanoLiaison {
+    final case class Config()
+
+    final case class ConnectionsPending(
+        cardanoBackend: Deferred[IO, CardanoBackend.Ref],
+        persistence: Deferred[IO, Persistence.Ref]
+    )
+
+    def create(config: Config, connections: ConnectionsPending): IO[CardanoLiaison] = {
+        IO(CardanoLiaison(config, connections))
+    }
+}
+
+final class CardanoLiaison private (config: Config, private val connections: ConnectionsPending)
+    extends Actor[IO, Request] {
+    private val subscribers = Ref.unsafe[IO, Option[Subscribers]](None)
+    private val state = State()
+
+    private final case class Subscribers(
+        cardanoBackend: CardanoBackend.Ref,
+        persistence: Persistence.Ref
+    )
+
     override def preStart: IO[Unit] =
         for {
             cardanoBackend <- connections.cardanoBackend.get
@@ -49,38 +72,6 @@ final case class CardanoLiaison(config: Config)(
             case x: ConfirmBlock =>
                 ???
         }
-}
 
-/** Cardano actor:
-  *
-  *   - Keeps track of confirmed L1 effects of L2 blocks.
-  *   - Periodically polls the Cardano blockchain for the head's utxo state.
-  *   - Submits whichever L1 effects are not yet reflected in the Cardano blockchain.
-  */
-object CardanoLiaison {
-    final case class Config()
-
-    final case class ConnectionsPending(
-        cardanoBackend: Deferred[IO, CardanoBackend.Ref],
-        persistence: Deferred[IO, Persistence.Ref]
-    )
-
-    final case class Subscribers(
-        cardanoBackend: CardanoBackend.Ref,
-        persistence: Persistence.Ref
-    )
-
-    def create(config: Config, connections: ConnectionsPending): IO[CardanoLiaison] = {
-        for {
-            subscribers <- Ref.of[IO, Option[Subscribers]](None)
-            state <- State.create
-        } yield CardanoLiaison(config)(connections)(subscribers, state)
-    }
-
-    final case class State()
-
-    object State {
-        def create: IO[State] =
-            State().pure
-    }
+    private final class State
 }

--- a/src/main/scala/hydrozoa/multisig/consensus/PeerLiaison.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/PeerLiaison.scala
@@ -9,18 +9,49 @@ import com.suprnation.actor.Actor.Receive
 
 import scala.annotation.targetName
 import scala.collection.immutable.Queue
-import PeerLiaison.{Config, ConnectionsPending, State, Subscribers}
+import PeerLiaison.{Config, ConnectionsPending, MaxEvents}
 import hydrozoa.multisig.protocol.Identifiers.*
 import hydrozoa.multisig.protocol.ConsensusProtocol.*
 import hydrozoa.multisig.protocol.PersistenceProtocol.*
 import hydrozoa.multisig.protocol.ConsensusProtocol.PeerLiaison.*
 
-final case class PeerLiaison(config: Config)(
-    private val connections: ConnectionsPending
-)(
-    private val subscribers: Ref[IO, Option[Subscribers]],
-    private val state: State
-) extends Actor[IO, Request] {
+/** Communication actor is connected to its counterpart at another peer:
+  *
+  *   - Requests communication batches from the counterpart.
+  *   - Responds to the counterpart's requests for communication batches.
+  */
+object PeerLiaison {
+    type MaxEvents = Int
+
+    final case class Config(
+        peerId: PeerId,
+        remotePeerId: PeerId,
+        maxLedgerEventsPerBatch: MaxEvents = 25
+    )
+
+    final case class ConnectionsPending(
+        blockProducer: Deferred[IO, BlockProducer.Ref],
+        persistence: Deferred[IO, Persistence.Ref],
+        remotePeerLiaison: Deferred[IO, PeerLiaisonRef]
+    )
+
+    def create(config: Config, connections: ConnectionsPending): IO[PeerLiaison] =
+        IO(PeerLiaison(config, connections))
+}
+
+final class PeerLiaison private (config: Config, connections: ConnectionsPending)
+    extends Actor[IO, Request] {
+    private val subscribers = Ref.unsafe[IO, Option[Subscribers]](None)
+    private val state = State()
+
+    private final case class Subscribers(
+        ackBlock: AckBlock.Subscriber,
+        newBlock: NewBlock.Subscriber,
+        newLedgerEvent: NewLedgerEvent.Subscriber,
+        persistence: Persistence.Ref,
+        remotePeerLiaison: PeerLiaisonRef
+    )
+
     override def preStart: IO[Unit] =
         for {
             blockProducer <- connections.blockProducer.get
@@ -92,72 +123,15 @@ final case class PeerLiaison(config: Config)(
                     _ <- x.events.traverse_(subs.newLedgerEvent ! _)
                 } yield ()
         }
-}
 
-/** Communication actor is connected to its counterpart at another peer:
-  *
-  *   - Requests communication batches from the counterpart.
-  *   - Responds to the counterpart's requests for communication batches.
-  */
-object PeerLiaison {
-    private type maxEvents = Int
-
-    final case class Config(
-        peerId: PeerId,
-        remotePeerId: PeerId,
-        maxLedgerEventsPerBatch: maxEvents = 25
-    )
-
-    final case class ConnectionsPending(
-        blockProducer: Deferred[IO, BlockProducer.Ref],
-        persistence: Deferred[IO, Persistence.Ref],
-        remotePeerLiaison: Deferred[IO, PeerLiaisonRef]
-    )
-
-    final case class Subscribers(
-        ackBlock: AckBlock.Subscriber,
-        newBlock: NewBlock.Subscriber,
-        newLedgerEvent: NewLedgerEvent.Subscriber,
-        persistence: Persistence.Ref,
-        remotePeerLiaison: PeerLiaisonRef
-    )
-
-    def create(config: Config, connections: ConnectionsPending): IO[PeerLiaison] =
-        for {
-            subscribers <- Ref.of[IO, Option[Subscribers]](None)
-            state <- State.create
-        } yield PeerLiaison(config)(connections)(subscribers, state)
-
-    object State {
-        def create: IO[State] =
-            for {
-                nAck <- Ref.of[IO, AckNum](AckNum(0))
-                nBlock <- Ref.of[IO, BlockNum](BlockNum(0))
-                nEvent <- Ref.of[IO, LedgerEventNum](LedgerEventNum(0))
-                qAck <- Ref.of[IO, Queue[AckBlock]](Queue())
-                qBlock <- Ref.of[IO, Queue[NewBlock]](Queue())
-                qEvent <- Ref.of[IO, Queue[NewLedgerEvent]](Queue())
-                sendBatchImmediately <- Ref.of[IO, Option[BatchId]](None)
-            } yield State(
-              nAck = nAck,
-              nBlock = nBlock,
-              nEvent = nEvent,
-              qAck = qAck,
-              qBlock = qBlock,
-              qEvent = qEvent,
-              sendBatchImmediately = sendBatchImmediately
-            )
-    }
-
-    final case class State(
-        private val nAck: Ref[IO, AckNum],
-        private val nBlock: Ref[IO, BlockNum],
-        private val nEvent: Ref[IO, LedgerEventNum],
-        private val qAck: Ref[IO, Queue[AckBlock]],
-        private val qBlock: Ref[IO, Queue[NewBlock]],
-        private val qEvent: Ref[IO, Queue[NewLedgerEvent]],
-        private val sendBatchImmediately: Ref[IO, Option[BatchId]]
-    ) {
+    private final class State {
+        private val nAck = Ref.unsafe[IO, AckNum](AckNum(0))
+        private val nBlock = Ref.unsafe[IO, BlockNum](BlockNum(0))
+        private val nEvent = Ref.unsafe[IO, LedgerEventNum](LedgerEventNum(0))
+        private val qAck = Ref.unsafe[IO, Queue[AckBlock]](Queue())
+        private val qBlock = Ref.unsafe[IO, Queue[NewBlock]](Queue())
+        private val qEvent = Ref.unsafe[IO, Queue[NewLedgerEvent]](Queue())
+        private val sendBatchImmediately = Ref.unsafe[IO, Option[BatchId]](None)
 
         /** Check whether there are no acks, blocks, or events queued-up to be sent out. */
         private def areEmptyQueues: IO[Boolean] =
@@ -200,7 +174,9 @@ object PeerLiaison {
             this.sendBatchImmediately.getAndSet(None)
 
         sealed trait ExtractNewMsgBatchError extends Throwable
+
         case object EmptyNewMsgBatch extends ExtractNewMsgBatchError
+
         case object OutOfBoundsGetMsgBatch extends ExtractNewMsgBatchError
 
         /** Given a locally-sourced ack, block, or event that just arrived, assuming that the next
@@ -259,7 +235,7 @@ object PeerLiaison {
         // query the database to properly respond. Currently, we just respond as if no messages are available to send.
         def extractNewMsgBatch(
             batchReq: GetMsgBatch,
-            maxEvents: maxEvents
+            maxEvents: MaxEvents
         ): IO[Either[ExtractNewMsgBatchError, NewMsgBatch]] =
             (for {
                 nAck <- this.nAck.get

--- a/src/main/scala/hydrozoa/multisig/ledger/dapp/tx/FallbackTx.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/dapp/tx/FallbackTx.scala
@@ -9,5 +9,4 @@ final case class FallbackTx(
     override val tx: Transaction
 ) extends Tx
 
-object FallbackTx {
-}
+object FallbackTx {}

--- a/src/main/scala/hydrozoa/multisig/ledger/dapp/tx/InitializationTx.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/dapp/tx/InitializationTx.scala
@@ -31,7 +31,7 @@ object InitializationTx {
         coins: BigInt,
         peers: NonEmptyList[VerificationKeyBytes]
     )
-    
+
     sealed trait BuildError extends Throwable
     case object IllegalChangeValue extends BuildError
 

--- a/src/main/scala/hydrozoa/multisig/ledger/dapp/tx/RolloutTx.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/dapp/tx/RolloutTx.scala
@@ -10,5 +10,4 @@ final case class RolloutTx(
     override val tx: Transaction
 ) extends Tx
 
-object RolloutTx {
-}
+object RolloutTx {}

--- a/src/main/scala/hydrozoa/multisig/ledger/virtual/Event.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/virtual/Event.scala
@@ -25,15 +25,15 @@ final case class L2EventWithdrawal(transaction: Transaction) extends L2Event {
 }
 
 /** A genesis event absorbs a number of transaction inputs from L1 and produces corresponding L2
- * outputs. The TxId of a Genesis Event comes from sorting the TxIds of the absorbed UTxOs,
- * encoding them to Cbor, concatenating, and taking the blake2b_256 hash.
- */
+  * outputs. The TxId of a Genesis Event comes from sorting the TxIds of the absorbed UTxOs,
+  * encoding them to Cbor, concatenating, and taking the blake2b_256 hash.
+  */
 final case class L2EventGenesis(utxosL1: Seq[(UtxoIdL1, OutputL1)]) extends L2Event {
     require(utxosL1.nonEmpty, "L2EventGenesis must consume at least one L1 deposit")
 
     /** The list of UTxOs that should appear on L2 corresponding to this genesis event. Malformed
-     * deposit UTxOs (non-Babbage outputs or with invalid datums) are skipped.
-     */
+      * deposit UTxOs (non-Babbage outputs or with invalid datums) are skipped.
+      */
     // FIXME: check if this is really the desired behavior. Should we do something else if we have a malformed
     // deposit output?
     // CHECK: Right now, we set the network component of the L2 address to be the same as the L1 network. Is this
@@ -42,24 +42,25 @@ final case class L2EventGenesis(utxosL1: Seq[(UtxoIdL1, OutputL1)]) extends L2Ev
         val mbL2Outs: Seq[Option[(UtxoIdL2, OutputL2)]] = {
             utxosL1.zipWithIndex.map((utxo, idx) => {
                 val l2TxIn = TransactionInput(transactionId = getEventId, index = idx)
-                if !utxo._2.isInstanceOf[Babbage] || !utxo._2.address.isInstanceOf[ShelleyAddress] then None
+                if !utxo._2.isInstanceOf[Babbage] || !utxo._2.address.isInstanceOf[ShelleyAddress]
+                then None
                 else {
                     val babbageTxOut = utxo._2.asInstanceOf[Babbage]
-                    val l1Network : Network = babbageTxOut.address.asInstanceOf[ShelleyAddress].network
+                    val l1Network: Network =
+                        babbageTxOut.address.asInstanceOf[ShelleyAddress].network
                     babbageTxOut.datumOption match {
                         case Some(Inline(datum)) =>
-
                             val dd: DepositUtxo.Datum = fromData(datum)
                             Some(
-                                UtxoId[L2](l2TxIn),
-                                Output[L2](
-                                    Babbage(
-                                        address = dd.address.toScalusLedger(network = l1Network),
-                                        value = Value(babbageTxOut.value.coin),
-                                        datumOption = dd.datum.asScala.map(Inline(_)),
-                                        scriptRef = None
-                                    )
+                              UtxoId[L2](l2TxIn),
+                              Output[L2](
+                                Babbage(
+                                  address = dd.address.toScalusLedger(network = l1Network),
+                                  value = Value(babbageTxOut.value.coin),
+                                  datumOption = dd.datum.asScala.map(Inline(_)),
+                                  scriptRef = None
                                 )
+                              )
                             )
 
                         case _ => None
@@ -72,17 +73,17 @@ final case class L2EventGenesis(utxosL1: Seq[(UtxoIdL1, OutputL1)]) extends L2Ev
     }
 
     override def getEventId: Hash[Blake2b_256, HashPurpose.TransactionHash] = Hash(
-        blake2b_256(
-            ByteString.fromArray(
-                // I know this is an insane way to do it, but transaction input apparently doesn't have an ordering instance
-                // yet
-                utxosL1
-                    .map((ti, _) => ti.transactionId.toHex ++ ti.index.toString)
-                    .sorted
-                    .flatMap(ti => Cbor.encode(ti).toByteArray)
-                    .toArray
-            )
+      blake2b_256(
+        ByteString.fromArray(
+          // I know this is an insane way to do it, but transaction input apparently doesn't have an ordering instance
+          // yet
+          utxosL1
+              .map((ti, _) => ti.transactionId.toHex ++ ti.index.toString)
+              .sorted
+              .flatMap(ti => Cbor.encode(ti).toByteArray)
+              .toArray
         )
+      )
     )
     def volume: Long = utxosL1.map((_, to) => to.value.coin.value).sum
 

--- a/src/main/scala/hydrozoa/multisig/ledger/virtual/HydrozoaMutator.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/virtual/HydrozoaMutator.scala
@@ -11,12 +11,12 @@ Then, finally, we define a mutator that both validates and processes any L2Event
 
 object HydrozoaGenesisMutator extends STSL2.Mutator {
     override def transit(context: Context, state: State, event: Event): Result = event match {
-        case g: L2EventGenesis => 
-          for {
-            _ <- L2ConformanceValidator.validate(context, state, event)
+        case g: L2EventGenesis =>
+            for {
+                _ <- L2ConformanceValidator.validate(context, state, event)
 
-          } yield(addGenesisUtxosToState(g, state))
-        case _                 => Right(state)
+            } yield (addGenesisUtxosToState(g, state))
+        case _ => Right(state)
     }
 
     // Fold over utxos passed in the genesis event, adding them to the UtxoSet with the same txId and an incrementing
@@ -58,8 +58,8 @@ object HydrozoaTransactionMutator extends STSL2.Mutator {
                  */
                 // Upstream mutators
                 state <- (
-                    RemoveInputsFromUtxoMutator.transit(context, state, event)
-                    )
+                  RemoveInputsFromUtxoMutator.transit(context, state, event)
+                )
                 state <- (AddOutputsToUtxoMutator.transit(context, state, event))
             yield state
         }
@@ -80,7 +80,7 @@ object HydrozoaWithdrawalMutator extends STSL2.Mutator {
                     if event.body.value.outputs.nonEmpty then
                         Left("Withdrawals cannot have outputs")
                     else Right(())
-                _ <- L2ConformanceValidator.validate(context, state, l2Event)    
+                _ <- L2ConformanceValidator.validate(context, state, l2Event)
 
                 // Upstream validators (applied alphabetically for ease of comparison in a file browser
                 // FIXME/Note (Peter, 2025-07-22): I don't know if all of these will apply or if this list is exhaustive,
@@ -109,8 +109,8 @@ object HydrozoaWithdrawalMutator extends STSL2.Mutator {
                  */
                 // Upstream mutators
                 state <- (
-                    RemoveInputsFromUtxoMutator.transit(context, state, event)
-                    )
+                  RemoveInputsFromUtxoMutator.transit(context, state, event)
+                )
             yield state
         }
         case _ => Right(state)

--- a/src/main/scala/hydrozoa/multisig/ledger/virtual/L2ConformanceValidator.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/virtual/L2ConformanceValidator.scala
@@ -27,10 +27,10 @@ object L2ConformanceValidator extends STSL2.Validator {
         case L2EventWithdrawal(tx)  => given_L2ConformanceValidator_Transaction.l2Validate(tx)
         case L2EventGenesis(resolvedSeq) =>
             mapLeft(_.toString)(
-                resolvedSeq.foldLeft[Either[Error, Unit]](Right(()))((acc, resolved) =>
-                    if acc.isLeft then acc
-                    else given_L2ConformanceValidator_TransactionOutput.l2Validate(resolved._2)
-                )
+              resolvedSeq.foldLeft[Either[Error, Unit]](Right(()))((acc, resolved) =>
+                  if acc.isLeft then acc
+                  else given_L2ConformanceValidator_TransactionOutput.l2Validate(resolved._2)
+              )
             )
     }
 }
@@ -40,8 +40,8 @@ object L2ConformanceValidator extends STSL2.Validator {
 
 /** Passes validation if the Option is None, or if the underlying value of the Some validates. */
 def validateIfPresent[T](
-                            value: Option[T]
-                        )(using v: L2ConformanceValidator[T]): Either[String, Unit] =
+    value: Option[T]
+)(using v: L2ConformanceValidator[T]): Either[String, Unit] =
     value match {
         case Some(s) => v.l2Validate(s)
         case None    => Right(())
@@ -74,9 +74,9 @@ given L2ConformanceValidator[DatumOption] with
 given L2ConformanceValidator[TransactionOutput] with
 
     /** Differs from the L1 Transaction Output in that: \- Only babbage-style outputs are allowed \-
-     * L2 transaction outputs can only contain Ada \- Datums, if present, must be inline \- Only
-     * native scripts or v3 plutus scripts allowed in the script ref
-     */
+      * L2 transaction outputs can only contain Ada \- Datums, if present, must be inline \- Only
+      * native scripts or v3 plutus scripts allowed in the script ref
+      */
     def l2Validate(l1: TransactionOutput): Either[String, Unit] = {
         for
             _ <- l1 match {
@@ -127,15 +127,15 @@ given L2ConformanceValidator[Transaction] with
 
 given L2ConformanceValidator[TransactionBody] with
     /** Differs from the L1 Tx Body as follows: \- The following omissions from the current spec
-     * (commit e2ef186, 2025-07-08 version): \- No certificates, withdrawals, mints,
-     * voting_procedures, proposal_procedures, current_treasury_value, or treasury_donation \-
-     * Omitting fields related to fees and collateral (see private discussion at
-     * https://discord.com/channels/@me/1387084765173121175/1389956276208926852; rationale being
-     * that someone can quit consensus if scripts keep failing)
-     */
+      * (commit e2ef186, 2025-07-08 version): \- No certificates, withdrawals, mints,
+      * voting_procedures, proposal_procedures, current_treasury_value, or treasury_donation \-
+      * Omitting fields related to fees and collateral (see private discussion at
+      * https://discord.com/channels/@me/1387084765173121175/1389956276208926852; rationale being
+      * that someone can quit consensus if scripts keep failing)
+      */
     def l2Validate(
-                      l1: TransactionBody
-                  ): Either[String, Unit] =
+        l1: TransactionBody
+    ): Either[String, Unit] =
         for
             // Validate prohibited fields from L1 transaction
             _ <- validateEquals("Collateral Inputs")(l1.collateralInputs)(Set.empty)
@@ -160,8 +160,8 @@ given L2ConformanceValidator[TransactionBody] with
 given L2ConformanceValidator[TransactionWitnessSet] with
     /** Bootstrap witnesses, and plutus scripts < V3 are not allowed */
     def l2Validate(
-                      l1: TransactionWitnessSet
-                  ): Either[String, Unit] =
+        l1: TransactionWitnessSet
+    ): Either[String, Unit] =
         for
             // Validate empty fields
             _ <- validateEquals("Bootstrap Witnesses")(l1.bootstrapWitnesses)(Set.empty)

--- a/src/main/scala/hydrozoa/multisig/ledger/virtual/L2STS.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/virtual/L2STS.scala
@@ -1,37 +1,37 @@
 package hydrozoa.multisig.ledger.virtual
 
-/** This module defines the "L2 STS". It is almost a direct clone of scalus's upstream "STS"
- * (state transition system), which is in turn modeled after the `IntersectMBO/cardano-ledger`
- * haskell repository.
- *
- * For a more formal treatment, see
- * https://github.com/intersectmbo/cardano-ledger/releases/latest/download/small-step-semantics.pdf.
- * The mapping from this document to our types is:
- *   - "States" = given by the `State` associated type, in our case the
- *     `scalus.cardano.ledger.rules.State` type
- *   - "Transitions" = implementations of the `transit` method on instances of STSL2.Mutator.
- *   - "Signals" = given by the `Event` associated type, in our case `L2Event` (as defined in
- *     `Event.scala`)
- *   - "Rules" = roughly, a set of calls to implementations of the `validate` method on instances
- *     of STSL2.Validator (the antecedents), followed by a calls to `transit` functions (the
- *     consequent).
- *   - "Environment" = the `Context` associated type, in our case the
- *     `scalus.cardano.ledger.rules.Context` type
- *
- * The overall principle is simple: `validate` checks a `(context, state, event)` tuple for
- * validity, `transit` takes `(context, state, event)` to a new `state`.
- *
- * Where possible, we use the upstream types for representing our own STS. This means that our
- * State, Context, and Transition types are "too big" -- for instance, our State type contains
- * information about the UTxO Map, which the L2 Ledger indeed makes use of, but ALSO contains
- * information about Certificate state, which the L2 Ledger does not support. We do this because we
- * want to re-use L1 ledger rules directly where possible without having to convert possibly large
- * data structures (such as the entire utxo map) each time; this is a performance vs type-safety
- * trade-off that we felt was worth it.
- *
- * The validation rules for our STSL2 that are native to hydrozoa (i.e., that do not apply to L1)
- * can be found in `L2ConformanceValidator.scala`.
- */
+/** This module defines the "L2 STS". It is almost a direct clone of scalus's upstream "STS" (state
+  * transition system), which is in turn modeled after the `IntersectMBO/cardano-ledger` haskell
+  * repository.
+  *
+  * For a more formal treatment, see
+  * https://github.com/intersectmbo/cardano-ledger/releases/latest/download/small-step-semantics.pdf.
+  * The mapping from this document to our types is:
+  *   - "States" = given by the `State` associated type, in our case the
+  *     `scalus.cardano.ledger.rules.State` type
+  *   - "Transitions" = implementations of the `transit` method on instances of STSL2.Mutator.
+  *   - "Signals" = given by the `Event` associated type, in our case `L2Event` (as defined in
+  *     `Event.scala`)
+  *   - "Rules" = roughly, a set of calls to implementations of the `validate` method on instances
+  *     of STSL2.Validator (the antecedents), followed by a calls to `transit` functions (the
+  *     consequent).
+  *   - "Environment" = the `Context` associated type, in our case the
+  *     `scalus.cardano.ledger.rules.Context` type
+  *
+  * The overall principle is simple: `validate` checks a `(context, state, event)` tuple for
+  * validity, `transit` takes `(context, state, event)` to a new `state`.
+  *
+  * Where possible, we use the upstream types for representing our own STS. This means that our
+  * State, Context, and Transition types are "too big" -- for instance, our State type contains
+  * information about the UTxO Map, which the L2 Ledger indeed makes use of, but ALSO contains
+  * information about Certificate state, which the L2 Ledger does not support. We do this because we
+  * want to re-use L1 ledger rules directly where possible without having to convert possibly large
+  * data structures (such as the entire utxo map) each time; this is a performance vs type-safety
+  * trade-off that we felt was worth it.
+  *
+  * The validation rules for our STSL2 that are native to hydrozoa (i.e., that do not apply to L1)
+  * can be found in `L2ConformanceValidator.scala`.
+  */
 
 import hydrozoa.*
 import hydrozoa.multisig.ledger.infG2Point
@@ -62,7 +62,6 @@ sealed trait STSL2 {
     def apply(context: Context, state: State, event: Event): Result
 
     protected final def failure(error: Error): Result = Left(error)
-    
 
 }
 
@@ -155,9 +154,9 @@ def getFinalPoly(binomial_poly: SList[Scalar]): SList[Scalar] = {
 
 // TODO: use multi-scalar multiplication
 def getG2Commitment(
-                       setup: SList[P2],
-                       subset: SList[Scalar]
-                   ): P2 = {
+    setup: SList[P2],
+    subset: SList[Scalar]
+): P2 = {
     val subsetInG2 =
         SList.map2(getFinalPoly(subset), setup): (sb, st) =>
             st.mult(sb)

--- a/src/main/scala/hydrozoa/multisig/protocol/ConsensusProtocol.scala
+++ b/src/main/scala/hydrozoa/multisig/protocol/ConsensusProtocol.scala
@@ -58,7 +58,7 @@ object ConsensusProtocol {
     final case class SubmitLedgerEvent(
         time: FiniteDuration,
         event: Unit, // FIXME
-        eventOutcome: Deferred[IO, Unit] // FIXME: LedgerEventOutcome]
+        deferredEventOutcome: Deferred[IO, Unit] // FIXME: LedgerEventOutcome]
     )
 
     /** A ledger event submission is constructed by taking a ledger event, timestamping it, and


### PR DESCRIPTION
I was troubled by the fact that our actors had their `Ref`s initialized by their parent and passed in as class constructor arguments. Even though we made sure not to leak the refs out of the `create` method of actors' companion objects, it still seemed weird. Also, it was inconvenient to define the `State` class of an actor in one place and initialize it in another.

So I decided to do it in the way described (as safe but non-recommended 🙂) in the [cats-effect docs about the `Ref.unsafe` method](https://typelevel.org/cats-effect/api/3.x/cats/effect/kernel/Ref$.html#unsafe[F[_],A](a:A)(implicitF:cats.effect.kernel.Sync[F]):cats.effect.kernel.Ref[F,A]).

Also, I made the `persistence` and `cardanoBackend` actor refs immutable config params to `MultisigRegimeManager` and its children. I doubt we'd want to change those when the multisig regime system is still running. Better to escalate an error and restart with a new config.