### PR TITLE
test failure repro for finalization txseq

### DIFF
--- a/src/test/scala/hydrozoa/multisig/ledger/dapp/txseq/FinalizationTxSeqBuilderTest.scala
+++ b/src/test/scala/hydrozoa/multisig/ledger/dapp/txseq/FinalizationTxSeqBuilderTest.scala
@@ -1,6 +1,9 @@
 package hydrozoa.multisig.ledger.dapp.txseq
 
 import hydrozoa.multisig.ledger.dapp.tx.*
+import hydrozoa.multisig.ledger.dapp.txseq.SeededFinalization.property
+import org.scalacheck.{Prop, Properties, Test}
+import org.scalacheck.Prop.{forAll, propBoolean}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import scalus.cardano.ledger.*
@@ -8,6 +11,20 @@ import scalus.cardano.ledger.rules.{CardanoMutator, Context, State}
 import scalus.cardano.txbuilder.TransactionBuilder
 import test.*
 import test.TransactionChain.*
+
+object SeededFinalization extends Properties("Finalization Tx Seq") {
+    import Prop.forAll
+    override def overrideParameters(p: Test.Parameters): Test.Parameters = {
+        p.withMinSuccessfulTests(10_000).withInitialSeed(-1574138723293646171L)
+    }
+
+    val _ = property("Build finalization tx sequence") =
+        forAll(genFinalizationTxSeqBuilder()) { (builder, args, _) =>
+            val res = builder.build(args)
+            s"Build failed with error: $res" |: res.isRight
+        }
+}
+
 
 class FinalizationTxSeqBuilderTest extends AnyFunSuite with ScalaCheckPropertyChecks {
 


### PR DESCRIPTION
Error message: 

```
failing seed for Finalization Tx Seq.Build finalization tx sequence is N77smo7C9snT7bXTCAqbrslVPPmjAxYZ0AFEE5SjekA=
! Finalization Tx Seq.Build finalization tx sequence: Falsified after 2268 
  passed tests.
> Labels of failing property: 
Build failed with error: Left(FinalizationPartialError((Transaction validat
  ion failed: InvalidTransactionSizeException - Transaction size 16387 exce
  eds maximum allowed size 16384 for transactionId "e8340b42e1e25b53e453685
  ffb5b8c0c6078a2d9db8276351760f9d8690a37cf",[/home/pdragos/Code/cardano-hy
  drozoa/hydrozoa/src/main/scala/hydrozoa/multisig/ledger/dapp/tx/Finalizat
  ionTx.scala:158 in hydrozoa.multisig.ledger.dapp.tx.FinalizationTx.Builde
  r.upgrade] Could not finalize context for finalization partial result)))
```

(note: I switched to using scalacheck directly for the reproduction because I still don't figure out how to reliably set seeds to scalatest + scalacheck... There seems to be a couple different options, some of which don't work)