### PR TITLE
integer request id

### DIFF
--- a/src/main/scala/hydrozoa/multisig/ledger/event/RequestId.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/event/RequestId.scala
@@ -4,7 +4,6 @@ import cats.implicits.catsSyntaxOrder
 import hydrozoa.multisig.consensus.peer.HeadPeerNumber
 import hydrozoa.multisig.ledger.event.RequestId.ValidityFlag.{Invalid, Valid}
 import io.circe.*
-import io.circe.generic.semiauto.*
 import io.circe.syntax.*
 import scala.annotation.targetName
 
@@ -37,18 +36,8 @@ object RequestId {
       }
     )
 
-    given Encoder[Id] = Encoder.instance(id =>
-        Json.obj(
-          "headPeerNumber" -> id._1.asJson,
-          "requestNumber" -> id._2.asJson
-        )
-    )
-    given Decoder[Id] = Decoder.instance(c =>
-        for {
-            hpn <- c.downField("headPeerNumber").as[HeadPeerNumber]
-            rn <- c.downField("requestNumber").as[RequestNumber]
-        } yield (hpn, rn)
-    )
+    given Encoder[Id] = Encoder.instance(id => Json.fromLong(id.asI64))
+    given Decoder[Id] = Decoder.decodeLong.map(fromI64)
 
     opaque type Id = (HeadPeerNumber, RequestNumber)
 

--- a/src/main/scala/hydrozoa/multisig/ledger/l2/L2LedgerCommand.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/l2/L2LedgerCommand.scala
@@ -10,7 +10,6 @@ import hydrozoa.multisig.ledger.l2
 import io.bullet.borer.derivation.CompactMapBasedCodecs.derived
 import io.bullet.borer.{Cbor, Decoder, Encoder}
 import io.circe.*
-import io.circe.generic.semiauto.*
 import io.circe.syntax.*
 import scala.util.Try
 import scalus.cardano.address.Address
@@ -90,7 +89,7 @@ object L2LedgerCommand {
             import Destination.given
             import hydrozoa.multisig.ledger.remote.RemoteL2LedgerCodecs.{given_Encoder_Value, given_Encoder_Coin}
             import hydrozoa.lib.cardano.cip116.JsonCodecs.CIP0116.Conway.{valueEncoder as _, valueDecoder as _, coinDecoder as _, coinEncoder as _, given}
-            import hydrozoa.multisig.server.JsonCodecs.requestIdEncoder
+            import RequestId.given
             (r: L2LedgerCommand.RegisterDeposit) =>
                 io.circe.Json.obj(
                   "requestId" -> r.requestId.asJson,
@@ -110,7 +109,7 @@ object L2LedgerCommand {
         given depositRegistrationDecoder: io.circe.Decoder[L2LedgerCommand.RegisterDeposit] = {
             import hydrozoa.lib.cardano.cip116.JsonCodecs.CIP0116.Conway.{valueEncoder as _, valueDecoder as _, coinDecoder as _, coinEncoder as _, given}
             import hydrozoa.multisig.ledger.remote.RemoteL2LedgerCodecs.{given_Decoder_Value, given_Decoder_Coin}
-            import hydrozoa.multisig.server.JsonCodecs.requestIdDecoder
+            import RequestId.given
             io.circe.generic.semiauto.deriveDecoder
         }
     }
@@ -125,7 +124,7 @@ object L2LedgerCommand {
     object ApplyDepositDecisions {
         given Codec[L2LedgerCommand.ApplyDepositDecisions] = {
             import BlockNumber.given
-            import hydrozoa.multisig.server.JsonCodecs.{requestIdEncoder, requestIdDecoder}
+            import RequestId.given
             io.circe.generic.semiauto.deriveCodec
         }
     }
@@ -157,9 +156,16 @@ object L2LedgerCommand {
                   "l2Payload" -> summon[io.circe.Encoder[ByteString]].apply(r.l2Payload)
                 )
 
-        // FIXME: As above, this can't possibly round-trip...
         given applyTransactionDecoder: io.circe.Decoder[L2LedgerCommand.ApplyTransaction] =
-            deriveDecoder
+            io.circe.Decoder.instance(c =>
+                for {
+                    rid <- c.downField("requestId").as[RequestId]
+                    vk <- c.downField("userVk").as[VerificationKey]
+                    bn <- c.downField("blockNumber").as[BlockNumber]
+                    t <- c.downField("blockCreationStartTime").as[PosixTime]
+                    p <- c.downField("l2Payload").as[ByteString]
+                } yield L2LedgerCommand.ApplyTransaction(rid, vk, bn, t, p)
+            )
     }
 
     object ProxyBlockConfirmation {

--- a/src/main/scala/hydrozoa/multisig/ledger/l2/L2LedgerCommand.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/l2/L2LedgerCommand.scala
@@ -90,6 +90,7 @@ object L2LedgerCommand {
             import Destination.given
             import hydrozoa.multisig.ledger.remote.RemoteL2LedgerCodecs.{given_Encoder_Value, given_Encoder_Coin}
             import hydrozoa.lib.cardano.cip116.JsonCodecs.CIP0116.Conway.{valueEncoder as _, valueDecoder as _, coinDecoder as _, coinEncoder as _, given}
+            import hydrozoa.multisig.server.JsonCodecs.requestIdEncoder
             (r: L2LedgerCommand.RegisterDeposit) =>
                 io.circe.Json.obj(
                   "requestId" -> r.requestId.asJson,
@@ -109,6 +110,7 @@ object L2LedgerCommand {
         given depositRegistrationDecoder: io.circe.Decoder[L2LedgerCommand.RegisterDeposit] = {
             import hydrozoa.lib.cardano.cip116.JsonCodecs.CIP0116.Conway.{valueEncoder as _, valueDecoder as _, coinDecoder as _, coinEncoder as _, given}
             import hydrozoa.multisig.ledger.remote.RemoteL2LedgerCodecs.{given_Decoder_Value, given_Decoder_Coin}
+            import hydrozoa.multisig.server.JsonCodecs.requestIdDecoder
             io.circe.generic.semiauto.deriveDecoder
         }
     }
@@ -121,7 +123,11 @@ object L2LedgerCommand {
     ) extends L2LedgerCommand.Real
 
     object ApplyDepositDecisions {
-        given Codec[L2LedgerCommand.ApplyDepositDecisions] = io.circe.generic.semiauto.deriveCodec
+        given Codec[L2LedgerCommand.ApplyDepositDecisions] = {
+            import BlockNumber.given
+            import hydrozoa.multisig.server.JsonCodecs.{requestIdEncoder, requestIdDecoder}
+            io.circe.generic.semiauto.deriveCodec
+        }
     }
 
     /** An L2Event, as forwarded to black-box L2 ledger. It can only be constructed with respect to

--- a/src/main/scala/hydrozoa/multisig/ledger/remote/RemoteL2LedgerCodecs.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/remote/RemoteL2LedgerCodecs.scala
@@ -26,6 +26,8 @@ object RemoteL2LedgerCodecs {
     export L2LedgerCommand.given
     export Destination.given
 
+    import hydrozoa.multisig.server.JsonCodecs.{requestIdEncoder, requestIdDecoder}
+
     // Coin as raw number (sugar-rush-ledger expects u64, not string)
     given Encoder[Coin] = Encoder.encodeLong.contramap(_.value)
     given Decoder[Coin] = Decoder.decodeLong.map(Coin.apply)

--- a/src/main/scala/hydrozoa/multisig/ledger/remote/RemoteL2LedgerCodecs.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/remote/RemoteL2LedgerCodecs.scala
@@ -26,7 +26,6 @@ object RemoteL2LedgerCodecs {
     export L2LedgerCommand.given
     export Destination.given
 
-    import hydrozoa.multisig.server.JsonCodecs.{requestIdEncoder, requestIdDecoder}
 
     // Coin as raw number (sugar-rush-ledger expects u64, not string)
     given Encoder[Coin] = Encoder.encodeLong.contramap(_.value)

--- a/src/main/scala/hydrozoa/multisig/persistence/codec/RefundTxCodec.scala
+++ b/src/main/scala/hydrozoa/multisig/persistence/codec/RefundTxCodec.scala
@@ -4,6 +4,7 @@ import cats.syntax.functor.*
 import hydrozoa.config.head.network.CardanoNetwork
 import hydrozoa.lib.cardano.scalus.QuantizedTime.{quantizedInstantDecoder, quantizedInstantEncoder}
 import hydrozoa.lib.cardano.scalus.codecs.json.Codecs.{transactionDecoder, transactionEncoder}
+import hydrozoa.multisig.ledger.event.RequestId
 import hydrozoa.multisig.ledger.l1.tx.RefundTx
 import hydrozoa.multisig.persistence.codec.DestinationCodec.given
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
@@ -18,7 +19,7 @@ import io.circe.{Decoder, Encoder}
   *     `CardanoNetwork.Section`, threaded through from this codec);
   *   - [[DestinationCodec]] — fresh CBOR-hex round-trip (the codec on the type itself is
   *     asymmetric);
-  *   - `RequestId` codec from `consensus.transport.Codecs`.
+  *   - `RequestId` codec from [[hydrozoa.multisig.ledger.event.RequestId]] (i64 packed form).
   *
   * `txLens` and `resolvedUtxos = ResolvedUtxos.empty` are derived from the case-class body, not
   * stored in JSON; on decode the case-class default values restore them.
@@ -26,12 +27,12 @@ import io.circe.{Decoder, Encoder}
 object RefundTxCodec:
 
     given postDatedEncoder(using CardanoNetwork.Section): Encoder[RefundTx.PostDated] = {
-        import hydrozoa.multisig.server.JsonCodecs.requestIdEncoder
+        import RequestId.given
         deriveEncoder[RefundTx.PostDated]
     }
 
     given postDatedDecoder(using CardanoNetwork.Section): Decoder[RefundTx.PostDated] = {
-        import hydrozoa.multisig.server.JsonCodecs.requestIdDecoder
+        import RequestId.given
         deriveDecoder[RefundTx.PostDated]
     }
 

--- a/src/main/scala/hydrozoa/multisig/persistence/codec/RefundTxCodec.scala
+++ b/src/main/scala/hydrozoa/multisig/persistence/codec/RefundTxCodec.scala
@@ -4,7 +4,6 @@ import cats.syntax.functor.*
 import hydrozoa.config.head.network.CardanoNetwork
 import hydrozoa.lib.cardano.scalus.QuantizedTime.{quantizedInstantDecoder, quantizedInstantEncoder}
 import hydrozoa.lib.cardano.scalus.codecs.json.Codecs.{transactionDecoder, transactionEncoder}
-import hydrozoa.multisig.consensus.transport.Codecs.given
 import hydrozoa.multisig.ledger.l1.tx.RefundTx
 import hydrozoa.multisig.persistence.codec.DestinationCodec.given
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
@@ -26,11 +25,15 @@ import io.circe.{Decoder, Encoder}
   */
 object RefundTxCodec:
 
-    given postDatedEncoder(using CardanoNetwork.Section): Encoder[RefundTx.PostDated] =
+    given postDatedEncoder(using CardanoNetwork.Section): Encoder[RefundTx.PostDated] = {
+        import hydrozoa.multisig.server.JsonCodecs.requestIdEncoder
         deriveEncoder[RefundTx.PostDated]
+    }
 
-    given postDatedDecoder(using CardanoNetwork.Section): Decoder[RefundTx.PostDated] =
+    given postDatedDecoder(using CardanoNetwork.Section): Decoder[RefundTx.PostDated] = {
+        import hydrozoa.multisig.server.JsonCodecs.requestIdDecoder
         deriveDecoder[RefundTx.PostDated]
+    }
 
     given refundTxEncoder(using CardanoNetwork.Section): Encoder[RefundTx] = Encoder.instance {
         case pd: RefundTx.PostDated => postDatedEncoder(using summon).apply(pd)

--- a/src/main/scala/hydrozoa/multisig/server/JsonCodecs.scala
+++ b/src/main/scala/hydrozoa/multisig/server/JsonCodecs.scala
@@ -241,6 +241,13 @@ object JsonCodecs {
     given headPeerNumberDecoder: Decoder[HeadPeerNumber] =
         Decoder.decodeInt.map(HeadPeerNumber.apply)
 
+    // RequestId codec
+    given requestIdEncoder: Encoder[RequestId] = (requestId: RequestId) =>
+        io.circe.Json.fromLong(requestId.asI64)
+
+    given requestIdDecoder: Decoder[RequestId] =
+        Decoder.decodeLong.map(RequestId.fromI64)
+
     // Response types
     given requestAcceptedEncoder: Encoder[RequestAccepted] = deriveEncoder[RequestAccepted]
 

--- a/src/main/scala/hydrozoa/multisig/server/JsonCodecs.scala
+++ b/src/main/scala/hydrozoa/multisig/server/JsonCodecs.scala
@@ -9,7 +9,7 @@ import hydrozoa.lib.cardano.cip116
 import hydrozoa.multisig.consensus.UserRequestBody.{DepositRequestBody, TransactionRequestBody}
 import hydrozoa.multisig.consensus.peer.HeadPeerNumber
 import hydrozoa.multisig.consensus.{UserRequest, UserRequestBody, UserRequestHeader}
-import hydrozoa.multisig.ledger.event.{RequestId, RequestNumber}
+import hydrozoa.multisig.ledger.event.RequestNumber
 import hydrozoa.multisig.server.ApiResponse.{Error, HeadInfo, RequestAccepted}
 import io.circe.generic.semiauto.*
 import io.circe.syntax.*
@@ -240,13 +240,6 @@ object JsonCodecs {
 
     given headPeerNumberDecoder: Decoder[HeadPeerNumber] =
         Decoder.decodeInt.map(HeadPeerNumber.apply)
-
-    // RequestId codec
-    given requestIdEncoder: Encoder[RequestId] = (requestId: RequestId) =>
-        io.circe.Json.fromLong(requestId.asI64)
-
-    given requestIdDecoder: Decoder[RequestId] =
-        Decoder.decodeLong.map(RequestId.fromI64)
 
     // Response types
     given requestAcceptedEncoder: Encoder[RequestAccepted] = deriveEncoder[RequestAccepted]


### PR DESCRIPTION
This changes the default encoding of RequestId to use the integer representation. I have not taken care to ensure that this change is limited to the interface with the L2; please let me know if that is a problem.