### PR TITLE
fix(rulebased): pin treasury output address in Evacuate

### DIFF
--- a/src/main/scala/hydrozoa/rulebased/ledger/l1/script/plutus/RuleBasedTreasuryScript.scala
+++ b/src/main/scala/hydrozoa/rulebased/ledger/l1/script/plutus/RuleBasedTreasuryScript.scala
@@ -112,6 +112,8 @@ object RuleBasedTreasuryValidator extends Validator {
         "version in treasuryInput and treasuryOutput must match"
     private inline val EvacuateSetupG2ShouldBePreserved =
         "setupG2 in treasuryInput and treasuryOutput must match"
+    private inline val EvacuateTreasuryWrongAddress =
+        "Treasury output must remain at the treasury script address"
 
     // Deinit redeemer
     private inline val DeinitRequiresResolvedTreasury =
@@ -281,6 +283,15 @@ object RuleBasedTreasuryValidator extends Validator {
                 //   - the tail be evacuatees
                 val List.Cons(changeOutput, List.Cons(treasuryOutput, evacuationOutputs)) =
                     tx.outputs: @unchecked
+
+                // The continuing treasury output must stay at the treasury script address. The
+                // checks below only constrain its beacon, datum and total value — not where it
+                // goes; without this an Evacuate could redirect the beacon and the entire treasury
+                // value to an arbitrary address (cf. the Resolve branch, which pins the address).
+                require(
+                  treasuryOutput.address === treasuryInput.address,
+                  EvacuateTreasuryWrongAddress
+                )
 
                 require(
                   treasuryOutput.value.toSortedMap

--- a/src/test/scala/hydrozoa/rulebased/ledger/l1/script/plutus/RuleBasedTreasuryScriptTest.scala
+++ b/src/test/scala/hydrozoa/rulebased/ledger/l1/script/plutus/RuleBasedTreasuryScriptTest.scala
@@ -2,12 +2,21 @@ package hydrozoa.rulebased.ledger.l1.script.plutus
 
 import hydrozoa.lib.cardano.scalus.Scalar as ScalusScalar
 import hydrozoa.multisig.ledger.commitment.{KzgCommitment, TrustedSetup}
+import hydrozoa.multisig.ledger.joint.EvacuationKey
+import hydrozoa.rulebased.ledger.l1.script.plutus.RuleBasedTreasuryValidator.given
+import hydrozoa.rulebased.ledger.l1.script.plutus.RuleBasedTreasuryValidator.{EvacuateRedeemer, TreasuryRedeemer}
+import hydrozoa.rulebased.ledger.l1.state.TreasuryState.RuleBasedTreasuryDatumOnchain
+import hydrozoa.rulebased.ledger.l1.state.TreasuryState.given
 import org.scalatest.funsuite.AnyFunSuite
 import scala.annotation.nowarn
 import scala.io.Source
-import scalus.cardano.onchain.plutus.prelude.List
 import scalus.cardano.onchain.plutus.prelude.crypto.bls12_381.G1
-import scalus.cardano.onchain.plutus.v3.ScriptContext
+import scalus.cardano.onchain.plutus.prelude.{List, Option}
+import scalus.cardano.onchain.plutus.v1.Value.+
+import scalus.cardano.onchain.plutus.v1.{Address, Credential, Value}
+import scalus.cardano.onchain.plutus.v2.{OutputDatum, TxOut}
+import scalus.cardano.onchain.plutus.v3.{PubKeyHash, ScriptContext, TxId, TxInInfo, TxInfo, TxOutRef}
+import scalus.uplc.builtin.Data.toData
 import scalus.uplc.builtin.bls12_381.*
 import scalus.uplc.builtin.{ByteString, Data}
 import scalus.|>
@@ -91,6 +100,95 @@ class RuleBasedTreasuryScriptTest extends AnyFunSuite {
 
         assert(
           RuleBasedTreasuryValidator.checkMembership(crsG2, accumulator, subset, proof)
+        )
+    }
+
+    // ---- C-01: Evacuate redirect — regression guard (see security review) ------------------
+    //
+    // `Evacuate` must keep the continuing treasury output at the treasury script address. The
+    // other checks only constrain that output's beacon, datum and total value — not where it
+    // goes. Without the address check, an empty-subset evacuation (proof = the current
+    // accumulator) is forced by value-preservation to put the ENTIRE treasury into the continuing
+    // output, which an attacker can simply address to themselves. This test pins the fix:
+    // identical txs, the only difference being the treasury output address.
+
+    private val headMp: ByteString = ByteString.fromHex("a0" * 28)
+    // CIP-67 HYDR (label 4937 -> prefix 0x01349900) beacon prefix + 28-byte head suffix.
+    private val beaconName: ByteString = ByteString.fromHex("01349900" + "bb" * 28)
+
+    private val treasuryValue: Value =
+        Value.lovelace(BigInt(100_000_000)) + Value(headMp, beaconName, BigInt(1))
+
+    // Compressed BLS12-381 G1 generator — a valid G1 point, reused as accumulator AND proof so
+    // the empty-subset membership check e(acc, g2) == e(proof, g2) holds (it reduces to acc == proof).
+    private val g1Point: ByteString = ByteString.fromHex(
+      "97f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb"
+    )
+    private val setupG2: List[ByteString] =
+        TrustedSetup.takeSrsG2(1).map(p2 => G2Element(p2).toCompressedByteString)
+
+    private val resolvedDatum: RuleBasedTreasuryDatumOnchain =
+        RuleBasedTreasuryDatumOnchain.ResolvedOnchain(
+          headMp = headMp,
+          evacuationActive = g1Point,
+          version = (BigInt(1), BigInt(0)),
+          setupG2 = setupG2
+        )
+
+    private val treasuryScriptAddr: Address =
+        Address.fromScriptHash(ByteString.fromHex("11" * 28))
+    private val attackerAddr: Address =
+        Address.fromCredential(
+          Credential.PubKeyCredential(PubKeyHash(ByteString.fromHex("ee" * 28)))
+        )
+
+    private val treasuryRef: TxOutRef = TxOutRef(TxId(ByteString.fromHex("ab" * 32)), BigInt(0))
+    private val treasuryInput: TxInInfo = TxInInfo(
+      treasuryRef,
+      TxOut(treasuryScriptAddr, treasuryValue, OutputDatum.OutputDatum(resolvedDatum.toData))
+    )
+
+    /** Runs the real on-chain `Evacuate` logic for an empty-subset evacuation whose continuing
+      * treasury output is addressed to `treasuryOutputAddr`. Returns Success iff the validator
+      * accepts the transaction (the BLS pairing check runs on the JVM via blst).
+      */
+    private def runEmptyEvacuate(treasuryOutputAddr: Address): scala.util.Try[Unit] = {
+        val changeOutput = TxOut(attackerAddr, Value.lovelace(BigInt(2_000_000)))
+        val treasuryOutput =
+            TxOut(treasuryOutputAddr, treasuryValue, OutputDatum.OutputDatum(resolvedDatum.toData))
+        val txInfo = TxInfo(
+          inputs = List(treasuryInput),
+          outputs = List(changeOutput, treasuryOutput),
+          id = TxId(ByteString.fromHex("cd" * 32))
+        )
+        val redeemer: TreasuryRedeemer = TreasuryRedeemer.Evacuate(
+          EvacuateRedeemer(evacuationKeys = List.empty[EvacuationKey], proof = g1Point)
+        )
+        scala.util.Try(
+          RuleBasedTreasuryValidator.spend(
+            Option.Some(resolvedDatum.toData),
+            redeemer.toData,
+            txInfo,
+            treasuryRef
+          )
+        )
+    }
+
+    test("C-01: Evacuate lets the resolved treasury be redirected to an attacker address") {
+        // Baseline: returning the treasury to its own script address is accepted — proving the
+        // transaction is otherwise valid and the ONLY thing varied below is the output address.
+        assert(
+          runEmptyEvacuate(treasuryScriptAddr).isSuccess,
+          "baseline honest no-op evacuation (treasury -> script address) should be accepted"
+        )
+
+        // ATTACK: identical tx, but the continuing treasury output (beacon + the ENTIRE treasury
+        // value) is addressed to the attacker's wallet. The address check must reject it.
+        // (Before the fix this was a Success — the live C-01 vulnerability.)
+        val attack = runEmptyEvacuate(attackerAddr)
+        assert(
+          attack.isFailure,
+          s"C-01 regression: a treasury output at a non-script address must be rejected, got: $attack"
         )
     }
 


### PR DESCRIPTION
## Summary

`RuleBasedTreasuryValidator`'s **`Evacuate`** branch pins the continuing treasury output's beacon token, datum fields and total value — but never its **address**. The `Resolve` branch checks the address; `Evacuate` does not.

Because `Evacuate` is **permissionless** (outputs are meant to be pinned by the KZG evacuation commitment), any third party can redirect a *resolved* treasury to an address they control.

### Exploit (empty-subset evacuation)

An `Evacuate` with `evacuationKeys = []` and `proof = <current accumulator>`:

- passes the membership check — with an empty subset, `e(acc, g₂) == e(proof, g₂)` reduces to `acc == proof`;
- has `evacuatedValue = 0`, so value-preservation `treasuryInput.value === treasuryOutput.value + evacuatedValue` **forces the entire treasury** (beacon + all backing funds) into the continuing output;
- …which the attacker simply addresses to their own wallet.

Every other check (beacon present, datum fields preserved, value preserved) still passes, so the whole treasury is stolen. Partial evacuations are affected too — the residual treasury that sits between batches can be redirected the same way.

## Fix

One `require`, mirroring the `Resolve` branch:

```scala
require(treasuryOutput.address === treasuryInput.address, EvacuateTreasuryWrongAddress)
```

## Test

`RuleBasedTreasuryScriptTest` gains a regression test that drives the **real** on-chain `Evacuate` logic (the BLS pairing runs on the JVM via `blst`). It submits two byte-for-byte identical transactions, varying only the treasury-output address:

- → treasury **script** address: accepted (proves the tx is otherwise valid);
- → **attacker** address: **rejected** by the new check.

Before the fix, the second case was accepted — the live vulnerability.

## Verification

- `sbtn "testOnly *RuleBasedTreasuryScriptTest"` → green (5 passed, 1 pre-existing `ignore`d).
- `scalafmtCheck` / `Test/scalafmtCheck` → clean; pre-commit `lint fmt check` passed.

> Heads-up unrelated to this PR: `just build-werror` currently reports 57 pre-existing `-Werror` "unused value of type Assertion" errors in `multisig/{consensus,persistence/recovery}` test files (from #467) under JDK 25. None are in the files this PR touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
