### PR TITLE
feat: scalus-emulator-based cardano backend

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,10 @@ dockerCommands := dockerCommands.value.flatMap {
     case other                => List(other)
 }
 
-val scalusVersion = "0.15.1"
+ThisBuild / resolvers +=
+    "Sonatype OSS New Snapshots" at "https://central.sonatype.com/repository/maven-snapshots/"
+
+val scalusVersion = "0.16.0+262-3314a0df-SNAPSHOT"
 val bloxbeanVersion = "0.7.1"
 val http4sVersion = "0.23.32"
 
@@ -118,7 +121,7 @@ lazy val integration: Project = (project in file("integration"))
     )
 
 // Latest Scala 3 LTS version
-ThisBuild / scalaVersion := "3.3.6"
+ThisBuild / scalaVersion := "3.3.7"
 
 ThisBuild / scalacOptions ++= Seq(
   "-feature",
@@ -133,7 +136,7 @@ ThisBuild / scalacOptions ++= Seq(
 )
 
 // Add the Scalus compiler plugin
-addCompilerPlugin("org.scalus" % "scalus-plugin_3" % scalusVersion)
+addCompilerPlugin("org.scalus" %% "scalus-plugin" % scalusVersion cross CrossVersion.full)
 
 // Custom commands to format and lint all subprojects
 // TODO: Restore integration module to fmt and lint
@@ -151,7 +154,7 @@ ThisBuild / testFrameworks += new TestFramework("org.scalatest.tools.Framework")
 
 inThisBuild(
   List(
-    scalaVersion := "3.3.6",
+    scalaVersion := "3.3.7",
     semanticdbEnabled := true,
     semanticdbVersion := scalafixSemanticdb.revision
   )

--- a/src/main/scala/hydrozoa/multisig/backend/cardano/CardanoBackendEmulator.scala
+++ b/src/main/scala/hydrozoa/multisig/backend/cardano/CardanoBackendEmulator.scala
@@ -1,0 +1,72 @@
+package hydrozoa.multisig.backend.cardano
+
+import cats.effect.{IO, Ref}
+import scalus.cardano.ledger.*
+import scalus.cardano.node.Emulator
+import scalus.uplc.builtin.Data
+
+class EmulatorContinuingTxTracker private (
+    submittedTxsRef: Ref[IO, List[Transaction]],
+    emulator: Emulator
+) extends ContinuingTxTracker[IO]:
+
+    def recordTx(tx: Transaction): IO[Unit] =
+        submittedTxsRef.update(_ :+ tx)
+
+    override def lastContinuingTxs(
+        asset: (PolicyId, AssetName),
+        after: TransactionHash
+    ): IO[Either[CardanoBackend.Error, List[(TransactionHash, Data)]]] =
+        submittedTxsRef.get.map { submittedTxs =>
+            val txsReversed = submittedTxs.reverse
+            val txsAfter = txsReversed.takeWhile(_.id != after)
+            val result = txsAfter.flatMap { tx =>
+                continuingInputRedeemer(tx, asset, emulator.utxos).map(tx.id -> _)
+            }
+            Right(result)
+        }
+
+    private def continuingInputRedeemer(
+        tx: Transaction,
+        asset: (PolicyId, AssetName),
+        utxos: Utxos
+    ): Option[Data] =
+        val inputWithAssetIdx = tx.body.value.inputs.toSeq.zipWithIndex
+            .find { (input, _) =>
+                utxos.get(input).exists(_.value.hasAsset(asset._1, asset._2))
+            }
+            .map(_._2)
+
+        val hasOutputWithAsset =
+            tx.body.value.outputs.exists(_.value.value.hasAsset(asset._1, asset._2))
+
+        for
+            inputIx <- inputWithAssetIdx
+            _ <- Option.when(hasOutputWithAsset)(())
+            redeemers <- tx.witnessSet.redeemers.map(_.value)
+            redeemer <- redeemers.toSeq.find(r =>
+                r.tag == RedeemerTag.Spend && r.index.toInt == inputIx
+            )
+        yield redeemer.data
+
+object EmulatorContinuingTxTracker:
+    def apply(emulator: Emulator): IO[EmulatorContinuingTxTracker] =
+        Ref.of[IO, List[Transaction]](List.empty).map { ref =>
+            new EmulatorContinuingTxTracker(ref, emulator)
+        }
+
+
+object CardanoBackendEmulator:
+    def apply(emulator: Emulator): IO[CardanoBackendV2] =
+        EmulatorContinuingTxTracker(emulator).map { tracker =>
+            val backend = new CardanoBackendV2(emulator, tracker) {
+                override def submitTx(
+                    tx: Transaction
+                ): IO[Either[CardanoBackend.Error, Unit]] =
+                    super.submitTx(tx).flatTap {
+                        case Right(_) => tracker.recordTx(tx)
+                        case Left(_)  => IO.unit
+                    }
+            }
+            backend
+        }

--- a/src/main/scala/hydrozoa/multisig/backend/cardano/CardanoBackendV2.scala
+++ b/src/main/scala/hydrozoa/multisig/backend/cardano/CardanoBackendV2.scala
@@ -1,0 +1,72 @@
+package hydrozoa.multisig.backend.cardano
+
+import cats.effect.IO
+import scalus.cardano.address.ShelleyAddress
+import scalus.cardano.ledger.*
+import scalus.cardano.node.*
+import scalus.uplc.builtin.Data
+
+import scala.concurrent.Future
+
+trait ContinuingTxTracker[F[_]]:
+    def lastContinuingTxs(
+        asset: (PolicyId, AssetName),
+        after: TransactionHash
+    ): F[Either[CardanoBackend.Error, List[(TransactionHash, Data)]]]
+
+class CardanoBackendV2(
+    val provider: BlockchainProvider,
+    val continuingTxTracker: ContinuingTxTracker[IO]
+) extends CardanoBackend[IO]:
+
+    override def resolve(input: TransactionInput): IO[Either[CardanoBackend.Error, Option[Utxo]]] =
+        IO.fromFuture(IO.delay(provider.findUtxo(input))).map {
+            case Right(utxo) => Right(Some(utxo))
+            case Left(_: UtxoQueryError.NotFound) => Right(None)
+            case Left(err) =>
+                Left(CardanoBackend.Error.Unexpected(s"UTxO query error: $err"))
+        }
+
+    override def utxosAt(address: ShelleyAddress): IO[Either[CardanoBackend.Error, Utxos]] =
+        IO.fromFuture(IO.delay(provider.findUtxos(address))).map {
+            _.left.map(err => CardanoBackend.Error.Unexpected(s"UTxO query error: $err"))
+        }
+
+    override def utxosAt(
+        address: ShelleyAddress,
+        asset: (PolicyId, AssetName)
+    ): IO[Either[CardanoBackend.Error, Utxos]] =
+        val query = UtxoQuery(
+          UtxoSource.FromAddress(address) && UtxoSource.FromAsset(asset._1, asset._2)
+        )
+        IO.fromFuture(IO.delay(provider.findUtxos(query))).map {
+            _.left.map(err => CardanoBackend.Error.Unexpected(s"UTxO query error: $err"))
+        }
+
+    override def isTxKnown(txHash: TransactionHash): IO[Either[CardanoBackend.Error, Boolean]] =
+        IO.fromFuture(IO.delay(provider.checkTransaction(txHash))).map { status =>
+            Right(status == TransactionStatus.Confirmed)
+        }.handleError(e =>
+            Left(CardanoBackend.Error.Unexpected(e.getMessage))
+        )
+
+    override def lastContinuingTxs(
+        asset: (PolicyId, AssetName),
+        after: TransactionHash
+    ): IO[Either[CardanoBackend.Error, List[(TransactionHash, Data)]]] =
+        continuingTxTracker.lastContinuingTxs(asset, after)
+
+    override def submitTx(tx: Transaction): IO[Either[CardanoBackend.Error, Unit]] =
+        IO.fromFuture(IO.delay(provider.submit(tx))).map {
+            case Right(_)  => Right(())
+            case Left(err) => Left(CardanoBackend.Error.InvalidTx(err.message))
+        }.handleError(e =>
+            Left(CardanoBackend.Error.Unexpected(e.getMessage))
+        )
+
+    override def fetchLatestParams: IO[Either[CardanoBackend.Error, ProtocolParams]] =
+        IO.fromFuture(IO.delay(provider.fetchLatestParams))
+            .map(Right(_))
+            .handleError(e =>
+                Left(CardanoBackend.Error.Unexpected(e.getMessage))
+            )


### PR DESCRIPTION
This is a bit of a POC of how the Scalus Emulator can fit into existing hydrozoa code.

Couple of points:

1) The existing Emulator traits seem to cover the basic network interaction well enough: querying utxos, querying chain info and submitting transactions. Therefore, it's possible to omit the `CardanoBackend` trait.
2) The existing application-specific functionality (for now, only the `def lastContinuingTxs`) can be moved to another, higher level trait.

As such, the integration seems pretty seamless.