### PR TITLE
Feat(spec): Update authors and contributors

### DIFF
--- a/specification/frontmatter/00-meta.tex
+++ b/specification/frontmatter/00-meta.tex
@@ -6,12 +6,18 @@
 \newcommand{\hydrozoaauthors}[4]{
     \begin{contributors}{#1}{#2}{#3}{#4}
       \contributor{George Flerovsky}{\href{https://github.com/GeorgeFlerovsky}{GeorgeFlerovsky (on Github)}}
+     \contributor{Ilia Rodionov}{\href{https://github.com/euonymos}{euonymos (on Github)}}
+     \contributor{Peter Dragos}{\href{https://github.com/dragospe}{dragospe (on Github)}}
     \end{contributors}
 }
 
 \newcommand{\hydrozoacontributors}[4]{
    \begin{contributors}{#1}{#2}{#3}{#4}
-     \contributor{Ilia Rodionov}{\href{https://github.com/euonymos}{euonymos (on Github)}}
+     \contributor{Adam Dean}{\href{https://github.com/Crypto2099}{Crypto2099 (on Github)}}
+     \contributor{Alexander Nemish}{\href{https://github.com/nau}{nau (on Github)}}
+     \contributor{Pi Lanningham}{\href{https://github.com/Quantumplation}{Quantumplation (on Github)}}
+     \contributor{}{}{}
+     \contributor{Sebastian Nagel}{\href{https://github.com/ch1bo}{ch1bo (on Github)}}
    \end{contributors}
 }
 


### PR DESCRIPTION
It's long past due to:

- Add Ilia and Peter to the spec's authors list.
- Add Adam, Alex, Pi, and Sebastian to the contributors list.