### PR TITLE
Generator Cleanup

### DIFF
--- a/src/test/scala/hydrozoa/config/ScriptReferenceUtxos.scala
+++ b/src/test/scala/hydrozoa/config/ScriptReferenceUtxos.scala
@@ -25,7 +25,6 @@ def generateScriptReferenceUtxos(network: CardanoNetwork.Section): Gen[ScriptRef
             )
         )
 
-
     mkUtxo = (id: TransactionInput, script: Script) =>
         Utxo(id, Babbage(address, Value.ada(10), None, Some(ScriptRef(script))))
 

--- a/src/test/scala/hydrozoa/config/head/HeadConfigGen.scala
+++ b/src/test/scala/hydrozoa/config/head/HeadConfigGen.scala
@@ -1,28 +1,29 @@
 package hydrozoa.config.head
 
-import cats.data.{Kleisli, ReaderT}
-import hydrozoa.config.head.initialization.BlockCreationEndTimeGen.{BlockCreationEndTimeGen, currentTimeBlockCreationEndTime}
+import cats.data.Kleisli
+import hydrozoa.config.head.initialization.BlockCreationEndTimeGen.currentTimeBlockCreationEndTime
 import hydrozoa.config.head.initialization.{InitializationParametersGenBottomUp, InitializationParametersGenTopDown, generateInitialBlock}
 import hydrozoa.config.head.multisig.fallback.generateFallbackContingency
-import hydrozoa.config.head.parameters.{GenHeadParams, generateHeadParameters}
-import org.scalacheck.{Gen, Prop, Properties}
-import test.given
-import test.{TestPeers, TestPeersSpec}
+import hydrozoa.config.head.multisig.timing.TxTiming.BlockTimes.BlockCreationEndTime
+import hydrozoa.config.head.parameters.{HeadParameters, generateHeadParameters}
+import org.scalacheck.{Prop, Properties}
+import test.{GenWithTestPeers, TestPeers, TestPeersSpec, given}
 
 type HeadConfigGen = (
-    generateBlockCreationEndTime: BlockCreationEndTimeGen,
-    generateHeadParameters: GenHeadParams,
+    generateBlockCreationEndTime: GenWithTestPeers[BlockCreationEndTime],
+    generateHeadParameters: GenWithTestPeers[HeadParameters],
     generateInitializationParameters: InitializationParametersGenBottomUp.GenInitializationParameters |
         InitializationParametersGenTopDown.GenWithDeps
-) => ReaderT[Gen, TestPeers, HeadConfig]
+) => GenWithTestPeers[HeadConfig]
 
 def generateHeadConfig(
-    generateBlockCreationEndTime: BlockCreationEndTimeGen = currentTimeBlockCreationEndTime,
-    generateHeadParameters: GenHeadParams = generateHeadParameters(),
+    generateBlockCreationEndTime: GenWithTestPeers[BlockCreationEndTime] =
+        currentTimeBlockCreationEndTime,
+    generateHeadParameters: GenWithTestPeers[HeadParameters] = generateHeadParameters(),
     generateInitializationParameters: InitializationParametersGenBottomUp.GenInitializationParameters |
         InitializationParametersGenTopDown.GenWithDeps =
         InitializationParametersGenBottomUp.generateInitializationParameters
-): ReaderT[Gen, TestPeers, HeadConfig] =
+): GenWithTestPeers[HeadConfig] =
     for {
         preinit <- generateHeadConfigPreInit(
           generateHeadParams = generateHeadParameters,
@@ -41,11 +42,11 @@ def generateHeadConfig(
     ).get
 
 def generateHeadConfigPreInit(
-    generateHeadParams: GenHeadParams = generateHeadParameters(),
+    generateHeadParams: GenWithTestPeers[HeadParameters] = generateHeadParameters(),
     generateInitializationParameters: InitializationParametersGenBottomUp.GenInitializationParameters |
         InitializationParametersGenTopDown.GenWithDeps =
         InitializationParametersGenBottomUp.generateInitializationParameters,
-): ReaderT[Gen, TestPeers, HeadConfig.Preinit] =
+): GenWithTestPeers[HeadConfig.Preinit] =
     for {
         testPeers <- Kleisli.ask
         cardanoNetwork = testPeers.cardanoNetwork

--- a/src/test/scala/hydrozoa/config/head/HeadConfigGen.scala
+++ b/src/test/scala/hydrozoa/config/head/HeadConfigGen.scala
@@ -7,7 +7,7 @@ import hydrozoa.config.head.multisig.settlement.{SettlementConfigGen, generateSe
 import hydrozoa.config.head.multisig.timing.TxTiming.BlockTimes.BlockCreationEndTime
 import hydrozoa.config.head.multisig.timing.{TxTimingGen, generateDefaultTxTiming}
 import hydrozoa.config.head.network.CardanoNetwork
-import hydrozoa.config.head.parameters.{GenHeadParams, generateHeadParameters}
+import hydrozoa.config.head.parameters.{GenHeadParams, HeadParameters, generateHeadParameters}
 import hydrozoa.config.head.rulebased.{DisputeResolutionConfigGen, generateDisputeResolutionConfig}
 import org.scalacheck.{Gen, Prop, Properties}
 import scalus.cardano.ledger.SlotConfig
@@ -16,9 +16,6 @@ import test.{TestPeers, TestPeersSpec}
 type HeadConfigGen =
     (testPeers: TestPeers) => (
         generateBlockCreationEndTime: SlotConfig => Gen[BlockCreationEndTime],
-        generateTxTiming: TxTimingGen,
-        generateFallbackContingency: FallbackContingencyGen,
-        generateDisputeResolutionConfig: DisputeResolutionConfigGen,
         generateHeadParameters: GenHeadParams,
         generateInitializationParameters: InitializationParametersGenBottomUp.GenInitializationParameters |
             InitializationParametersGenTopDown.GenWithDeps
@@ -27,25 +24,17 @@ type HeadConfigGen =
 def generateHeadConfig(testPeers: TestPeers)(
     generateBlockCreationEndTime: SlotConfig => Gen[BlockCreationEndTime] =
         currentTimeBlockCreationEndTime,
-    generateTxTiming: TxTimingGen = generateDefaultTxTiming,
-    generateFallbackContingency: FallbackContingencyGen = generateFallbackContingency,
-    generateDisputeResolutionConfig: DisputeResolutionConfigGen = generateDisputeResolutionConfig,
-    generateHeadParameters: GenHeadParams = generateHeadParameters,
+    generateHeadParameters: GenHeadParams = generateHeadParameters(),
     generateInitializationParameters: InitializationParametersGenBottomUp.GenInitializationParameters |
         InitializationParametersGenTopDown.GenWithDeps =
         InitializationParametersGenBottomUp.generateInitializationParameters
 ): Gen[HeadConfig] =
     for {
         preinit <- generateHeadConfigPreInit(testPeers)(
-          generateTxTiming = generateTxTiming,
-          generateFallbackContingency = generateFallbackContingency,
-          generateDisputeResolutionConfig = generateDisputeResolutionConfig,
-          generateHeadParameters = generateHeadParameters,
+          generateHeadParams = generateHeadParameters,
           generateInitializationParameters = generateInitializationParameters
         )
         initialBlock <- generateInitialBlock(testPeers)(
-          generateTxTiming = Gen.const((_ : CardanoNetwork.Section) ?=> preinit.headParams.txTiming),
-          generateHeadParameters = _ => (_, _, _, _) => Gen.const(preinit.headParams),
           generateBlockCreationEndTime = generateBlockCreationEndTime,
           generateInitializationParameters = preinit.initializationParams
         )
@@ -60,22 +49,14 @@ def generateHeadConfig(testPeers: TestPeers)(
 def generateHeadConfigPreInit(testPeers: TestPeers)(
     generateBlockCreationEndTime: SlotConfig => Gen[BlockCreationEndTime] =
         currentTimeBlockCreationEndTime,
-    generateTxTiming: TxTimingGen = generateDefaultTxTiming,
-    generateFallbackContingency: FallbackContingencyGen = generateFallbackContingency,
-    generateDisputeResolutionConfig: DisputeResolutionConfigGen = generateDisputeResolutionConfig,
-    generateHeadParameters: GenHeadParams = generateHeadParameters,
+    generateHeadParams : GenHeadParams = generateHeadParameters(),
     generateInitializationParameters: InitializationParametersGenBottomUp.GenInitializationParameters |
         InitializationParametersGenTopDown.GenWithDeps =
         InitializationParametersGenBottomUp.generateInitializationParameters,
     generateSettlementConfig: SettlementConfigGen = generateSettlementConfig
 ): Gen[HeadConfig.Preinit] = for {
     cardanoNetwork <- Gen.const(testPeers.network)
-    headParams <- generateHeadParameters(cardanoNetwork)(
-      generateTxTiming,
-      generateFallbackContingency,
-      generateDisputeResolutionConfig,
-      generateSettlementConfig
-    )
+    headParams <- generateHeadParams
     initializationParams <- generateInitializationParameters match {
         case g: InitializationParametersGenBottomUp.GenInitializationParameters =>
             g(testPeers)(
@@ -96,7 +77,7 @@ def generateHeadConfigPreInit(testPeers: TestPeers)(
 } yield HeadConfig
     .Preinit(
       cardanoNetwork = cardanoNetwork,
-      headParams = headParams,
+      headParams = headParams(using cardanoNetwork),
       headPeers = testPeers.mkHeadPeers,
       initializationParams = initializationParams
     )

--- a/src/test/scala/hydrozoa/config/head/HeadConfigGen.scala
+++ b/src/test/scala/hydrozoa/config/head/HeadConfigGen.scala
@@ -1,6 +1,6 @@
 package hydrozoa.config.head
 
-import hydrozoa.config.head.initialization.BlockCreationEndTimeGen.currentTimeBlockCreationEndTime
+import hydrozoa.config.head.initialization.BlockCreationEndTimeGen.{BlockCreationEndTimeGen, currentTimeBlockCreationEndTime}
 import hydrozoa.config.head.initialization.{InitializationParametersGenBottomUp, InitializationParametersGenTopDown, generateInitialBlock}
 import hydrozoa.config.head.multisig.fallback.{FallbackContingencyGen, generateFallbackContingency, mkFallbackContingency}
 import hydrozoa.config.head.multisig.settlement.{SettlementConfigGen, generateSettlementConfig}
@@ -15,14 +15,14 @@ import test.{TestPeers, TestPeersSpec}
 
 type HeadConfigGen =
     (testPeers: TestPeers) => (
-        generateBlockCreationEndTime: SlotConfig => Gen[BlockCreationEndTime],
+        generateBlockCreationEndTime: BlockCreationEndTimeGen,
         generateHeadParameters: GenHeadParams,
         generateInitializationParameters: InitializationParametersGenBottomUp.GenInitializationParameters |
             InitializationParametersGenTopDown.GenWithDeps
     ) => Gen[HeadConfig]
 
 def generateHeadConfig(testPeers: TestPeers)(
-    generateBlockCreationEndTime: SlotConfig => Gen[BlockCreationEndTime] =
+    generateBlockCreationEndTime: BlockCreationEndTimeGen =
         currentTimeBlockCreationEndTime,
     generateHeadParameters: GenHeadParams = generateHeadParameters(),
     generateInitializationParameters: InitializationParametersGenBottomUp.GenInitializationParameters |
@@ -47,13 +47,10 @@ def generateHeadConfig(testPeers: TestPeers)(
     ).get
 
 def generateHeadConfigPreInit(testPeers: TestPeers)(
-    generateBlockCreationEndTime: SlotConfig => Gen[BlockCreationEndTime] =
-        currentTimeBlockCreationEndTime,
     generateHeadParams : GenHeadParams = generateHeadParameters(),
     generateInitializationParameters: InitializationParametersGenBottomUp.GenInitializationParameters |
         InitializationParametersGenTopDown.GenWithDeps =
         InitializationParametersGenBottomUp.generateInitializationParameters,
-    generateSettlementConfig: SettlementConfigGen = generateSettlementConfig
 ): Gen[HeadConfig.Preinit] = for {
     cardanoNetwork <- Gen.const(testPeers.network)
     headParams <- generateHeadParams

--- a/src/test/scala/hydrozoa/config/head/HeadConfigGen.scala
+++ b/src/test/scala/hydrozoa/config/head/HeadConfigGen.scala
@@ -1,40 +1,34 @@
 package hydrozoa.config.head
 
+import cats.data.{Kleisli, ReaderT}
 import hydrozoa.config.head.initialization.BlockCreationEndTimeGen.{BlockCreationEndTimeGen, currentTimeBlockCreationEndTime}
 import hydrozoa.config.head.initialization.{InitializationParametersGenBottomUp, InitializationParametersGenTopDown, generateInitialBlock}
-import hydrozoa.config.head.multisig.fallback.{FallbackContingencyGen, generateFallbackContingency, mkFallbackContingency}
-import hydrozoa.config.head.multisig.settlement.{SettlementConfigGen, generateSettlementConfig}
-import hydrozoa.config.head.multisig.timing.TxTiming.BlockTimes.BlockCreationEndTime
-import hydrozoa.config.head.multisig.timing.{TxTimingGen, generateDefaultTxTiming}
-import hydrozoa.config.head.network.CardanoNetwork
-import hydrozoa.config.head.parameters.{GenHeadParams, HeadParameters, generateHeadParameters}
-import hydrozoa.config.head.rulebased.{DisputeResolutionConfigGen, generateDisputeResolutionConfig}
+import hydrozoa.config.head.multisig.fallback.generateFallbackContingency
+import hydrozoa.config.head.parameters.{GenHeadParams, generateHeadParameters}
 import org.scalacheck.{Gen, Prop, Properties}
-import scalus.cardano.ledger.SlotConfig
+import test.given
 import test.{TestPeers, TestPeersSpec}
 
-type HeadConfigGen =
-    (testPeers: TestPeers) => (
-        generateBlockCreationEndTime: BlockCreationEndTimeGen,
-        generateHeadParameters: GenHeadParams,
-        generateInitializationParameters: InitializationParametersGenBottomUp.GenInitializationParameters |
-            InitializationParametersGenTopDown.GenWithDeps
-    ) => Gen[HeadConfig]
+type HeadConfigGen = (
+    generateBlockCreationEndTime: BlockCreationEndTimeGen,
+    generateHeadParameters: GenHeadParams,
+    generateInitializationParameters: InitializationParametersGenBottomUp.GenInitializationParameters |
+        InitializationParametersGenTopDown.GenWithDeps
+) => ReaderT[Gen, TestPeers, HeadConfig]
 
-def generateHeadConfig(testPeers: TestPeers)(
-    generateBlockCreationEndTime: BlockCreationEndTimeGen =
-        currentTimeBlockCreationEndTime,
+def generateHeadConfig(
+    generateBlockCreationEndTime: BlockCreationEndTimeGen = currentTimeBlockCreationEndTime,
     generateHeadParameters: GenHeadParams = generateHeadParameters(),
     generateInitializationParameters: InitializationParametersGenBottomUp.GenInitializationParameters |
         InitializationParametersGenTopDown.GenWithDeps =
         InitializationParametersGenBottomUp.generateInitializationParameters
-): Gen[HeadConfig] =
+): ReaderT[Gen, TestPeers, HeadConfig] =
     for {
-        preinit <- generateHeadConfigPreInit(testPeers)(
+        preinit <- generateHeadConfigPreInit(
           generateHeadParams = generateHeadParameters,
           generateInitializationParameters = generateInitializationParameters
         )
-        initialBlock <- generateInitialBlock(testPeers)(
+        initialBlock <- generateInitialBlock(
           generateBlockCreationEndTime = generateBlockCreationEndTime,
           generateInitializationParameters = preinit.initializationParams
         )
@@ -46,39 +40,39 @@ def generateHeadConfig(testPeers: TestPeers)(
       initialBlock = initialBlock.initialBlock
     ).get
 
-def generateHeadConfigPreInit(testPeers: TestPeers)(
-    generateHeadParams : GenHeadParams = generateHeadParameters(),
+def generateHeadConfigPreInit(
+    generateHeadParams: GenHeadParams = generateHeadParameters(),
     generateInitializationParameters: InitializationParametersGenBottomUp.GenInitializationParameters |
         InitializationParametersGenTopDown.GenWithDeps =
         InitializationParametersGenBottomUp.generateInitializationParameters,
-): Gen[HeadConfig.Preinit] = for {
-    cardanoNetwork <- Gen.const(testPeers.network)
-    headParams <- generateHeadParams
-    initializationParams <- generateInitializationParameters match {
-        case g: InitializationParametersGenBottomUp.GenInitializationParameters =>
-            g(testPeers)(
-              generateFallbackContingency,
-            )
-        case InitializationParametersGenTopDown.GenWithDeps(
-              generator,
-              generateGenesisUtxosL1,
-              equityRange
-            ) =>
-            generator(testPeers)(
-              generateFallbackContingency,
-              generateGenesisUtxosL1,
-              equityRange
-            )
-    }
+): ReaderT[Gen, TestPeers, HeadConfig.Preinit] =
+    for {
+        testPeers <- Kleisli.ask
+        cardanoNetwork = testPeers.cardanoNetwork
+        headParams <- generateHeadParams
+        initializationParams <- generateInitializationParameters match {
+            case g: InitializationParametersGenBottomUp.GenInitializationParameters =>
+                g(generateFallbackContingency)
+            case InitializationParametersGenTopDown.GenWithDeps(
+                  generator,
+                  generateGenesisUtxosL1,
+                  equityRange
+                ) =>
+                generator(
+                  generateFallbackContingency,
+                  generateGenesisUtxosL1,
+                  equityRange
+                )
+        }
 
-} yield HeadConfig
-    .Preinit(
-      cardanoNetwork = cardanoNetwork,
-      headParams = headParams(using cardanoNetwork),
-      headPeers = testPeers.mkHeadPeers,
-      initializationParams = initializationParams
-    )
-    .get
+    } yield HeadConfig
+        .Preinit(
+          cardanoNetwork = cardanoNetwork,
+          headParams = headParams,
+          headPeers = testPeers.mkHeadPeers,
+          initializationParams = initializationParams
+        )
+        .get
 
 object HeadConfigTest extends Properties("Head config") {
 
@@ -86,13 +80,13 @@ object HeadConfigTest extends Properties("Head config") {
       TestPeersSpec
           .generate()
           .flatMap(TestPeers.generate)
-          .flatMap(generateHeadConfigPreInit(_)())
+          .flatMap(generateHeadConfigPreInit().run(_))
     )(_ => true)
 
     val _ = property("full config generates") = Prop.forAll(
       TestPeersSpec
           .generate()
           .flatMap(TestPeers.generate)
-          .flatMap(generateHeadConfig(_)())
+          .flatMap(generateHeadConfig().run(_))
     )(_ => true)
 }

--- a/src/test/scala/hydrozoa/config/head/HeadConfigGen.scala
+++ b/src/test/scala/hydrozoa/config/head/HeadConfigGen.scala
@@ -2,7 +2,7 @@ package hydrozoa.config.head
 
 import hydrozoa.config.head.initialization.BlockCreationEndTimeGen.currentTimeBlockCreationEndTime
 import hydrozoa.config.head.initialization.{InitializationParametersGenBottomUp, InitializationParametersGenTopDown, generateInitialBlock}
-import hydrozoa.config.head.multisig.fallback.{FallbackContingencyGen, generateFallbackContingency}
+import hydrozoa.config.head.multisig.fallback.{FallbackContingencyGen, generateFallbackContingency, mkFallbackContingency}
 import hydrozoa.config.head.multisig.settlement.{SettlementConfigGen, generateSettlementConfig}
 import hydrozoa.config.head.multisig.timing.TxTiming.BlockTimes.BlockCreationEndTime
 import hydrozoa.config.head.multisig.timing.{TxTimingGen, generateDefaultTxTiming}
@@ -44,7 +44,7 @@ def generateHeadConfig(testPeers: TestPeers)(
           generateInitializationParameters = generateInitializationParameters
         )
         initialBlock <- generateInitialBlock(testPeers)(
-          generateTxTiming = _ => Gen.const(preinit.headParams.txTiming),
+          generateTxTiming = Gen.const((_ : CardanoNetwork.Section) ?=> preinit.headParams.txTiming),
           generateHeadParameters = _ => (_, _, _, _) => Gen.const(preinit.headParams),
           generateBlockCreationEndTime = generateBlockCreationEndTime,
           generateInitializationParameters = preinit.initializationParams

--- a/src/test/scala/hydrozoa/config/head/initialization/InitialBlockGen.scala
+++ b/src/test/scala/hydrozoa/config/head/initialization/InitialBlockGen.scala
@@ -23,73 +23,78 @@ def generateInitialBlock(testPeers: TestPeers)(
     generateBlockCreationEndTime: BlockCreationEndTimeGen = currentTimeBlockCreationEndTime,
     generateInitializationParameters: InitializationParametersGenBottomUp.GenInitializationParameters |
         InitializationParametersGenTopDown.GenWithDeps | InitializationParameters =
-        InitializationParametersGenBottomUp.generateInitializationParameters,
-    generateSettlementConfig: SettlementConfigGen = generateSettlementConfig
+        InitializationParametersGenBottomUp.generateInitializationParameters : InitializationParametersGenBottomUp.GenInitializationParameters,
 ): Gen[InitialBlock] = {
     for {
         cardanoNetwork <- Gen.const(testPeers.network)
 
-        headParams <- generateHeadParameters
+        res <- {
+            given CardanoNetwork.Section = cardanoNetwork
 
-        initializationParameters <- generateInitializationParameters match {
-            case g: InitializationParametersGenBottomUp.GenInitializationParameters =>
-                g(testPeers)(Gen.const(_ ?=> headParams(using cardanoNetwork).fallbackContingency))
-            case InitializationParametersGenTopDown.GenWithDeps(
-                  generator,
-                  generateGenesisUtxosL1,
-                  equityRange
-                ) =>
-                generator(testPeers)(
-                  generateFallbackContingency,
-                  generateGenesisUtxosL1,
-                  equityRange
+            for {
+                headParams <- generateHeadParameters
+
+                initializationParameters <- generateInitializationParameters match {
+                    case g: InitializationParametersGenBottomUp.GenInitializationParameters =>
+                        g(testPeers)(Gen.const(_ ?=> headParams.fallbackContingency))
+                    case InitializationParametersGenTopDown.GenWithDeps(
+                        generator,
+                        generateGenesisUtxosL1,
+                        equityRange
+                    ) =>
+                        generator(testPeers)(
+                            generateFallbackContingency,
+                            generateGenesisUtxosL1,
+                            equityRange
+                        )
+                    case ps: InitializationParameters => Gen.const(ps)
+                }
+
+                config = HeadConfig
+                    .Preinit(
+                        cardanoNetwork = cardanoNetwork,
+                        headParams = headParams,
+                        headPeers = testPeers.mkHeadPeers,
+                        initializationParams = initializationParameters
+                    )
+                    .get
+
+                blockCreationEndTime <- generateBlockCreationEndTime
+
+                initTxSeq =
+                    InitializationTxSeq.Build(config)(blockCreationEndTime).result match {
+                        case Left(e) =>
+                            throw new RuntimeException(e.toString, e)
+                        case Right(x) => x
+                    }
+
+                fallbackTxStartTime = initTxSeq.fallbackTx.fallbackTxStartTime
+                forcedMajorBlockTime = headParams.txTiming.forcedMajorBlockTime(fallbackTxStartTime)
+                majorBlockWakeupTime = TxTiming.majorBlockWakeupTime(forcedMajorBlockTime, None)
+
+            } yield InitialBlock(
+                Block.MultiSigned.Initial(
+                    blockBrief = BlockBrief.Initial(
+                        BlockHeader.Initial(
+                            startTime = BlockCreationStartTime(blockCreationEndTime - 10.seconds),
+                            endTime = blockCreationEndTime,
+                            fallbackTxStartTime = initTxSeq.fallbackTx.fallbackTxStartTime,
+                            majorBlockWakeupTime = majorBlockWakeupTime,
+                            kzgCommitment = initializationParameters.initialEvacuationMap.kzgCommitment
+                        )
+                    ),
+                    effects = BlockEffects.MultiSigned.Initial(
+                        initializationTx = initTxSeq.initializationTx
+                            .focus(_.tx)
+                            .modify(testPeers.multisignTx),
+                        fallbackTx = initTxSeq.fallbackTx
+                            .focus(_.tx)
+                            .modify(testPeers.multisignTx)
+                    )
                 )
-            case ps: InitializationParameters => Gen.const(ps)
-        }
-
-        config = HeadConfig
-            .Preinit(
-              cardanoNetwork = cardanoNetwork,
-              headParams = headParams(using cardanoNetwork),
-              headPeers = testPeers.mkHeadPeers,
-              initializationParams = initializationParameters
             )
-            .get
-
-        blockCreationEndTime <- generateBlockCreationEndTime(config.slotConfig)
-
-        initTxSeq =
-            InitializationTxSeq.Build(config)(blockCreationEndTime).result match {
-                case Left(e) =>
-                    throw new RuntimeException(e.toString, e)
-                case Right(x) => x
-            }
-
-        fallbackTxStartTime = initTxSeq.fallbackTx.fallbackTxStartTime
-        forcedMajorBlockTime = headParams(using cardanoNetwork).txTiming.forcedMajorBlockTime(fallbackTxStartTime)
-        majorBlockWakeupTime = TxTiming.majorBlockWakeupTime(forcedMajorBlockTime, None)
-
-    } yield InitialBlock(
-      Block.MultiSigned.Initial(
-        blockBrief = BlockBrief.Initial(
-          BlockHeader.Initial(
-            startTime = BlockCreationStartTime(blockCreationEndTime - 10.seconds),
-            endTime = blockCreationEndTime,
-            fallbackTxStartTime = initTxSeq.fallbackTx.fallbackTxStartTime,
-            majorBlockWakeupTime = majorBlockWakeupTime,
-            kzgCommitment = initializationParameters.initialEvacuationMap.kzgCommitment
-          )
-        ),
-        effects = BlockEffects.MultiSigned.Initial(
-          initializationTx = initTxSeq.initializationTx
-              .focus(_.tx)
-              .modify(testPeers.multisignTx),
-          fallbackTx = initTxSeq.fallbackTx
-              .focus(_.tx)
-              .modify(testPeers.multisignTx)
-        )
-      )
-    )
+        }
+        } yield res
 }
 
 object InitialBlockTest extends Properties("Initial block") {

--- a/src/test/scala/hydrozoa/config/head/initialization/InitialBlockGen.scala
+++ b/src/test/scala/hydrozoa/config/head/initialization/InitialBlockGen.scala
@@ -19,10 +19,7 @@ import scala.concurrent.duration.DurationInt
 import test.{TestPeers, TestPeersSpec}
 
 def generateInitialBlock(testPeers: TestPeers)(
-    generateTxTiming: TxTimingGen = generateDefaultTxTiming,
-    generateFallbackContingency: FallbackContingencyGen = generateFallbackContingency,
-    generateDisputeResolutionConfig: DisputeResolutionConfigGen = generateDisputeResolutionConfig,
-    generateHeadParameters: GenHeadParams = generateHeadParameters,
+    generateHeadParameters: GenHeadParams = generateHeadParameters(),
     generateBlockCreationEndTime: BlockCreationEndTimeGen = currentTimeBlockCreationEndTime,
     generateInitializationParameters: InitializationParametersGenBottomUp.GenInitializationParameters |
         InitializationParametersGenTopDown.GenWithDeps | InitializationParameters =
@@ -32,16 +29,11 @@ def generateInitialBlock(testPeers: TestPeers)(
     for {
         cardanoNetwork <- Gen.const(testPeers.network)
 
-        headParams <- generateHeadParameters(cardanoNetwork)(
-          generateTxTiming,
-          generateFallbackContingency,
-          generateDisputeResolutionConfig,
-          generateSettlementConfig
-        )
+        headParams <- generateHeadParameters
 
         initializationParameters <- generateInitializationParameters match {
             case g: InitializationParametersGenBottomUp.GenInitializationParameters =>
-                g(testPeers)(Gen.const(_ ?=> headParams.fallbackContingency))
+                g(testPeers)(Gen.const(_ ?=> headParams(using cardanoNetwork).fallbackContingency))
             case InitializationParametersGenTopDown.GenWithDeps(
                   generator,
                   generateGenesisUtxosL1,
@@ -58,7 +50,7 @@ def generateInitialBlock(testPeers: TestPeers)(
         config = HeadConfig
             .Preinit(
               cardanoNetwork = cardanoNetwork,
-              headParams = headParams,
+              headParams = headParams(using cardanoNetwork),
               headPeers = testPeers.mkHeadPeers,
               initializationParams = initializationParameters
             )
@@ -74,7 +66,7 @@ def generateInitialBlock(testPeers: TestPeers)(
             }
 
         fallbackTxStartTime = initTxSeq.fallbackTx.fallbackTxStartTime
-        forcedMajorBlockTime = headParams.txTiming.forcedMajorBlockTime(fallbackTxStartTime)
+        forcedMajorBlockTime = headParams(using cardanoNetwork).txTiming.forcedMajorBlockTime(fallbackTxStartTime)
         majorBlockWakeupTime = TxTiming.majorBlockWakeupTime(forcedMajorBlockTime, None)
 
     } yield InitialBlock(

--- a/src/test/scala/hydrozoa/config/head/initialization/InitialBlockGen.scala
+++ b/src/test/scala/hydrozoa/config/head/initialization/InitialBlockGen.scala
@@ -1,100 +1,94 @@
 package hydrozoa.config.head.initialization
 
+import cats.data.{Kleisli, ReaderT}
 import hydrozoa.config.head.HeadConfig
 import hydrozoa.config.head.initialization.BlockCreationEndTimeGen.{BlockCreationEndTimeGen, currentTimeBlockCreationEndTime}
-import hydrozoa.config.head.multisig.fallback.{FallbackContingencyGen, generateFallbackContingency, mkFallbackContingency}
-import hydrozoa.config.head.multisig.settlement.{SettlementConfigGen, generateSettlementConfig}
+import hydrozoa.config.head.multisig.fallback.generateFallbackContingency
+import hydrozoa.config.head.multisig.timing.TxTiming
 import hydrozoa.config.head.multisig.timing.TxTiming.BlockTimes.BlockCreationStartTime
-import hydrozoa.config.head.multisig.timing.{TxTiming, TxTimingGen, generateDefaultTxTiming}
-import hydrozoa.config.head.network.CardanoNetwork
 import hydrozoa.config.head.parameters.{GenHeadParams, generateHeadParameters}
-import hydrozoa.config.head.rulebased.{DisputeResolutionConfigGen, generateDisputeResolutionConfig}
 import hydrozoa.multisig.ledger.block.{Block, BlockBrief, BlockEffects, BlockHeader}
 import hydrozoa.multisig.ledger.l1.txseq.InitializationTxSeq
 import monocle.Focus.focus
 import org.scalacheck.Test.Parameters
 import org.scalacheck.{Gen, Prop, Properties}
-
 import scala.concurrent.duration.DurationInt
+import test.given
 import test.{TestPeers, TestPeersSpec}
 
-def generateInitialBlock(testPeers: TestPeers)(
+def generateInitialBlock(
     generateHeadParameters: GenHeadParams = generateHeadParameters(),
     generateBlockCreationEndTime: BlockCreationEndTimeGen = currentTimeBlockCreationEndTime,
     generateInitializationParameters: InitializationParametersGenBottomUp.GenInitializationParameters |
         InitializationParametersGenTopDown.GenWithDeps | InitializationParameters =
-        InitializationParametersGenBottomUp.generateInitializationParameters : InitializationParametersGenBottomUp.GenInitializationParameters,
-): Gen[InitialBlock] = {
+        InitializationParametersGenBottomUp.generateInitializationParameters: InitializationParametersGenBottomUp.GenInitializationParameters,
+): ReaderT[Gen, TestPeers, InitialBlock] = {
     for {
-        cardanoNetwork <- Gen.const(testPeers.network)
+        testPeers <- Kleisli.ask
+        cardanoNetwork = testPeers.cardanoNetwork
 
-        res <- {
-            given CardanoNetwork.Section = cardanoNetwork
+        headParams <- generateHeadParameters
 
-            for {
-                headParams <- generateHeadParameters
-
-                initializationParameters <- generateInitializationParameters match {
-                    case g: InitializationParametersGenBottomUp.GenInitializationParameters =>
-                        g(testPeers)(Gen.const(_ ?=> headParams.fallbackContingency))
-                    case InitializationParametersGenTopDown.GenWithDeps(
-                        generator,
-                        generateGenesisUtxosL1,
-                        equityRange
-                    ) =>
-                        generator(testPeers)(
-                            generateFallbackContingency,
-                            generateGenesisUtxosL1,
-                            equityRange
-                        )
-                    case ps: InitializationParameters => Gen.const(ps)
-                }
-
-                config = HeadConfig
-                    .Preinit(
-                        cardanoNetwork = cardanoNetwork,
-                        headParams = headParams,
-                        headPeers = testPeers.mkHeadPeers,
-                        initializationParams = initializationParameters
-                    )
-                    .get
-
-                blockCreationEndTime <- generateBlockCreationEndTime
-
-                initTxSeq =
-                    InitializationTxSeq.Build(config)(blockCreationEndTime).result match {
-                        case Left(e) =>
-                            throw new RuntimeException(e.toString, e)
-                        case Right(x) => x
-                    }
-
-                fallbackTxStartTime = initTxSeq.fallbackTx.fallbackTxStartTime
-                forcedMajorBlockTime = headParams.txTiming.forcedMajorBlockTime(fallbackTxStartTime)
-                majorBlockWakeupTime = TxTiming.majorBlockWakeupTime(forcedMajorBlockTime, None)
-
-            } yield InitialBlock(
-                Block.MultiSigned.Initial(
-                    blockBrief = BlockBrief.Initial(
-                        BlockHeader.Initial(
-                            startTime = BlockCreationStartTime(blockCreationEndTime - 10.seconds),
-                            endTime = blockCreationEndTime,
-                            fallbackTxStartTime = initTxSeq.fallbackTx.fallbackTxStartTime,
-                            majorBlockWakeupTime = majorBlockWakeupTime,
-                            kzgCommitment = initializationParameters.initialEvacuationMap.kzgCommitment
-                        )
-                    ),
-                    effects = BlockEffects.MultiSigned.Initial(
-                        initializationTx = initTxSeq.initializationTx
-                            .focus(_.tx)
-                            .modify(testPeers.multisignTx),
-                        fallbackTx = initTxSeq.fallbackTx
-                            .focus(_.tx)
-                            .modify(testPeers.multisignTx)
-                    )
+        initializationParameters <- generateInitializationParameters match {
+            case g: InitializationParametersGenBottomUp.GenInitializationParameters =>
+                g(Kleisli.liftF(Gen.const(headParams.fallbackContingency)))
+            case InitializationParametersGenTopDown.GenWithDeps(
+                  generator,
+                  generateGenesisUtxosL1,
+                  equityRange
+                ) =>
+                generator(
+                  generateFallbackContingency,
+                  generateGenesisUtxosL1,
+                  equityRange
                 )
-            )
+            case ps: InitializationParameters => ReaderT.liftF(Gen.const(ps))
         }
-        } yield res
+
+        config = HeadConfig
+            .Preinit(
+              cardanoNetwork = cardanoNetwork,
+              headParams = headParams,
+              headPeers = testPeers.mkHeadPeers,
+              initializationParams = initializationParameters
+            )
+            .get
+
+        blockCreationEndTime <- generateBlockCreationEndTime
+
+        initTxSeq =
+            InitializationTxSeq.Build(config)(blockCreationEndTime).result match {
+                case Left(e) =>
+                    throw new RuntimeException(e.toString, e)
+                case Right(x) => x
+            }
+
+        fallbackTxStartTime = initTxSeq.fallbackTx.fallbackTxStartTime
+        forcedMajorBlockTime = headParams.txTiming.forcedMajorBlockTime(fallbackTxStartTime)
+        majorBlockWakeupTime = TxTiming.majorBlockWakeupTime(forcedMajorBlockTime, None)
+
+    } yield InitialBlock(
+      Block.MultiSigned.Initial(
+        blockBrief = BlockBrief.Initial(
+          BlockHeader.Initial(
+            startTime = BlockCreationStartTime(blockCreationEndTime - 10.seconds),
+            endTime = blockCreationEndTime,
+            fallbackTxStartTime = initTxSeq.fallbackTx.fallbackTxStartTime,
+            majorBlockWakeupTime = majorBlockWakeupTime,
+            kzgCommitment = initializationParameters.initialEvacuationMap.kzgCommitment
+          )
+        ),
+        effects = BlockEffects.MultiSigned.Initial(
+          initializationTx = initTxSeq.initializationTx
+              .focus(_.tx)
+              .modify(testPeers.multisignTx),
+          fallbackTx = initTxSeq.fallbackTx
+              .focus(_.tx)
+              .modify(testPeers.multisignTx)
+        )
+      )
+    )
+
 }
 
 object InitialBlockTest extends Properties("Initial block") {
@@ -106,6 +100,6 @@ object InitialBlockTest extends Properties("Initial block") {
       TestPeersSpec
           .generate()
           .flatMap(TestPeers.generate)
-          .flatMap(generateInitialBlock(_)())
+          .flatMap(generateInitialBlock().run(_))
     )(_ => true)
 }

--- a/src/test/scala/hydrozoa/config/head/initialization/InitialBlockGen.scala
+++ b/src/test/scala/hydrozoa/config/head/initialization/InitialBlockGen.scala
@@ -2,27 +2,27 @@ package hydrozoa.config.head.initialization
 
 import cats.data.{Kleisli, ReaderT}
 import hydrozoa.config.head.HeadConfig
-import hydrozoa.config.head.initialization.BlockCreationEndTimeGen.{BlockCreationEndTimeGen, currentTimeBlockCreationEndTime}
+import hydrozoa.config.head.initialization.BlockCreationEndTimeGen.currentTimeBlockCreationEndTime
 import hydrozoa.config.head.multisig.fallback.generateFallbackContingency
 import hydrozoa.config.head.multisig.timing.TxTiming
-import hydrozoa.config.head.multisig.timing.TxTiming.BlockTimes.BlockCreationStartTime
-import hydrozoa.config.head.parameters.{GenHeadParams, generateHeadParameters}
+import hydrozoa.config.head.multisig.timing.TxTiming.BlockTimes.{BlockCreationEndTime, BlockCreationStartTime}
+import hydrozoa.config.head.parameters.{HeadParameters, generateHeadParameters}
 import hydrozoa.multisig.ledger.block.{Block, BlockBrief, BlockEffects, BlockHeader}
 import hydrozoa.multisig.ledger.l1.txseq.InitializationTxSeq
 import monocle.Focus.focus
 import org.scalacheck.Test.Parameters
 import org.scalacheck.{Gen, Prop, Properties}
 import scala.concurrent.duration.DurationInt
-import test.given
-import test.{TestPeers, TestPeersSpec}
+import test.{GenWithTestPeers, TestPeers, TestPeersSpec, given}
 
 def generateInitialBlock(
-    generateHeadParameters: GenHeadParams = generateHeadParameters(),
-    generateBlockCreationEndTime: BlockCreationEndTimeGen = currentTimeBlockCreationEndTime,
+    generateHeadParameters: GenWithTestPeers[HeadParameters] = generateHeadParameters(),
+    generateBlockCreationEndTime: GenWithTestPeers[BlockCreationEndTime] =
+        currentTimeBlockCreationEndTime,
     generateInitializationParameters: InitializationParametersGenBottomUp.GenInitializationParameters |
         InitializationParametersGenTopDown.GenWithDeps | InitializationParameters =
         InitializationParametersGenBottomUp.generateInitializationParameters: InitializationParametersGenBottomUp.GenInitializationParameters,
-): ReaderT[Gen, TestPeers, InitialBlock] = {
+): GenWithTestPeers[InitialBlock] = {
     for {
         testPeers <- Kleisli.ask
         cardanoNetwork = testPeers.cardanoNetwork

--- a/src/test/scala/hydrozoa/config/head/initialization/InitialBlockGen.scala
+++ b/src/test/scala/hydrozoa/config/head/initialization/InitialBlockGen.scala
@@ -2,7 +2,7 @@ package hydrozoa.config.head.initialization
 
 import hydrozoa.config.head.HeadConfig
 import hydrozoa.config.head.initialization.BlockCreationEndTimeGen.{BlockCreationEndTimeGen, currentTimeBlockCreationEndTime}
-import hydrozoa.config.head.multisig.fallback.{FallbackContingencyGen, generateFallbackContingency}
+import hydrozoa.config.head.multisig.fallback.{FallbackContingencyGen, generateFallbackContingency, mkFallbackContingency}
 import hydrozoa.config.head.multisig.settlement.{SettlementConfigGen, generateSettlementConfig}
 import hydrozoa.config.head.multisig.timing.TxTiming.BlockTimes.BlockCreationStartTime
 import hydrozoa.config.head.multisig.timing.{TxTiming, TxTimingGen, generateDefaultTxTiming}
@@ -14,6 +14,7 @@ import hydrozoa.multisig.ledger.l1.txseq.InitializationTxSeq
 import monocle.Focus.focus
 import org.scalacheck.Test.Parameters
 import org.scalacheck.{Gen, Prop, Properties}
+
 import scala.concurrent.duration.DurationInt
 import test.{TestPeers, TestPeersSpec}
 
@@ -40,7 +41,7 @@ def generateInitialBlock(testPeers: TestPeers)(
 
         initializationParameters <- generateInitializationParameters match {
             case g: InitializationParametersGenBottomUp.GenInitializationParameters =>
-                g(testPeers)(_ => Gen.const(headParams.fallbackContingency))
+                g(testPeers)(Gen.const(_ ?=> headParams.fallbackContingency))
             case InitializationParametersGenTopDown.GenWithDeps(
                   generator,
                   generateGenesisUtxosL1,

--- a/src/test/scala/hydrozoa/config/head/initialization/InitializationParametersGen.scala
+++ b/src/test/scala/hydrozoa/config/head/initialization/InitializationParametersGen.scala
@@ -2,7 +2,8 @@ package hydrozoa.config.head.initialization
 
 import cats.*
 import cats.data.*
-import cats.syntax.semigroup.*
+import cats.data.Kleisli.{ask, liftF}
+import cats.syntax.all.*
 import hydrozoa.config.head.initialization.InitializationParameters.HeadId
 import hydrozoa.config.head.multisig.fallback.{FallbackContingency, FallbackContingencyGen, generateFallbackContingency}
 import hydrozoa.config.head.multisig.timing.TxTiming.BlockTimes.BlockCreationEndTime
@@ -21,10 +22,8 @@ import hydrozoa.multisig.ledger.joint.obligation.Payout
 import hydrozoa.multisig.ledger.joint.{EvacuationKey, EvacuationMap}
 import hydrozoa.multisig.ledger.l1.token.CIP67
 import hydrozoa.rulebased.ledger.l1.script.plutus.RuleBasedTreasuryValidator.given
-
 import java.time.Instant
 import org.scalacheck.{Gen, Prop, Properties}
-
 import scala.collection.immutable.{SortedMap, TreeMap}
 import scala.concurrent.duration.DurationInt
 import scalus.cardano.address.Address
@@ -35,6 +34,7 @@ import spire.math.{Rational, SafeLong}
 import test.Generators.Hydrozoa.*
 import test.Generators.Other.genValueDistributionWithMinAdaUtxo
 import test.Generators.loggerGenerators
+import test.given
 import test.{Generators, TestPeers, TestPeersSpec}
 
 // TODO: George: what do you think of expanding our shortening citizenship?
@@ -43,40 +43,47 @@ import test.{Generators, TestPeers, TestPeersSpec}
 //   - parameters -> params (and the same for types)
 
 object BlockCreationEndTimeGen {
-    type BlockCreationEndTimeGen =  Gen[CardanoNetwork.Section ?=> BlockCreationEndTime]
+    type BlockCreationEndTimeGen = ReaderT[Gen, CardanoNetwork.Section, BlockCreationEndTime]
 
     /** Generate [[BlockCreationEndTime]] between 0 and 10 years from the zero slot time. Good for
       * all tests but Yaci-based ones.
       */
     def generateBlockCreationEndTime: BlockCreationEndTimeGen =
-        Gen
-            .choose(0L, 10 * 365.days.toSeconds)
-            .map(offsetSeconds => (cardanoNetwork : CardanoNetwork.Section) ?=>
-                BlockCreationEndTime(
-                  QuantizedInstant(
-                    slotConfig = cardanoNetwork.slotConfig,
-                    instant = Instant.ofEpochMilli(cardanoNetwork.slotConfig.zeroTime + offsetSeconds * 1_000)
-                  )
+        ReaderT(cardanoNetwork =>
+            Gen
+                .choose(0L, 10 * 365.days.toSeconds)
+                .map(offsetSeconds =>
+                    BlockCreationEndTime(
+                      QuantizedInstant(
+                        slotConfig = cardanoNetwork.slotConfig,
+                        instant = Instant.ofEpochMilli(
+                          cardanoNetwork.slotConfig.zeroTime + offsetSeconds * 1_000
+                        )
+                      )
+                    )
                 )
-            )
+        )
 
     /** This "generator" checks that [[slotConfig]] is usable right now and returns the current time
       * as the block creation end time under given slot configuration. This is supposed to be used
       * with Yaci, when we cannot set the time on L1.
       */
-    final def currentTimeBlockCreationEndTime : BlockCreationEndTimeGen =
+    final def currentTimeBlockCreationEndTime: BlockCreationEndTimeGen =
         val now = Instant.now()
-        Gen.const({
-            (cardanoNetwork : CardanoNetwork.Section) ?=>
-                require(cardanoNetwork.slotConfig.zeroSlot <= now.toEpochMilli, "zero slot time cannot be in the future")
+        ReaderT(cardanoNetwork =>
+            Gen.const {
+                require(
+                  cardanoNetwork.slotConfig.zeroSlot <= now.toEpochMilli,
+                  "zero slot time cannot be in the future"
+                )
 
                 BlockCreationEndTime(
-                    QuantizedInstant(
-                        slotConfig = cardanoNetwork.slotConfig,
-                        instant = now
-                    )
+                  QuantizedInstant(
+                    slotConfig = cardanoNetwork.slotConfig,
+                    instant = now
+                  )
                 )
-        }
+            }
         )
 }
 
@@ -85,13 +92,11 @@ object InitializationParametersGenTopDown {
     import BlockCreationEndTimeGen.*
 
     type GenInitializationParameters =
-        (testPeers: TestPeers) => (
+        (
             generateFallbackContingency: FallbackContingencyGen,
             generateGenesisUtxosL1: GenesisUtxosGen,
             equityRange: (Coin, Coin)
-        ) => Gen[
-          InitializationParameters
-        ]
+        ) => ReaderT[Gen, TestPeers, InitializationParameters]
 
     type GenInitializationParameters2 =
         (
@@ -103,7 +108,7 @@ object InitializationParametersGenTopDown {
           InitializationParameters
         ]
 
-    type GenesisUtxosGen = CardanoNetwork => Gen[Map[HeadPeerNumber, Utxos]]
+    type GenesisUtxosGen = ReaderT[Gen, CardanoNetwork.Section, Map[HeadPeerNumber, Utxos]]
 
     case class GenWithDeps(
         generator: GenInitializationParameters = generateInitializationParameters,
@@ -123,49 +128,54 @@ object InitializationParametersGenTopDown {
       *
       * Support multi assets.
       */
-    def generateInitializationParameters(testPeers: TestPeers)(
+    def generateInitializationParameters(
         generateFallbackContingency: FallbackContingencyGen = generateFallbackContingency,
         generateGenesisUtxosL1: GenesisUtxosGen,
         equityRange: (Coin, Coin) = Coin(5_000_000) -> Coin(500_000_000)
-    ): Gen[InitializationParameters] =
+    ): ReaderT[Gen, TestPeers, InitializationParameters] =
         for {
-            cardanoNetwork <- Gen.const(testPeers.network)
+            testPeers <- ask
+            cardanoNetwork = testPeers.cardanoNetwork
             fallbackContingency <- generateFallbackContingency
-            genesisUtxos <- generateGenesisUtxosL1(cardanoNetwork)
+            genesisUtxos <- generateGenesisUtxosL1
 
             // We are calculating equity upfront to avoid using .suchThat
-            totalEquity <- Gen.choose(equityRange._1, equityRange._2)
+            totalEquity <- liftF(Gen.choose(equityRange._1, equityRange._2))
             peersEquity: SortedMap[HeadPeerNumber, Coin] <-
-                Gen.listOfN(
-                  testPeers.nHeadPeers - 1,
-                  Gen.frequency(3 -> Gen.const(0), 7 -> Gen.choose(1, 10))
-                ).map(tail => NonEmptyList.apply(1, tail))
-                    .map(ws => unsafeNormalizeWeights[Int](ws, Rational.apply))
-                    .map(_.distribute(SafeLong.apply(totalEquity.value)))
-                    .map(_.zipWithIndex)
-                    .map(
-                      _.map((coinSL, ix) => HeadPeerNumber(ix) -> Coin(coinSL.getLong.get)).toList
-                          .to(SortedMap)
-                    )
+                liftF(
+                  Gen.listOfN(
+                    testPeers.nHeadPeers - 1,
+                    Gen.frequency(3 -> Gen.const(0), 7 -> Gen.choose(1, 10))
+                  ).map(tail => NonEmptyList.apply(1, tail))
+                      .map(ws => unsafeNormalizeWeights[Int](ws, Rational.apply))
+                      .map(_.distribute(SafeLong.apply(totalEquity.value)))
+                      .map(_.zipWithIndex)
+                      .map(
+                        _.map((coinSL, ix) => HeadPeerNumber(ix) -> Coin(coinSL.getLong.get)).toList
+                            .to(SortedMap)
+                      )
+                )
 
             // Peers' contributions
-            contributions <- Gen.sequence[List[Contribution], Contribution](
-              testPeers.headPeerNums
-                  .map(hpn =>
-                      generatePeerContribution(
-                        headPeerNumber = hpn,
-                        peerUtxos = genesisUtxos(hpn),
-                        fallbackContingency = fallbackContingency(using cardanoNetwork),
-                        peerEquity = peersEquity(hpn),
-                        cardanoNetwork = cardanoNetwork
-                      )
-                  )
-                  .toList
+            contributions <- liftF(
+              Gen.sequence[List[Contribution], Contribution](
+                testPeers.headPeerNums
+                    .map(hpn =>
+                        generatePeerContribution(
+                          headPeerNumber = hpn,
+                          peerUtxos = genesisUtxos(hpn),
+                          fallbackContingency = fallbackContingency,
+                          peerEquity = peersEquity(hpn),
+                          cardanoNetwork = cardanoNetwork
+                        )
+                    )
+                    .toList
+              )
             )
 
             // Combining together, .get is safe since it's derived from non-empty [[testPeers]]
             total = Semigroup.combineAllOption(contributions).get
-            seedUtxo <- Gen.oneOf(total.fundingUtxos)
+            seedUtxo <- liftF(Gen.oneOf(total.fundingUtxos))
             genesisId = L2Genesis.mkGenesisId(seedUtxo.input)
 
             initialEvacuationMap =
@@ -388,7 +398,6 @@ end CappedValueGen
 // ===================================
 
 object InitializationParametersGenBottomUp {
-    import BlockCreationEndTimeGen.*
 
     /**   - An L2 utxo set that contains only pub key, ada-only utxos, spendable by some test peer
       *   - A seed utxo from a known peer with enough ada to cover the l2 utxo set
@@ -404,54 +413,58 @@ object InitializationParametersGenBottomUp {
       */
 
     type GenInitializationParameters =
-        TestPeers => (FallbackContingencyGen) => Gen[
-          InitializationParameters
-        ]
+        FallbackContingencyGen => ReaderT[Gen, TestPeers, InitializationParameters]
 
-    def generateInitializationParameters(testPeers: TestPeers)(
-        generateFallbackContingency: FallbackContingencyGen = generateFallbackContingency
-    ): Gen[InitializationParameters] =
+    def generateInitializationParameters(
+        fallbackContingencyGen: FallbackContingencyGen = generateFallbackContingency
+    ): ReaderT[Gen, TestPeers, InitializationParameters] =
         for {
-            cardanoNetwork <- Gen.const(testPeers.network)
+            testPeers <- ask
+            cardanoNetwork = testPeers.cardanoNetwork
 
-            fallbackContingency <- generateFallbackContingency
+            fallbackContingency <- fallbackContingencyGen
 
-            nUtxos <- Gen.choose(1, 20)
+            nUtxos <- liftF(Gen.choose(1, 20))
             // Pubkey utxos (at least one) at some peer address(es), with at least 5 ada
             // We generate these up front so that we know they have the same multiassets
             utxos: Utxos <-
-                Generators.Other
-                    .genSequencedValueDistribution(
-                      nValues = nUtxos,
-                      minCoin = Coin.ada(5),
-                      mapping = v =>
-                          for {
-                              peer <- Gen.oneOf(testPeers.headPeerNums.toList)
-                              utxo <- genPubKeyUtxo(
-                                address = testPeers.addressFor(peer),
-                                genValue = Gen.const(v)
-                              )(using cardanoNetwork)
-                          } yield utxo
-                    )
-                    .map(nel => Map.from(nel.toList.map(_.toTuple)))
+                liftF(
+                  Generators.Other
+                      .genSequencedValueDistribution(
+                        nValues = nUtxos,
+                        minCoin = Coin.ada(5),
+                        mapping = v =>
+                            for {
+                                peer <- Gen.oneOf(testPeers.headPeerNums.toList)
+                                utxo <- genPubKeyUtxo(
+                                  address = testPeers.addressFor(peer),
+                                  genValue = Gen.const(v)
+                                )(using cardanoNetwork)
+                            } yield utxo
+                      )
+                      .map(nel => Map.from(nel.toList.map(_.toTuple)))
+                )
 
             // Results in at least one change utxo and zero or more l2 utxos
-            (changeUtxos, l2Utxos) <- Gen
-                .choose(1, utxos.size)
-                .map(index => utxos.splitAt(index))
+            changeAndL2Utxos <- liftF(
+              Gen
+                  .choose(1, utxos.size)
+                  .map(index => utxos.splitAt(index))
+            )
 
+            (changeUtxos, l2Utxos) = changeAndL2Utxos
             l2Value = l2Utxos.values.map(_.value).fold(Value.zero)(_ + _)
 
-            equityContributions <- generateEquityContributions(testPeers.nHeadPeers)
+            equityContributions <- liftF(generateEquityContributions(testPeers.nHeadPeers))
             equity = equityContributions.toSortedMap.values.map(Value(_)) |> Value.combine
 
             changeAmount = changeUtxos.map(_._2.value) |> Value.combine
 
             grossFundingAmount = equity
                 + l2Value
-                + Value(fallbackContingency(using cardanoNetwork).collectiveContingency.total)
+                + Value(fallbackContingency.collectiveContingency.total)
                 + Value.lovelace(
-                  fallbackContingency(using cardanoNetwork).individualContingency.total.value * testPeers.nHeadPeers
+                  fallbackContingency.individualContingency.total.value * testPeers.nHeadPeers
                 )
                 + changeAmount
 
@@ -466,14 +479,14 @@ object InitializationParametersGenBottomUp {
                 } yield utxo
 
             fundingUtxosList <-
-                for {
+                liftF(for {
                     nFundingUtxos <- Gen.choose(1, 20)
                     utxos <- Gen.listOfN(nFundingUtxos, genUtxoFromKnownPeer)
                     distributed <- genValueDistributionWithMinAdaUtxo(
                       value = grossFundingAmount,
                       utxoList = NonEmptyList.fromListUnsafe(utxos),
                     )(using cardanoNetwork)
-                } yield distributed
+                } yield distributed)
 
             seedUtxo = fundingUtxosList.head
             additionalFundingUtxos: Utxos = Map.from(
@@ -514,10 +527,14 @@ object InitializationParametersTest extends Properties("Initialization Parameter
           .generate()
           .flatMap(TestPeers.generate)
           .flatMap(testPeers =>
-              InitializationParametersGenTopDown.generateInitializationParameters(testPeers)(
-                generateGenesisUtxosL1 = cn =>
-                    yaciTestSauceGenesis(cn.network)(testPeers).map((k, v) => k.headPeerNumber -> v)
-              )
+              InitializationParametersGenTopDown
+                  .generateInitializationParameters(
+                    generateGenesisUtxosL1 = ReaderT((cn: CardanoNetwork.Section) =>
+                        yaciTestSauceGenesis(cn.network)(testPeers)
+                            .map((k, v) => k.headPeerNumber -> v)
+                    )
+                  )
+                  .run(testPeers)
           )
     )(_ => true)
 
@@ -525,7 +542,7 @@ object InitializationParametersTest extends Properties("Initialization Parameter
       TestPeersSpec
           .generate()
           .flatMap(TestPeers.generate)
-          .flatMap(InitializationParametersGenBottomUp.generateInitializationParameters(_)())
+          .flatMap(InitializationParametersGenBottomUp.generateInitializationParameters().run(_))
     )(_ => true)
 
 }

--- a/src/test/scala/hydrozoa/config/head/initialization/InitializationParametersGen.scala
+++ b/src/test/scala/hydrozoa/config/head/initialization/InitializationParametersGen.scala
@@ -5,7 +5,7 @@ import cats.data.*
 import cats.data.Kleisli.{ask, liftF}
 import cats.syntax.all.*
 import hydrozoa.config.head.initialization.InitializationParameters.HeadId
-import hydrozoa.config.head.multisig.fallback.{FallbackContingency, FallbackContingencyGen, generateFallbackContingency}
+import hydrozoa.config.head.multisig.fallback.{FallbackContingency, generateFallbackContingency}
 import hydrozoa.config.head.multisig.timing.TxTiming.BlockTimes.BlockCreationEndTime
 import hydrozoa.config.head.network.CardanoNetwork
 import hydrozoa.config.head.network.CardanoNetwork.ensureMinAda
@@ -34,8 +34,7 @@ import spire.math.{Rational, SafeLong}
 import test.Generators.Hydrozoa.*
 import test.Generators.Other.genValueDistributionWithMinAdaUtxo
 import test.Generators.loggerGenerators
-import test.given
-import test.{Generators, TestPeers, TestPeersSpec}
+import test.{GenWithTestPeers, Generators, TestPeers, TestPeersSpec, given}
 
 // TODO: George: what do you think of expanding our shortening citizenship?
 //   - generate -> gen
@@ -43,12 +42,11 @@ import test.{Generators, TestPeers, TestPeersSpec}
 //   - parameters -> params (and the same for types)
 
 object BlockCreationEndTimeGen {
-    type BlockCreationEndTimeGen = ReaderT[Gen, CardanoNetwork.Section, BlockCreationEndTime]
 
     /** Generate [[BlockCreationEndTime]] between 0 and 10 years from the zero slot time. Good for
       * all tests but Yaci-based ones.
       */
-    def generateBlockCreationEndTime: BlockCreationEndTimeGen =
+    def generateBlockCreationEndTime: GenWithTestPeers[BlockCreationEndTime] =
         ReaderT(cardanoNetwork =>
             Gen
                 .choose(0L, 10 * 365.days.toSeconds)
@@ -68,7 +66,7 @@ object BlockCreationEndTimeGen {
       * as the block creation end time under given slot configuration. This is supposed to be used
       * with Yaci, when we cannot set the time on L1.
       */
-    final def currentTimeBlockCreationEndTime: BlockCreationEndTimeGen =
+    final def currentTimeBlockCreationEndTime: GenWithTestPeers[BlockCreationEndTime] =
         val now = Instant.now()
         ReaderT(cardanoNetwork =>
             Gen.const {
@@ -89,30 +87,27 @@ object BlockCreationEndTimeGen {
 
 object InitializationParametersGenTopDown {
     import CappedValueGen.*
-    import BlockCreationEndTimeGen.*
 
     type GenInitializationParameters =
         (
-            generateFallbackContingency: FallbackContingencyGen,
-            generateGenesisUtxosL1: GenesisUtxosGen,
+            generateFallbackContingency: GenWithTestPeers[FallbackContingency],
+            generateGenesisUtxosL1: GenWithTestPeers[Map[HeadPeerNumber, Utxos]],
             equityRange: (Coin, Coin)
-        ) => ReaderT[Gen, TestPeers, InitializationParameters]
+        ) => GenWithTestPeers[InitializationParameters]
 
     type GenInitializationParameters2 =
         (
-            generateHeadStartTime: BlockCreationEndTimeGen,
-            generateFallbackContingency: FallbackContingencyGen,
-            generateGenesisUtxosL1: GenesisUtxosGen,
+            generateHeadStartTime: GenWithTestPeers[BlockCreationEndTime],
+            generateFallbackContingency: GenWithTestPeers[FallbackContingency],
+            generateGenesisUtxosL1: GenWithTestPeers[Map[HeadPeerNumber, Utxos]],
             equityRange: (Coin, Coin)
         ) => Gen[
           InitializationParameters
         ]
 
-    type GenesisUtxosGen = ReaderT[Gen, CardanoNetwork.Section, Map[HeadPeerNumber, Utxos]]
-
     case class GenWithDeps(
         generator: GenInitializationParameters = generateInitializationParameters,
-        generateGenesisUtxosL1: GenesisUtxosGen,
+        generateGenesisUtxosL1: GenWithTestPeers[Map[HeadPeerNumber, Utxos]],
         equityRange: (Coin, Coin) = Coin(5_000_000) -> Coin(500_000_000)
     )
 
@@ -129,10 +124,11 @@ object InitializationParametersGenTopDown {
       * Support multi assets.
       */
     def generateInitializationParameters(
-        generateFallbackContingency: FallbackContingencyGen = generateFallbackContingency,
-        generateGenesisUtxosL1: GenesisUtxosGen,
+        generateFallbackContingency: GenWithTestPeers[FallbackContingency] =
+            generateFallbackContingency,
+        generateGenesisUtxosL1: GenWithTestPeers[Map[HeadPeerNumber, Utxos]],
         equityRange: (Coin, Coin) = Coin(5_000_000) -> Coin(500_000_000)
-    ): ReaderT[Gen, TestPeers, InitializationParameters] =
+    ): GenWithTestPeers[InitializationParameters] =
         for {
             testPeers <- ask
             cardanoNetwork = testPeers.cardanoNetwork
@@ -413,11 +409,11 @@ object InitializationParametersGenBottomUp {
       */
 
     type GenInitializationParameters =
-        FallbackContingencyGen => ReaderT[Gen, TestPeers, InitializationParameters]
+        GenWithTestPeers[FallbackContingency] => GenWithTestPeers[InitializationParameters]
 
     def generateInitializationParameters(
-        fallbackContingencyGen: FallbackContingencyGen = generateFallbackContingency
-    ): ReaderT[Gen, TestPeers, InitializationParameters] =
+        fallbackContingencyGen: GenWithTestPeers[FallbackContingency] = generateFallbackContingency
+    ): GenWithTestPeers[InitializationParameters] =
         for {
             testPeers <- ask
             cardanoNetwork = testPeers.cardanoNetwork

--- a/src/test/scala/hydrozoa/config/head/initialization/InitializationParametersGen.scala
+++ b/src/test/scala/hydrozoa/config/head/initialization/InitializationParametersGen.scala
@@ -125,7 +125,7 @@ object InitializationParametersGenTopDown {
     ): Gen[InitializationParameters] =
         for {
             cardanoNetwork <- Gen.const(testPeers.network)
-            fallbackContingency <- generateFallbackContingency(cardanoNetwork)
+            fallbackContingency <- generateFallbackContingency
             genesisUtxos <- generateGenesisUtxosL1(cardanoNetwork)
 
             // We are calculating equity upfront to avoid using .suchThat
@@ -150,7 +150,7 @@ object InitializationParametersGenTopDown {
                       generatePeerContribution(
                         headPeerNumber = hpn,
                         peerUtxos = genesisUtxos(hpn),
-                        fallbackContingency = fallbackContingency,
+                        fallbackContingency = fallbackContingency(using cardanoNetwork),
                         peerEquity = peersEquity(hpn),
                         cardanoNetwork = cardanoNetwork
                       )
@@ -410,7 +410,7 @@ object InitializationParametersGenBottomUp {
             cardanoNetwork <- Gen.const(testPeers.network)
             headStartTime <- generateBlockCreationEndTime(cardanoNetwork.slotConfig)
 
-            fallbackContingency <- generateFallbackContingency(cardanoNetwork)
+            fallbackContingency <- generateFallbackContingency
 
             nUtxos <- Gen.choose(1, 20)
             // Pubkey utxos (at least one) at some peer address(es), with at least 5 ada
@@ -445,9 +445,9 @@ object InitializationParametersGenBottomUp {
 
             grossFundingAmount = equity
                 + l2Value
-                + Value(fallbackContingency.collectiveContingency.total)
+                + Value(fallbackContingency(using cardanoNetwork).collectiveContingency.total)
                 + Value.lovelace(
-                  fallbackContingency.individualContingency.total.value * testPeers.nHeadPeers
+                  fallbackContingency(using cardanoNetwork).individualContingency.total.value * testPeers.nHeadPeers
                 )
                 + changeAmount
 

--- a/src/test/scala/hydrozoa/config/head/initialization/InitializationParametersGen.scala
+++ b/src/test/scala/hydrozoa/config/head/initialization/InitializationParametersGen.scala
@@ -21,8 +21,10 @@ import hydrozoa.multisig.ledger.joint.obligation.Payout
 import hydrozoa.multisig.ledger.joint.{EvacuationKey, EvacuationMap}
 import hydrozoa.multisig.ledger.l1.token.CIP67
 import hydrozoa.rulebased.ledger.l1.script.plutus.RuleBasedTreasuryValidator.given
+
 import java.time.Instant
 import org.scalacheck.{Gen, Prop, Properties}
+
 import scala.collection.immutable.{SortedMap, TreeMap}
 import scala.concurrent.duration.DurationInt
 import scalus.cardano.address.Address
@@ -41,19 +43,19 @@ import test.{Generators, TestPeers, TestPeersSpec}
 //   - parameters -> params (and the same for types)
 
 object BlockCreationEndTimeGen {
-    type BlockCreationEndTimeGen = SlotConfig => Gen[BlockCreationEndTime]
+    type BlockCreationEndTimeGen =  Gen[CardanoNetwork.Section ?=> BlockCreationEndTime]
 
-    /** Generate [[blockCreationEndTime]] between 0 and 10 years from the zero slot time. Good for
+    /** Generate [[BlockCreationEndTime]] between 0 and 10 years from the zero slot time. Good for
       * all tests but Yaci-based ones.
       */
-    def generateBlockCreationEndTime(slotConfig: SlotConfig): Gen[BlockCreationEndTime] =
+    def generateBlockCreationEndTime: BlockCreationEndTimeGen =
         Gen
             .choose(0L, 10 * 365.days.toSeconds)
-            .map(offsetSeconds =>
+            .map(offsetSeconds => (cardanoNetwork : CardanoNetwork.Section) ?=>
                 BlockCreationEndTime(
                   QuantizedInstant(
-                    slotConfig = slotConfig,
-                    instant = Instant.ofEpochMilli(slotConfig.zeroTime + offsetSeconds * 1_000)
+                    slotConfig = cardanoNetwork.slotConfig,
+                    instant = Instant.ofEpochMilli(cardanoNetwork.slotConfig.zeroTime + offsetSeconds * 1_000)
                   )
                 )
             )
@@ -62,16 +64,19 @@ object BlockCreationEndTimeGen {
       * as the block creation end time under given slot configuration. This is supposed to be used
       * with Yaci, when we cannot set the time on L1.
       */
-    final def currentTimeBlockCreationEndTime(slotConfig: SlotConfig): Gen[BlockCreationEndTime] =
+    final def currentTimeBlockCreationEndTime : BlockCreationEndTimeGen =
         val now = Instant.now()
-        require(slotConfig.zeroSlot <= now.toEpochMilli, "zero slot time cannot be in the future")
-        Gen.const(
-          BlockCreationEndTime(
-            QuantizedInstant(
-              slotConfig = slotConfig,
-              instant = now
-            )
-          )
+        Gen.const({
+            (cardanoNetwork : CardanoNetwork.Section) ?=>
+                require(cardanoNetwork.slotConfig.zeroSlot <= now.toEpochMilli, "zero slot time cannot be in the future")
+
+                BlockCreationEndTime(
+                    QuantizedInstant(
+                        slotConfig = cardanoNetwork.slotConfig,
+                        instant = now
+                    )
+                )
+        }
         )
 }
 
@@ -408,7 +413,6 @@ object InitializationParametersGenBottomUp {
     ): Gen[InitializationParameters] =
         for {
             cardanoNetwork <- Gen.const(testPeers.network)
-            headStartTime <- generateBlockCreationEndTime(cardanoNetwork.slotConfig)
 
             fallbackContingency <- generateFallbackContingency
 

--- a/src/test/scala/hydrozoa/config/head/multisig/fallback/FallbackContingencyGen.scala
+++ b/src/test/scala/hydrozoa/config/head/multisig/fallback/FallbackContingencyGen.scala
@@ -1,22 +1,17 @@
 package hydrozoa.config.head.multisig.fallback
 
-import cats.data.{Reader, ReaderT}
-import hydrozoa.config.head.network.CardanoNetwork
+import cats.data.ReaderT
 import org.scalacheck.Gen
 import scalus.cardano.ledger.Coin
+import test.GenWithTestPeers
 
-type FallbackContingencyGen = ReaderT[Gen, CardanoNetwork.Section, FallbackContingency]
-
-/** TODO: Improve?
-  */
-def mkFallbackContingency: Reader[CardanoNetwork.Section, FallbackContingency] =
-    Reader(cardanoNetwork =>
-        cardanoNetwork.mkFallbackContingencyWithDefaults(
-          tallyTxFee = Coin.ada(3),
-          voteTxFee = Coin.ada(3)
+def generateFallbackContingency: GenWithTestPeers[FallbackContingency] = {
+    ReaderT(cardanoNetwork =>
+        Gen.const(
+          cardanoNetwork.mkFallbackContingencyWithDefaults(
+            tallyTxFee = Coin.ada(3),
+            voteTxFee = Coin.ada(3)
+          )
         )
     )
-
-def generateFallbackContingency: FallbackContingencyGen = {
-    ReaderT(network => Gen.const(mkFallbackContingency(network)))
 }

--- a/src/test/scala/hydrozoa/config/head/multisig/fallback/FallbackContingencyGen.scala
+++ b/src/test/scala/hydrozoa/config/head/multisig/fallback/FallbackContingencyGen.scala
@@ -1,18 +1,22 @@
 package hydrozoa.config.head.multisig.fallback
 
+import cats.data.{Reader, ReaderT}
 import hydrozoa.config.head.network.CardanoNetwork
 import org.scalacheck.Gen
 import scalus.cardano.ledger.Coin
 
-type FallbackContingencyGen =  Gen[CardanoNetwork.Section ?=> FallbackContingency]
+type FallbackContingencyGen = ReaderT[Gen, CardanoNetwork.Section, FallbackContingency]
 
 /** TODO: Improve?
   */
-def mkFallbackContingency(using cardanoNetwork: CardanoNetwork.Section): FallbackContingency =
-      cardanoNetwork.mkFallbackContingencyWithDefaults(
-        tallyTxFee = Coin.ada(3),
-        voteTxFee = Coin.ada(3)
+def mkFallbackContingency: Reader[CardanoNetwork.Section, FallbackContingency] =
+    Reader(cardanoNetwork =>
+        cardanoNetwork.mkFallbackContingencyWithDefaults(
+          tallyTxFee = Coin.ada(3),
+          voteTxFee = Coin.ada(3)
+        )
     )
 
-def generateFallbackContingency : FallbackContingencyGen =
-    (_ : CardanoNetwork.Section) ?=> mkFallbackContingency
+def generateFallbackContingency: FallbackContingencyGen = {
+    ReaderT(network => Gen.const(mkFallbackContingency(network)))
+}

--- a/src/test/scala/hydrozoa/config/head/multisig/fallback/FallbackContingencyGen.scala
+++ b/src/test/scala/hydrozoa/config/head/multisig/fallback/FallbackContingencyGen.scala
@@ -4,14 +4,15 @@ import hydrozoa.config.head.network.CardanoNetwork
 import org.scalacheck.Gen
 import scalus.cardano.ledger.Coin
 
-type FallbackContingencyGen = CardanoNetwork => Gen[FallbackContingency]
+type FallbackContingencyGen =  Gen[CardanoNetwork.Section ?=> FallbackContingency]
 
 /** TODO: Improve?
   */
-def generateFallbackContingency(cardanoNetwork: CardanoNetwork): Gen[FallbackContingency] =
-    Gen.const(
+def mkFallbackContingency(using cardanoNetwork: CardanoNetwork.Section): FallbackContingency =
       cardanoNetwork.mkFallbackContingencyWithDefaults(
         tallyTxFee = Coin.ada(3),
         voteTxFee = Coin.ada(3)
-      )
     )
+
+def generateFallbackContingency : FallbackContingencyGen =
+    (_ : CardanoNetwork.Section) ?=> mkFallbackContingency

--- a/src/test/scala/hydrozoa/config/head/multisig/timing/TxTimingGen.scala
+++ b/src/test/scala/hydrozoa/config/head/multisig/timing/TxTimingGen.scala
@@ -2,25 +2,14 @@ package hydrozoa.config.head.multisig.timing
 
 import cats.*
 import cats.data.*
-import hydrozoa.config.head.network
-import hydrozoa.config.head.network.CardanoNetwork
 import org.scalacheck.Gen
+import test.GenWithTestPeers
 
-type TxTimingGen = ReaderT[Gen, CardanoNetwork.Section, TxTiming]
+def generateDefaultTxTiming: GenWithTestPeers[TxTiming] =
+    ReaderT(network => Gen.const(TxTiming.default(network.slotConfig)))
 
-def generateDefaultTxTiming: TxTimingGen = ReaderT(network => Gen.const(mkDefaultTxTiming(network)))
+def generateYaciTxTiming: GenWithTestPeers[TxTiming] =
+    ReaderT(network => Gen.const(TxTiming.yaci(network.slotConfig)))
 
-def generateYaciTxTiming: TxTimingGen =
-    ReaderT(network => Gen.const(mkYaciTxTiming(network)))
-
-def generateTestnetTxTiming: TxTimingGen =
-    ReaderT(network => mkTestnetTxTiming(network))
-
-def mkDefaultTxTiming: Reader[CardanoNetwork.Section, TxTiming] =
-    Reader(cardanoNetwork => TxTiming.default(cardanoNetwork.slotConfig))
-
-def mkYaciTxTiming: Reader[CardanoNetwork.Section, TxTiming] =
-    Reader(cardanoNetwork => TxTiming.yaci(cardanoNetwork.slotConfig))
-
-def mkTestnetTxTiming: Reader[CardanoNetwork.Section, TxTiming] =
-    Reader(cardanoNetwork => TxTiming.testnet(cardanoNetwork.slotConfig))
+def generateTestnetTxTiming: GenWithTestPeers[TxTiming] =
+    ReaderT(network => TxTiming.testnet(network.slotConfig))

--- a/src/test/scala/hydrozoa/config/head/multisig/timing/TxTimingGen.scala
+++ b/src/test/scala/hydrozoa/config/head/multisig/timing/TxTimingGen.scala
@@ -1,12 +1,27 @@
 package hydrozoa.config.head.multisig.timing
 
+import hydrozoa.config.head.network
+import hydrozoa.config.head.network.CardanoNetwork
 import org.scalacheck.Gen
 import scalus.cardano.ledger.SlotConfig
 
-type TxTimingGen = SlotConfig => Gen[TxTiming]
+type TxTimingGen =  Gen[CardanoNetwork.Section ?=> TxTiming]
 
-def generateDefaultTxTiming = (slotConfig: SlotConfig) => Gen.const(TxTiming.default(slotConfig))
+def generateDefaultTxTiming: TxTimingGen =
+    Gen.const((_ : CardanoNetwork.Section) ?=> mkDefaultTxTiming)
 
-def generateYaciTxTiming = (slotConfig: SlotConfig) => Gen.const(TxTiming.yaci(slotConfig))
+def generateYaciTxTiming: TxTimingGen =
+    Gen.const((_ : CardanoNetwork.Section) ?=> mkYaciTxTiming)
 
-def generateTestnetTxTiming = (slotConfig: SlotConfig) => Gen.const(TxTiming.testnet(slotConfig))
+def generateTestnetTxTiming: TxTimingGen =
+    Gen.const((_ : CardanoNetwork.Section) ?=> mkTestnetTxTiming)
+
+
+def mkDefaultTxTiming(using cardanoNetwork: CardanoNetwork.Section): TxTiming =
+    TxTiming.default(cardanoNetwork.slotConfig)
+
+def mkYaciTxTiming(using cardanoNetwork: CardanoNetwork.Section): TxTiming =
+    TxTiming.yaci(cardanoNetwork.slotConfig)
+
+def mkTestnetTxTiming(using cardanoNetwork: CardanoNetwork.Section): TxTiming =
+    TxTiming.testnet(cardanoNetwork.slotConfig)

--- a/src/test/scala/hydrozoa/config/head/multisig/timing/TxTimingGen.scala
+++ b/src/test/scala/hydrozoa/config/head/multisig/timing/TxTimingGen.scala
@@ -1,27 +1,26 @@
 package hydrozoa.config.head.multisig.timing
 
+import cats.*
+import cats.data.*
 import hydrozoa.config.head.network
 import hydrozoa.config.head.network.CardanoNetwork
 import org.scalacheck.Gen
-import scalus.cardano.ledger.SlotConfig
 
-type TxTimingGen =  Gen[CardanoNetwork.Section ?=> TxTiming]
+type TxTimingGen = ReaderT[Gen, CardanoNetwork.Section, TxTiming]
 
-def generateDefaultTxTiming: TxTimingGen =
-    Gen.const((_ : CardanoNetwork.Section) ?=> mkDefaultTxTiming)
+def generateDefaultTxTiming: TxTimingGen = ReaderT(network => Gen.const(mkDefaultTxTiming(network)))
 
 def generateYaciTxTiming: TxTimingGen =
-    Gen.const((_ : CardanoNetwork.Section) ?=> mkYaciTxTiming)
+    ReaderT(network => Gen.const(mkYaciTxTiming(network)))
 
 def generateTestnetTxTiming: TxTimingGen =
-    Gen.const((_ : CardanoNetwork.Section) ?=> mkTestnetTxTiming)
+    ReaderT(network => mkTestnetTxTiming(network))
 
+def mkDefaultTxTiming: Reader[CardanoNetwork.Section, TxTiming] =
+    Reader(cardanoNetwork => TxTiming.default(cardanoNetwork.slotConfig))
 
-def mkDefaultTxTiming(using cardanoNetwork: CardanoNetwork.Section): TxTiming =
-    TxTiming.default(cardanoNetwork.slotConfig)
+def mkYaciTxTiming: Reader[CardanoNetwork.Section, TxTiming] =
+    Reader(cardanoNetwork => TxTiming.yaci(cardanoNetwork.slotConfig))
 
-def mkYaciTxTiming(using cardanoNetwork: CardanoNetwork.Section): TxTiming =
-    TxTiming.yaci(cardanoNetwork.slotConfig)
-
-def mkTestnetTxTiming(using cardanoNetwork: CardanoNetwork.Section): TxTiming =
-    TxTiming.testnet(cardanoNetwork.slotConfig)
+def mkTestnetTxTiming: Reader[CardanoNetwork.Section, TxTiming] =
+    Reader(cardanoNetwork => TxTiming.testnet(cardanoNetwork.slotConfig))

--- a/src/test/scala/hydrozoa/config/head/parameters/HeadParametersGen.scala
+++ b/src/test/scala/hydrozoa/config/head/parameters/HeadParametersGen.scala
@@ -19,14 +19,17 @@ def generateHeadParameters(cardanoNetwork: CardanoNetwork)(
     generateFallbackContingency: FallbackContingencyGen = generateFallbackContingency,
     generateDisputeResolutionConfig: DisputeResolutionConfigGen = generateDisputeResolutionConfig,
     generateSettlementConfig: Gen[SettlementConfig] = generateSettlementConfig
-): Gen[HeadParameters] = for {
-    txTiming <- generateTxTiming(cardanoNetwork.slotConfig)
-    fallbackContingency <- generateFallbackContingency(cardanoNetwork)
-    disputeResolutionConfig <- generateDisputeResolutionConfig(cardanoNetwork.slotConfig)
-    settlementConfig <- generateSettlementConfig
-} yield HeadParameters(
-  txTiming = txTiming,
-  fallbackContingency = fallbackContingency,
-  disputeResolutionConfig = disputeResolutionConfig,
-  settlementConfig = settlementConfig
-)
+): Gen[HeadParameters] = {
+    given CardanoNetwork = cardanoNetwork
+    for {
+        txTiming <- generateTxTiming
+        fallbackContingency <- generateFallbackContingency
+        disputeResolutionConfig <- generateDisputeResolutionConfig
+        settlementConfig <- generateSettlementConfig
+    } yield HeadParameters(
+        txTiming = txTiming,
+        fallbackContingency = fallbackContingency,
+        disputeResolutionConfig = disputeResolutionConfig,
+        settlementConfig = settlementConfig
+    )
+}

--- a/src/test/scala/hydrozoa/config/head/parameters/HeadParametersGen.scala
+++ b/src/test/scala/hydrozoa/config/head/parameters/HeadParametersGen.scala
@@ -1,13 +1,15 @@
 package hydrozoa.config.head.parameters
 
+import cats.data.*
 import hydrozoa.config.head.multisig.fallback.{FallbackContingencyGen, generateFallbackContingency}
 import hydrozoa.config.head.multisig.settlement.{SettlementConfig, generateSettlementConfig}
 import hydrozoa.config.head.multisig.timing.{TxTimingGen, generateDefaultTxTiming}
 import hydrozoa.config.head.network.CardanoNetwork
 import hydrozoa.config.head.rulebased.{DisputeResolutionConfigGen, generateDisputeResolutionConfig}
 import org.scalacheck.Gen
+import test.given
 
-type GenHeadParams = Gen[CardanoNetwork.Section ?=> HeadParameters]
+type GenHeadParams = ReaderT[Gen, CardanoNetwork.Section, HeadParameters]
 
 def generateHeadParameters(
     generateTxTiming: TxTimingGen = generateDefaultTxTiming,
@@ -19,11 +21,11 @@ def generateHeadParameters(
         txTiming <- generateTxTiming
         fallbackContingency <- generateFallbackContingency
         disputeResolutionConfig <- generateDisputeResolutionConfig
-        settlementConfig <- generateSettlementConfig
-    } yield (_ : CardanoNetwork.Section) ?=> HeadParameters(
-        txTiming = txTiming,
-        fallbackContingency = fallbackContingency,
-        disputeResolutionConfig = disputeResolutionConfig,
-        settlementConfig = settlementConfig
+        settlementConfig <- ReaderT.liftF(generateSettlementConfig)
+    } yield HeadParameters(
+      txTiming = txTiming,
+      fallbackContingency = fallbackContingency.fallbackContingency,
+      disputeResolutionConfig = disputeResolutionConfig,
+      settlementConfig = settlementConfig
     )
 }

--- a/src/test/scala/hydrozoa/config/head/parameters/HeadParametersGen.scala
+++ b/src/test/scala/hydrozoa/config/head/parameters/HeadParametersGen.scala
@@ -7,26 +7,20 @@ import hydrozoa.config.head.network.CardanoNetwork
 import hydrozoa.config.head.rulebased.{DisputeResolutionConfigGen, generateDisputeResolutionConfig}
 import org.scalacheck.Gen
 
-type GenHeadParams = CardanoNetwork => (
-    TxTimingGen,
-    FallbackContingencyGen,
-    DisputeResolutionConfigGen,
-    Gen[SettlementConfig]
-) => Gen[HeadParameters]
+type GenHeadParams = Gen[CardanoNetwork.Section ?=> HeadParameters]
 
-def generateHeadParameters(cardanoNetwork: CardanoNetwork)(
+def generateHeadParameters(
     generateTxTiming: TxTimingGen = generateDefaultTxTiming,
     generateFallbackContingency: FallbackContingencyGen = generateFallbackContingency,
     generateDisputeResolutionConfig: DisputeResolutionConfigGen = generateDisputeResolutionConfig,
     generateSettlementConfig: Gen[SettlementConfig] = generateSettlementConfig
-): Gen[HeadParameters] = {
-    given CardanoNetwork = cardanoNetwork
+): GenHeadParams = {
     for {
         txTiming <- generateTxTiming
         fallbackContingency <- generateFallbackContingency
         disputeResolutionConfig <- generateDisputeResolutionConfig
         settlementConfig <- generateSettlementConfig
-    } yield HeadParameters(
+    } yield (_ : CardanoNetwork.Section) ?=> HeadParameters(
         txTiming = txTiming,
         fallbackContingency = fallbackContingency,
         disputeResolutionConfig = disputeResolutionConfig,

--- a/src/test/scala/hydrozoa/config/head/parameters/HeadParametersGen.scala
+++ b/src/test/scala/hydrozoa/config/head/parameters/HeadParametersGen.scala
@@ -1,22 +1,21 @@
 package hydrozoa.config.head.parameters
 
 import cats.data.*
-import hydrozoa.config.head.multisig.fallback.{FallbackContingencyGen, generateFallbackContingency}
+import hydrozoa.config.head.multisig.fallback.{FallbackContingency, generateFallbackContingency}
 import hydrozoa.config.head.multisig.settlement.{SettlementConfig, generateSettlementConfig}
-import hydrozoa.config.head.multisig.timing.{TxTimingGen, generateDefaultTxTiming}
-import hydrozoa.config.head.network.CardanoNetwork
-import hydrozoa.config.head.rulebased.{DisputeResolutionConfigGen, generateDisputeResolutionConfig}
+import hydrozoa.config.head.multisig.timing.{TxTiming, generateDefaultTxTiming}
+import hydrozoa.config.head.rulebased.dispute.{DisputeResolutionConfig, generateDisputeResolutionConfig}
 import org.scalacheck.Gen
-import test.given
-
-type GenHeadParams = ReaderT[Gen, CardanoNetwork.Section, HeadParameters]
+import test.{GenWithTestPeers, given}
 
 def generateHeadParameters(
-    generateTxTiming: TxTimingGen = generateDefaultTxTiming,
-    generateFallbackContingency: FallbackContingencyGen = generateFallbackContingency,
-    generateDisputeResolutionConfig: DisputeResolutionConfigGen = generateDisputeResolutionConfig,
+    generateTxTiming: GenWithTestPeers[TxTiming] = generateDefaultTxTiming,
+    generateFallbackContingency: GenWithTestPeers[FallbackContingency] =
+        generateFallbackContingency,
+    generateDisputeResolutionConfig: GenWithTestPeers[DisputeResolutionConfig] =
+        generateDisputeResolutionConfig,
     generateSettlementConfig: Gen[SettlementConfig] = generateSettlementConfig
-): GenHeadParams = {
+): GenWithTestPeers[HeadParameters] = {
     for {
         txTiming <- generateTxTiming
         fallbackContingency <- generateFallbackContingency

--- a/src/test/scala/hydrozoa/config/head/rulebased/dispute/DisputeResolutionConfigGen.scala
+++ b/src/test/scala/hydrozoa/config/head/rulebased/dispute/DisputeResolutionConfigGen.scala
@@ -1,21 +1,13 @@
-package hydrozoa.config.head.rulebased
+package hydrozoa.config.head.rulebased.dispute
 
 import cats.*
 import cats.data.*
-import hydrozoa.config.head.network.CardanoNetwork
-import hydrozoa.config.head.rulebased.dispute.DisputeResolutionConfig
 import hydrozoa.lib.cardano.scalus.QuantizedTime.QuantizedFiniteDuration
 import org.scalacheck.Gen
 import scala.concurrent.duration.DurationInt
-import test.given
+import test.{GenWithTestPeers, given}
 
-// Not setting a default on purpose. 90% of the time you will want this to
-// be coherent with some other slot config, so it's better to force the user
-// to pass None explicitly.
-
-type DisputeResolutionConfigGen = ReaderT[Gen, CardanoNetwork.Section, DisputeResolutionConfig]
-
-def generateDisputeResolutionConfig: DisputeResolutionConfigGen =
+def generateDisputeResolutionConfig: GenWithTestPeers[DisputeResolutionConfig] =
     for {
         cardanoNetwork <- Kleisli.ask
         // 1 hour to 5 days

--- a/src/test/scala/hydrozoa/config/head/rulebased/dispute/DisputeResolutionConfigGen.scala
+++ b/src/test/scala/hydrozoa/config/head/rulebased/dispute/DisputeResolutionConfigGen.scala
@@ -1,8 +1,10 @@
 package hydrozoa.config.head.rulebased
 
+import hydrozoa.config.head.network.CardanoNetwork
 import hydrozoa.config.head.rulebased.dispute.DisputeResolutionConfig
 import hydrozoa.lib.cardano.scalus.QuantizedTime.QuantizedFiniteDuration
 import org.scalacheck.Gen
+
 import scala.concurrent.duration.DurationInt
 import scalus.cardano.ledger.SlotConfig
 
@@ -10,16 +12,16 @@ import scalus.cardano.ledger.SlotConfig
 // be coherent with some other slot config, so it's better to force the user
 // to pass None explicitly.
 
-type DisputeResolutionConfigGen = Gen[SlotConfig] => Gen[DisputeResolutionConfig]
+type DisputeResolutionConfigGen = Gen[CardanoNetwork.Section ?=> DisputeResolutionConfig]
 
-def generateDisputeResolutionConfig(
-    genSlotConfig: Gen[SlotConfig]
-): Gen[DisputeResolutionConfig] =
+def generateDisputeResolutionConfig: Gen[CardanoNetwork.Section ?=> DisputeResolutionConfig] =
     for {
-        slotConfig <- genSlotConfig
         // 1 hour to 5 days
         seconds <- Gen.choose(60 * 60, 60 * 60 * 24 * 5)
-    } yield DisputeResolutionConfig(
-      votingDuration =
-          QuantizedFiniteDuration(slotConfig = slotConfig, finiteDuration = seconds.seconds)
-    )
+    } yield {
+        (cardanoNetwork: CardanoNetwork.Section) ?=>
+            DisputeResolutionConfig(
+                votingDuration =
+                    QuantizedFiniteDuration(slotConfig = cardanoNetwork.slotConfig, finiteDuration = seconds.seconds)
+            )
+    }

--- a/src/test/scala/hydrozoa/config/head/rulebased/dispute/DisputeResolutionConfigGen.scala
+++ b/src/test/scala/hydrozoa/config/head/rulebased/dispute/DisputeResolutionConfigGen.scala
@@ -1,27 +1,31 @@
 package hydrozoa.config.head.rulebased
 
+import cats.*
+import cats.data.*
 import hydrozoa.config.head.network.CardanoNetwork
 import hydrozoa.config.head.rulebased.dispute.DisputeResolutionConfig
 import hydrozoa.lib.cardano.scalus.QuantizedTime.QuantizedFiniteDuration
 import org.scalacheck.Gen
-
 import scala.concurrent.duration.DurationInt
-import scalus.cardano.ledger.SlotConfig
+import test.given
 
 // Not setting a default on purpose. 90% of the time you will want this to
 // be coherent with some other slot config, so it's better to force the user
 // to pass None explicitly.
 
-type DisputeResolutionConfigGen = Gen[CardanoNetwork.Section ?=> DisputeResolutionConfig]
+type DisputeResolutionConfigGen = ReaderT[Gen, CardanoNetwork.Section, DisputeResolutionConfig]
 
-def generateDisputeResolutionConfig: Gen[CardanoNetwork.Section ?=> DisputeResolutionConfig] =
+def generateDisputeResolutionConfig: DisputeResolutionConfigGen =
     for {
+        cardanoNetwork <- Kleisli.ask
         // 1 hour to 5 days
-        seconds <- Gen.choose(60 * 60, 60 * 60 * 24 * 5)
+        seconds <- ReaderT.liftF(Gen.choose(60 * 60, 60 * 60 * 24 * 5))
     } yield {
-        (cardanoNetwork: CardanoNetwork.Section) ?=>
-            DisputeResolutionConfig(
-                votingDuration =
-                    QuantizedFiniteDuration(slotConfig = cardanoNetwork.slotConfig, finiteDuration = seconds.seconds)
-            )
+
+        DisputeResolutionConfig(
+          votingDuration = QuantizedFiniteDuration(
+            slotConfig = cardanoNetwork.slotConfig,
+            finiteDuration = seconds.seconds
+          )
+        )
     }

--- a/src/test/scala/hydrozoa/config/node/MultiNodeConfig.scala
+++ b/src/test/scala/hydrozoa/config/node/MultiNodeConfig.scala
@@ -106,7 +106,7 @@ object MultiNodeConfig {
         generateFallbackContingency: FallbackContingencyGen = generateFallbackContingency,
         generateDisputeResolutionConfig: DisputeResolutionConfigGen =
             generateDisputeResolutionConfig,
-        generateHeadParameters: GenHeadParams = generateHeadParameters,
+        generateHeadParameters: GenHeadParams = generateHeadParameters(),
         generateInitializationParameters: InitializationParametersGenBottomUp.GenInitializationParameters |
             InitializationParametersGenTopDown.GenWithDeps =
             InitializationParametersGenBottomUp.generateInitializationParameters,
@@ -120,9 +120,6 @@ object MultiNodeConfig {
         ret <- generateForTestPeers(testPeers)(
           generateHeadConfig,
           generateHeadStartTime,
-          generateTxTiming,
-          generateFallbackContingency,
-          generateDisputeResolutionConfig,
           generateHeadParameters,
           generateInitializationParameters,
           generateNodeOperationEvacuationConfig,
@@ -135,11 +132,7 @@ object MultiNodeConfig {
         generateHeadConfig: HeadConfigGen = hydrozoa.config.head.generateHeadConfig,
         generateBlockCreationEndTime: SlotConfig => Gen[BlockCreationEndTime] =
             currentTimeBlockCreationEndTime,
-        generateTxTiming: TxTimingGen = generateDefaultTxTiming,
-        generateFallbackContingency: FallbackContingencyGen = generateFallbackContingency,
-        generateDisputeResolutionConfig: DisputeResolutionConfigGen =
-            generateDisputeResolutionConfig,
-        generateHeadParameters: GenHeadParams = generateHeadParameters,
+        generateHeadParameters: GenHeadParams = generateHeadParameters(),
         generateInitializationParameters: InitializationParametersGenBottomUp.GenInitializationParameters |
             InitializationParametersGenTopDown.GenWithDeps =
             InitializationParametersGenBottomUp.generateInitializationParameters,
@@ -152,9 +145,6 @@ object MultiNodeConfig {
         for {
             headConfig <- generateHeadConfig(testPeers)(
               generateBlockCreationEndTime = generateBlockCreationEndTime,
-              generateTxTiming = generateTxTiming,
-              generateFallbackContingency = generateFallbackContingency,
-              generateDisputeResolutionConfig = generateDisputeResolutionConfig,
               generateHeadParameters = generateHeadParameters,
               generateInitializationParameters = generateInitializationParameters,
             )

--- a/src/test/scala/hydrozoa/config/node/MultiNodeConfig.scala
+++ b/src/test/scala/hydrozoa/config/node/MultiNodeConfig.scala
@@ -2,7 +2,7 @@ package hydrozoa.config.node
 
 import cats.data.NonEmptyList
 import cats.effect.unsafe.IORuntime
-import hydrozoa.config.head.initialization.BlockCreationEndTimeGen.currentTimeBlockCreationEndTime
+import hydrozoa.config.head.initialization.BlockCreationEndTimeGen.{BlockCreationEndTimeGen, currentTimeBlockCreationEndTime}
 import hydrozoa.config.head.initialization.{InitializationParametersGenBottomUp, InitializationParametersGenTopDown}
 import hydrozoa.config.head.multisig.fallback.{FallbackContingencyGen, generateFallbackContingency, mkFallbackContingency}
 import hydrozoa.config.head.multisig.timing.TxTiming.BlockTimes.BlockCreationEndTime
@@ -100,12 +100,8 @@ object MultiNodeConfig {
 
     def generate(spec: TestPeersSpec)(
         generateHeadConfig: HeadConfigGen = hydrozoa.config.head.generateHeadConfig,
-        generateHeadStartTime: SlotConfig => Gen[BlockCreationEndTime] =
+        generateHeadStartTime: BlockCreationEndTimeGen =
             currentTimeBlockCreationEndTime,
-        generateTxTiming: TxTimingGen = generateDefaultTxTiming,
-        generateFallbackContingency: FallbackContingencyGen = generateFallbackContingency,
-        generateDisputeResolutionConfig: DisputeResolutionConfigGen =
-            generateDisputeResolutionConfig,
         generateHeadParameters: GenHeadParams = generateHeadParameters(),
         generateInitializationParameters: InitializationParametersGenBottomUp.GenInitializationParameters |
             InitializationParametersGenTopDown.GenWithDeps =
@@ -130,7 +126,7 @@ object MultiNodeConfig {
 
     def generateForTestPeers(testPeers: TestPeers)(
         generateHeadConfig: HeadConfigGen = hydrozoa.config.head.generateHeadConfig,
-        generateBlockCreationEndTime: SlotConfig => Gen[BlockCreationEndTime] =
+        generateBlockCreationEndTime: BlockCreationEndTimeGen =
             currentTimeBlockCreationEndTime,
         generateHeadParameters: GenHeadParams = generateHeadParameters(),
         generateInitializationParameters: InitializationParametersGenBottomUp.GenInitializationParameters |

--- a/src/test/scala/hydrozoa/config/node/MultiNodeConfig.scala
+++ b/src/test/scala/hydrozoa/config/node/MultiNodeConfig.scala
@@ -4,7 +4,7 @@ import cats.data.NonEmptyList
 import cats.effect.unsafe.IORuntime
 import hydrozoa.config.head.initialization.BlockCreationEndTimeGen.currentTimeBlockCreationEndTime
 import hydrozoa.config.head.initialization.{InitializationParametersGenBottomUp, InitializationParametersGenTopDown}
-import hydrozoa.config.head.multisig.fallback.{FallbackContingencyGen, generateFallbackContingency}
+import hydrozoa.config.head.multisig.fallback.{FallbackContingencyGen, generateFallbackContingency, mkFallbackContingency}
 import hydrozoa.config.head.multisig.timing.TxTiming.BlockTimes.BlockCreationEndTime
 import hydrozoa.config.head.multisig.timing.{TxTimingGen, generateDefaultTxTiming}
 import hydrozoa.config.head.network.CardanoNetwork

--- a/src/test/scala/hydrozoa/config/node/MultiNodeConfig.scala
+++ b/src/test/scala/hydrozoa/config/node/MultiNodeConfig.scala
@@ -1,16 +1,9 @@
 package hydrozoa.config.node
 
-import cats.data.NonEmptyList
+import cats.data.Kleisli.liftF
+import cats.data.{NonEmptyList, ReaderT}
 import cats.effect.unsafe.IORuntime
-import hydrozoa.config.head.initialization.BlockCreationEndTimeGen.{BlockCreationEndTimeGen, currentTimeBlockCreationEndTime}
-import hydrozoa.config.head.initialization.{InitializationParametersGenBottomUp, InitializationParametersGenTopDown}
-import hydrozoa.config.head.multisig.fallback.{FallbackContingencyGen, generateFallbackContingency, mkFallbackContingency}
-import hydrozoa.config.head.multisig.timing.TxTiming.BlockTimes.BlockCreationEndTime
-import hydrozoa.config.head.multisig.timing.{TxTimingGen, generateDefaultTxTiming}
-import hydrozoa.config.head.network.CardanoNetwork
-import hydrozoa.config.head.parameters.{GenHeadParams, generateHeadParameters}
-import hydrozoa.config.head.rulebased.{DisputeResolutionConfigGen, generateDisputeResolutionConfig}
-import hydrozoa.config.head.{HeadConfig, HeadConfigGen}
+import hydrozoa.config.head.HeadConfig
 import hydrozoa.config.node.operation.evacuation.{NodeOperationEvacuationConfigGen, generateNodeOperationEvacuationConfig}
 import hydrozoa.config.node.operation.multisig.{NodeOperationMultisigConfig, generateNodeOperationMultisigConfig}
 import hydrozoa.config.node.owninfo.OwnHeadPeerPrivate
@@ -22,8 +15,9 @@ import hydrozoa.multisig.ledger.block.Block.MultiSigned
 import hydrozoa.multisig.ledger.block.BlockHeader
 import org.scalacheck.util.Pretty
 import org.scalacheck.{Gen, Prop, Properties, PropertyM}
-import scalus.cardano.ledger.{AddrKeyHash, SlotConfig, Transaction, VKeyWitness}
+import scalus.cardano.ledger.{AddrKeyHash, Transaction, VKeyWitness}
 import scalus.uplc.builtin.Builtins.blake2b_224
+import test.given
 import test.{TestM, TestMFixedEnv, TestPeers, TestPeersSpec}
 
 /** Multi-node config is a tool for test suites that allows multisigning effects as well as giving
@@ -99,13 +93,8 @@ object MultiNodeConfig {
     def generateDefault: Gen[MultiNodeConfig] = generate(TestPeersSpec.default)()
 
     def generate(spec: TestPeersSpec)(
-        generateHeadConfig: HeadConfigGen = hydrozoa.config.head.generateHeadConfig,
-        generateHeadStartTime: BlockCreationEndTimeGen =
-            currentTimeBlockCreationEndTime,
-        generateHeadParameters: GenHeadParams = generateHeadParameters(),
-        generateInitializationParameters: InitializationParametersGenBottomUp.GenInitializationParameters |
-            InitializationParametersGenTopDown.GenWithDeps =
-            InitializationParametersGenBottomUp.generateInitializationParameters,
+        generateHeadConfig: ReaderT[Gen, TestPeers, HeadConfig] =
+            hydrozoa.config.head.generateHeadConfig(),
         generateNodeOperationEvacuationConfig: NodeOperationEvacuationConfigGen =
             generateNodeOperationEvacuationConfig,
         generateNodeOperationMultisigConfig: Gen[NodeOperationMultisigConfig] =
@@ -113,58 +102,49 @@ object MultiNodeConfig {
         generateScriptReferenceUtxos: ScriptReferenceUtxosGen = generateScriptReferenceUtxos
     ): Gen[MultiNodeConfig] = for {
         testPeers <- TestPeers.generate(spec)
-        ret <- generateForTestPeers(testPeers)(
+        ret <- generateForTestPeers(
           generateHeadConfig,
-          generateHeadStartTime,
-          generateHeadParameters,
-          generateInitializationParameters,
           generateNodeOperationEvacuationConfig,
           generateNodeOperationMultisigConfig,
           generateScriptReferenceUtxos
-        )
+        ).run(testPeers)
     } yield ret
 
-    def generateForTestPeers(testPeers: TestPeers)(
-        generateHeadConfig: HeadConfigGen = hydrozoa.config.head.generateHeadConfig,
-        generateBlockCreationEndTime: BlockCreationEndTimeGen =
-            currentTimeBlockCreationEndTime,
-        generateHeadParameters: GenHeadParams = generateHeadParameters(),
-        generateInitializationParameters: InitializationParametersGenBottomUp.GenInitializationParameters |
-            InitializationParametersGenTopDown.GenWithDeps =
-            InitializationParametersGenBottomUp.generateInitializationParameters,
+    def generateForTestPeers(
+        generateHeadConfig: ReaderT[Gen, TestPeers, HeadConfig] =
+            hydrozoa.config.head.generateHeadConfig(),
         generateNodeOperationEvacuationConfig: NodeOperationEvacuationConfigGen =
             generateNodeOperationEvacuationConfig,
         generateNodeOperationMultisigConfig: Gen[NodeOperationMultisigConfig] =
             generateNodeOperationMultisigConfig,
         generateScriptReferenceUtxos: ScriptReferenceUtxosGen = generateScriptReferenceUtxos
-    ): Gen[MultiNodeConfig] =
+    ): ReaderT[Gen, TestPeers, MultiNodeConfig] =
         for {
-            headConfig <- generateHeadConfig(testPeers)(
-              generateBlockCreationEndTime = generateBlockCreationEndTime,
-              generateHeadParameters = generateHeadParameters,
-              generateInitializationParameters = generateInitializationParameters,
-            )
+            testPeers <- ReaderT.ask
+            headConfig <- generateHeadConfig
 
             nodePrivateConfigs <-
-                Gen.sequence[List[
-                  (HeadPeerNumber, NodePrivateConfig)
-                ], (HeadPeerNumber, NodePrivateConfig)](
-                  testPeers.headPeerIds.toList.map(peerId =>
-                      for {
-                          nomc <- generateNodeOperationMultisigConfig
-                          ohpp = OwnHeadPeerPrivate(
-                            testPeers.walletFor(peerId._1),
-                            headConfig.headPeers
-                          ).get
-                          noec <- generateNodeOperationEvacuationConfig(ohpp.ownHeadWallet)
-                          sru <- generateScriptReferenceUtxos(headConfig)
-                      } yield peerId._1 -> NodePrivateConfig(
-                        ownHeadPeerPrivate = ohpp,
-                        // Re-using the same wallet for now, don't know if this will work
-                        nodeOperationEvacuationConfig = noec,
-                        nodeOperationMultisigConfig = nomc,
-                        scriptReferenceUtxos = sru
-                      )
+                liftF(
+                  Gen.sequence[List[
+                    (HeadPeerNumber, NodePrivateConfig)
+                  ], (HeadPeerNumber, NodePrivateConfig)](
+                    testPeers.headPeerIds.toList.map(peerId =>
+                        for {
+                            nomc <- generateNodeOperationMultisigConfig
+                            ohpp = OwnHeadPeerPrivate(
+                              testPeers.walletFor(peerId._1),
+                              headConfig.headPeers
+                            ).get
+                            noec <- generateNodeOperationEvacuationConfig(ohpp.ownHeadWallet)
+                            sru <- generateScriptReferenceUtxos(headConfig)
+                        } yield peerId._1 -> NodePrivateConfig(
+                          ownHeadPeerPrivate = ohpp,
+                          // Re-using the same wallet for now, don't know if this will work
+                          nodeOperationEvacuationConfig = noec,
+                          nodeOperationMultisigConfig = nomc,
+                          scriptReferenceUtxos = sru
+                        )
+                    )
                   )
                 )
         } yield new MultiNodeConfig(

--- a/src/test/scala/hydrozoa/config/node/MultiNodeConfig.scala
+++ b/src/test/scala/hydrozoa/config/node/MultiNodeConfig.scala
@@ -17,8 +17,7 @@ import org.scalacheck.util.Pretty
 import org.scalacheck.{Gen, Prop, Properties, PropertyM}
 import scalus.cardano.ledger.{AddrKeyHash, Transaction, VKeyWitness}
 import scalus.uplc.builtin.Builtins.blake2b_224
-import test.given
-import test.{TestM, TestMFixedEnv, TestPeers, TestPeersSpec}
+import test.{GenWithTestPeers, TestM, TestMFixedEnv, TestPeers, TestPeersSpec, given}
 
 /** Multi-node config is a tool for test suites that allows multisigning effects as well as giving
   * the access to the head config, which is common for all peers.
@@ -93,7 +92,7 @@ object MultiNodeConfig {
     def generateDefault: Gen[MultiNodeConfig] = generate(TestPeersSpec.default)()
 
     def generate(spec: TestPeersSpec)(
-        generateHeadConfig: ReaderT[Gen, TestPeers, HeadConfig] =
+        generateHeadConfig: GenWithTestPeers[HeadConfig] =
             hydrozoa.config.head.generateHeadConfig(),
         generateNodeOperationEvacuationConfig: NodeOperationEvacuationConfigGen =
             generateNodeOperationEvacuationConfig,
@@ -111,14 +110,14 @@ object MultiNodeConfig {
     } yield ret
 
     def generateForTestPeers(
-        generateHeadConfig: ReaderT[Gen, TestPeers, HeadConfig] =
+        generateHeadConfig: GenWithTestPeers[HeadConfig] =
             hydrozoa.config.head.generateHeadConfig(),
         generateNodeOperationEvacuationConfig: NodeOperationEvacuationConfigGen =
             generateNodeOperationEvacuationConfig,
         generateNodeOperationMultisigConfig: Gen[NodeOperationMultisigConfig] =
             generateNodeOperationMultisigConfig,
         generateScriptReferenceUtxos: ScriptReferenceUtxosGen = generateScriptReferenceUtxos
-    ): ReaderT[Gen, TestPeers, MultiNodeConfig] =
+    ): GenWithTestPeers[MultiNodeConfig] =
         for {
             testPeers <- ReaderT.ask
             headConfig <- generateHeadConfig

--- a/src/test/scala/test/TestPeers.scala
+++ b/src/test/scala/test/TestPeers.scala
@@ -1,6 +1,6 @@
 package test
 
-import cats.data.NonEmptyList
+import cats.data.{NonEmptyList, ReaderT}
 import com.bloxbean.cardano.client.account.Account
 import com.bloxbean.cardano.client.common.model.Network as BloxbeanNetwork
 import com.bloxbean.cardano.client.crypto.cip1852.DerivationPath.createExternalAddressDerivationPathForAccount
@@ -23,6 +23,8 @@ import scalus.cardano.ledger.ArbitraryInstances.*
 import scalus.cardano.ledger.{CardanoInfo, ProtocolParams, SlotConfig, Transaction, VKeyWitness}
 import scalus.crypto.ed25519.VerificationKey
 import test.Generators.loggerGenerators
+
+type GenWithTestPeers[A] = ReaderT[Gen, TestPeers, A]
 
 /** TestPeers object provides everything test suites may need to operate a peer in a head:
   *   - head peer numbers

--- a/src/test/scala/test/TestPeers.scala
+++ b/src/test/scala/test/TestPeers.scala
@@ -8,6 +8,7 @@ import hydrozoa.*
 import hydrozoa.config.head.network.CardanoNetwork
 import hydrozoa.config.head.network.CardanoNetworkGen.given_Arbitrary_CardanoNetwork
 import hydrozoa.config.head.peers.HeadPeers
+import hydrozoa.config.head.rulebased.scripts.RuleBasedScriptAddresses
 import hydrozoa.lib.cardano.scalus.VerificationKeyExtra.shelleyAddress
 import hydrozoa.lib.cardano.scalus.txbuilder.Transaction.attachVKeyWitnesses
 import hydrozoa.lib.cardano.wallet.WalletModule
@@ -17,9 +18,9 @@ import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Test.Parameters
 import org.scalacheck.{Gen, Prop, Properties}
 import scala.collection.mutable
-import scalus.cardano.address.ShelleyAddress
+import scalus.cardano.address.{Network, ShelleyAddress}
 import scalus.cardano.ledger.ArbitraryInstances.*
-import scalus.cardano.ledger.{Transaction, VKeyWitness}
+import scalus.cardano.ledger.{CardanoInfo, ProtocolParams, SlotConfig, Transaction, VKeyWitness}
 import scalus.crypto.ed25519.VerificationKey
 import test.Generators.loggerGenerators
 
@@ -36,14 +37,15 @@ import test.Generators.loggerGenerators
   * transactions on behalf of prospective head peers.
   *
   * @param seedPhrase
-  * @param network
+  * @param cardanoNetwork
   * @param peersNumber
   */
+
 case class TestPeers private (
     seedPhrase: SeedPhrase,
-    network: CardanoNetwork,
+    override val cardanoNetwork: CardanoNetwork,
     peersNumber: Int
-) {
+) extends CardanoNetwork.Section {
     import TestPeerName.maxPeers
 
     require(
@@ -135,7 +137,7 @@ case class TestPeers private (
     private val accountCache: mutable.Map[TestPeerName, Account] = mutable.Map.empty
         .withDefault(peer =>
             Account.createFromMnemonic(
-              network.asBloxbeanNetwork,
+              cardanoNetwork.asBloxbeanNetwork,
               seedPhrase.mnemonic,
               createExternalAddressDerivationPathForAccount(peer.ordinal)
             )
@@ -145,7 +147,7 @@ case class TestPeers private (
 
     private val addressCache: mutable.Map[TestPeerName, ShelleyAddress] =
         mutable.Map.empty.withDefault(peer =>
-            verificationKeyFor(peer).shelleyAddress()(using network)
+            verificationKeyFor(peer).shelleyAddress()(using cardanoNetwork)
         )
 
     private val walletCache: mutable.Map[TestPeerName, HeadPeerWallet] = mutable.Map.empty
@@ -158,6 +160,22 @@ case class TestPeers private (
               hdKeyPair.getPrivateKey
             )
         })
+
+    override def cardanoInfo: CardanoInfo = cardanoNetwork.cardanoInfo
+
+    override def network: Network = cardanoNetwork.network
+
+    override def slotConfig: SlotConfig = cardanoNetwork.slotConfig
+
+    override def cardanoProtocolParams: ProtocolParams = cardanoNetwork.cardanoProtocolParams
+
+    override def ruleBasedScriptAddresses: RuleBasedScriptAddresses =
+        cardanoNetwork.ruleBasedScriptAddresses
+
+    override def ruleBasedTreasuryAddress: ShelleyAddress = cardanoNetwork.ruleBasedTreasuryAddress
+
+    override def ruleBasedDisputeResolutionAddress: ShelleyAddress =
+        cardanoNetwork.ruleBasedDisputeResolutionAddress
 }
 
 object TestPeers:


### PR DESCRIPTION
This PR accomplishes the following:

----

(1): It does a similar transformation as with the rulebased transaction builders. 

Functions that previously looked like 

```scala
def foo(config : Config)(arg1 : Arg1, ..., argN : ArgN) : Result
```

are now 

```scala
def foo(arg1 : Arg1, ..., argN : ArgN) : Reader[Config, Result]
```
This allows us to avoid repeatedly passing the same argument over and over. 

> Note: I couldn't get context parameters (`given/using` and `?=>` ) to work; they don't seem to compose well and scala immediately tries to apply the implicit parameter. This meant that partial applicaation ended up with some ugly stuff like `(_ : Config) ?=> foo()`, where `foo ::  Config ?=> Args => Res`, to reapply a context lambda; and the reverse of `Args => Config ?=> Res` doesn't work because currying context functions isn't supported yet. 

----

(2): It replaces trivial type aliases parameterized over `TestPeers` or `CardanoNetwork` with a single type alias.

Specifically, I introduced a `type GenWithTestPeers[A] = ReaderT[Gen, TestPeers, A]`. 

This replaces things like `type BlockCreationEndTimeGen = TestPeers => Gen[BlockCreationEndTime]`, which makes it more clear that  such a type alias is of a common form.

This does _not_ replace non-trivial generator dependencies such as `HeadConfigGen`, which requires more generators as parameters to ensure consistency. However, it becomes more apparent that even `HeadConfigGen` is composed of these simpler `GenWithTestPeers` atoms.

----

(3) It detangles some dependencies in the generators.  For instance:

```scala
type HeadConfigGen =
    (testPeers: TestPeers) => (
        generateBlockCreationEndTime: SlotConfig => Gen[BlockCreationEndTime],
        generateTxTiming: TxTimingGen,
        generateFallbackContingency: FallbackContingencyGen,
        generateDisputeResolutionConfig: DisputeResolutionConfigGen,
        generateHeadParameters: GenHeadParams,
        generateInitializationParameters: InitializationParametersGenBottomUp.GenInitializationParameters |
            InitializationParametersGenTopDown.GenWithDeps
    ) => Gen[HeadConfig]
```

becomes

```scala
type HeadConfigGen = (
    generateBlockCreationEndTime: GenWithTestPeers[BlockCreationEndTime],
    generateHeadParameters: GenWithTestPeers[HeadParameters],
    generateInitializationParameters: InitializationParametersGenBottomUp.GenInitializationParameters |
        InitializationParametersGenTopDown.GenWithDeps
) => GenWithTestPeers[HeadConfig]
```

with no loss in functionality.

The issue was that the previous setup was passing in all dependencies to each function -- we were passing in every generator needed to construct the fields of a `HeadConfig`, and then passing in a parameterized generator that essentially just assembled these. A better approach is to just pass in the generator for the thing you want; if we need to extract a `Gen[FallbackContingency]` from a `Gen[HeadParams]`, for instance, we just do:

```scala
for {
  headParams <- genHeadParams
} yield headParams.fallbackContingency
```

It's not necessary to pass both.

-----

(4) Makes `TestPeers` extend `CardanoNetwork.Section`.

Generally, everything in the generators affected was either trivially parameterized on `TestPeers` or `CardanoNetwork`, or was parameterized on generators that were. This unifies all three.