### PR TITLE
PoC for non-fixed-sized block headers

### DIFF
--- a/src/test/scala/hydrozoa/multisig/ledger/block/BlockHeaderTest.scala
+++ b/src/test/scala/hydrozoa/multisig/ledger/block/BlockHeaderTest.scala
@@ -1,0 +1,33 @@
+package hydrozoa.multisig.ledger.block
+
+import hydrozoa.multisig.ledger.block.BlockHeader.Minor
+import hydrozoa.rulebased.ledger.l1.tx.CommonGenerators.genOnchainBlockHeader
+import org.scalacheck.*
+import org.scalacheck.util.Pretty
+
+object BlockHeaderTest extends Properties("Block header test") {
+    given ppBlockHeadOnchain: (List[BlockHeader.Minor.Onchain] => Pretty) = headers =>
+        Pretty(_ =>
+            headers
+                .map(header =>
+                    "Onchain(" +
+                        s"\n\tblockNum: ${header.blockNum}," +
+                        s"\n\tstartTime: ${header.startTime}," +
+                        s"\n\tversionMajor: ${header.versionMajor}," +
+                        s"\n\tversionMinor: ${header.versionMinor}," +
+                        s"\n\tcommitment: ${header.commitment.take(8)}(...)" +
+                        "\n)"
+                )
+                .mkString("[", ", ", "]")
+        )
+
+    val _ = property("Fixed size block headers") = Prop.forAllNoShrink(
+      Gen.nonEmptyListOf(for {
+          versionMajor <- Gen.posNum[Int]
+          header <- genOnchainBlockHeader(versionMajor)
+      } yield header)
+    )(listOfHeaders =>
+        val lengths = listOfHeaders.map(Minor.Onchain.Serialized(_).length)
+        lengths.forall(_ == lengths.head)
+    )
+}


### PR DESCRIPTION
Demos a failing property test for randomly generated (but sensible) on-chain block headers. On test failure I saw had `[62, 63, 62]` for the lengths.

