### PR TITLE
Actor handles

### DIFF
--- a/src/main/scala/hydrozoa/lib/handle/Handle.scala
+++ b/src/main/scala/hydrozoa/lib/handle/Handle.scala
@@ -1,0 +1,21 @@
+package hydrozoa.lib.handle
+
+object Handle {
+    trait RequestAsync
+
+    trait RequestSync extends RequestAsync {
+        type Response
+    }
+
+    trait HandleAsync[F[+_], -Request <: RequestAsync] {
+        def !(req: Request): F[Unit]
+    }
+
+    trait HandleOnlySync[F[+_], -Request <: RequestSync] {
+        def ?(request: Request): F[request.Response]
+    }
+
+    trait Handle[F[+_], -RequestA <: RequestAsync, -RequestS <: RequestSync]
+        extends HandleAsync[F, RequestA],
+          HandleOnlySync[F, RequestS]
+}

--- a/src/main/scala/hydrozoa/lib/handle/actor/ActorHandle.scala
+++ b/src/main/scala/hydrozoa/lib/handle/actor/ActorHandle.scala
@@ -1,0 +1,103 @@
+package hydrozoa.lib.handle.actor
+
+import cats.MonadError
+import cats.effect.{Deferred, GenConcurrent}
+import cats.syntax.all.*
+import com.suprnation.actor.ActorRef.ActorRef
+
+object ActorHandle {
+    import hydrozoa.lib.handle.Handle.*
+
+    sealed trait ActorRequestSync[F[+_], +RequestS <: RequestSync](
+        val request: RequestS,
+        private val deferredResponse: Deferred[F, Either[Throwable, request.Response]]
+    )(implicit F: MonadError[F, Throwable]) {
+        def receiveSync(f: RequestS => F[request.Response]): F[Unit] =
+            for {
+                eResult <- f(request).attempt
+                _ <- deferredResponse.complete(eResult)
+            } yield ()
+
+        def complete(response: request.Response): F[Unit] =
+            deferredResponse.complete(Right(response)).void
+    }
+
+    object ActorRequestSync {
+        def apply[F[+_], RequestS <: RequestSync](
+            request: RequestS,
+            deferredResponse: Deferred[F, Either[Throwable, request.Response]]
+        )(implicit F: MonadError[F, Throwable]): ActorRequestSync[F, RequestS] =
+            new ActorRequestSync(request, deferredResponse) {}
+    }
+
+    sealed trait ActorHandleAsync[F[+_], -RequestA <: RequestAsync]
+        extends HandleAsync[F, RequestA] {
+        def asyncActorRef: ActorRef[F, RequestA]
+
+        override def !(request: RequestA): F[Unit] =
+            this.asyncActorRef ! request
+    }
+
+    object ActorHandleAsync {
+        def apply[F[+_], RequestA <: RequestAsync](
+            a: ActorRef[F, RequestA]
+        ): ActorHandleAsync[F, RequestA] =
+            new ActorHandleAsync {
+                override val asyncActorRef: ActorRef[F, RequestA] = a
+            }
+    }
+
+    sealed trait ActorHandleSyncOnly[F[+_], -RequestS <: RequestSync](implicit
+        F: GenConcurrent[F, Throwable]
+    ) extends HandleOnlySync[F, RequestS] {
+        def syncActorRef: ActorHandleSyncOnly.Ref[F, RequestS]
+
+        override def ?(request: RequestS): F[request.Response] =
+            for {
+                deferredResponse <- Deferred[F, Either[Throwable, request.Response]]
+                actorRequest = ActorRequestSync(request, deferredResponse)
+                _ <- this.syncActorRef ! actorRequest
+                response <- deferredResponse.get.rethrow
+            } yield response
+    }
+
+    object ActorHandleSyncOnly {
+        type Ref[F[+_], -RequestS <: RequestSync] = ActorRef[F, Request[F, RequestS]]
+        type Request[F[+_], +RequestS <: RequestSync] = ActorRequestSync[F, RequestS]
+
+        def apply[F[+_], RequestS <: RequestSync](
+            a: Ref[F, RequestS]
+        )(implicit F: GenConcurrent[F, Throwable]): ActorHandleSyncOnly[F, RequestS] =
+            new ActorHandleSyncOnly {
+                override val syncActorRef: ActorRef[F, ActorRequestSync[F, RequestS]] = a
+            }
+    }
+
+    sealed trait ActorHandle[F[+_], -RequestA <: RequestAsync, -RequestS <: RequestSync]
+        extends Handle[F, RequestA, RequestS],
+          ActorHandleAsync[F, RequestA],
+          ActorHandleSyncOnly[F, RequestS] {
+        def actorRef: ActorHandle.Ref[F, RequestA, RequestS]
+
+        override def asyncActorRef: ActorRef[F, RequestA] = actorRef
+
+        override def syncActorRef: ActorRef[F, ActorRequestSync[F, RequestS]] = actorRef
+    }
+
+    object ActorHandle {
+        type Ref2[F[+_], -RequestS <: RequestSync] = Ref[F, RequestS, RequestS]
+
+        type Ref[F[+_], -RequestA <: RequestAsync, -RequestS <: RequestSync] =
+            ActorRef[F, Request[F, RequestA, RequestS]]
+
+        type Request[F[+_], +RequestA <: RequestAsync, +RequestS <: RequestSync] =
+            RequestA | ActorRequestSync[F, RequestS]
+
+        def apply[F[+_], RequestA <: RequestSync, RequestS <: RequestSync](
+            a: Ref[F, RequestA, RequestS]
+        )(implicit F: GenConcurrent[F, Throwable]): ActorHandle[F, RequestA, RequestS] =
+            new ActorHandle {
+                override val actorRef: Ref[F, RequestA, RequestS] = a
+            }
+    }
+}

--- a/src/main/scala/hydrozoa/lib/handle/actor/ActorHandle.scala
+++ b/src/main/scala/hydrozoa/lib/handle/actor/ActorHandle.scala
@@ -28,6 +28,9 @@ object ActorHandle {
             deferredResponse: Deferred[F, Either[Throwable, request.Response]]
         )(implicit F: MonadError[F, Throwable]): ActorRequestSync[F, RequestS] =
             new ActorRequestSync(request, deferredResponse) {}
+            
+        def unapply[F[+_], RequestS <: RequestSync](a: ActorRequestSync[F, RequestS]): RequestS =
+            a.request
     }
 
     sealed trait ActorHandleAsync[F[+_], -RequestA <: RequestAsync]

--- a/src/main/scala/hydrozoa/multisig/MultisigRegimeManager.scala
+++ b/src/main/scala/hydrozoa/multisig/MultisigRegimeManager.scala
@@ -29,15 +29,11 @@ object MultisigRegimeManager {
         persistence: Persistence.Ref
     )
 
-    def create(
-        config: Config
-    ): IO[MultisigRegimeManager] =
-        IO(MultisigRegimeManager(config))
+    def create(config: Config): IO[MultisigRegimeManager] =
+        IO(new MultisigRegimeManager(config) {})
 }
 
-final class MultisigRegimeManager private (
-    config: Config
-) extends Actor[IO, Request] {
+trait MultisigRegimeManager(config: Config) extends Actor[IO, Request] {
 
     override def supervisorStrategy: SupervisionStrategy[IO] =
         OneForOneStrategy[IO](maxNrOfRetries = 3, withinTimeRange = 1 minute) {
@@ -64,61 +60,75 @@ final class MultisigRegimeManager private (
             pendingCardanoLiaison <- Deferred[IO, ConsensusProtocol.CardanoLiaison.Ref]
             pendingTransactionSequencer <- Deferred[IO, ConsensusProtocol.TransactionSequencer.Ref]
 
-            blockProducer <- context.actorOf(
-              BlockProducer.create(
-                BlockProducer.Config(peerId = config.peerId, persistence = config.persistence),
-                BlockProducer.ConnectionsPending(
-                  cardanoLiaison = pendingCardanoLiaison,
-                  peerLiaisons = pendingLocalPeerLiaisons,
-                  transactionSequencer = pendingTransactionSequencer
+            blockProducer <- {
+                import BlockProducer.{Config, ConnectionsPending}
+                context.actorOf(
+                  BlockProducer(
+                    Config(peerId = config.peerId, persistence = config.persistence),
+                    ConnectionsPending(
+                      cardanoLiaison = pendingCardanoLiaison,
+                      peerLiaisons = pendingLocalPeerLiaisons,
+                      transactionSequencer = pendingTransactionSequencer
+                    )
+                  )
                 )
-              )
-            )
+            }
 
-            localPeerLiaisonsPendingRemoteActors <- config.peers
-                .filterNot(_ == config.peerId)
-                .traverse(pid =>
-                    for {
-                        pendingRemotePeerLiaison <- Deferred[IO, ConsensusProtocol.PeerLiaison.Ref]
-                        localPeerLiaison <- context.actorOf(
-                          PeerLiaison.create(
-                            PeerLiaison.Config(
-                              peerId = config.peerId,
-                              remotePeerId = pid,
-                              persistence = config.persistence
-                            ),
-                            PeerLiaison.ConnectionsPending(
-                              blockProducer = pendingBlockProducer,
-                              remotePeerLiaison = pendingRemotePeerLiaison
+            localPeerLiaisonsPendingRemoteActors <- {
+                import PeerLiaison.{Config, ConnectionsPending}
+                config.peers
+                    .filterNot(_ == config.peerId)
+                    .traverse(pid =>
+                        for {
+                            pendingRemotePeerLiaison <- Deferred[
+                              IO,
+                              ConsensusProtocol.PeerLiaison.Ref
+                            ]
+                            localPeerLiaison <- context.actorOf(
+                              PeerLiaison(
+                                Config(
+                                  peerId = config.peerId,
+                                  remotePeerId = pid,
+                                  persistence = config.persistence
+                                ),
+                                ConnectionsPending(
+                                  blockProducer = pendingBlockProducer,
+                                  remotePeerLiaison = pendingRemotePeerLiaison
+                                )
+                              )
                             )
-                          )
-                        )
-                    } yield (localPeerLiaison, pendingRemotePeerLiaison)
-                )
+                        } yield (localPeerLiaison, pendingRemotePeerLiaison)
+                    )
+            }
 
             localPeerLiaisons = localPeerLiaisonsPendingRemoteActors.map(_._1)
 
-            cardanoLiaison <- context.actorOf(
-              CardanoLiaison.create(
-                CardanoLiaison.Config(
-                  persistence = config.persistence,
-                  cardanoBackend = config.cardanoBackend
-                ),
-                CardanoLiaison.ConnectionsPending(
+            cardanoLiaison <- {
+                import CardanoLiaison.{Config, ConnectionsPending}
+                context.actorOf(
+                  CardanoLiaison(
+                    Config(
+                      persistence = config.persistence,
+                      cardanoBackend = config.cardanoBackend
+                    ),
+                    ConnectionsPending(
+                    )
+                  )
                 )
-              )
-            )
+            }
 
-            transactionSequencer <- context.actorOf(
-              TransactionSequencer.create(
-                TransactionSequencer
-                    .Config(peerId = config.peerId, persistence = config.persistence),
-                TransactionSequencer.ConnectionsPending(
-                  blockProducer = pendingBlockProducer,
-                  peerLiaisons = pendingLocalPeerLiaisons
+            transactionSequencer <- {
+                import TransactionSequencer.{Config, ConnectionsPending}
+                context.actorOf(
+                  TransactionSequencer(
+                    Config(peerId = config.peerId, persistence = config.persistence),
+                    ConnectionsPending(
+                      blockProducer = pendingBlockProducer,
+                      peerLiaisons = pendingLocalPeerLiaisons
+                    )
+                  )
                 )
-              )
-            )
+            }
 
             _ <- pendingBlockProducer.complete(blockProducer)
             _ <- pendingLocalPeerLiaisons.complete(localPeerLiaisons)

--- a/src/main/scala/hydrozoa/multisig/MultisigRegimeManager.scala
+++ b/src/main/scala/hydrozoa/multisig/MultisigRegimeManager.scala
@@ -29,7 +29,7 @@ object MultisigRegimeManager {
         persistence: Persistence.Ref
     )
 
-    def create(config: Config): IO[MultisigRegimeManager] =
+    def apply(config: Config): IO[MultisigRegimeManager] =
         IO(new MultisigRegimeManager(config) {})
 }
 

--- a/src/main/scala/hydrozoa/multisig/backend/cardano/CardanoBackend.scala
+++ b/src/main/scala/hydrozoa/multisig/backend/cardano/CardanoBackend.scala
@@ -13,10 +13,10 @@ import hydrozoa.multisig.protocol.CardanoBackendProtocol.CardanoBackend.*
   */
 object CardanoBackend {
     def create(): IO[CardanoBackend] =
-        CardanoBackend().pure
+        IO.pure(new CardanoBackend {})
 }
 
-final case class CardanoBackend() extends Actor[IO, Request] {
+trait CardanoBackend extends Actor[IO, Request] {
     override def receive: Receive[IO, Request] =
         PartialFunction.fromFunction({
             case x: SubmitL1Effects     => ???

--- a/src/main/scala/hydrozoa/multisig/backend/cardano/CardanoBackend.scala
+++ b/src/main/scala/hydrozoa/multisig/backend/cardano/CardanoBackend.scala
@@ -12,7 +12,7 @@ import hydrozoa.multisig.protocol.CardanoBackendProtocol.CardanoBackend.*
   *   - Responds to queries about utxo state.
   */
 object CardanoBackend {
-    def create(): IO[CardanoBackend] =
+    def apply(): IO[CardanoBackend] =
         IO.pure(new CardanoBackend {})
 }
 

--- a/src/main/scala/hydrozoa/multisig/consensus/BlockProducer.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/BlockProducer.scala
@@ -28,13 +28,12 @@ object BlockProducer {
         transactionSequencer: Deferred[IO, TransactionSequencer.Ref]
     )
 
-    def create(config: Config, connections: ConnectionsPending): IO[BlockProducer] = {
-        IO(BlockProducer(config, connections))
+    def apply(config: Config, connections: ConnectionsPending): IO[BlockProducer] = {
+        IO(new BlockProducer(config = config, connections = connections) {})
     }
 }
 
-final class BlockProducer private (config: Config, private val connections: ConnectionsPending)
-    extends Actor[IO, Request] {
+trait BlockProducer(config: Config, connections: ConnectionsPending) extends Actor[IO, Request] {
     private val subscribers = Ref.unsafe[IO, Option[Subscribers]](None)
     private val state = State()
 

--- a/src/main/scala/hydrozoa/multisig/consensus/CardanoLiaison.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/CardanoLiaison.scala
@@ -26,13 +26,12 @@ object CardanoLiaison {
 
     final case class ConnectionsPending()
 
-    def create(config: Config, connections: ConnectionsPending): IO[CardanoLiaison] = {
-        IO(CardanoLiaison(config, connections))
+    def apply(config: Config, connections: ConnectionsPending): IO[CardanoLiaison] = {
+        IO(new CardanoLiaison(config, connections) {})
     }
 }
 
-final class CardanoLiaison private (config: Config, private val connections: ConnectionsPending)
-    extends Actor[IO, Request] {
+trait CardanoLiaison(config: Config, connections: ConnectionsPending) extends Actor[IO, Request] {
     private val subscribers = Ref.unsafe[IO, Option[Subscribers]](None)
     private val state = State()
 

--- a/src/main/scala/hydrozoa/multisig/consensus/PeerLiaison.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/PeerLiaison.scala
@@ -35,12 +35,11 @@ object PeerLiaison {
         remotePeerLiaison: Deferred[IO, PeerLiaisonRef]
     )
 
-    def create(config: Config, connections: ConnectionsPending): IO[PeerLiaison] =
-        IO(PeerLiaison(config, connections))
+    def apply(config: Config, connections: ConnectionsPending): IO[PeerLiaison] =
+        IO(new PeerLiaison(config, connections) {})
 }
 
-final class PeerLiaison private (config: Config, connections: ConnectionsPending)
-    extends Actor[IO, Request] {
+trait PeerLiaison(config: Config, connections: ConnectionsPending) extends Actor[IO, Request] {
     private val subscribers = Ref.unsafe[IO, Option[Subscribers]](None)
     private val state = State()
 

--- a/src/main/scala/hydrozoa/multisig/consensus/TransactionSequencer.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/TransactionSequencer.scala
@@ -27,14 +27,12 @@ object TransactionSequencer {
         peerLiaisons: Deferred[IO, List[PeerLiaison.Ref]]
     )
 
-    def create(config: Config, connections: ConnectionsPending): IO[TransactionSequencer] =
-        IO(TransactionSequencer(config, connections))
+    def apply(config: Config, connections: ConnectionsPending): IO[TransactionSequencer] =
+        IO(new TransactionSequencer(config, connections) {})
 }
 
-final class TransactionSequencer private (
-    config: Config,
-    private val connections: ConnectionsPending
-) extends Actor[IO, Request] {
+trait TransactionSequencer(config: Config, connections: ConnectionsPending)
+    extends Actor[IO, Request] {
     private val subscribers = Ref.unsafe[IO, Option[Subscribers]](None)
     private val state = State()
 

--- a/src/main/scala/hydrozoa/multisig/persistence/Persistence.scala
+++ b/src/main/scala/hydrozoa/multisig/persistence/Persistence.scala
@@ -2,9 +2,9 @@ package hydrozoa.multisig.persistence
 
 import cats.effect.IO
 import cats.effect.Ref
-import cats.implicits._
-import com.suprnation.actor.Actor.ReplyingReceive
-import com.suprnation.actor.ReplyingActor
+import cats.implicits.*
+import com.suprnation.actor.Actor.{Actor, Receive}
+import hydrozoa.lib.handle.actor.ActorHandle.ActorRequestSync
 import hydrozoa.multisig.protocol.*
 import hydrozoa.multisig.protocol.Identifiers.*
 import hydrozoa.multisig.protocol.ConsensusProtocol.*
@@ -23,40 +23,45 @@ object Persistence {
         IO(new Persistence {})
 }
 
-trait Persistence extends ReplyingActor[IO, Request, Response] {
+trait Persistence extends Actor[IO, Request] {
     private val acks = Ref.unsafe[IO, TreeMap[AckId, AckBlock]](TreeMap())
     private val batches = Ref.unsafe[IO, TreeMap[BatchId, GetMsgBatch]](TreeMap())
     private val blocks = Ref.unsafe[IO, TreeMap[BlockId, NewBlock]](TreeMap())
     private val events = Ref.unsafe[IO, TreeMap[LedgerEventId, NewLedgerEvent]](TreeMap())
     private val confirmedBlock = Ref.unsafe[IO, Option[BlockId]](None)
     
-    override def receive: ReplyingReceive[IO, Request, Response] =
-        PartialFunction.fromFunction({
-            case PersistRequest(data) =>
-                data match {
-                    case x: NewLedgerEvent =>
-                        events.update(m => m + (x.id -> x)) >>
-                            PutSucceeded.pure
-                    case x: NewBlock =>
-                        blocks.update(m => m + (x.id -> x)) >>
-                            PutSucceeded.pure
-                    case x: AckBlock =>
-                        acks.update(m => m + (x.id -> x)) >>
-                            PutSucceeded.pure
-                    case x: ConfirmBlock =>
-                        confirmedBlock.update(_ => Some(x.id)) >>
-                            PutSucceeded.pure
-                    case x: NewMsgBatch =>
-                        batches.update(m => m + (x.id -> x.nextGetMsgBatch)) >>
-                            x.ack.traverse_(y => acks.update(m => m + (y.id -> y))) >>
-                            x.block.traverse_(y => blocks.update(m => m + (y.id -> y))) >>
-                            events.update(m => m ++ x.events.map(y => y.id -> y)) >>
-                            PutSucceeded.pure
-                }
-            case x: PutL1Effects            => ???
-            case x: PutCardanoHeadState     => ???
-            case x: GetBlockData            => ???
-            case x: GetConfirmedLocalEvents => ???
-            case x: GetConfirmedL1Effects   => ???
-        })
+    override def receive: Receive[IO, Request] =
+        PartialFunction.fromFunction(this.receiveTotal)
+
+    private def receiveTotal(req: Request): IO[Unit] =
+        req match {
+            case r: ActorRequestSync[IO, PersistRequest] => r.receiveSync(handlePersist)
+            case r: ActorRequestSync[IO, PutL1Effects] => ???
+            case r: ActorRequestSync[IO, PutCardanoHeadState] => ???
+            case r: ActorRequestSync[IO, GetBlockData] => ???
+            case r: ActorRequestSync[IO, GetConfirmedL1Effects] => ???
+            case r: ActorRequestSync[IO, GetConfirmedLocalEvents] => ???
+        }
+
+    private def handlePersist(req: PersistRequest): IO[PutResponse] =
+        req.data match {
+            case x: NewLedgerEvent =>
+                events.update(m => m + (x.id -> x)) >>
+                    PutSucceeded.pure
+            case x: NewBlock =>
+                blocks.update(m => m + (x.id -> x)) >>
+                    PutSucceeded.pure
+            case x: AckBlock =>
+                acks.update(m => m + (x.id -> x)) >>
+                    PutSucceeded.pure
+            case x: ConfirmBlock =>
+                confirmedBlock.update(_ => Some(x.id)) >>
+                    PutSucceeded.pure
+            case x: NewMsgBatch =>
+                batches.update(m => m + (x.id -> x.nextGetMsgBatch)) >>
+                    x.ack.traverse_(y => acks.update(m => m + (y.id -> y))) >>
+                    x.block.traverse_(y => blocks.update(m => m + (y.id -> y))) >>
+                    events.update(m => m ++ x.events.map(y => y.id -> y)) >>
+                    PutSucceeded.pure
+        }
 }

--- a/src/main/scala/hydrozoa/multisig/persistence/Persistence.scala
+++ b/src/main/scala/hydrozoa/multisig/persistence/Persistence.scala
@@ -11,7 +11,7 @@ import hydrozoa.multisig.protocol.ConsensusProtocol.*
 import hydrozoa.multisig.protocol.PersistenceProtocol.Persistence.*
 import hydrozoa.multisig.protocol.PersistenceProtocol.Persistence.PutResponse.*
 
-import scala.collection.immutable
+import scala.collection.immutable.TreeMap
 
 /** Persistence actor is a mock interface to a key-value store (e.g. RocksDB):
   *
@@ -19,24 +19,17 @@ import scala.collection.immutable
   *   - Gets data that was put into the store (i.e. read/retrieve)
   */
 object Persistence {
-    def create(): IO[Persistence] = {
-        for {
-            acks <- Ref[IO].of(immutable.TreeMap[AckId, AckBlock]())
-            batches <- Ref[IO].of(immutable.TreeMap[BatchId, GetMsgBatch]())
-            blocks <- Ref[IO].of(immutable.TreeMap[BlockId, NewBlock]())
-            events <- Ref[IO].of(immutable.TreeMap[LedgerEventId, NewLedgerEvent]())
-            confirmedBlock <- Ref[IO].of(Option.empty)
-        } yield Persistence()(acks, batches, blocks, events, confirmedBlock)
-    }
+    def create(): IO[Persistence] =
+        IO(new Persistence {})
 }
 
-final case class Persistence()(
-    private val acks: Ref[IO, immutable.TreeMap[AckId, AckBlock]],
-    private val batches: Ref[IO, immutable.TreeMap[BatchId, GetMsgBatch]],
-    private val blocks: Ref[IO, immutable.TreeMap[BlockId, NewBlock]],
-    private val events: Ref[IO, immutable.TreeMap[LedgerEventId, NewLedgerEvent]],
-    private val confirmedBlock: Ref[IO, Option[BlockId]]
-) extends ReplyingActor[IO, Request, Response] {
+trait Persistence extends ReplyingActor[IO, Request, Response] {
+    private val acks = Ref.unsafe[IO, TreeMap[AckId, AckBlock]](TreeMap())
+    private val batches = Ref.unsafe[IO, TreeMap[BatchId, GetMsgBatch]](TreeMap())
+    private val blocks = Ref.unsafe[IO, TreeMap[BlockId, NewBlock]](TreeMap())
+    private val events = Ref.unsafe[IO, TreeMap[LedgerEventId, NewLedgerEvent]](TreeMap())
+    private val confirmedBlock = Ref.unsafe[IO, Option[BlockId]](None)
+    
     override def receive: ReplyingReceive[IO, Request, Response] =
         PartialFunction.fromFunction({
             case PersistRequest(data) =>

--- a/src/main/scala/hydrozoa/multisig/persistence/Persistence.scala
+++ b/src/main/scala/hydrozoa/multisig/persistence/Persistence.scala
@@ -19,7 +19,7 @@ import scala.collection.immutable.TreeMap
   *   - Gets data that was put into the store (i.e. read/retrieve)
   */
 object Persistence {
-    def create(): IO[Persistence] =
+    def apply(): IO[Persistence] =
         IO(new Persistence {})
 }
 

--- a/src/main/scala/hydrozoa/multisig/persistence/Persistence.scala
+++ b/src/main/scala/hydrozoa/multisig/persistence/Persistence.scala
@@ -23,23 +23,23 @@ object Persistence {
         IO(new Persistence {})
 }
 
-trait Persistence extends Actor[IO, Request] {
+trait Persistence extends Actor[IO, ActorRequest] {
     private val acks = Ref.unsafe[IO, TreeMap[AckId, AckBlock]](TreeMap())
     private val batches = Ref.unsafe[IO, TreeMap[BatchId, GetMsgBatch]](TreeMap())
     private val blocks = Ref.unsafe[IO, TreeMap[BlockId, NewBlock]](TreeMap())
     private val events = Ref.unsafe[IO, TreeMap[LedgerEventId, NewLedgerEvent]](TreeMap())
     private val confirmedBlock = Ref.unsafe[IO, Option[BlockId]](None)
-    
-    override def receive: Receive[IO, Request] =
+
+    override def receive: Receive[IO, ActorRequest] =
         PartialFunction.fromFunction(this.receiveTotal)
 
-    private def receiveTotal(req: Request): IO[Unit] =
+    private def receiveTotal(req: ActorRequest): IO[Unit] =
         req match {
-            case r: ActorRequestSync[IO, PersistRequest] => r.receiveSync(handlePersist)
-            case r: ActorRequestSync[IO, PutL1Effects] => ???
-            case r: ActorRequestSync[IO, PutCardanoHeadState] => ???
-            case r: ActorRequestSync[IO, GetBlockData] => ???
-            case r: ActorRequestSync[IO, GetConfirmedL1Effects] => ???
+            case r: ActorRequestSync[IO, PersistRequest]          => r.receiveSync(handlePersist)
+            case r: ActorRequestSync[IO, PutL1Effects]            => ???
+            case r: ActorRequestSync[IO, PutCardanoHeadState]     => ???
+            case r: ActorRequestSync[IO, GetBlockData]            => ???
+            case r: ActorRequestSync[IO, GetConfirmedL1Effects]   => ???
             case r: ActorRequestSync[IO, GetConfirmedLocalEvents] => ???
         }
 

--- a/src/main/scala/hydrozoa/multisig/protocol/PersistenceProtocol.scala
+++ b/src/main/scala/hydrozoa/multisig/protocol/PersistenceProtocol.scala
@@ -1,37 +1,46 @@
 package hydrozoa.multisig.protocol
 
 import cats.effect.IO
-import com.suprnation.actor.ReplyingActorRef
+import com.suprnation.actor.ActorRef.ActorRef
+import hydrozoa.lib.handle.Handle.RequestSync
+import hydrozoa.lib.handle.actor.ActorHandle.ActorRequestSync
 import hydrozoa.multisig.protocol.ConsensusProtocol.Persisted
 
 object PersistenceProtocol {
     object Persistence {
         type PersistenceRef = Ref
-        type Ref = ReplyingActorRef[IO, Request, Response]
+        type Ref = ActorRef[IO, Request]
         type Request =
-            PersistRequest | PutL1Effects | PutCardanoHeadState | GetBlockData |
-                GetConfirmedL1Effects | GetConfirmedLocalEvents
-
-        type Response =
-            PutResponse | GetBlockDataResp | GetConfirmedL1EffectsResp | GetConfirmedLocalEventsResp
+            ActorRequestSync[IO, PersistRequest] |
+            ActorRequestSync[IO, PutL1Effects] |
+            ActorRequestSync[IO, PutCardanoHeadState] |
+            ActorRequestSync[IO, GetBlockData] |
+            ActorRequestSync[IO, GetConfirmedL1Effects] |
+            ActorRequestSync[IO, GetConfirmedLocalEvents]
 
         /** ==Put/write data into the persistence system== */
         final case class PersistRequest(
             data: Persisted.Request
-        )
+        ) extends RequestSync {
+            override type Response = PutResponse
+        }
 
         /** Successfully persisted the data. */
         enum PutResponse:
             case PutSucceeded
-            // case PutFailed
+            case PutFailed
 
         /** Persist L1 effects of L2 blocks */
         final case class PutL1Effects(
-        )
+        ) extends RequestSync {
+            override type Response = PutResponse
+        }
 
         /** Persist the head's latest utxo state in Cardano */
         final case class PutCardanoHeadState(
-        )
+        ) extends RequestSync {
+            override type Response = PutResponse
+        }
 
         /** ==Get/read data from the persistence system== */
 
@@ -39,7 +48,9 @@ object PersistenceProtocol {
           * deposits).
           */
         final case class GetBlockData(
-        )
+        ) extends RequestSync {
+            override type Response = GetBlockDataResp
+        }
 
         /** Response to [[GetBlockData]]. */
         final case class GetBlockDataResp(
@@ -52,7 +63,9 @@ object PersistenceProtocol {
           *     referenced by the block.
           */
         final case class GetConfirmedLocalEvents(
-        )
+        ) extends RequestSync {
+            override type Response = GetConfirmedLocalEventsResp
+        }
 
         /** Response to [[GetConfirmedLocalEvents]]. */
         final case class GetConfirmedLocalEventsResp(
@@ -60,7 +73,9 @@ object PersistenceProtocol {
 
         /** Retrieve L1 effects of confirmed L2 blocks. */
         final case class GetConfirmedL1Effects(
-        )
+        ) extends RequestSync {
+            override type Response = GetConfirmedL1EffectsResp
+        }
 
         /** Response to [[GetConfirmedL1Effects]]. */
         final case class GetConfirmedL1EffectsResp(

--- a/src/main/scala/hydrozoa/multisig/protocol/PersistenceProtocol.scala
+++ b/src/main/scala/hydrozoa/multisig/protocol/PersistenceProtocol.scala
@@ -3,20 +3,21 @@ package hydrozoa.multisig.protocol
 import cats.effect.IO
 import com.suprnation.actor.ActorRef.ActorRef
 import hydrozoa.lib.handle.Handle.RequestSync
-import hydrozoa.lib.handle.actor.ActorHandle.ActorRequestSync
+import hydrozoa.lib.handle.actor.ActorHandle.{ActorHandleSyncOnly, ActorRequestSync}
 import hydrozoa.multisig.protocol.ConsensusProtocol.Persisted
 
 object PersistenceProtocol {
     object Persistence {
+        type Handle = ActorHandleSyncOnly[IO, Request, ActorRequest]
         type PersistenceRef = Ref
-        type Ref = ActorRef[IO, Request]
-        type Request =
-            ActorRequestSync[IO, PersistRequest] |
-            ActorRequestSync[IO, PutL1Effects] |
-            ActorRequestSync[IO, PutCardanoHeadState] |
-            ActorRequestSync[IO, GetBlockData] |
-            ActorRequestSync[IO, GetConfirmedL1Effects] |
-            ActorRequestSync[IO, GetConfirmedLocalEvents]
+        type Ref = ActorRef[IO, ActorRequest]
+        type ActorRequest =
+            ActorRequestSync[IO, PersistRequest] | ActorRequestSync[IO, PutL1Effects] |
+                ActorRequestSync[IO, PutCardanoHeadState] | ActorRequestSync[IO, GetBlockData] |
+                ActorRequestSync[IO, GetConfirmedL1Effects] |
+                ActorRequestSync[IO, GetConfirmedLocalEvents]
+        
+        type Request = PersistRequest | PutL1Effects | PutCardanoHeadState| GetBlockData | GetConfirmedL1Effects | GetConfirmedLocalEvents
 
         /** ==Put/write data into the persistence system== */
         final case class PersistRequest(


### PR DESCRIPTION
Good news: kinda succeeded (i.e. it compiles) implementing an abstract mechanism for defining:

- a synchronous request type (`RequestSync`) and its corresponding response type (`requestSync.Response`)
- an augmented type (specialized for actors) that includes the sync request and a deferred cell for the response (`ActorRequestSync`)
- methods to complete the deferred cell

Good news: it seems to work in `Persistence.scala`.

Bad news: I can't figure out how to work with a union type (A | B | C) and a type-level function mapped over the union (F(A) | F(B) | F(C)).

Seems too complicated, so I'm abandoning this PR for now. 