### PR TITLE
refactor(mrm): move WS transport setup into MultisigRegimeManager.res…

### DIFF
--- a/src/main/scala/hydrozoa/app/Bootstrap.scala
+++ b/src/main/scala/hydrozoa/app/Bootstrap.scala
@@ -37,6 +37,7 @@ import java.security.SecureRandom
 import monocle.Focus.focus
 import org.bouncycastle.crypto.generators.Ed25519KeyPairGenerator
 import org.bouncycastle.crypto.params.{Ed25519KeyGenerationParameters, Ed25519PrivateKeyParameters, Ed25519PublicKeyParameters}
+import org.http4s.Uri
 import scala.collection.immutable.{SortedMap, TreeMap}
 import scala.concurrent.duration.DurationInt
 import scalus.cardano.address.Address
@@ -94,6 +95,8 @@ object Bootstrap:
         vKey: VerificationKey,
         sKey: SigningKey,
         minEquity: Coin,
+        hydrozoaHost: String,
+        hydrozoaPort: String,
     ): IO[NodeConfig] = for {
         _ <- IO.pure(())
 
@@ -215,7 +218,12 @@ object Bootstrap:
         seedUtxo = utxosSelected.head
         valueSelected = Value.combine(utxosSelected.map(_.output.value).toList)
 
-        headPeers = HeadPeers(NonEmptyMap.one(HeadPeerNumber.zero, HeadPeerData(vKey, "FIXME"))).get
+        headPeers = HeadPeers(
+          NonEmptyMap.one(
+            HeadPeerNumber.zero,
+            HeadPeerData(vKey, Uri.unsafeFromString(s"ws://$hydrozoaHost:$hydrozoaPort"))
+          )
+        ).get
 
         initializationParameters = InitializationParameters(
           initialEvacuationMap = evacMap,
@@ -314,8 +322,8 @@ object Bootstrap:
                 // NOTE: Reusing the same multisig wallet, in production this should be a different wallet
                 evacuationWallet = ownHeadWallet
               ),
-              hydrozoaHost = ???,
-              hydrozoaPort = ???,
+              hydrozoaHost = hydrozoaHost,
+              hydrozoaPort = hydrozoaPort,
               blockfrostApiKey = ???,
               nodeOperationMultisigConfig = NodeOperationMultisigConfig.default
             )

--- a/src/main/scala/hydrozoa/app/Main.scala
+++ b/src/main/scala/hydrozoa/app/Main.scala
@@ -4,7 +4,7 @@ import cats.effect.{ExitCode, IO, IOApp, Resource}
 import cats.implicits.*
 import com.bloxbean.cardano.client.util.HexUtil
 import com.bloxbean.cardano.client.util.HexUtil.encodeHexString
-import com.comcast.ip4s.{host, port}
+import com.comcast.ip4s.{Host, Port, host, port}
 import com.suprnation.actor.ActorSystem
 import hydrozoa.config.head.network.{CardanoNetwork, StandardCardanoNetwork}
 import hydrozoa.lib.cardano.scalus.VerificationKeyExtra.shelleyAddress
@@ -45,6 +45,8 @@ object Main extends IOApp {
         signingKey: SigningKey,
         minEquity: Coin,
         blockfrostApiKey: String,
+        hydrozoaHost: String,
+        hydrozoaPort: String,
         sugarRushHost: String,
         sugarRushPort: String,
         tokenRecoveryAddress: Option[ShelleyAddress],
@@ -122,6 +124,9 @@ object Main extends IOApp {
                   .map(Coin.apply)
             )
 
+            hydrozoaHost <- getOptionalEnvVar("HYDROZOA_HOST", "0.0.0.0")
+            hydrozoaPort <- getOptionalEnvVar("HYDROZOA_PORT", "9001")
+
             sugarRushHost <- getOptionalEnvVar("SUGAR_RUSH_HOST", "localhost")
             sugarRushPort <- getOptionalEnvVar("SUGAR_RUSH_PORT", "3001")
 
@@ -160,6 +165,8 @@ object Main extends IOApp {
           signingKey = sKey,
           minEquity = minEquity,
           blockfrostApiKey = blockfrostKey,
+          hydrozoaHost = hydrozoaHost,
+          hydrozoaPort = hydrozoaPort,
           sugarRushHost = sugarRushHost,
           sugarRushPort = sugarRushPort,
           tokenRecoveryAddress = tokenRecoveryAddressOpt,
@@ -182,7 +189,9 @@ object Main extends IOApp {
             nodeConfig <- Bootstrap.mkNodeConfig(cardanoNetwork, backend)(
               vKey = env.verificationKey,
               sKey = env.signingKey,
-              minEquity = env.minEquity
+              minEquity = env.minEquity,
+              hydrozoaHost = env.hydrozoaHost,
+              hydrozoaPort = env.hydrozoaPort,
             )
             _ <- logger.info(s"headAddress: ${nodeConfig.headMultisigAddress.toBech32.get}")
             _ <- logger.info(s"initTx hash: ${nodeConfig.initializationTx.tx.id}")
@@ -225,25 +234,35 @@ object Main extends IOApp {
                     tokenRecoveryAddress = env.tokenRecoveryAddress
                   )
             )
-        } yield (env, backend, nodeConfig, remoteL2Ledger, persistence, system)
 
-        resource.use { case (env, backend, nodeConfig, remoteL2Ledger, persistence, system) =>
             // Main runs a head node (Bootstrap builds the config via NodeConfig.mkHeadConfig),
             // so the peer index is this node's head peer number.
-            val mrmTracer =
-                Slf4jTracer.sink.contramap(
-                  MultisigRegimeManagerEventFormat.humanFormat(
-                    HeadPeerNumber(nodeConfig.ownPeerIndex)
-                  )
+            mrmTracer = Slf4jTracer.sink.contramap(
+              MultisigRegimeManagerEventFormat.humanFormat(HeadPeerNumber(nodeConfig.ownPeerIndex))
+            )
+            bindHost = Host
+                .fromString(env.hydrozoaHost)
+                .getOrElse(
+                  throw new IllegalArgumentException(s"Invalid HYDROZOA_HOST: ${env.hydrozoaHost}")
                 )
+            bindPort = Port
+                .fromString(env.hydrozoaPort)
+                .getOrElse(
+                  throw new IllegalArgumentException(s"Invalid HYDROZOA_PORT: ${env.hydrozoaPort}")
+                )
+            mrm <- MultisigRegimeManager.resource(
+              nodeConfig,
+              backend,
+              remoteL2Ledger,
+              persistence,
+              mrmTracer,
+              bindHost,
+              bindPort,
+            )
+        } yield (env, nodeConfig, system, mrm)
+
+        resource.use { case (env, nodeConfig, system, mrm) =>
             for {
-                mrm <- MultisigRegimeManager.apply(
-                  nodeConfig,
-                  backend,
-                  remoteL2Ledger,
-                  persistence,
-                  mrmTracer
-                )
                 _ <- system.actorOf(mrm, "MultisigRegimeManager")
                 _ <- logger.info("Hydrozoa node started successfully")
 

--- a/src/main/scala/hydrozoa/config/head/peers/HeadPeers.scala
+++ b/src/main/scala/hydrozoa/config/head/peers/HeadPeers.scala
@@ -8,6 +8,7 @@ import hydrozoa.multisig.consensus.peer.{HeadPeerId, HeadPeerNumber}
 import hydrozoa.multisig.ledger.l1.script.multisig.HeadMultisigScript
 import io.circe.*
 import io.circe.generic.semiauto.*
+import org.http4s.Uri
 import scalus.cardano.address.{ShelleyAddress, ShelleyDelegationPart, ShelleyPaymentPart}
 import scalus.cardano.ledger.AddrKeyHash
 import scalus.crypto.ed25519.VerificationKey
@@ -16,9 +17,9 @@ import scalus.uplc.builtin.Builtins.blake2b_224
 import HeadPeerNumber.given
 
 /** @param webSocketAddress
-  *   The connection address for the head peer, i.e. "ws://192.168.10.8081"
+  *   The connection address for the head peer, e.g. `ws://192.168.1.1:8081`
   */
-final case class HeadPeerData(verificationKey: VerificationKey, webSocketAddress: String)
+final case class HeadPeerData(verificationKey: VerificationKey, webSocketAddress: Uri)
 
 /** Invariant: Peer numbers must be contiguous, starting from 0.
   * @param headPeerData
@@ -59,6 +60,10 @@ object HeadPeers {
     ): Decoder[NonEmptyMap[HeadPeerNumber, A]] =
         Decoder.decodeNonEmptyMap
 
+    private given uriEncoder: Encoder[Uri] = Encoder.encodeString.contramap(_.renderString)
+    private given uriDecoder: Decoder[Uri] =
+        Decoder.decodeString.emap(Uri.fromString(_).left.map(_.message))
+
     given headPeersEncoder: Encoder[HeadPeers] =
         Encoder.instance(headPeers =>
             Json.obj(
@@ -74,7 +79,7 @@ object HeadPeers {
                 vKeys <- headPeerDataFieldDecoder[VerificationKey].tryDecode(
                   c.downField("headPeerVKeys")
                 )
-                addresses <- headPeerDataFieldDecoder[String].tryDecode(
+                addresses <- headPeerDataFieldDecoder[Uri].tryDecode(
                   c.downField("headPeerAddresses")
                 )
 

--- a/src/main/scala/hydrozoa/multisig/MultisigRegimeManager.scala
+++ b/src/main/scala/hydrozoa/multisig/MultisigRegimeManager.scala
@@ -1,12 +1,14 @@
 package hydrozoa.multisig
 
 import cats.*
-import cats.effect.{Deferred, IO}
+import cats.effect.{Deferred, IO, Resource}
 import cats.implicits.*
+import com.comcast.ip4s.{Host, Port}
 import com.suprnation.actor.Actor.{Actor, Receive}
 import com.suprnation.actor.ActorRef.NoSendActorRef
 import com.suprnation.actor.SupervisorStrategy.Escalate
 import com.suprnation.actor.{OneForOneStrategy, SupervisionStrategy}
+import hydrozoa.config.head.network.CardanoNetwork
 import hydrozoa.config.node.NodeConfig
 import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.MultisigRegimeManager.*
@@ -16,10 +18,13 @@ import hydrozoa.multisig.backend.cardano.CardanoBackend
 import hydrozoa.multisig.consensus.*
 import hydrozoa.multisig.consensus.liaison.PeerLiaisonEvent
 import hydrozoa.multisig.consensus.limiter.{Limiter, LimiterEvent}
-import hydrozoa.multisig.consensus.peer.{CoilPeerNumber, HeadPeerNumber, PeerId}
+import hydrozoa.multisig.consensus.peer.{CoilPeerNumber, HeadPeerId, HeadPeerNumber, PeerId}
+import hydrozoa.multisig.consensus.transport.{NodeWsServer, NodeWsServerEvent, PeerWsTransport, PeerWsTransportEvent, RemotePeerProxy}
 import hydrozoa.multisig.ledger.joint.{JointLedger, JointLedgerEvent}
 import hydrozoa.multisig.ledger.l2.L2Ledger
 import hydrozoa.multisig.persistence.Persistence
+import org.http4s.Uri
+import org.http4s.jdkhttpclient.JdkWSClient
 import scala.concurrent.duration.DurationInt
 
 trait MultisigRegimeManager(
@@ -27,7 +32,8 @@ trait MultisigRegimeManager(
     cardanoBackend: CardanoBackend[IO],
     l2Ledger: L2Ledger[IO],
     persistence: Persistence[IO],
-    tracer: ContraTracer[IO, MultisigRegimeManagerEvent]
+    tracer: ContraTracer[IO, MultisigRegimeManagerEvent],
+    wsTransport: PeerWsTransport,
 ) extends Actor[IO, Request] {
 
     /** Specialize the regime-wide tracer down to per-actor channels. The contramap pushes the
@@ -81,6 +87,9 @@ trait MultisigRegimeManager(
             tracer.traceWith(MRMEvent.TerminatedDependency(dependencyType))
         // TODO: Implement a way to receive a remote comm actor and connect it to its corresponding local comm actor
     }
+
+    private def watchChildren(pairs: (NoSendActorRef[IO], Actors)*): IO[Unit] =
+        pairs.toList.traverse_ { (ref, actor) => context.watch(ref, TerminatedChild(actor, ref)) }
 
     def preStartLocal: IO[Unit] =
         for {
@@ -154,6 +163,22 @@ trait MultisigRegimeManager(
                     )
             }
 
+            // Register local liaisons and spawn one RemotePeerProxy per remote head peer.
+            remoteHeadProxies <- {
+                val remoteIds = config.headPeerIds.toList.filterNot(_.peerNum == ownHeadNum)
+                for {
+                    _ <- remoteIds.zip(headPeerLiaisons).traverse_ {
+                        case (remoteId, localLiaison) =>
+                            wsTransport.register(remoteId, localLiaison)
+                    }
+                    proxies <- remoteIds.traverse { remoteId =>
+                        context
+                            .actorOf(RemotePeerProxy(remoteId, wsTransport))
+                            .map(remoteId.peerNum -> _)
+                    }
+                } yield proxies.toMap
+            }
+
             hubbedCoilPeers = config.hubbedCoilPeerNums(ownHeadNum)
 
             // If this head peer is a hub, spawn the relay sequencer for its coil peers' hard-acks
@@ -194,6 +219,7 @@ trait MultisigRegimeManager(
               coilRelay = coilRelay,
               coilAckSequencer = coilAckSequencer,
               coilPeerLiaisons = coilPeerLiaisons,
+              remoteHeadLiaisons = remoteHeadProxies,
             )
 
             _ <- pendingConnections.complete(connections)
@@ -201,29 +227,15 @@ trait MultisigRegimeManager(
 
             _ <- tracer.traceWith(WatchingActors)
 
-            _ <- context.watch(blockWeaver, TerminatedChild(Actors.BlockWeaver, blockWeaver))
-            _ <- headPeerLiaisons.traverse(r =>
-                context.watch(r, TerminatedChild(Actors.PeerLiaisonHeadToHead, r))
+            _ <- watchChildren(
+              blockWeaver -> Actors.BlockWeaver,
+              cardanoLiaison -> Actors.CardanoLiaison,
+              requestSequencer -> Actors.RequestSequencer,
+              stackComposer -> Actors.StackComposer,
+              slowConsensusActor -> Actors.SlowConsensus,
             )
-            _ <- coilPeerLiaisons.traverse(r =>
-                context.watch(r, TerminatedChild(Actors.PeerLiaisonHeadToHead, r))
-            )
-            _ <- context.watch(
-              cardanoLiaison,
-              TerminatedChild(Actors.CardanoLiaison, cardanoLiaison)
-            )
-            _ <- context.watch(
-              requestSequencer,
-              TerminatedChild(Actors.RequestSequencer, requestSequencer)
-            )
-            _ <- context.watch(
-              stackComposer,
-              TerminatedChild(Actors.StackComposer, stackComposer)
-            )
-            _ <- context.watch(
-              slowConsensusActor,
-              TerminatedChild(Actors.SlowConsensus, slowConsensusActor)
-            )
+            _ <- (headPeerLiaisons.toList ++ coilPeerLiaisons)
+                .traverse_(r => watchChildren(r -> Actors.PeerLiaisonHeadToHead))
         } yield ()
 }
 
@@ -274,22 +286,50 @@ object MultisigRegimeManager {
 
     type PendingConnections = Deferred[IO, Connections]
 
-    def apply(
+    def resource(
         config: NodeConfig,
         cardanoBackend: CardanoBackend[IO],
         virtualLedger: L2Ledger[IO],
         persistence: Persistence[IO],
-        tracer: ContraTracer[IO, MultisigRegimeManagerEvent]
-    ): IO[MultisigRegimeManager] =
-        IO(
-          new MultisigRegimeManager(
-            config,
-            cardanoBackend,
-            virtualLedger,
-            persistence,
-            tracer
-          ) {}
-        )
+        tracer: ContraTracer[IO, MultisigRegimeManagerEvent],
+        bindHost: Host,
+        bindPort: Port,
+    )(using CardanoNetwork.Section): Resource[IO, MultisigRegimeManager] = {
+        val ownHeadPeerId = config.ownPeerId match {
+            case PeerId.Head(n) => config.headPeerIds.find(_.peerNum == n).get
+            case PeerId.Coil(_) =>
+                throw new IllegalStateException("MultisigRegimeManager runs only on head peers")
+        }
+        val remotes: Map[HeadPeerId, Uri] = config.headPeerIds
+            .filterNot(_.peerNum == ownHeadPeerId.peerNum)
+            .toList
+            .flatMap { pid =>
+                config.headPeers.headPeerData
+                    .lookup(pid.peerNum)
+                    .map(hpd => pid -> (hpd.webSocketAddress / "head"))
+            }
+            .toMap
+        for {
+            client <- Resource.eval(JdkWSClient.simple[IO])
+            pwtTracer = tracer.contramap(MultisigRegimeManagerEvent.PWT.apply)
+            nwsTracer = tracer.contramap(MultisigRegimeManagerEvent.NWS.apply)
+            transport <- Resource.eval(PeerWsTransport.create(ownHeadPeerId, remotes, pwtTracer))
+            _ <- NodeWsServer.resource(bindHost, bindPort, List(transport.routes), nwsTracer)
+            _ <- transport.startDialers(client)
+            mrm <- Resource.eval(
+              IO(
+                new MultisigRegimeManager(
+                  config,
+                  cardanoBackend,
+                  virtualLedger,
+                  persistence,
+                  tracer,
+                  transport,
+                ) {}
+              )
+            )
+        } yield mrm
+    }
 
     /** Multisig regime's protocol for actor requests and responses. See diagram:
       * [[https://app.excalidraw.com/s/9N3iw9j24UW/9eRJ7Dwu42X]]

--- a/src/main/scala/hydrozoa/multisig/MultisigRegimeManagerEvent.scala
+++ b/src/main/scala/hydrozoa/multisig/MultisigRegimeManagerEvent.scala
@@ -4,6 +4,7 @@ import hydrozoa.multisig.MultisigRegimeManager.{Actors, Dependencies}
 import hydrozoa.multisig.consensus.liaison.PeerLiaisonEvent
 import hydrozoa.multisig.consensus.limiter.LimiterEvent
 import hydrozoa.multisig.consensus.peer.PeerId
+import hydrozoa.multisig.consensus.transport.{NodeWsServerEvent, PeerWsTransportEvent}
 import hydrozoa.multisig.consensus.{BlockWeaverEvent, CardanoLiaisonEvent, EventSequencerEvent, FastConsensusActorEvent, SlowConsensusActorEvent, StackComposerEvent}
 import hydrozoa.multisig.ledger.joint.JointLedgerEvent
 
@@ -30,6 +31,8 @@ object MultisigRegimeManagerEvent:
         extends MultisigRegimeManagerEvent
     final case class BWL(event: LimiterEvent) extends MultisigRegimeManagerEvent
     final case class SCL(event: LimiterEvent) extends MultisigRegimeManagerEvent
+    final case class PWT(event: PeerWsTransportEvent) extends MultisigRegimeManagerEvent
+    final case class NWS(event: NodeWsServerEvent) extends MultisigRegimeManagerEvent
     case object StartingActors extends MultisigRegimeManagerEvent
     case object WatchingActors extends MultisigRegimeManagerEvent
     final case class TerminatedActor(actor: Actors) extends MultisigRegimeManagerEvent

--- a/src/main/scala/hydrozoa/multisig/MultisigRegimeManagerEventFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/MultisigRegimeManagerEventFormat.scala
@@ -1,10 +1,11 @@
 package hydrozoa.multisig
 
 import hydrozoa.lib.logging.LogEvent
-import hydrozoa.multisig.MultisigRegimeManagerEvent.{BW, BWL, CL, ES, FCA, JL, PL, SC, SCA, SCL, StartingActors, TerminatedActor, TerminatedDependency, WatchingActors}
+import hydrozoa.multisig.MultisigRegimeManagerEvent.*
 import hydrozoa.multisig.consensus.liaison.PeerLiaisonEventFormat
 import hydrozoa.multisig.consensus.limiter.LimiterEventFormat
 import hydrozoa.multisig.consensus.peer.{HeadPeerNumber, PeerId}
+import hydrozoa.multisig.consensus.transport.{NodeWsServerEventFormat, PeerWsTransportEventFormat}
 import hydrozoa.multisig.consensus.{BlockWeaverEventFormat, CardanoLiaisonEventFormat, EventSequencerEventFormat, FastConsensusActorEventFormat, SlowConsensusActorEventFormat, StackComposerEventFormat}
 import hydrozoa.multisig.ledger.joint.JointLedgerEventFormat
 
@@ -26,6 +27,8 @@ object MultisigRegimeManagerEventFormat:
                 PeerLiaisonEventFormat.humanFormat(PeerId.Head(peerNum), remotePeerId)(pl)
             case BWL(bwl)                  => LimiterEventFormat.humanFormat("BlockWeaver")(bwl)
             case SCL(scl)                  => LimiterEventFormat.humanFormat("StackComposer")(scl)
+            case PWT(pwt)                  => PeerWsTransportEventFormat.humanFormat(peerNum)(pwt)
+            case NWS(nws)                  => NodeWsServerEventFormat.humanFormat(peerNum)(nws)
             case StartingActors            => info("Starting multisig actors...")
             case WatchingActors            => info("Watching multisig actors...")
             case TerminatedActor(actor)    => warn(s"Terminated $actor actor")

--- a/src/main/scala/hydrozoa/multisig/consensus/transport/NodeWsServer.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/transport/NodeWsServer.scala
@@ -3,7 +3,8 @@ package hydrozoa.multisig.consensus.transport
 import cats.effect.{IO, Resource}
 import cats.syntax.semigroupk.*
 import com.comcast.ip4s.{Host, Port}
-import hydrozoa.lib.logging.Logging
+import hydrozoa.lib.logging.ContraTracer
+import hydrozoa.multisig.consensus.transport.NodeWsServerEvent.Bound
 import org.http4s.HttpRoutes
 import org.http4s.ember.server.EmberServerBuilder
 import org.http4s.implicits.*
@@ -23,9 +24,9 @@ object NodeWsServer {
     def resource(
         bindHost: Host,
         bindPort: Port,
-        routes: List[WebSocketBuilder2[IO] => HttpRoutes[IO]]
-    ): Resource[IO, Server] = {
-        val logger = Logging.loggerIO(s"NodeWsServer.$bindHost:$bindPort")
+        routes: List[WebSocketBuilder2[IO] => HttpRoutes[IO]],
+        tracer: ContraTracer[IO, NodeWsServerEvent],
+    ): Resource[IO, Server] =
         EmberServerBuilder
             .default[IO]
             .withHost(bindHost)
@@ -42,6 +43,5 @@ object NodeWsServer {
                     .orNotFound
             )
             .build
-            .evalTap(_ => logger.info(s"WS server bound at ws://$bindHost:$bindPort"))
-    }
+            .evalTap(_ => tracer.traceWith(Bound(bindHost, bindPort)))
 }

--- a/src/main/scala/hydrozoa/multisig/consensus/transport/NodeWsServerEvent.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/transport/NodeWsServerEvent.scala
@@ -1,0 +1,12 @@
+package hydrozoa.multisig.consensus.transport
+
+import com.comcast.ip4s.{Host, Port}
+
+/** Typed events emitted by [[NodeWsServer]]. Pure data; formatters in [[NodeWsServerEventFormat]]
+  * decide how each variant is rendered to a particular sink.
+  */
+sealed trait NodeWsServerEvent
+
+object NodeWsServerEvent:
+    /** Emitted once when the Ember server successfully binds its listening socket. */
+    final case class Bound(host: Host, port: Port) extends NodeWsServerEvent

--- a/src/main/scala/hydrozoa/multisig/consensus/transport/NodeWsServerEventFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/transport/NodeWsServerEventFormat.scala
@@ -1,0 +1,19 @@
+package hydrozoa.multisig.consensus.transport
+
+import hydrozoa.lib.logging.LogEvent
+import hydrozoa.multisig.consensus.peer.HeadPeerNumber
+import hydrozoa.multisig.consensus.transport.NodeWsServerEvent.*
+
+/** Renderers from [[NodeWsServerEvent]] to [[LogEvent]]. */
+object NodeWsServerEventFormat:
+
+    /** Routes under `NodeWsServer.<own>` — tune the server's events for one peer at once. */
+    def humanFormat(own: HeadPeerNumber)(e: NodeWsServerEvent): LogEvent = {
+        val ownPn: Int = own
+        val ev = LogEvent.From(Map("peer" -> ownPn.toString), s"NodeWsServer.$ownPn")
+        import ev.*
+        e match {
+            case Bound(host, port) =>
+                info(s"WS server bound at ws://$host:$port")
+        }
+    }

--- a/src/main/scala/hydrozoa/multisig/consensus/transport/PeerWsTransport.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/transport/PeerWsTransport.scala
@@ -6,9 +6,10 @@ import cats.syntax.all.*
 import com.suprnation.actor.ActorRef.ActorRef
 import fs2.Stream
 import hydrozoa.config.head.network.CardanoNetwork
-import hydrozoa.lib.logging.Logging
+import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.consensus.liaison.{LiaisonProtocol, PeerLiaisonHeadToHead}
 import hydrozoa.multisig.consensus.peer.HeadPeerId
+import hydrozoa.multisig.consensus.transport.PeerWsTransportEvent.*
 import org.http4s.client.websocket.{WSClient, WSFrame, WSRequest}
 import org.http4s.dsl.io.*
 import org.http4s.server.websocket.WebSocketBuilder2
@@ -36,9 +37,8 @@ final class PeerWsTransport private (
     private val outboxes: Map[HeadPeerId, Queue[IO, String]],
     private val inboundRef: Ref[IO, Map[HeadPeerId, PeerLiaisonHeadToHead.Handle]],
     private val remotes: Map[HeadPeerId, Uri],
+    private val tracer: ContraTracer[IO, PeerWsTransportEvent],
 )(using CardanoNetwork.Section) {
-
-    private val logger = Logging.loggerIO(s"PeerWsTransport.${ownPeerId.peerNum: Int}")
 
     /** Wire a local PeerLiaisonHeadToHead handle as the inbound dispatch target for messages
       * arriving from [[remote]]. Must be called before the link to [[remote]] starts receiving
@@ -56,14 +56,11 @@ final class PeerWsTransport private (
                 val line = HeadFrame.encode(HeadFrame.Msg(wire))
                 outboxes.get(remote) match {
                     case Some(q) => q.offer(line)
-                    case None =>
-                        logger.warn(s"send: no outbox for remote=${remote.peerNum: Int}")
+                    case None    => tracer.traceWith(NoOutboxForRemote(remote))
                 }
             // TODO: this should be panic at least, better should be not possible by types @Claude
             case None =>
-                logger.warn(
-                  s"send: dropping non-wire request to remote=${remote.peerNum: Int}: $request"
-                )
+                tracer.traceWith(DroppingNonWireRequest(remote))
         }
 
     private def dispatchInbound(
@@ -73,11 +70,8 @@ final class PeerWsTransport private (
         inboundRef.get.flatMap { m =>
             m.get(remote) match {
                 case Some(liaison) => liaison ! payload
-                case None          =>
-                    // TODO This may be panic, but then there will be a very simple way to shut down any peer
-                    logger.warn(
-                      s"inbound from remote=${remote.peerNum: Int} but no liaison registered"
-                    )
+                // TODO This may be panic, but then there will be a very simple way to shut down any peer
+                case None => tracer.traceWith(NoLiaisonForInbound(remote))
             }
         }
 
@@ -90,14 +84,14 @@ final class PeerWsTransport private (
                 // Hello is only valid on the first frame; subsequent ones ignored.
                 IO.unit
             case Left(err) =>
-                logger.warn(
-                  s"failed to decode frame from remote=${remote.peerNum: Int}: ${err.getMessage}"
-                )
+                tracer.traceWith(ClientDecodeError(remote, err))
         }
 
-    /** Long-running dialer for a single remote. Reconnects with exponential backoff (capped).
-      * Outbox is preserved across reconnects.
+    /** Long-running dialer for a single remote. Attempts to reconnect forever with a 1-second
+      * delay. Outbox is preserved across reconnects.
       */
+    // FIXME: The comment previously read "attempts to reconnect with an exponential backoff", but this wasn't
+    //   reflected in the code. I'm leaving the old behavior until someone can say which is correct.
     private def dialerLoop(
         client: WSClient[IO],
         remote: HeadPeerId,
@@ -108,14 +102,12 @@ final class PeerWsTransport private (
         def once: IO[Unit] =
             client.connectHighLevel(request).use { conn =>
                 val helloLine = HeadFrame.encode(HeadFrame.Hello(ownPeerId.peerNum))
-                logger.info(s"dialer: connected to remote=${remote.peerNum: Int} at $uri") >>
+                tracer.traceWith(DialerConnected(remote, uri)) >>
                     conn.send(WSFrame.Text(helloLine)) >>
                     WsDuplex.run(conn, outboxes(remote), onLine(remote))
             }
 
-        val attempt: IO[Unit] = once.handleErrorWith(e =>
-            logger.warn(s"dialer to remote=${remote.peerNum: Int} failed: ${e.getMessage}")
-        )
+        val attempt: IO[Unit] = once.handleErrorWith(e => tracer.traceWith(DialerFailed(remote, e)))
 
         (attempt >> IO.sleep(1.second)).foreverM
     }
@@ -144,21 +136,18 @@ final class PeerWsTransport private (
                             val ownPn: Int = ownPeerId.peerNum
                             if pn < ownPn && pn >= 0 then {
                                 val remote = HeadPeerId(pn, ownPeerId.nHeadPeers)
-                                logger.info(s"server: accepted inbound from remote=$pn") >>
+                                tracer.traceWith(ServerAccepted(remote)) >>
                                     peerD.complete(remote).void
                             } else {
-                                logger.warn(
-                                  s"server: rejecting hello from peerNum=$pn " +
-                                      s"(own=$ownPn, must be lower)"
-                                )
+                                tracer.traceWith(ServerRejectedHello(pn, ownPn))
                             }
                         case Right(HeadFrame.Msg(payload)) =>
                             peerD.tryGet.flatMap {
                                 case Some(remote) => dispatchInbound(remote, payload)
-                                case None => logger.warn("server: msg before hello, dropping")
+                                case None         => tracer.traceWith(ServerMsgBeforeHello)
                             }
                         case Left(err) =>
-                            logger.warn(s"server: failed to decode frame: ${err.getMessage}")
+                            tracer.traceWith(ServerDecodeError(err))
                     }
                 case _ => IO.unit
             }
@@ -178,7 +167,11 @@ final class PeerWsTransport private (
         remotes.toList
             .filter { case (rid, _) => (rid.peerNum: Int) > (ownPeerId.peerNum: Int) }
             .traverse_ { case (rid, uri) =>
-                Resource.make(dialerLoop(client, rid, uri).start)(_.cancel).void
+                Resource
+                    .make(dialerLoop(client, rid, uri).start)(fiber =>
+                        tracer.traceWith(DialerStopped(rid, uri)) >> fiber.cancel
+                    )
+                    .void
             }
 }
 
@@ -192,15 +185,18 @@ object PeerWsTransport {
       *   identity of this peer.
       * @param remotes
       *   remote peers to their WebSocket URI (used for dialing higher-numbered peers).
+      * @param tracer
+      *   sink for transport-level events.
       */
     def create(
         ownPeerId: HeadPeerId,
         remotes: Map[HeadPeerId, Uri],
+        tracer: ContraTracer[IO, PeerWsTransportEvent],
     )(using CardanoNetwork.Section): IO[PeerWsTransport] =
         for {
             outboxes <- remotes.keys.toList
                 .traverse(rid => Queue.unbounded[IO, String].map(rid -> _))
                 .map(_.toMap)
             inboundRef <- Ref[IO].of(Map.empty[HeadPeerId, PeerLiaisonHeadToHead.Handle])
-        } yield new PeerWsTransport(ownPeerId, outboxes, inboundRef, remotes)
+        } yield new PeerWsTransport(ownPeerId, outboxes, inboundRef, remotes, tracer)
 }

--- a/src/main/scala/hydrozoa/multisig/consensus/transport/PeerWsTransportEvent.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/transport/PeerWsTransportEvent.scala
@@ -1,0 +1,54 @@
+package hydrozoa.multisig.consensus.transport
+
+import hydrozoa.multisig.consensus.peer.HeadPeerId
+import org.http4s.Uri
+
+/** Typed events emitted by [[PeerWsTransport]]. Pure data; formatters in
+  * [[PeerWsTransportEventFormat]] decide how each variant is rendered to a particular sink.
+  */
+sealed trait PeerWsTransportEvent
+
+object PeerWsTransportEvent:
+
+    // ---- send / dispatch ----
+
+    /** `send` was called for a remote that has no outbox — wiring bug. */
+    final case class NoOutboxForRemote(remote: HeadPeerId) extends PeerWsTransportEvent
+
+    /** `send` was called with a request variant that cannot be serialised over the wire. */
+    final case class DroppingNonWireRequest(remote: HeadPeerId) extends PeerWsTransportEvent
+
+    /** An inbound frame arrived from a remote that has no registered local liaison. */
+    final case class NoLiaisonForInbound(remote: HeadPeerId) extends PeerWsTransportEvent
+
+    // ---- dialer (client side) ----
+
+    /** A dialer successfully connected to a remote peer. */
+    final case class DialerConnected(remote: HeadPeerId, uri: Uri) extends PeerWsTransportEvent
+
+    /** A dialer attempt to a remote peer failed. */
+    final case class DialerFailed(remote: HeadPeerId, cause: Throwable) extends PeerWsTransportEvent
+
+    /** The dialer fiber for a remote peer was cancelled (resource release). */
+    final case class DialerStopped(remote: HeadPeerId, uri: Uri) extends PeerWsTransportEvent
+
+    /** A frame received on an active dialer connection could not be decoded. */
+    final case class ClientDecodeError(remote: HeadPeerId, cause: Throwable)
+        extends PeerWsTransportEvent
+
+    // ---- server (accept side) ----
+
+    /** The server accepted an inbound connection after receiving a valid `Hello`. */
+    final case class ServerAccepted(remote: HeadPeerId) extends PeerWsTransportEvent
+
+    /** The server rejected a `Hello` because the peer number violates the topology constraint (only
+      * lower-numbered peers dial higher-numbered peers).
+      */
+    final case class ServerRejectedHello(remotePeerNum: Int, ownPeerNum: Int)
+        extends PeerWsTransportEvent
+
+    /** A `Msg` frame arrived on the server side before the peer sent its `Hello`. */
+    case object ServerMsgBeforeHello extends PeerWsTransportEvent
+
+    /** A frame on the server side could not be decoded. */
+    final case class ServerDecodeError(cause: Throwable) extends PeerWsTransportEvent

--- a/src/main/scala/hydrozoa/multisig/consensus/transport/PeerWsTransportEventFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/transport/PeerWsTransportEventFormat.scala
@@ -1,0 +1,44 @@
+package hydrozoa.multisig.consensus.transport
+
+import hydrozoa.lib.logging.LogEvent
+import hydrozoa.multisig.consensus.peer.HeadPeerNumber
+import hydrozoa.multisig.consensus.transport.PeerWsTransportEvent.*
+
+/** Renderers from [[PeerWsTransportEvent]] to [[LogEvent]]. */
+object PeerWsTransportEventFormat:
+
+    /** Routes under `PeerWsTransport.<own>` — tune all transport events for one peer at once. */
+    def humanFormat(own: HeadPeerNumber)(e: PeerWsTransportEvent): LogEvent = {
+        val ownPn: Int = own
+        val ev = LogEvent.From(Map("peer" -> ownPn.toString), s"PeerWsTransport.$ownPn")
+        import ev.*
+        e match {
+            case NoOutboxForRemote(remote) =>
+                warn(s"send: no outbox for remote=${remote.peerNum: Int}")
+            case DroppingNonWireRequest(remote) =>
+                warn(s"send: dropping non-wire request to remote=${remote.peerNum: Int}")
+            case NoLiaisonForInbound(remote) =>
+                warn(s"inbound from remote=${remote.peerNum: Int} but no liaison registered")
+            case DialerConnected(remote, uri) =>
+                info(s"dialer: connected to remote=${remote.peerNum: Int} at $uri")
+            case DialerFailed(remote, cause) =>
+                warn(s"dialer to remote=${remote.peerNum: Int} failed: ${cause.getMessage}")
+            case DialerStopped(remote, uri) =>
+                info(s"dialer: stopped for remote=${remote.peerNum: Int} at $uri")
+            case ClientDecodeError(remote, cause) =>
+                warn(
+                  s"failed to decode frame from remote=${remote.peerNum: Int}: ${cause.getMessage}"
+                )
+            case ServerAccepted(remote) =>
+                info(s"server: accepted inbound from remote=${remote.peerNum: Int}")
+            case ServerRejectedHello(remotePeerNum, ownPeerNum) =>
+                warn(
+                  s"server: rejecting hello from peerNum=$remotePeerNum " +
+                      s"(own=$ownPeerNum, must be lower)"
+                )
+            case ServerMsgBeforeHello =>
+                warn("server: msg before hello, dropping")
+            case ServerDecodeError(cause) =>
+                warn(s"server: failed to decode frame: ${cause.getMessage}")
+        }
+    }

--- a/src/test/scala/test/TestPeers.scala
+++ b/src/test/scala/test/TestPeers.scala
@@ -15,6 +15,7 @@ import hydrozoa.lib.cardano.scalus.txbuilder.Transaction.attachVKeyWitnesses
 import hydrozoa.lib.cardano.wallet.WalletModule
 import hydrozoa.multisig.consensus.peer.{HeadPeerId, HeadPeerNumber, PeerWallet}
 import hydrozoa.multisig.ledger.l1.tx.Tx
+import org.http4s.Uri
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Test.Parameters
 import org.scalacheck.{Gen, Prop, Properties}
@@ -74,7 +75,7 @@ case class TestPeers private (
 
         val headPeerVKeys: NonEmptyList[VerificationKey] = helper(verificationKeyFor)
 
-        val headPeersAddresses: NonEmptyList[String] = helper(webSocketAddressFor)
+        val headPeersAddresses: NonEmptyList[Uri] = helper(webSocketAddressFor)
 
         headPeerVKeys
             .zip(headPeersAddresses)
@@ -90,13 +91,13 @@ case class TestPeers private (
 
     }
 
-    def webSocketAddressFor(peerNumber: HeadPeerNumber): String =
+    def webSocketAddressFor(peerNumber: HeadPeerNumber): Uri =
         webSocketAddressFor(TestPeerName.fromOrdinal(peerNumber))
 
     // TODO: What do we want here?
-    def webSocketAddressFor(peer: TestPeerName): String = {
+    def webSocketAddressFor(peer: TestPeerName): Uri = {
         _require(peer)
-        s"ws://localhost/${peer.name}"
+        Uri.unsafeFromString(s"ws://localhost/${peer.name}")
     }
 
     def verificationKeyFor(peerNumber: HeadPeerNumber): VerificationKey =


### PR DESCRIPTION
…ource

- PeerWsTransport and NodeWsServer: replace loggerIO with ContraTracer (PeerWsTransportEvent/Format, NodeWsServerEvent/Format); add PWT/NWS cases to MultisigRegimeManagerEvent roll-up
- MultisigRegimeManager: replace apply with resource, composing WS client → transport → server → dialers as a Resource chain; spawn RemotePeerProxy actors and register liaisons in preStartLocal; add watchChildren varargs helper to collapse the context.watch calls
- HeadPeerData.webSocketAddress: String → Uri with circe codecs
- Bootstrap/Main: wire HYDROZOA_HOST/PORT through EnvConfig; populate webSocketAddress from env; pass bindHost/bindPort to MRM.resource