### PR TITLE
Add `TestM`

### DIFF
--- a/src/main/scala/hydrozoa/multisig/ledger/DappLedger.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/DappLedger.scala
@@ -15,12 +15,9 @@ import hydrozoa.multisig.ledger.dapp.tx.*
 import hydrozoa.multisig.ledger.dapp.txseq.{FinalizationTxSeq, SettlementTxSeq}
 import hydrozoa.multisig.ledger.dapp.utxo.{DepositUtxo, MultisigRegimeUtxo, MultisigTreasuryUtxo}
 import hydrozoa.multisig.ledger.joint.obligation.Payout
-import hydrozoa.multisig.ledger.virtual.{GenesisObligation, L2EventGenesis}
+import hydrozoa.multisig.ledger.virtual.GenesisObligation
 import hydrozoa.multisig.ledger.virtual.commitment.KzgCommitment.KzgCommitment
-import hydrozoa.multisig.protocol.types.Block.Version.Full
 import hydrozoa.multisig.protocol.types.{Block, LedgerEvent}
-import scalus.builtin.ByteString
-
 import scala.collection.immutable.Queue
 import scala.language.implicitConversions
 import scalus.cardano.address.ShelleyAddress

--- a/src/main/scala/hydrozoa/multisig/ledger/VirtualLedger.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/VirtualLedger.scala
@@ -167,7 +167,7 @@ object VirtualLedger {
 
         def ?: : this.Send = SyncRequest.send(_, this)
     }
-    
+
     //////////////////////////////////////////////
     // Other Types
     final case class Config(

--- a/src/test/scala/hydrozoa/multisig/ledger/JointLedgerTest.scala
+++ b/src/test/scala/hydrozoa/multisig/ledger/JointLedgerTest.scala
@@ -2,320 +2,206 @@ package hydrozoa.multisig.ledger
 
 import cats.*
 import cats.data.*
-import scalus.builtin.{ByteString, platform}
 import cats.effect.*
 import cats.effect.unsafe.implicits.*
-import cats.syntax.all.*
-import com.suprnation.actor.ActorRef.ActorRef
-import com.suprnation.actor.{ActorSystem, test as _}
-import hydrozoa.config.EquityShares
-import hydrozoa.maxNonPlutusTxFee
+import com.suprnation.actor.test as _
 import hydrozoa.multisig.ledger.DappLedger.Requests.{GetState, RegisterDeposit}
 import hydrozoa.multisig.ledger.JointLedger.Requests.{CompleteBlockRegular, StartBlock}
-import hydrozoa.multisig.ledger.dapp.script.multisig.HeadMultisigScript
-import hydrozoa.multisig.ledger.dapp.tx.InitializationTx.SpentUtxos
-import hydrozoa.multisig.ledger.dapp.tx.{Tx, minInitTreasuryAda}
-import hydrozoa.multisig.ledger.dapp.txseq.{DepositRefundTxSeq, InitializationTxSeq}
+import hydrozoa.multisig.ledger.dapp.txseq.DepositRefundTxSeq
 import hydrozoa.multisig.ledger.dapp.utxo.DepositUtxo
-import hydrozoa.multisig.ledger.virtual.{GenesisObligation, L2EventGenesis}
-import hydrozoa.multisig.ledger.virtual.commitment.KzgCommitment
+import hydrozoa.multisig.ledger.virtual.GenesisObligation
 import hydrozoa.multisig.protocol.types.*
-import hydrozoa.multisig.protocol.types.Block.Version.Full
-import hydrozoa.rulebased.ledger.dapp.tx.genEquityShares
 import org.scalacheck.*
 import org.scalacheck.Prop.propBoolean
-import scalus.builtin.ByteString
-import scalus.cardano.address.ShelleyPaymentPart.Key
 import scalus.cardano.ledger.{Block as _, *}
-import scalus.compiler.sir.SIRBuiltins.blake2b_256
+import scalus.ledger.api.v3.PosixTime
 import scalus.prelude.Option as SOption
-import scalus.testing.kit.TestUtil
-import test.Generators.Hydrozoa.*
-import test.PrettyGivens.given
 import test.*
-
-import scala.concurrent.duration.{FiniteDuration, SECONDS}
-
+import test.Generators.Hydrozoa.*
 
 object JointLedgerTest extends Properties("Joint Ledger Test") {
 
-  import org.scalacheck.PropertyM.*
+    import TestM.*
 
-  override def overrideParameters(p: Test.Parameters): Test.Parameters = {
-    p
-      .withMinSuccessfulTests(1)
-  }
+    override def overrideParameters(p: Test.Parameters): Test.Parameters = {
+        p
+            .withMinSuccessfulTests(1)
+    }
 
-  type TestError =
-    InitializationTxSeq.Builder.Error
-      | DepositRefundTxSeq.Builder.Error
-      | DappLedger.Errors.RegisterDepositError
+    /** Helper utilities to send actor Requests to the JointLedger
+      */
+    object Requests {
 
-  type ET[A] = EitherT[IO, TestError, A]
+        val getState: TestM[JointLedger.State] =
+            for {
+                env <- ask
+                state <- liftR(env.jointLedger ?: JointLedger.Requests.GetState)
+            } yield state
 
-  
-//  type TestM = PropertyM[ReaderT[IntializedTestEnvironment, EitherT[IO, TestError]] A]
-  
-  // Accept "any" as the error
-  def runner(mProp: ET[Prop]): Prop =
-    Prop.secure(mProp.value.unsafeRunSync() match {
-      case Left(e) =>
-        s"Failed: $e" |: false
-      case Right(p) => p
-    })
-    
-  case class InitializedTestEnvironment(
-                                         // contained in config 
-                                         hns: HeadMultisigScript,
-                                         peers: NonEmptyList[TestPeer],
-                                         actorSystem: ActorSystem[IO],
-                                         initTx: InitializationTxSeq,  // Move to HeadConfig
-                                         config: Tx.Builder.Config, // Move to HeadConfig
-                                         virtualLedger: ActorRef[IO, VirtualLedger.Request],
-                                         dappLedger: ActorRef[IO, DappLedger.Requests.Request],
-                                         jointLedger: ActorRef[IO, JointLedger.Requests.Request],
-                                       )
+        def registerDeposit(
+            serializedDeposit: Array[Byte],
+            eventId: LedgerEvent.Id,
+            virtualOutputs: NonEmptyList[GenesisObligation]
+        ): TestM[Unit] =
+            registerDeposit(RegisterDeposit(serializedDeposit, eventId, virtualOutputs))
 
-  val initializationScenario: PropertyM[ET, InitializedTestEnvironment] =
-    for {
-      peers <- pick[ET, NonEmptyList[TestPeer]](genTestPeers.label("Test Peers"))
-
-      // We make sure that the seed utxo has at least enough for the treasury and multisig witness UTxO, plus
-      // a max non-plutus fee
-      seedUtxo <- pick[ET, Utxo](
-        genAdaOnlyPubKeyUtxo(
-          peers.head,
-          minimumCoin = minInitTreasuryAda
-            + Coin(maxNonPlutusTxFee(testProtocolParams).value * 2)
-        ).map(x => Utxo(x._1, x._2)).label("Initialization: seed utxo")
-      )
-
-      otherSpentUtxos <- pick[ET, List[Utxo]](
-        Gen
-          .listOf(genAdaOnlyPubKeyUtxo(peers.head))
-          .map(_.map(x => Utxo(x._1, x._2)))
-          .label("Initialization: other spent utxos")
-      )
-
-      spentUtxos = NonEmptyList(seedUtxo, otherSpentUtxos)
-
-      // Initial deposit must be at least enough for the minAda of the treasury, and no more than the
-      // sum of the seed utxos, while leaving enough left for the estimated fee and the minAda of the change
-      // output
-      initialDeposit <- pick[ET, Coin](
-        Gen
-          .choose(
-            minInitTreasuryAda.value,
-            sumUtxoValues(spentUtxos.toList).coin.value
-              - maxNonPlutusTxFee(testTxBuilderEnvironment.protocolParams).value
-              - minPubkeyAda().value
-          )
-          .map(Coin(_))
-          .label("Initializtion: initial deposit")
-      )
-
-      initTxArgs =
-        InitializationTxSeq.Builder.Args(
-          spentUtxos = SpentUtxos(seedUtxo, otherSpentUtxos),
-          initialDeposit = initialDeposit,
-          peers = peers.map(_.wallet.exportVerificationKeyBytes),
-          env = testTxBuilderEnvironment,
-          evaluator = testEvaluator,
-          validators = nonSigningValidators,
-          initializationTxChangePP =
-            Key(AddrKeyHash.fromByteString(ByteString.fill(28, 1.toByte))),
-          tallyFeeAllowance = Coin.ada(2),
-          votingDuration = 100
-        )
-
-      hns = HeadMultisigScript(peers.map(_.wallet.exportVerificationKeyBytes))
-
-      system <- run(
-        EitherT.right[TestError](ActorSystem[IO]("DappLedger").allocated.map(_._1))
-      )
-      initTx <- run(
-        EitherT
-          .fromEither[IO](InitializationTxSeq.Builder.build(initTxArgs))
-          .leftWiden[TestError]
-      )
-
-      config = Tx.Builder.Config(
-        headNativeScript = hns,
-        multisigRegimeUtxo = initTx.initializationTx.multisigRegimeWitness,
-        tokenNames = initTx.initializationTx.tokenNames,
-        env = TestUtil.testEnvironment,
-        evaluator = testEvaluator,
-        validators = nonSigningValidators
-      )
-
-      virtualLedgerConfig = VirtualLedger.Config(
-        slotConfig = config.env.slotConfig,
-        slot = 0,
-        protocolParams = config.env.protocolParams,
-        network = testNetwork
-      )
-      virtualLedger <- run(
-        EitherT.right[TestError](system.actorOf(VirtualLedger(virtualLedgerConfig)))
-      )
-
-      dappLedger <- run(
-        EitherT.right[TestError](
-          system.actorOf(
-            DappLedger.create(initTx.initializationTx, config, virtualLedger)
-          )
-        )
-      )
-
-      equityShares <- pick[ET, EquityShares](genEquityShares(peers).label("Equity shares"))
-
-      jointLedger <- run(EitherT.right[TestError](
-        system.actorOf(
-          JointLedger(dappLedger = dappLedger,
-            virtualLedger = virtualLedger,
-            peerLiaisons = Seq.empty,
-            tallyFeeAllowance = Coin.ada(2),
-            initialBlockTime = FiniteDuration(0, SECONDS), // FIXME: Generate
-            initialBlockKzg = KzgCommitment.empty,
-            equityShares = equityShares,
-            multisigRegimeUtxo = config.multisigRegimeUtxo,
-            votingDuration = 0,
-            treasuryTokenName = config.tokenNames.headTokenName)
-        )
-      ))
-
-    } yield InitializedTestEnvironment(
-      hns,
-      peers,
-      system,
-      initTx,
-      config,
-      virtualLedger,
-      dappLedger,
-      jointLedger
-    )
-
-  def depositScenario(e: InitializedTestEnvironment): PropertyM[ET, (DepositRefundTxSeq, RegisterDeposit)] = {
-    import e.*
-    val peer = peers.head
-    for {
-      virtualOutputs <-
-        pick[ET, NonEmptyList[GenesisObligation]](
-          Gen.nonEmptyListOf(genGenesisObligation(peer, minimumCoin = Coin.ada(5)))
-            .map(NonEmptyList.fromListUnsafe)
-            .label("Virtual Outputs")
-        )
-
-      virtualOutputsValue = Value.combine(
-        virtualOutputs.map(vo => Value(vo.l2OutputValue)).toList
-      )
-
-      utxosFundingTail <- pick[ET, List[Utxo]](
-        Gen
-          .listOf(
-            genAdaOnlyPubKeyUtxo(peer, minimumCoin = Coin.ada(5))
-          )
-          .label("Funding Utxos: Tail")
-      )
-
-      utxosFundingHead <- pick[ET, Utxo](
-        genAdaOnlyPubKeyUtxo(
-          peer,
-          minimumCoin = virtualOutputsValue.coin
-        ).label("Funding Utxos: Head")
-      )
-
-      utxosFunding = NonEmptyList(utxosFundingHead, utxosFundingTail)
-
-      utxosFundingValue = Value.combine(utxosFunding.toList.map(_._2.value))
-
-      depositRefundSeqBuilder = DepositRefundTxSeq.Builder(
-        config = config,
-        refundInstructions = DepositUtxo.Refund.Instructions(
-          LedgerToPlutusTranslation.getAddress(peer.address()),
-          SOption.None,
-          100
-        ),
-        donationToTreasury = Coin.zero,
-        refundValue = virtualOutputsValue,
-        virtualOutputs = virtualOutputs,
-        changeAddress = peer.address(),
-        utxosFunding = utxosFunding
-      )
-
-      depositRefundTxSeq <- run(EitherT.fromEither[IO](depositRefundSeqBuilder.build))
-
-      signedTx = signTx(peer, depositRefundTxSeq.depositTx.tx)
-
-      serializedDeposit = signedTx.toCbor
-      req =
-        RegisterDeposit(
-          serializedDeposit = serializedDeposit,
-          virtualOutputs = virtualOutputs,
-          eventId = LedgerEvent.Id(0, 1)
-        )
-
-      _ <- run(EitherT.right[TestError](jointLedger ? req))
-    } yield (depositRefundTxSeq, req)
-  }
-
-  val _ = property("Joint Ledger Happy Path") = monadic(
-    runner = runner,
-    m = for {
-      // Step 1: Set up the actor system and run the initialization tx, put the joint ledger in producing mode
-      initTestEnv <- initializationScenario
-      _ <- run(EitherT.right[TestError](initTestEnv.jointLedger ! StartBlock(1, Set.empty)))
-
-      // Step 2: generate a deposit and observe that it appears in the dapp ledger correctly
-      seqAndReq <- depositScenario(initTestEnv)
-      (depositRefundTxSeq, depositReq) = seqAndReq
-      s <- run(EitherT.right[TestError](initTestEnv.dappLedger ?: GetState))
-
-      _ <- assertWith[ET](
-        msg = s"We should only have 1 deposit in the state. We have ${s.deposits.length}",
-        condition = s.deposits.length == 1
-      )
-      _ <- assertWith[ET](
-        msg = "Correct deposit(s) in state",
-        condition = s.deposits.head._2 == depositRefundTxSeq.depositTx.depositProduced
-      )
-      _ <- assertWith[ET](
-        msg = "Correct treasury in state",
-        condition = s.treasury == initTestEnv.initTx.initializationTx.treasuryProduced
-      )
-
-      // Step 3: Complete a block
-      _ <- run(EitherT.right(initTestEnv.jointLedger ! testMCompleteBlockRegular(None)))
-      jointLedgerState <- run(EitherT.right(initTestEnv.jointLedger ?: JointLedger.Requests.GetState))
-      _ <- assertWith[ET](
-        msg = "Finished block should be minor",
-        condition = jointLedgerState match {
-          case Done(block: Block.Minor) => true
-          case _ => false
-        }
-      )
-
-      // Step 4: Complete another block.
-      _ <- run(EitherT.right[TestError](initTestEnv.jointLedger ! StartBlock(2, Set(depositReq.eventId))))
-      _ <- run(EitherT.right(initTestEnv.jointLedger ! CompleteBlockRegular(None)))
-
-      jointLedgerState <- run(EitherT.right(initTestEnv.jointLedger ?: JointLedger.Requests.GetState))
-      majorBlock <- jointLedgerState match {
-          case Done(block: Block.Major) => monadForPropM[ET].pure(block)
-          case _ => PropertyM.fail_[ET, Block.Major]("finished block should be major")
+        def registerDeposit(req: RegisterDeposit): TestM[Unit] = {
+            for {
+                jl <- asks(_.jointLedger)
+                _ <- liftR(jl ? req)
+            } yield ()
         }
 
-      kzgCommit <- run(EitherT.right(initTestEnv.virtualLedger ?: VirtualLedger.GetCurrentKzgCommitment))
-      expectedUtxos = L2EventGenesis(depositRefundTxSeq.depositTx.depositProduced.virtualOutputs,
-          TransactionHash.fromByteString(platform.blake2b_256(initTestEnv.config.tokenNames.headTokenName.bytes ++ 
-            ByteString.fromBigIntBigEndian(BigInt(Full.unapply(majorBlock.header.blockVersion)._1))))).asUtxos
-      
-      _ <- assertWith[ET](
-        msg = "KZG Commitment is correct",
-        condition = kzgCommit == KzgCommitment.calculateCommitment(KzgCommitment.hashToScalar(expectedUtxos))
-      )
+        def startBlock(req: StartBlock): TestM[Unit] =
+            ask.flatMap(env => liftR(env.jointLedger ! req))
 
+        def startBlock(
+            blockCreationTime: PosixTime,
+            pollResults: Set[LedgerEvent.Id]
+        ): TestM[Unit] =
+            startBlock(StartBlock(blockCreationTime, pollResults))
 
-    } yield true
-  )
+        def completeBlockRegular(req: CompleteBlockRegular): TestM[Unit] =
+            for {
+                jl <- asks(_.jointLedger)
+                _ <- liftR(jl ! req)
+            } yield ()
+
+        def completeBlockRegular(referenceBlock: Option[Block]): TestM[Unit] =
+            completeBlockRegular(CompleteBlockRegular(referenceBlock))
+
+    }
+
+    /** Helper utilties to execute particular scenarios, such as "generating a random deposit and
+      * sending it to the JointLedger"
+      */
+    object Scenarios {
+
+        /** Generate a random (sensible) deposit from the first peer and send it to the joint ledger
+          */
+        val deposit: TestM[(DepositRefundTxSeq, RegisterDeposit)] = {
+            import Requests.*
+            for {
+                env <- ask
+                peer = env.peers.head
+                virtualOutputs <-
+                    pick(
+                      Gen.nonEmptyListOf(genGenesisObligation(peer, minimumCoin = Coin.ada(5)))
+                          .map(NonEmptyList.fromListUnsafe)
+                          .label("Virtual Outputs")
+                    )
+
+                virtualOutputsValue = Value.combine(
+                  virtualOutputs.map(vo => Value(vo.l2OutputValue)).toList
+                )
+
+                utxosFundingTail <- pick(
+                  Gen
+                      .listOf(
+                        genAdaOnlyPubKeyUtxo(peer, minimumCoin = Coin.ada(5))
+                      )
+                      .label("Funding Utxos: Tail")
+                )
+
+                utxosFundingHead <- pick(
+                  genAdaOnlyPubKeyUtxo(
+                    peer,
+                    minimumCoin = virtualOutputsValue.coin
+                  ).label("Funding Utxos: Head")
+                )
+
+                utxosFunding = NonEmptyList(utxosFundingHead, utxosFundingTail)
+
+                utxosFundingValue = Value.combine(utxosFunding.toList.map(_._2.value))
+
+                depositRefundSeqBuilder = DepositRefundTxSeq.Builder(
+                  config = env.config,
+                  refundInstructions = DepositUtxo.Refund.Instructions(
+                    LedgerToPlutusTranslation.getAddress(peer.address()),
+                    SOption.None,
+                    100
+                  ),
+                  donationToTreasury = Coin.zero,
+                  refundValue = virtualOutputsValue,
+                  virtualOutputs = virtualOutputs,
+                  changeAddress = peer.address(),
+                  utxosFunding = utxosFunding
+                )
+
+                depositRefundTxSeq <- lift(depositRefundSeqBuilder.build)
+
+                signedTx = signTx(peer, depositRefundTxSeq.depositTx.tx)
+
+                serializedDeposit = signedTx.toCbor
+                req =
+                    RegisterDeposit(
+                      serializedDeposit = serializedDeposit,
+                      virtualOutputs = virtualOutputs,
+                      eventId = LedgerEvent.Id(0, 1)
+                    )
+
+                _ <- registerDeposit(req)
+            } yield (depositRefundTxSeq, req)
+        }
+    }
+
+    val _ = property("Joint Ledger Happy Path") =
+        import Requests.*
+        import Scenarios.*
+        run(for {
+            // Step 1: Put the joint ledger in producing mode
+            _ <- startBlock(1, Set.empty)
+
+            // Step 2: generate a deposit and observe that it appears in the dapp ledger correctly
+            seqAndReq <- deposit
+            (depositRefundTxSeq, depositReq) = seqAndReq
+
+            env <- ask
+            s <- liftR(env.dappLedger ?: GetState)
+
+            _ <- assertWith(
+              msg = s"We should only have 1 deposit in the state. We have ${s.deposits.length}",
+              condition = s.deposits.length == 1
+            )
+            _ <- assertWith(
+              msg = "Correct deposit(s) in state",
+              condition = s.deposits.head._2 == depositRefundTxSeq.depositTx.depositProduced
+            )
+            _ <- assertWith(
+              msg = "Correct treasury in state",
+              condition = s.treasury == env.initTx.initializationTx.treasuryProduced
+            )
+
+            // Step 3: Complete a block
+            _ <- completeBlockRegular(None)
+            jointLedgerState <- getState
+            _ <- assertWith(
+              msg = "Finished block should be minor",
+              condition = jointLedgerState match {
+                  case JointLedger.Done(block: Block.Minor) => true
+                  case _                                    => false
+              }
+            )
+
+            // Step 4: Complete another block.
+            _ <- startBlock(2, Set(depositReq.eventId))
+            _ <- completeBlockRegular(None)
+
+            jointLedgerState <- getState
+            majorBlock <- jointLedgerState match {
+                case JointLedger.Done(block: Block.Major) => pure(block)
+                case _                                    => fail("finished block should be major")
+            }
+
+//      kzgCommit <- run(EitherT.right(initTestEnv.virtualLedger ?: VirtualLedger.GetCurrentKzgCommitment))
+//      expectedUtxos = L2EventGenesis(depositRefundTxSeq.depositTx.depositProduced.virtualOutputs,
+//          TransactionHash.fromByteString(platform.blake2b_256(initTestEnv.config.tokenNames.headTokenName.bytes ++
+//            ByteString.fromBigIntBigEndian(BigInt(Full.unapply(majorBlock.header.blockVersion)._1))))).asUtxos
+//
+//      _ <- assertWith[ET](
+//        msg = "KZG Commitment is correct",
+//        condition = kzgCommit == KzgCommitment.calculateCommitment(KzgCommitment.hashToScalar(expectedUtxos))
+//      )
+
+        } yield true)
 }
-

--- a/src/test/scala/test/PrettyGivens.scala
+++ b/src/test/scala/test/PrettyGivens.scala
@@ -1,49 +1,56 @@
 package test
 
 import org.scalacheck.util.Pretty
-import scalus.cardano.ledger.*
 import scalus.cardano.address.*
 import scalus.cardano.address.ShelleyPaymentPart.*
+import scalus.cardano.ledger.*
 import scalus.cardano.ledger.TransactionOutput.Babbage
 
 object PrettyGivens {
 
-  given prettyUtxo: (Utxo => Pretty) = utxo => Pretty(params =>
-    s"Utxo(${Pretty.pretty(utxo.input)},${Pretty.pretty(utxo.output)})")
+    given prettyUtxo: (Utxo => Pretty) = utxo =>
+        Pretty(params => s"Utxo(${Pretty.pretty(utxo.input)},${Pretty.pretty(utxo.output)})")
 
-  given prettyTxIn: (TransactionInput => Pretty) = ti => Pretty(params =>
-    val truncatedHash = ti.transactionId.toHex.take(6)
-    s"$truncatedHash(...)#${ti.index}")
+    given prettyTxIn: (TransactionInput => Pretty) = ti =>
+        Pretty(params =>
+            val truncatedHash = ti.transactionId.toHex.take(6)
+            s"$truncatedHash(...)#${ti.index}"
+        )
 
-  given prettyShelleyPP: (ShelleyPaymentPart => Pretty) = x => Pretty(_ =>
-    x match {
-      case Key(k) => s"$Key(${k.toHex.take(6)}(...))"
-      case ShelleyPaymentPart.Script(s) => s"Script${s.toHex.take(6)}(...)"
-    }
-  )
+    given prettyShelleyPP: (ShelleyPaymentPart => Pretty) = x =>
+        Pretty(_ =>
+            x match {
+                case Key(k)                       => s"$Key(${k.toHex.take(6)}(...))"
+                case ShelleyPaymentPart.Script(s) => s"Script${s.toHex.take(6)}(...)"
+            }
+        )
 
-  given prettyShelleyAddress: (ShelleyAddress => Pretty) = x => Pretty(_ =>
-    s"ShelleyAddress(${Pretty.pretty(x.network)},${Pretty.pretty(x.payment)},${Pretty.pretty(x.delegation)}}"
-  )
+    given prettyShelleyAddress: (ShelleyAddress => Pretty) = x =>
+        Pretty(_ =>
+            s"ShelleyAddress(${Pretty.pretty(x.network)},${Pretty.pretty(x.payment)},${Pretty.pretty(x.delegation)}}"
+        )
 
-  given prettyAddress: (Address => Pretty) = a => Pretty(_ =>
-    a match {
-      case sa: ShelleyAddress => Pretty.pretty(sa)
-      case x => Pretty.pretty(x)
-    }
-  )
+    given prettyAddress: (Address => Pretty) = a =>
+        Pretty(_ =>
+            a match {
+                case sa: ShelleyAddress => Pretty.pretty(sa)
+                case x                  => Pretty.pretty(x)
+            }
+        )
 
-  given prettyBabbage: (Babbage => Pretty) = babbage => Pretty(_ =>
-    s"Babbage(${Pretty.pretty(babbage.address)}," +
-      s" ${Pretty.pretty(babbage.value)}," +
-      s"${Pretty.pretty(babbage.datumOption)}," +
-      s"${Pretty.pretty(babbage.scriptRef)})"
-  )
+    given prettyBabbage: (Babbage => Pretty) = babbage =>
+        Pretty(_ =>
+            s"Babbage(${Pretty.pretty(babbage.address)}," +
+                s" ${Pretty.pretty(babbage.value)}," +
+                s"${Pretty.pretty(babbage.datumOption)}," +
+                s"${Pretty.pretty(babbage.scriptRef)})"
+        )
 
-  given prettyOutput: (TransactionOutput => Pretty) = to => Pretty(_ =>
-    to match {
-      case b: Babbage => Pretty.pretty(b)
-      case to => Pretty.pretty(to)
-    }
-  )
+    given prettyOutput: (TransactionOutput => Pretty) = to =>
+        Pretty(_ =>
+            to match {
+                case b: Babbage => Pretty.pretty(b)
+                case to         => Pretty.pretty(to)
+            }
+        )
 }

--- a/src/test/scala/test/TestM.scala
+++ b/src/test/scala/test/TestM.scala
@@ -1,0 +1,282 @@
+package test
+
+import cats.*
+import cats.data.*
+import cats.effect.*
+import cats.effect.unsafe.IORuntime
+import cats.syntax.all.*
+import com.suprnation.actor.ActorRef.ActorRef
+import com.suprnation.actor.ActorSystem
+import hydrozoa.config.EquityShares
+import hydrozoa.maxNonPlutusTxFee
+import hydrozoa.multisig.ledger.*
+import hydrozoa.multisig.ledger.dapp.script.multisig.HeadMultisigScript
+import hydrozoa.multisig.ledger.dapp.tx.InitializationTx.SpentUtxos
+import hydrozoa.multisig.ledger.dapp.tx.{Tx, minInitTreasuryAda}
+import hydrozoa.multisig.ledger.dapp.txseq.{DepositRefundTxSeq, InitializationTxSeq}
+import hydrozoa.multisig.ledger.virtual.commitment.KzgCommitment
+import hydrozoa.rulebased.ledger.dapp.tx.genEquityShares
+import org.scalacheck.Prop.propBoolean
+import org.scalacheck.PropertyM.{monadForPropM, monadic}
+import org.scalacheck.{Gen, Prop, PropertyM}
+import scala.concurrent.duration.{FiniteDuration, SECONDS}
+import scalus.builtin.ByteString
+import scalus.cardano.address.ShelleyPaymentPart.Key
+import scalus.cardano.ledger.{AddrKeyHash, Coin, Utxo}
+import scalus.testing.kit.TestUtil
+import test.Generators.Hydrozoa.genAdaOnlyPubKeyUtxo
+
+/** The "environment" that is contained in the ReaderT of the TestM
+  * @param peers
+  * @param actorSystem
+  * @param initTx
+  * @param config
+  * @param virtualLedger
+  * @param dappLedger
+  * @param jointLedger
+  */
+// TODO (Peter,  2025-12-23): This is one particular place where the "row types" extension can be extremely useful.
+// In particular, there may be certain tests where we don't _actually_ want to instantiate the entire TestR environment.
+// So instead of hard-coding TestR into TestM, we could instead:
+// - Define TestR as below, and have it extend "HasPeers", "HasActorSystem", etc.
+// - Parameterize TestM's reader environment such that it can be modified to take a `R : HasPeers : HasActorSystem`
+//   if only those fields are actually necessary.
+// This helps a lot with mocks. I'm not going to worry about it for now, because its both pretty noisy to do in scala
+// (compared to purescript using row types or haskell using labelled optics), and we probably won't need it for an MVP.
+case class TestR(
+    peers: NonEmptyList[TestPeer],
+    actorSystem: ActorSystem[IO],
+    initTx: InitializationTxSeq, // Move to HeadConfig
+    config: Tx.Builder.Config, // Move to HeadConfig
+    virtualLedger: ActorRef[IO, VirtualLedger.Request],
+    dappLedger: ActorRef[IO, DappLedger.Requests.Request],
+    jointLedger: ActorRef[IO, JointLedger.Requests.Request],
+)
+
+type TestError =
+    InitializationTxSeq.Builder.Error | DepositRefundTxSeq.Builder.Error |
+        DappLedger.Errors.RegisterDepositError
+
+private type ET[A] = EitherT[IO, TestError, A]
+private type PT[A] = PropertyM[ET, A]
+private type RT[A] = ReaderT[PT, TestR, A]
+
+/** Describes a computation that:
+  *   - Has access to some [[TestR]] environment
+  *   - Accepts continuations (within [[PropertyM]])
+  *   - Can throw errors of type [[TestError]]
+  *   - Can perform [[IO]]
+  *   - Can generate values (via the [[Gen]] within [[PropertyM]]
+  *   - Returns values of type A
+  * @param unTestM
+  * @tparam A
+  */
+case class TestM[A](unTestM: RT[A]) {
+    def map[B](f: A => B): TestM[B] = TestM(this.unTestM.map(f))
+    def flatMap[B](f: A => TestM[B]): TestM[B] = TestM(this.unTestM.flatMap(a => f(a).unTestM))
+}
+
+object TestM {
+
+    /** Get the instantiated TestR test environment
+      */
+    val ask: TestM[TestR] = TestM(Kleisli.ask)
+    // TODO: Right now, this generates everything. In the future, we can provide arguments like
+    // `peers :: Option[NonEmptyList[TestPeer]]` such that we set the peers exactly to the option,
+    // or generate otherwise. This goes along with the comment on [[run]] for passing initializers directly to run
+    private val defaultInitializer: PropertyM[ET, TestR] = {
+        for {
+            peers <- PropertyM.pick[ET, NonEmptyList[TestPeer]](genTestPeers.label("Test Peers"))
+
+            // We make sure that the seed utxo has at least enough for the treasury and multisig witness UTxO, plus
+            // a max non-plutus fee
+            seedUtxo <- PropertyM.pick[ET, Utxo](
+              genAdaOnlyPubKeyUtxo(
+                peers.head,
+                minimumCoin = minInitTreasuryAda
+                    + Coin(maxNonPlutusTxFee(testProtocolParams).value * 2)
+              ).map(x => Utxo(x._1, x._2)).label("Initialization: seed utxo")
+            )
+
+            otherSpentUtxos <- PropertyM.pick[ET, List[Utxo]](
+              Gen
+                  .listOf(genAdaOnlyPubKeyUtxo(peers.head))
+                  .map(_.map(x => Utxo(x._1, x._2)))
+                  .label("Initialization: other spent utxos")
+            )
+
+            spentUtxos = NonEmptyList(seedUtxo, otherSpentUtxos)
+
+            // Initial deposit must be at least enough for the minAda of the treasury, and no more than the
+            // sum of the seed utxos, while leaving enough left for the estimated fee and the minAda of the change
+            // output
+            initialDeposit <- PropertyM.pick[ET, Coin](
+              Gen
+                  .choose(
+                    minInitTreasuryAda.value,
+                    sumUtxoValues(spentUtxos.toList).coin.value
+                        - maxNonPlutusTxFee(testTxBuilderEnvironment.protocolParams).value
+                        - minPubkeyAda().value
+                  )
+                  .map(Coin(_))
+                  .label("Initializtion: initial deposit")
+            )
+
+            initTxArgs =
+                InitializationTxSeq.Builder.Args(
+                  spentUtxos = SpentUtxos(seedUtxo, otherSpentUtxos),
+                  initialDeposit = initialDeposit,
+                  peers = peers.map(_.wallet.exportVerificationKeyBytes),
+                  env = testTxBuilderEnvironment,
+                  evaluator = testEvaluator,
+                  validators = nonSigningValidators,
+                  initializationTxChangePP =
+                      Key(AddrKeyHash.fromByteString(ByteString.fill(28, 1.toByte))),
+                  tallyFeeAllowance = Coin.ada(2),
+                  votingDuration = 100
+                )
+
+            hns = HeadMultisigScript(peers.map(_.wallet.exportVerificationKeyBytes))
+
+            system <- PropertyM.run(
+              EitherT.right[TestError](ActorSystem[IO]("DappLedger").allocated.map(_._1))
+            )
+            initTx <- PropertyM.run(
+              EitherT
+                  .fromEither[IO](InitializationTxSeq.Builder.build(initTxArgs))
+                  .leftWiden[TestError]
+            )
+
+            config = Tx.Builder.Config(
+              headNativeScript = hns,
+              multisigRegimeUtxo = initTx.initializationTx.multisigRegimeWitness,
+              tokenNames = initTx.initializationTx.tokenNames,
+              env = TestUtil.testEnvironment,
+              evaluator = testEvaluator,
+              validators = nonSigningValidators
+            )
+
+            virtualLedgerConfig = VirtualLedger.Config(
+              slotConfig = config.env.slotConfig,
+              slot = 0,
+              protocolParams = config.env.protocolParams,
+              network = testNetwork
+            )
+            virtualLedger <- PropertyM.run(
+              EitherT.right[TestError](system.actorOf(VirtualLedger(virtualLedgerConfig)))
+            )
+
+            dappLedger <- PropertyM.run(
+              EitherT.right[TestError](
+                system.actorOf(
+                  DappLedger.create(initTx.initializationTx, config, virtualLedger)
+                )
+              )
+            )
+
+            equityShares <- PropertyM.pick[ET, EquityShares](
+              genEquityShares(peers).label("Equity shares")
+            )
+
+            jointLedger <- PropertyM.run(
+              EitherT.right[TestError](
+                system.actorOf(
+                  JointLedger(
+                    dappLedger = dappLedger,
+                    virtualLedger = virtualLedger,
+                    peerLiaisons = Seq.empty,
+                    tallyFeeAllowance = Coin.ada(2),
+                    initialBlockTime = FiniteDuration(0, SECONDS), // FIXME: Generate
+                    initialBlockKzg = KzgCommitment.empty,
+                    equityShares = equityShares,
+                    multisigRegimeUtxo = config.multisigRegimeUtxo,
+                    votingDuration = 0,
+                    treasuryTokenName = config.tokenNames.headTokenName
+                  )
+                )
+              )
+            )
+
+        } yield TestR(
+          peers,
+          system,
+          initTx,
+          config,
+          virtualLedger,
+          dappLedger,
+          jointLedger
+        )
+    }
+
+    def asks[A](f: TestR => A): TestM[A] =
+        for {
+            env <- ask
+        } yield f(env)
+
+    def pick[A](gen: Gen[A]): TestM[A] = TestM(Kleisli.liftF(PropertyM.pick(gen)))
+
+    def pure[A](a: A): TestM[A] = TestM(Kleisli.pure(a))
+
+    def fail(msg: String): TestM[Unit] = TestM(Kleisli.liftF(PropertyM.fail_(msg)))
+
+    def assertWith(condition: Boolean, msg: String): TestM[Unit] =
+        TestM(Kleisli.liftF(PropertyM.assertWith(condition, msg)))
+
+    /** Given a computation of type [[TestM]] that returns a value that can be implicitly turned
+      * into a [[Prop]], run the computation.
+      * @param testM
+      *   The computation to run
+      * @param initializer
+      *   the computation that generates and sets up the [[TestR]] environment passed to [[testM]].
+      *   Defaults to a (sensibly) randomly generated environment.
+      * @param toProp
+      *   The implicit function that transforms the result of the computation into a [[Prop]]
+      * @param ioRuntime
+      *   The implicit IO runtime in which [[IO]] effects can be executed
+      * @tparam A
+      * @return
+      */
+    def run[A](testM: TestM[A], initializer: PT[TestR] = defaultInitializer)(using
+        toProp: A => Prop,
+        ioRuntime: IORuntime
+    ): Prop = {
+
+        // The runner tries to eliminate the EitherT[IO, TestError, Prop] to get an Prop.
+        // If it gets a Left[TestError], it means no property could be extracted, so we consider it a test failure and
+        // report the error.
+        // If we can generate a prop, we just return it.
+        def runner(mProp: ET[Prop]): Prop =
+            Prop.secure(mProp.value.unsafeRunSync() match {
+                case Left(e) =>
+                    s"Failed: $e" |: false
+                case Right(p) => p
+            })
+
+        monadic(
+          runner = runner,
+          m =
+              // This runs the initialization within the `PropertyM` first, in order to give the computation in `TestM`
+              // access to the fully-initialized environment
+              for {
+                  env <- initializer
+                  res <- testM.unTestM.run(env)
+              } yield res
+        )
+    }
+
+    // ===================================
+    // Lifts
+    // ===================================
+    def liftR[A](io: IO[A]): TestM[A] = {
+        TestM(
+          unTestM = Kleisli.liftF(PropertyM.run(EitherT.right(io)))
+        )
+    }
+
+    def liftL[A](io: IO[TestError]): TestM[A] =
+        TestM(Kleisli.liftF(PropertyM.run(EitherT.left(io))))
+
+    def lift[A](e: Either[TestError, A]): TestM[A] =
+        TestM(Kleisli.liftF(PropertyM.run(EitherT.fromEither(e))))
+
+}


### PR DESCRIPTION
An initial implementation of `TestM`. The API can be expanded with additional lifts as necessary.

Pay particular attention to the `Requests` and `Scenarios` objects within `JointLedgerTest`