### PR TITLE
Synchronous requests with specific responses

### DIFF
--- a/src/main/scala/hydrozoa/lib/actor/SyncRequest.scala
+++ b/src/main/scala/hydrozoa/lib/actor/SyncRequest.scala
@@ -1,0 +1,25 @@
+package hydrozoa.lib.actor
+
+import cats.MonadError
+import cats.effect.Deferred
+import cats.syntax.all.*
+import com.suprnation.actor.ActorRef.ActorRef
+
+trait SyncRequest[F[+_], Response](implicit F: MonadError[F, Throwable]) {
+    def dResponse: Deferred[F, Either[Throwable, Response]]
+    def handleRequest(f: this.type => F[Response]): F[Unit] =
+        for {
+            eResult <- f(this).attempt
+            _ <- dResponse.complete(eResult)
+        } yield ()
+
+    def ?:(actorRef: ActorRef[F, this.type]): F[Either[Throwable, Response]] =
+        for {
+            _ <- actorRef ! this
+            eResponse <- this.dResponse.get
+        } yield eResponse
+}
+
+object SyncRequest {
+    type DeferredResponse[F[+_], R] = Deferred[F, Either[Throwable, R]]
+}

--- a/src/main/scala/hydrozoa/multisig/consensus/CardanoLiaison.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/CardanoLiaison.scala
@@ -1,6 +1,5 @@
 package hydrozoa.multisig.consensus
 
-import cats.effect.Deferred
 import cats.effect.IO
 import cats.effect.Ref
 import cats.implicits.*

--- a/src/main/scala/hydrozoa/multisig/consensus/PeerLiaison.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/PeerLiaison.scala
@@ -112,7 +112,8 @@ trait PeerLiaison(config: Config, connections: ConnectionsPending) extends Actor
                 } yield ()
             case x: NewMsgBatch =>
                 for {
-                    _ <- config.persistence ? Persistence.PersistRequest(x)
+                    persistenceRequest <- Persistence.PersistRequest(x)
+                    _ <- config.persistence ?: persistenceRequest
                     _ <- subs.remotePeerLiaison ! x.nextGetMsgBatch
                     _ <- x.ack.traverse_(subs.ackBlock ! _)
                     _ <- x.block.traverse_(subs.newBlock ! _)

--- a/src/main/scala/hydrozoa/multisig/consensus/TransactionSequencer.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/TransactionSequencer.scala
@@ -72,7 +72,8 @@ trait TransactionSequencer(config: Config, connections: ConnectionsPending)
                     newNum <- state.enqueueDeferredEventOutcome(x.deferredEventOutcome)
                     newId = (config.peerId, newNum)
                     newEvent = NewLedgerEvent(newId, x.time, x.event)
-                    _ <- config.persistence ? Persistence.PersistRequest(newEvent)
+                    persistenceRequest <- Persistence.PersistRequest(newEvent)
+                    _ <- config.persistence ?: persistenceRequest
                     _ <- (subs.newLedgerEvent ! newEvent).parallel
                 } yield ()
             case x: ConfirmBlock =>

--- a/src/main/scala/hydrozoa/multisig/persistence/Persistence.scala
+++ b/src/main/scala/hydrozoa/multisig/persistence/Persistence.scala
@@ -2,8 +2,8 @@ package hydrozoa.multisig.persistence
 
 import cats.effect.IO
 import cats.effect.Ref
-import cats.implicits._
-import com.suprnation.actor.Actor.ReplyingReceive
+import cats.implicits.*
+import com.suprnation.actor.Actor.{Actor, Receive}
 import com.suprnation.actor.ReplyingActor
 import hydrozoa.multisig.protocol.*
 import hydrozoa.multisig.protocol.Identifiers.*
@@ -23,40 +23,42 @@ object Persistence {
         IO(new Persistence {})
 }
 
-trait Persistence extends ReplyingActor[IO, Request, Response] {
+trait Persistence extends Actor[IO, Request] {
     private val acks = Ref.unsafe[IO, TreeMap[AckId, AckBlock]](TreeMap())
     private val batches = Ref.unsafe[IO, TreeMap[BatchId, GetMsgBatch]](TreeMap())
     private val blocks = Ref.unsafe[IO, TreeMap[BlockId, NewBlock]](TreeMap())
     private val events = Ref.unsafe[IO, TreeMap[LedgerEventId, NewLedgerEvent]](TreeMap())
     private val confirmedBlock = Ref.unsafe[IO, Option[BlockId]](None)
-    
-    override def receive: ReplyingReceive[IO, Request, Response] =
+
+    override def receive: Receive[IO, Request] =
         PartialFunction.fromFunction({
-            case PersistRequest(data) =>
-                data match {
-                    case x: NewLedgerEvent =>
-                        events.update(m => m + (x.id -> x)) >>
-                            PutSucceeded.pure
-                    case x: NewBlock =>
-                        blocks.update(m => m + (x.id -> x)) >>
-                            PutSucceeded.pure
-                    case x: AckBlock =>
-                        acks.update(m => m + (x.id -> x)) >>
-                            PutSucceeded.pure
-                    case x: ConfirmBlock =>
-                        confirmedBlock.update(_ => Some(x.id)) >>
-                            PutSucceeded.pure
-                    case x: NewMsgBatch =>
-                        batches.update(m => m + (x.id -> x.nextGetMsgBatch)) >>
-                            x.ack.traverse_(y => acks.update(m => m + (y.id -> y))) >>
-                            x.block.traverse_(y => blocks.update(m => m + (y.id -> y))) >>
-                            events.update(m => m ++ x.events.map(y => y.id -> y)) >>
-                            PutSucceeded.pure
-                }
-            case x: PutL1Effects            => ???
-            case x: PutCardanoHeadState     => ???
-            case x: GetBlockData            => ???
-            case x: GetConfirmedLocalEvents => ???
-            case x: GetConfirmedL1Effects   => ???
+            case x: PersistRequest =>
+                x.handleRequest({ case PersistRequest(data, dResp) =>
+                    for {
+                        _ <- data match {
+                            case x: NewLedgerEvent =>
+                                events.update(m => m + (x.id -> x))
+                            case x: NewBlock =>
+                                blocks.update(m => m + (x.id -> x))
+                            case x: AckBlock =>
+                                acks.update(m => m + (x.id -> x))
+                            case x: ConfirmBlock =>
+                                confirmedBlock.update(_ => Some(x.id))
+                            case x: NewMsgBatch =>
+                                batches.update(m => m + (x.id -> x.nextGetMsgBatch)) >>
+                                    x.ack.traverse_(y => acks.update(m => m + (y.id -> y))) >>
+                                    x.block.traverse_(y => blocks.update(m => m + (y.id -> y))) >>
+                                    events.update(m => m ++ x.events.map(y => y.id -> y))
+                        }
+                    } yield PutSucceeded
+
+                })
+            case x: PutL1Effects        => x.handleRequest(_ => IO.pure(PutSucceeded))
+            case x: PutCardanoHeadState => x.handleRequest(_ => IO.pure(PutSucceeded))
+            case x: GetBlockData        => x.handleRequest(_ => IO.pure(GetBlockDataResp()))
+            case x: GetConfirmedLocalEvents =>
+                x.handleRequest(_ => IO.pure(GetConfirmedLocalEventsResp()))
+            case x: GetConfirmedL1Effects =>
+                x.handleRequest(_ => IO.pure(GetConfirmedL1EffectsResp()))
         })
 }

--- a/src/main/scala/hydrozoa/multisig/protocol/PersistenceProtocol.scala
+++ b/src/main/scala/hydrozoa/multisig/protocol/PersistenceProtocol.scala
@@ -1,7 +1,10 @@
 package hydrozoa.multisig.protocol
 
-import cats.effect.IO
+import cats.effect.{Deferred, IO}
+import cats.syntax.all.*
 import com.suprnation.actor.ReplyingActorRef
+import hydrozoa.lib.actor.SyncRequest
+import hydrozoa.lib.actor.SyncRequest.*
 import hydrozoa.multisig.protocol.ConsensusProtocol.Persisted
 
 object PersistenceProtocol {
@@ -17,8 +20,15 @@ object PersistenceProtocol {
 
         /** ==Put/write data into the persistence system== */
         final case class PersistRequest(
-            data: Persisted.Request
-        )
+            data: Persisted.Request,
+            override val dResponse: DeferredResponse[IO, PutResponse]
+        ) extends SyncRequest[IO, PutResponse]
+
+        object PersistRequest {
+            def apply(data: Persisted.Request): IO[PersistRequest] = for {
+                deferredResponse <- Deferred[IO, Either[Throwable, PutResponse]]
+            } yield PersistRequest(data, deferredResponse)
+        }
 
         /** Successfully persisted the data. */
         enum PutResponse:
@@ -27,11 +37,25 @@ object PersistenceProtocol {
 
         /** Persist L1 effects of L2 blocks */
         final case class PutL1Effects(
-        )
+            override val dResponse: DeferredResponse[IO, PutResponse]
+        ) extends SyncRequest[IO, PutResponse]
+
+        object PutL1Effects {
+            def apply(): IO[PutL1Effects] = for {
+                deferredResponse <- Deferred[IO, Either[Throwable, PutResponse]]
+            } yield PutL1Effects(deferredResponse)
+        }
 
         /** Persist the head's latest utxo state in Cardano */
         final case class PutCardanoHeadState(
-        )
+            override val dResponse: DeferredResponse[IO, PutResponse]
+        ) extends SyncRequest[IO, PutResponse]
+
+        object PutCardanoHeadState {
+            def apply(): IO[PutCardanoHeadState] = for {
+                deferredResponse <- Deferred[IO, Either[Throwable, PutResponse]]
+            } yield PutCardanoHeadState(deferredResponse)
+        }
 
         /** ==Get/read data from the persistence system== */
 
@@ -39,11 +63,18 @@ object PersistenceProtocol {
           * deposits).
           */
         final case class GetBlockData(
-        )
+            override val dResponse: DeferredResponse[IO, GetBlockDataResp]
+        ) extends SyncRequest[IO, GetBlockDataResp]
 
         /** Response to [[GetBlockData]]. */
         final case class GetBlockDataResp(
         )
+
+        object GetBlockData {
+            def apply(): IO[GetBlockData] = for {
+                deferredResponse <- Deferred[IO, Either[Throwable, GetBlockDataResp]]
+            } yield GetBlockData(deferredResponse)
+        }
 
         /** Retrieve local events referenced by a confirmed block:
           *
@@ -52,18 +83,32 @@ object PersistenceProtocol {
           *     referenced by the block.
           */
         final case class GetConfirmedLocalEvents(
-        )
+            override val dResponse: DeferredResponse[IO, GetConfirmedLocalEventsResp]
+        ) extends SyncRequest[IO, GetConfirmedLocalEventsResp]
 
         /** Response to [[GetConfirmedLocalEvents]]. */
         final case class GetConfirmedLocalEventsResp(
         )
 
+        object GetConfirmedLocalEvents {
+            def apply(): IO[GetConfirmedLocalEvents] = for {
+                deferredResponse <- Deferred[IO, Either[Throwable, GetConfirmedLocalEventsResp]]
+            } yield GetConfirmedLocalEvents(deferredResponse)
+        }
+
         /** Retrieve L1 effects of confirmed L2 blocks. */
         final case class GetConfirmedL1Effects(
-        )
+            override val dResponse: DeferredResponse[IO, GetConfirmedL1EffectsResp]
+        ) extends SyncRequest[IO, GetConfirmedL1EffectsResp]
 
         /** Response to [[GetConfirmedL1Effects]]. */
         final case class GetConfirmedL1EffectsResp(
         )
+
+        object GetConfirmedL1Effects {
+            def apply(): IO[GetConfirmedL1Effects] = for {
+                deferredResponse <- Deferred[IO, Either[Throwable, GetConfirmedL1EffectsResp]]
+            } yield GetConfirmedL1Effects(deferredResponse)
+        }
     }
 }


### PR DESCRIPTION
The replying actor from `cats-actors` can provide responses to synchronous requests, but it only allows you to define the union type of requests and the union type of responses separately. This means that it doesn't allow you to specify the specific response type that you expect to receive for a given request type. Instead, I guess it wants you to do partial matching on the full union type of responses to fish-out your specific response.

So, instead, I implemented an alternative mechanism for making synchronous requests:

- To define a request type that should be paired with the type of its expected response, extend the `SyncRequest` type.
- This will add a new field `dResponse` to your request type that you should override to the appropriate `Deferred` value. You can use the `SyncRequest.DeferredResponse` type alias to help you do this.
- Now, you can send your request synchronously to the recipient using the `?:` operator, which is defined as a right-associative operator-method of `SyncRequest`.
- The recipient of your request can process the synchronous request `x` by providing a handler function `(x.type => IO[Response])` to `x.handleRequest`, which will capture any `Throwable` raised by the handler at the recipient and send it back in an `Either` to be re-raised at the sender.