### PR TITLE
Pair deconstruction regression

### DIFF
--- a/src/main/scala/hydrozoa/rulebased/ledger/dapp/script/plutus/DisputeResolutionScript.scala
+++ b/src/main/scala/hydrozoa/rulebased/ledger/dapp/script/plutus/DisputeResolutionScript.scala
@@ -241,25 +241,25 @@ object DisputeResolutionValidator extends Validator {
                   VoteMultisigCheck
                 )
 
-                // Temporary workaround
-                import scalus.prelude.List.{Cons, Nil}
-                @tailrec
-                def verifySignatures(a: List[ByteString], b: List[ByteString]): Unit =
-                    a match
-                        case Cons(h1, t1) =>
-                            b match
-                                case Cons(h2, t2) =>
-                                    require(verifyEd25519Signature(h1, msg, h2))
-                                    verifySignatures(t1, t2)
-                                case Nil          => ()
-                        case Nil => ()
+                //// Temporary workaround
+                //import scalus.prelude.List.{Cons, Nil}
+                //@tailrec
+                //def verifySignatures(a: List[ByteString], b: List[ByteString]): Unit =
+                //    a match
+                //        case Cons(h1, t1) =>
+                //            b match
+                //                case Cons(h2, t2) =>
+                //                    require(verifyEd25519Signature(h1, msg, h2))
+                //                    verifySignatures(t1, t2)
+                //                case Nil          => ()
+                //        case Nil => ()
+                //
+                //verifySignatures(treasuryDatum.peers, voteRedeemer.multisig)
 
-                verifySignatures(treasuryDatum.peers, voteRedeemer.multisig)
-
-                //@annotation.unused
-                //val unused = List.map2(treasuryDatum.peers, voteRedeemer.multisig)((vk, sig) =>
-                //    //require(verifyEd25519Signature(vk, msg, sig), VoteMultisigCheck)
-                //)
+                @annotation.unused
+                val unused = List.map2(treasuryDatum.peers, voteRedeemer.multisig)((vk, sig) =>
+                    require(verifyEd25519Signature(vk, msg, sig), VoteMultisigCheck)
+                )
 
                 // The versionMajor field must match between treasury and voteRedeemer.
                 require(


### PR DESCRIPTION
Run tests in `VoteTxTest.scala` to reproduce. Based on Peter's fix over the recent master. The only commit reverts back a workaround solution we use now. Strangely enough, I see that the same function (`List.map2`) is used in the other validator, and this works AFAICT. The error I get:

```
TestFailedException was thrown during property evaluation.
  Message: Build failed Plutus script evaluation failed: Builtin error: MkCons Apply(Apply(Force(Builtin(MkCons)), Const(Unit)), Const(List(Data,List()))), caused by scalus.uplc.eval.KnownTypeUnliftingError: Expected type Data, got VCon(Unit), execution trace: DisputeResolution <CR> Vote
  Location: (VoteTxTest.scala:159)
```