### PR TITLE
Run N head peers + M coil peers from a shared head config

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "andrej-karpathy-skills@karpathy-skills": true
+  }
+}

--- a/.env.example
+++ b/.env.example
@@ -6,17 +6,28 @@
 BLOCKFROST_API_KEY=your_blockfrost_api_key_here
 
 # Cardano Verification Key (Ed25519)
-# Hex-encoded, 64 hex characters (32 bytes)
+# This node's OWN key. Hex-encoded, 64 hex characters (32 bytes).
+# Must match this node's entry in the shared head config (see peers.example.json).
 # Example: a1b2c3d4e5f6789012345678901234567890123456789012345678901234abcd
 CARDANO_VERIFICATION_KEY=your_64_char_hex_verification_key_here
 
 # Cardano Signing Key (Ed25519)
-# Hex-encoded, 64 hex characters (32 bytes)
+# This node's OWN key. Hex-encoded, 64 hex characters (32 bytes).
 # Example: d4e5f6789012345678901234567890123456789012345678901234567890abcd
 CARDANO_SIGNING_KEY=your_64_char_hex_signing_key_here
 
-# Head Equity (in lovelace)
-# 1 ADA = 1,000,000 lovelace
+# This node's identity within the head: <head|coil>:<index>
+# The index must match this node's position in the shared head config:
+# head peers by verification-key order, coil peers by their coil number.
+# Examples: head:0 (the funding head peer), head:1, coil:0, coil:3
+NODE_ID=head:0
+
+# Path to the shared head config artifact produced by BuildHeadConfig.
+# Every node in the head loads the SAME file. Optional; defaults to head-config.json.
+HEAD_CONFIG_PATH=head-config.json
+
+# Head equity (in lovelace) — used by BuildHeadConfig ONLY, not by a running node.
+# Head peer 0's L2 equity contribution. 1 ADA = 1,000,000 lovelace.
 # Example: 2000000 = 2 ADA
 EQUITY=2000000
 
@@ -24,7 +35,7 @@ EQUITY=2000000
 SUGAR_RUSH_HOST=sugar-rush
 SUGAR_RUSH_PORT=3000
 
-# Hydrozoa's http server
+# Hydrozoa's user-facing http server (head nodes only)
 HTTP_HOST=localhost
 HTTP_PORT=3000
 

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,10 @@ target/
 #scratches
 .scratch
 
+# Generated shared head config and per-node persistence (produced at runtime)
+/head-config.json
+/.hydrozoa-data/
+
 # Local scratch / notes (not for commit)
 .scratch/
 

--- a/peers.example.json
+++ b/peers.example.json
@@ -1,0 +1,33 @@
+{
+  "_comment": [
+    "Head+coil membership for one head, consumed by BuildHeadConfig to produce the shared",
+    "head-config.json that every node then loads. Authored once from GenerateKeyPair output.",
+    "headPeers: ordered; the head peer's index (its NODE_ID) is its position here, head peer 0",
+    "first. webSocketAddress is where the peer is dialed for inter-peer consensus traffic.",
+    "coilPeers: ordered by coil number (its NODE_ID); each names the head peer that hubs it.",
+    "A coil peer is never dialed (it dials its hub), so it carries no address.",
+    "coilQuorum: how many coil signatures the head multisig requires (must be <= number of",
+    "coil peers). verificationKey is 64 hex chars (32-byte Ed25519). The parser ignores _comment."
+  ],
+  "headPeers": [
+    {
+      "verificationKey": "0000000000000000000000000000000000000000000000000000000000000000",
+      "webSocketAddress": "ws://hydranth-0:4001"
+    },
+    {
+      "verificationKey": "1111111111111111111111111111111111111111111111111111111111111111",
+      "webSocketAddress": "ws://hydranth-1:4001"
+    }
+  ],
+  "coilPeers": [
+    {
+      "verificationKey": "2222222222222222222222222222222222222222222222222222222222222222",
+      "hubHeadPeerNumber": 0
+    },
+    {
+      "verificationKey": "3333333333333333333333333333333333333333333333333333333333333333",
+      "hubHeadPeerNumber": 1
+    }
+  ],
+  "coilQuorum": 1
+}

--- a/src/main/scala/hydrozoa/app/Bootstrap.scala
+++ b/src/main/scala/hydrozoa/app/Bootstrap.scala
@@ -6,7 +6,7 @@ import cats.effect.{ExitCode, IO, IOApp}
 import com.bloxbean.cardano.client.util.HexUtil
 import hydrozoa.app.Main.loadEnv
 import hydrozoa.config.head.HeadConfig
-import hydrozoa.config.head.coil.CoilPeers
+import hydrozoa.config.head.coil.{CoilPeerData, CoilPeers}
 import hydrozoa.config.head.initialization.{InitialBlock, InitializationParameters}
 import hydrozoa.config.head.multisig.fallback.FallbackContingency.mkFallbackContingencyWithDefaults
 import hydrozoa.config.head.multisig.settlement.SettlementConfig
@@ -16,10 +16,8 @@ import hydrozoa.config.head.network.{CardanoNetwork, StandardCardanoNetwork}
 import hydrozoa.config.head.parameters.HeadParameters
 import hydrozoa.config.head.peers.{HeadPeerData, HeadPeers}
 import hydrozoa.config.head.rulebased.dispute.DisputeResolutionConfig
-import hydrozoa.config.node.NodeConfig
-import hydrozoa.config.node.operation.evacuation.NodeOperationEvacuationConfig
-import hydrozoa.config.node.operation.multisig.NodeOperationMultisigConfig
 import hydrozoa.config.{HydrozoaBlueprint, ScriptReferenceUtxos}
+import hydrozoa.lib.cardano.cip116.JsonCodecs.CIP0116.Conway.given
 import hydrozoa.lib.cardano.scalus.QuantizedTime.QuantizedInstant.realTimeQuantizedInstant
 import hydrozoa.lib.cardano.scalus.QuantizedTime.quantize
 import hydrozoa.lib.cardano.scalus.VerificationKeyExtra.shelleyAddress
@@ -33,12 +31,16 @@ import hydrozoa.multisig.ledger.joint.obligation.Payout
 import hydrozoa.multisig.ledger.joint.{EvacuationKey, EvacuationMap, evacuationKeyOrdering}
 import hydrozoa.multisig.ledger.l1.txseq.InitializationTxSeq
 import hydrozoa.rulebased.ledger.l1.script.plutus.RuleBasedTreasuryValidator.evacuationKeyToData
+import io.circe.generic.semiauto.deriveDecoder
+import io.circe.syntax.*
+import io.circe.{Decoder, parser}
+import io.github.cdimascio.dotenv.Dotenv
+import java.nio.file.{Files, Path}
 import java.security.SecureRandom
 import monocle.Focus.focus
 import org.bouncycastle.crypto.generators.Ed25519KeyPairGenerator
 import org.bouncycastle.crypto.params.{Ed25519KeyGenerationParameters, Ed25519PrivateKeyParameters, Ed25519PublicKeyParameters}
 import scala.collection.immutable.{SortedMap, TreeMap}
-import scala.concurrent.duration.DurationInt
 import scalus.cardano.address.Address
 import scalus.cardano.ledger.TransactionOutput.Babbage
 import scalus.cardano.ledger.{Coin, Hash32, KeepRaw, PlutusScriptEvaluator, ScriptRef, TransactionHash, TransactionInput, TransactionOutput, Utxo, Value}
@@ -80,24 +82,34 @@ object Bootstrap:
             (vKey, sKey)
         }
 
-    /** @return
-      *   NodeConfig, such that:
-      *   - one node is in the head
-      *   - the provided key pair [[vKey]]/[[sKey]] is used for that only node
-      *   - the initial equity is not less than [[minEquity]]
-      *   - the initial l2 is empty
-      *   - Cardano preview is used
-      *   - utxos available on l1 VKey's enterprise address will be used for funding the head
-      *   - the initial l2 parameters are empty
+    /** The static head+coil membership the build step turns into a shared [[HeadConfig]]: each head
+      * peer's verification key + WebSocket address, each coil peer's verification key + hub head
+      * peer, and the coil quorum. Authored once (from [[GenerateKeyPair]] output) and shared with
+      * every node. Head peer 0 is the first entry in [[headPeers]].
       */
-    def mkNodeConfig(cardanoNetwork: CardanoNetwork, backend: CardanoBackend[IO])(
-        vKey: VerificationKey,
-        sKey: SigningKey,
-        minEquity: Coin,
-    ): IO[NodeConfig] = for {
-        _ <- IO.pure(())
+    final case class Membership(
+        headPeers: List[HeadPeerData],
+        coilPeers: List[CoilPeerData],
+        coilQuorum: Int
+    )
 
-        ownHeadWallet = PeerWallet.scalusWallet(vKey, sKey)
+    object Membership {
+        private given Decoder[HeadPeerData] = deriveDecoder[HeadPeerData]
+        given Decoder[Membership] = deriveDecoder[Membership]
+    }
+
+    /** Build the shared [[HeadConfig]] every node loads, for an N-head + M-coil head.
+      *
+      * Only head peer 0 funds the head: it contributes [[minEquity]] as L2 equity and covers the
+      * whole head's fallback contingency (the collective share once, plus one individual share per
+      * head peer) from its own L1 enterprise address. Heads 1..N-1 contribute zero and just co-sign
+      * the stack-0 initialization; coil peers fund nothing. The initial L2 ledger and L2 parameters
+      * are empty, and Cardano preview is used.
+      */
+    def mkSharedHeadConfig(cardanoNetwork: CardanoNetwork, backend: CardanoBackend[IO])(
+        membership: Membership,
+        minEquity: Coin
+    ): IO[HeadConfig] = for {
         startTimeInstant <- realTimeQuantizedInstant(cardanoNetwork.slotConfig)
         blockCreationStartTime = BlockCreationStartTime(startTimeInstant)
 
@@ -109,7 +121,7 @@ object Bootstrap:
           ),
           disputeResolutionConfig = DisputeResolutionConfig.default(cardanoNetwork.slotConfig),
           settlementConfig = SettlementConfig(PositiveInt.unsafeApply(100)),
-          coilQuorum = 0,
+          coilQuorum = membership.coilQuorum,
           l2ParamsHash = Hash32.fromByteString(ByteString.empty),
         )
 
@@ -144,8 +156,23 @@ object Bootstrap:
           )
         )
 
-        peerAddress = vKey.shelleyAddress()(using cardanoNetwork)
-        _ <- logger.info(s"Peer address: ${peerAddress.toBech32.get}")
+        headPeers <- IO.fromOption(
+          HeadPeers(
+            NonEmptyMap.fromMapUnsafe(
+              SortedMap.from(
+                membership.headPeers.zipWithIndex.map((data, i) => HeadPeerNumber(i) -> data)
+              )
+            )
+          )
+        )(RuntimeException("head peers must be a non-empty list (head peer 0 first)"))
+
+        coilPeers = CoilPeers.indexed(membership.coilPeers)
+        nHeadPeers = membership.headPeers.size
+
+        // Head peer 0 is the sole funder; its L1 enterprise address supplies the seed and funding.
+        funderVKey = membership.headPeers.head.verificationKey
+        peerAddress = funderVKey.shelleyAddress()(using cardanoNetwork)
+        _ <- logger.info(s"Funder (head peer 0) address: ${peerAddress.toBech32.get}")
 
         // Fetch UTXOs from backend
         utxosResult <- backend.utxosAt(peerAddress)
@@ -155,15 +182,22 @@ object Bootstrap:
           )
         )
 
-        // Calculate required value: minEquity + contingency + max non-Plutus tx fee for initialization
-        maxNonPlutusTxFee = cardanoNetwork.maxNonPlutusTxFee
-        zeroPeerContingency = headParams.fallbackContingency.totalContingencyFor(
-          HeadPeerNumber.zero
+        // The whole head's fallback contingency, all funded by head peer 0: the collective share
+        // once plus one individual share per head peer.
+        fallbackContingency = headParams.fallbackContingency
+        totalContingency = Coin(
+          fallbackContingency.collectiveContingency.total.value +
+              nHeadPeers.toLong * fallbackContingency.individualContingency.total.value
         )
-        requiredValue = Value(minEquity + zeroPeerContingency + maxNonPlutusTxFee)
+
+        // Calculate required value: equity + total head contingency + evacuation fee account +
+        // max non-Plutus tx fee for initialization
+        maxNonPlutusTxFee = cardanoNetwork.maxNonPlutusTxFee
+        requiredValue = Value(minEquity + totalContingency + maxNonPlutusTxFee) + feeAccValue
         _ <- logger.info(
           s"Required value: ${minEquity.value} lovelace (equity) + " +
-              s"${zeroPeerContingency} lovelace (peer contingency) + " +
+              s"${totalContingency.value} lovelace (total head contingency) + " +
+              s"${feeAccValue.coin.value} lovelace (evacuation fee account) + " +
               s"${maxNonPlutusTxFee.value} lovelace (fee) = ${requiredValue.coin.value} lovelace"
         )
 
@@ -215,19 +249,25 @@ object Bootstrap:
         seedUtxo = utxosSelected.head
         valueSelected = Value.combine(utxosSelected.map(_.output.value).toList)
 
-        headPeers = HeadPeers(NonEmptyMap.one(HeadPeerNumber.zero, HeadPeerData(vKey, "FIXME"))).get
+        // Only head peer 0 contributes equity; heads 1..N-1 contribute zero and just co-sign.
+        initialEquityContributions = NonEmptyMap.fromMapUnsafe(
+          SortedMap.from(
+            membership.headPeers.zipWithIndex.map((_, i) =>
+                HeadPeerNumber(i) -> (if i == 0 then minEquity else Coin.zero)
+            )
+          )
+        )
 
         initializationParameters = InitializationParameters(
           initialEvacuationMap = evacMap,
-          initialEquityContributions =
-              NonEmptyMap(HeadPeerNumber.zero -> minEquity, SortedMap.empty),
+          initialEquityContributions = initialEquityContributions,
           seedUtxo = seedUtxo,
           additionalFundingUtxos = utxosSelected.tail.map(_.toTuple).toMap,
           initialChangeOutputs = List(
             TransactionOutput.Babbage(
               address = peerAddress,
               value = valueSelected - Value(minEquity) -
-                  Value(zeroPeerContingency) - feeAccValue,
+                  Value(totalContingency) - feeAccValue,
               datumOption = None,
               scriptRef = None
             )
@@ -240,7 +280,7 @@ object Bootstrap:
                 cardanoNetwork = cardanoNetwork,
                 headParams = headParams,
                 headPeers = headPeers,
-                coilPeers = CoilPeers.empty,
+                coilPeers = coilPeers,
                 initializationParams = initializationParameters,
                 scriptReferenceUtxos = fakeScriptReferenceUtxos(cardanoNetwork)
               )
@@ -304,23 +344,7 @@ object Bootstrap:
                   RuntimeException("failure building head config; get logs for details")
                 )
         }
-    } yield {
-        NodeConfig
-            .mkHeadConfig(
-              headConfig = headConfig,
-              ownHeadWallet = ownHeadWallet,
-              nodeOperationEvacuationConfig = NodeOperationEvacuationConfig(
-                evacuationBotPollingPeriod = 1.minute,
-                // NOTE: Reusing the same multisig wallet, in production this should be a different wallet
-                evacuationWallet = ownHeadWallet
-              ),
-              hydrozoaHost = ???,
-              hydrozoaPort = ???,
-              blockfrostApiKey = ???,
-              nodeOperationMultisigConfig = NodeOperationMultisigConfig.default
-            )
-            .get
-    }
+    } yield headConfig
 
     // TODO: remove once we have a proper way of doing things
     def fakeScriptReferenceUtxos(network: CardanoNetwork.Section): ScriptReferenceUtxos =
@@ -375,6 +399,73 @@ object Bootstrap:
         )
 
 end Bootstrap
+
+/** Build the shared head config artifact every node loads.
+  *
+  * Usage: sbt "runMain hydrozoa.app.BuildHeadConfig <peers.json> [<out.json>]"
+  *
+  * Reads the head+coil membership from `<peers.json>`, funds the head from head peer 0's L1
+  * address, and writes the resulting [[HeadConfig]] as JSON to `<out.json>` (default
+  * `head-config.json`). Every node then loads this same artifact.
+  *
+  * Required environment variables:
+  *   - BLOCKFROST_API_KEY: Blockfrost API key for the Cardano backend
+  *   - EQUITY: head peer 0's equity contribution in lovelace
+  */
+object BuildHeadConfig extends IOApp:
+
+    private val logger = Logging.loggerIO("hydrozoa.app.BuildHeadConfig")
+
+    private val cardanoNetwork: StandardCardanoNetwork = CardanoNetwork.Preview
+
+    private lazy val dotenv: Dotenv = Dotenv.configure().ignoreIfMissing().load()
+
+    private def mandatoryEnvVar(name: String): IO[String] =
+        IO(
+          Option(dotenv.get(name))
+              .orElse(sys.env.get(name))
+              .getOrElse(
+                throw new IllegalStateException(
+                  s"Required environment variable not set: $name (checked .env file and system environment)"
+                )
+              )
+        )
+
+    override def run(args: List[String]): IO[ExitCode] = args match {
+        case membershipPath :: rest =>
+            val outPath = rest.headOption.getOrElse("head-config.json")
+            for {
+                blockfrostKey <- mandatoryEnvVar("BLOCKFROST_API_KEY")
+                equityStr <- mandatoryEnvVar("EQUITY")
+                minEquity <- IO.fromEither(
+                  equityStr.toLongOption
+                      .toRight(
+                        new IllegalArgumentException(
+                          s"EQUITY must be a valid long, got: $equityStr"
+                        )
+                      )
+                      .map(Coin.apply)
+                )
+                membershipStr <- IO.blocking(Files.readString(Path.of(membershipPath)))
+                membership <- IO.fromEither(parser.decode[Bootstrap.Membership](membershipStr))
+                _ <- logger.info(
+                  s"Building shared head config: ${membership.headPeers.size} head peer(s), " +
+                      s"${membership.coilPeers.size} coil peer(s), coil quorum ${membership.coilQuorum}"
+                )
+                backend <- CardanoBackendBlockfrost(Left(cardanoNetwork), blockfrostKey)
+                headConfig <- Bootstrap.mkSharedHeadConfig(cardanoNetwork, backend)(
+                  membership,
+                  minEquity
+                )
+                _ <- IO.blocking(Files.writeString(Path.of(outPath), headConfig.asJson.spaces2))
+                _ <- logger.info(s"Wrote shared head config to $outPath")
+            } yield ExitCode.Success
+        case Nil =>
+            IO.println(
+              "Usage: sbt \"runMain hydrozoa.app.BuildHeadConfig <peers.json> [<out.json>]\""
+            ).as(ExitCode.Error)
+    }
+end BuildHeadConfig
 
 /** Main entry point for generating a new Ed25519 key pair.
   *

--- a/src/main/scala/hydrozoa/app/Bootstrap.scala
+++ b/src/main/scala/hydrozoa/app/Bootstrap.scala
@@ -122,7 +122,9 @@ object Bootstrap:
           disputeResolutionConfig = DisputeResolutionConfig.default(cardanoNetwork.slotConfig),
           settlementConfig = SettlementConfig(PositiveInt.unsafeApply(100)),
           coilQuorum = membership.coilQuorum,
-          l2ParamsHash = Hash32.fromByteString(ByteString.empty),
+          // Placeholder: the L2 params hash is not consumed yet. Hash32 requires 32 bytes, so use
+          // a zero hash rather than empty bytes (which fail the length check).
+          l2ParamsHash = Hash32.fromByteString(ByteString.fromArray(new Array[Byte](32))),
         )
 
         // This is the temporary hard-coded evacuation map - 10 ADA

--- a/src/main/scala/hydrozoa/app/Bootstrap.scala
+++ b/src/main/scala/hydrozoa/app/Bootstrap.scala
@@ -122,7 +122,7 @@ object Bootstrap:
           disputeResolutionConfig = DisputeResolutionConfig.default(cardanoNetwork.slotConfig),
           settlementConfig = SettlementConfig(PositiveInt.unsafeApply(100)),
           coilQuorum = membership.coilQuorum,
-          l2ParamsHash = Hash32.fromByteString(ByteString.empty),
+          l2ParamsHash = Hash32.fromByteString(ByteString.fromArray(new Array[Byte](32))),
         )
 
         // This is the temporary hard-coded evacuation map - 10 ADA

--- a/src/main/scala/hydrozoa/app/Main.scala
+++ b/src/main/scala/hydrozoa/app/Main.scala
@@ -2,30 +2,35 @@ package hydrozoa.app
 
 import cats.effect.{ExitCode, IO, IOApp, Resource}
 import cats.implicits.*
-import com.bloxbean.cardano.client.util.HexUtil
-import com.bloxbean.cardano.client.util.HexUtil.encodeHexString
-import com.comcast.ip4s.{host, port}
+import com.comcast.ip4s.{Host, Port, host, port}
 import com.suprnation.actor.ActorSystem
+import hydrozoa.config.head.HeadConfig
 import hydrozoa.config.head.network.{CardanoNetwork, StandardCardanoNetwork}
+import hydrozoa.config.node.NodeConfig
+import hydrozoa.config.node.operation.evacuation.NodeOperationEvacuationConfig
+import hydrozoa.config.node.operation.multisig.NodeOperationMultisigConfig
 import hydrozoa.lib.cardano.scalus.VerificationKeyExtra.shelleyAddress
-import hydrozoa.lib.logging.{Logging, Slf4jTracer}
-import hydrozoa.multisig.backend.cardano.CardanoBackendBlockfrost
-import hydrozoa.multisig.consensus.peer.HeadPeerNumber
+import hydrozoa.lib.logging.{Logging, Slf4jTracer, withCtx}
+import hydrozoa.multisig.backend.cardano.{CardanoBackend, CardanoBackendBlockfrost}
+import hydrozoa.multisig.consensus.peer.{HeadPeerNumber, PeerId, PeerWallet}
 import hydrozoa.multisig.ledger.remote.RemoteL2Ledger
 import hydrozoa.multisig.persistence.rocksdb.RocksDbBackendStore
 import hydrozoa.multisig.persistence.{Cf, Persistence}
 import hydrozoa.multisig.server.HydrozoaServer
-import hydrozoa.multisig.{HeadMultisigRegimeManager, HeadMultisigRegimeManagerEventFormat}
+import hydrozoa.multisig.{CoilMultisigRegimeManager, HeadMultisigRegimeManager, HeadMultisigRegimeManagerEventFormat}
 import io.github.cdimascio.dotenv.Dotenv
-import java.nio.file.Path
+import java.nio.file.{Files, Path}
+import scala.concurrent.duration.DurationInt
 import scalus.cardano.address.{Address, ShelleyAddress}
-import scalus.cardano.ledger.Coin
 import scalus.crypto.ed25519.{SigningKey, VerificationKey}
 import scalus.uplc.builtin.ByteString
 
 /** Hydrozoa application entry point.
   *
-  * Runs the Hydrozoa node using cats-effect IOApp for resource-safe initialization and shutdown.
+  * Runs one Hydrozoa node — a head peer or a coil peer — using cats-effect IOApp for resource-safe
+  * initialization and shutdown. The shared head config (the full head+coil membership, produced
+  * once by [[BuildHeadConfig]]) is loaded from a JSON artifact; this node supplies only its own
+  * signing key and its identity (`NODE_ID`).
   *
   * Configuration is loaded from:
   *   1. .env file in the current directory (if present)
@@ -35,7 +40,12 @@ import scalus.uplc.builtin.ByteString
   *   - BLOCKFROST_API_KEY: Blockfrost API key for Cardano backend
   *   - CARDANO_VERIFICATION_KEY: Hex-encoded Ed25519 verification key (64 hex chars = 32 bytes)
   *   - CARDANO_SIGNING_KEY: Hex-encoded Ed25519 signing key (64 hex chars = 32 bytes)
-  *   - EQUITY: Minimum equity size in lovelace (e.g., "2000000" for 2 ADA)
+  *   - NODE_ID: this node's identity as `<head|coil>:<index>` (e.g. "head:0", "coil:3")
+  *   - ADMIN_USERNAME / ADMIN_PASSWORD: credentials for the user-facing HTTP server (head nodes)
+  *
+  * Optional environment variables:
+  *   - HEAD_CONFIG_PATH: path to the shared head config JSON (default "head-config.json")
+  *   - HTTP_HOST / HTTP_PORT: user-facing HTTP server bind (default "0.0.0.0" / "8080")
   */
 object Main extends IOApp {
 
@@ -43,7 +53,6 @@ object Main extends IOApp {
     final case class EnvConfig(
         verificationKey: VerificationKey,
         signingKey: SigningKey,
-        minEquity: Coin,
         blockfrostApiKey: String,
         sugarRushHost: String,
         sugarRushPort: String,
@@ -53,6 +62,14 @@ object Main extends IOApp {
     ) {
         val sugarRushUri: String = s"ws://$sugarRushHost:$sugarRushPort/ws"
     }
+
+    /** Whether this node runs as a head peer or a coil peer. */
+    enum NodeKind {
+        case Head, Coil
+    }
+
+    /** This node's identity: its kind and its peer index within that kind (the `NODE_ID` env). */
+    final case class NodeIdentity(kind: NodeKind, index: Int)
 
     private val logger = Logging.loggerIO("hydrozoa.app.Main")
 
@@ -111,17 +128,6 @@ object Main extends IOApp {
             sKey = SigningKey.unsafeFromByteString(sKeyBs)
             _ <- logger.info("Loaded signing key")
 
-            minEquityStr <- getMandatoryEnvVar("EQUITY")
-            minEquity <- IO.fromEither(
-              minEquityStr.toLongOption
-                  .toRight(
-                    new IllegalArgumentException(
-                      s"EQUITY must be a valid long, got: $minEquityStr"
-                    )
-                  )
-                  .map(Coin.apply)
-            )
-
             sugarRushHost <- getOptionalEnvVar("SUGAR_RUSH_HOST", "localhost")
             sugarRushPort <- getOptionalEnvVar("SUGAR_RUSH_PORT", "3001")
 
@@ -153,12 +159,9 @@ object Main extends IOApp {
             adminUsername <- getMandatoryEnvVar("ADMIN_USERNAME")
             adminPassword <- getMandatoryEnvVar("ADMIN_PASSWORD")
             _ <- logger.info(s"Loaded admin credentials for user: $adminUsername")
-
-            _ <- logger.info(s"Minimum equity: $minEquity lovelace")
         } yield EnvConfig(
           verificationKey = vKey,
           signingKey = sKey,
-          minEquity = minEquity,
           blockfrostApiKey = blockfrostKey,
           sugarRushHost = sugarRushHost,
           sugarRushPort = sugarRushPort,
@@ -167,37 +170,139 @@ object Main extends IOApp {
           adminPassword = adminPassword
         )
 
+    /** Parse the `NODE_ID` env (`<head|coil>:<index>`) into a [[NodeIdentity]]. */
+    private def parseNodeId(raw: String): IO[NodeIdentity] =
+        raw.trim.split(":") match {
+            case Array(kindStr, idxStr) =>
+                val kindIO = kindStr.toLowerCase match {
+                    case "head" => IO.pure(NodeKind.Head)
+                    case "coil" => IO.pure(NodeKind.Coil)
+                    case other =>
+                        IO.raiseError(
+                          new IllegalArgumentException(
+                            s"NODE_ID type must be 'head' or 'coil', got: $other"
+                          )
+                        )
+                }
+                val idxIO = IO.fromOption(idxStr.toIntOption)(
+                  new IllegalArgumentException(s"NODE_ID index must be an integer, got: $idxStr")
+                )
+                (kindIO, idxIO).mapN(NodeIdentity.apply)
+            case _ =>
+                IO.raiseError(
+                  new IllegalArgumentException(s"NODE_ID must be '<head|coil>:<index>', got: $raw")
+                )
+        }
+
+    /** Load and resolve the shared head config artifact every node shares. */
+    private def loadHeadConfig(path: String, backend: CardanoBackend[IO]): IO[HeadConfig] =
+        for {
+            jsonStr <- IO.blocking(Files.readString(Path.of(path)))
+            headConfig <- HeadConfig.fromJson(jsonStr, backend).value.flatMap {
+                case Right(hc) => IO.pure(hc)
+                case Left(err) =>
+                    IO.raiseError(
+                      new RuntimeException(s"Failed to load head config from $path: $err")
+                    )
+            }
+        } yield headConfig
+
+    /** Build this node's [[NodeConfig]] from the shared head config and its own wallet, dispatching
+      * on the node kind. Fails if the wallet's key is not among the head config's peers of that
+      * kind, or if the derived peer index disagrees with the declared `NODE_ID` index.
+      */
+    private def buildNodeConfig(
+        headConfig: HeadConfig,
+        ownWallet: PeerWallet,
+        identity: NodeIdentity,
+        httpHost: String,
+        httpPort: String,
+        blockfrostApiKey: String
+    ): IO[NodeConfig] = {
+        val evacuationConfig = NodeOperationEvacuationConfig(
+          evacuationBotPollingPeriod = 1.minute,
+          // NOTE: reusing the node wallet; production should use a separate evacuation wallet.
+          evacuationWallet = ownWallet
+        )
+        val multisigConfig = NodeOperationMultisigConfig.default
+        val built: Option[NodeConfig] = identity.kind match {
+            case NodeKind.Head =>
+                NodeConfig.mkHeadConfig(
+                  headConfig,
+                  ownWallet,
+                  evacuationConfig,
+                  multisigConfig,
+                  httpHost,
+                  httpPort,
+                  blockfrostApiKey
+                )
+            case NodeKind.Coil =>
+                NodeConfig.mkCoilConfig(
+                  headConfig,
+                  ownWallet,
+                  evacuationConfig,
+                  multisigConfig,
+                  httpHost,
+                  httpPort,
+                  blockfrostApiKey
+                )
+        }
+        for {
+            nodeConfig <- IO.fromOption(built)(
+              new RuntimeException(
+                s"the configured signing key is not among the head config's ${identity.kind} peers"
+              )
+            )
+            _ <- IO.raiseUnless(nodeConfig.ownPeerIndex == identity.index)(
+              new RuntimeException(
+                s"NODE_ID index ${identity.index} does not match the index derived from the wallet " +
+                    s"key (${nodeConfig.ownPeerIndex}); check NODE_ID and the signing key match the head config"
+              )
+            )
+        } yield nodeConfig
+    }
+
     val cardanoNetwork: StandardCardanoNetwork = CardanoNetwork.Preview
     given CardanoNetwork.Section = cardanoNetwork
 
-    override def run(args: List[String]): IO[ExitCode] =
-        val setupIO = for {
-            _ <- logger.info("Starting Hydrozoa node...")
-            env <- loadEnv
-            _ <- logger.info("Starting Cardano Blockfrost Backend...")
-            backend <- CardanoBackendBlockfrost(
-              network = Left(cardanoNetwork),
-              apiKey = env.blockfrostApiKey
-            )
-            nodeConfig <- Bootstrap.mkNodeConfig(cardanoNetwork, backend)(
-              vKey = env.verificationKey,
-              sKey = env.signingKey,
-              minEquity = env.minEquity
-            )
-            _ <- logger.info(s"headAddress: ${nodeConfig.headMultisigAddress.toBech32.get}")
-            _ <- logger.info(s"initTx hash: ${nodeConfig.initializationTx.tx.id}")
-            _ <- logger.info(
-              s"initTx: ${encodeHexString(nodeConfig.initializationTx.tx.toCbor)}"
-            )
-        } yield (env, backend, nodeConfig)
-
+    override def run(args: List[String]): IO[ExitCode] = {
         val resource = for {
-            result <- Resource.eval(setupIO)
-            (env, backend, nodeConfig) = result
-
-            _ <- Resource.eval(
-              logger.info(s"Connecting to L2 ledger at ${env.sugarRushUri}")
+            env <- Resource.eval(loadEnv)
+            identity <- Resource.eval(getMandatoryEnvVar("NODE_ID").flatMap(parseNodeId))
+            headConfigPath <- Resource.eval(
+              getOptionalEnvVar("HEAD_CONFIG_PATH", "head-config.json")
             )
+            httpHost <- Resource.eval(getOptionalEnvVar("HTTP_HOST", "0.0.0.0"))
+            httpPort <- Resource.eval(getOptionalEnvVar("HTTP_PORT", "8080"))
+            _ <- Resource.eval(
+              logger.info(s"Starting Hydrozoa ${identity.kind} node ${identity.index}...")
+            )
+
+            _ <- Resource.eval(logger.info("Starting Cardano Blockfrost Backend..."))
+            backend <- Resource.eval(
+              CardanoBackendBlockfrost(
+                network = Left(cardanoNetwork),
+                apiKey = env.blockfrostApiKey
+              )
+            )
+
+            headConfig <- Resource.eval(loadHeadConfig(headConfigPath, backend))
+            ownWallet = PeerWallet.scalusWallet(env.verificationKey, env.signingKey)
+            nodeConfig <- Resource.eval(
+              buildNodeConfig(
+                headConfig,
+                ownWallet,
+                identity,
+                httpHost,
+                httpPort,
+                env.blockfrostApiKey
+              )
+            )
+            _ <- Resource.eval(
+              logger.info(s"headAddress: ${nodeConfig.headMultisigAddress.toBech32.get}")
+            )
+
+            _ <- Resource.eval(logger.info(s"Connecting to L2 ledger at ${env.sugarRushUri}"))
             remoteL2Ledger <- Resource.eval(
               RemoteL2Ledger.create(
                 wsUri = env.sugarRushUri,
@@ -205,10 +310,7 @@ object Main extends IOApp {
               )
             )
 
-            // Per-peer persistence store. Default path; later milestones will surface this
-            // through NodeConfig (P1 skeleton; see design §7). Open the RocksDB-backed
-            // BackendStore (byte-level primitive), then wrap it in the typed Persistence the
-            // actor topology consumes.
+            // Per-node persistence store, keyed by this node's own peer label (e.g. "0", "c3").
             backendStore <- RocksDbBackendStore.open(
               Path.of(s".hydrozoa-data/peer-${nodeConfig.ownPeerLabel}/rocksdb"),
               Cf.mkAll(
@@ -230,50 +332,82 @@ object Main extends IOApp {
                     tokenRecoveryAddress = env.tokenRecoveryAddress
                   )
             )
-        } yield (env, backend, nodeConfig, remoteL2Ledger, persistence, system)
+        } yield (env, backend, nodeConfig, remoteL2Ledger, persistence, system, httpHost, httpPort)
 
-        resource.use { case (env, backend, nodeConfig, remoteL2Ledger, persistence, system) =>
-            // Main runs a head node (Bootstrap builds the config via NodeConfig.mkHeadConfig),
-            // so the peer index is this node's head peer number.
-            val mrmTracer =
-                Slf4jTracer.sink.contramap(
-                  HeadMultisigRegimeManagerEventFormat.humanFormat(
-                    HeadPeerNumber(nodeConfig.ownPeerIndex)
-                  )
-                )
-            for {
-                mrm <- HeadMultisigRegimeManager.apply(
-                  nodeConfig,
+        resource.use {
+            case (
+                  env,
                   backend,
+                  nodeConfig,
                   remoteL2Ledger,
                   persistence,
-                  mrmTracer
-                )
-                _ <- system.actorOf(mrm, "HeadMultisigRegimeManager")
-                _ <- logger.info("Hydrozoa node started successfully")
+                  system,
+                  httpHost,
+                  httpPort
+                ) =>
+                // The regime-manager formatter is keyed by head peer number; for a coil node we
+                // reuse it for the shared sub-actor events and override the "peer" context with the
+                // coil's own label so logs stay unambiguous.
+                val mrmTracer =
+                    Slf4jTracer.sink
+                        .withCtx(_.updated("peer", nodeConfig.ownPeerLabel))
+                        .contramap(
+                          HeadMultisigRegimeManagerEventFormat.humanFormat(
+                            HeadPeerNumber(nodeConfig.ownPeerIndex)
+                          )
+                        )
 
-                // Start HTTP server once RequestSequencer is available
-                _ <- mrm.connectionsDeferred.get.flatMap { connections =>
-                    val serverConfig = HydrozoaServer.Config(
-                      host = host"0.0.0.0",
-                      port = port"8080",
-                      adminUsername = env.adminUsername,
-                      adminPassword = env.adminPassword
-                    )
-                    logger.info("Starting HTTP server...") *>
-                        HydrozoaServer
-                            .create(
-                              connections.requestSequencer,
-                              connections.blockWeaver,
-                              nodeConfig.headConfig,
-                              serverConfig
+                nodeConfig.ownPeerId match {
+                    case PeerId.Head(_) =>
+                        for {
+                            mrm <- HeadMultisigRegimeManager.apply(
+                              nodeConfig,
+                              backend,
+                              remoteL2Ledger,
+                              persistence,
+                              mrmTracer
                             )
-                            .use(_ => IO.never)
-                            .start // Run in background
-                            .void
-                }
+                            _ <- system.actorOf(mrm, "HeadMultisigRegimeManager")
+                            _ <- logger.info("Hydrozoa head node started successfully")
 
-                _ <- system.waitForTermination
-            } yield ExitCode.Success
+                            // Start HTTP server once RequestSequencer is available
+                            _ <- mrm.connectionsDeferred.get.flatMap { connections =>
+                                val serverConfig = HydrozoaServer.Config(
+                                  host = Host.fromString(httpHost).getOrElse(host"0.0.0.0"),
+                                  port = Port.fromString(httpPort).getOrElse(port"8080"),
+                                  adminUsername = env.adminUsername,
+                                  adminPassword = env.adminPassword
+                                )
+                                logger.info("Starting HTTP server...") *>
+                                    HydrozoaServer
+                                        .create(
+                                          connections.requestSequencer,
+                                          connections.blockWeaver,
+                                          nodeConfig.headConfig,
+                                          serverConfig
+                                        )
+                                        .use(_ => IO.never)
+                                        .start // Run in background
+                                        .void
+                            }
+
+                            _ <- system.waitForTermination
+                        } yield ExitCode.Success
+
+                    case PeerId.Coil(_) =>
+                        for {
+                            mrm <- CoilMultisigRegimeManager.apply(
+                              nodeConfig,
+                              backend,
+                              remoteL2Ledger,
+                              persistence,
+                              mrmTracer
+                            )
+                            _ <- system.actorOf(mrm, "CoilMultisigRegimeManager")
+                            _ <- logger.info("Hydrozoa coil node started successfully")
+                            _ <- system.waitForTermination
+                        } yield ExitCode.Success
+                }
         }
+    }
 }

--- a/src/main/scala/hydrozoa/app/Main.scala
+++ b/src/main/scala/hydrozoa/app/Main.scala
@@ -20,6 +20,7 @@ import hydrozoa.multisig.server.HydrozoaServer
 import hydrozoa.multisig.{CoilMultisigRegimeManager, HeadMultisigRegimeManager, HeadMultisigRegimeManagerEventFormat}
 import io.github.cdimascio.dotenv.Dotenv
 import java.nio.file.{Files, Path}
+import org.http4s.jdkhttpclient.JdkWSClient
 import scala.concurrent.duration.DurationInt
 import scalus.cardano.address.{Address, ShelleyAddress}
 import scalus.crypto.ed25519.{SigningKey, VerificationKey}
@@ -332,7 +333,28 @@ object Main extends IOApp {
                     tokenRecoveryAddress = env.tokenRecoveryAddress
                   )
             )
-        } yield (env, backend, nodeConfig, remoteL2Ledger, persistence, system, httpHost, httpPort)
+
+            // Per-process WS transports: bind this node's server and dial its peers. The wiring's
+            // tag (Left = head, Right = coil) carries the right transports for the manager to
+            // register its liaisons on and build remote proxy handles from.
+            wsClient <- Resource.eval(JdkWSClient.simple[IO])
+            wsWiring <- nodeConfig.ownPeerId match {
+                case PeerId.Head(n) =>
+                    NodeTransport.headResource(nodeConfig, wsClient, n).map(Left(_))
+                case PeerId.Coil(n) =>
+                    NodeTransport.coilResource(nodeConfig, wsClient, n).map(Right(_))
+            }
+        } yield (
+          env,
+          backend,
+          nodeConfig,
+          remoteL2Ledger,
+          persistence,
+          system,
+          httpHost,
+          httpPort,
+          wsWiring
+        )
 
         resource.use {
             case (
@@ -343,7 +365,8 @@ object Main extends IOApp {
                   persistence,
                   system,
                   httpHost,
-                  httpPort
+                  httpPort,
+                  wsWiring
                 ) =>
                 // The regime-manager formatter is keyed by head peer number; for a coil node we
                 // reuse it for the shared sub-actor events and override the "peer" context with the
@@ -357,15 +380,17 @@ object Main extends IOApp {
                           )
                         )
 
-                nodeConfig.ownPeerId match {
-                    case PeerId.Head(_) =>
+                // The wiring's tag is this node's kind (Left = head, Right = coil).
+                wsWiring match {
+                    case Left(headWiring) =>
                         for {
                             mrm <- HeadMultisigRegimeManager.apply(
                               nodeConfig,
                               backend,
                               remoteL2Ledger,
                               persistence,
-                              mrmTracer
+                              mrmTracer,
+                              headWiring
                             )
                             _ <- system.actorOf(mrm, "HeadMultisigRegimeManager")
                             _ <- logger.info("Hydrozoa head node started successfully")
@@ -394,14 +419,15 @@ object Main extends IOApp {
                             _ <- system.waitForTermination
                         } yield ExitCode.Success
 
-                    case PeerId.Coil(_) =>
+                    case Right(coilWiring) =>
                         for {
                             mrm <- CoilMultisigRegimeManager.apply(
                               nodeConfig,
                               backend,
                               remoteL2Ledger,
                               persistence,
-                              mrmTracer
+                              mrmTracer,
+                              coilWiring
                             )
                             _ <- system.actorOf(mrm, "CoilMultisigRegimeManager")
                             _ <- logger.info("Hydrozoa coil node started successfully")

--- a/src/main/scala/hydrozoa/app/Main.scala
+++ b/src/main/scala/hydrozoa/app/Main.scala
@@ -214,7 +214,9 @@ object Main extends IOApp {
                     network <- {
                         given onlyNetwork: io.circe.Decoder[CardanoNetwork] =
                             io.circe.Decoder.instance(
-                              _.downField("cardanoNetwork").as[CardanoNetwork](using cardanoNetworkDecoder)
+                              _.downField("cardanoNetwork").as[CardanoNetwork](using
+                                cardanoNetworkDecoder
+                              )
                             )
                         parser.decode[CardanoNetwork](jsonStr)
                     }

--- a/src/main/scala/hydrozoa/app/Main.scala
+++ b/src/main/scala/hydrozoa/app/Main.scala
@@ -5,6 +5,7 @@ import cats.implicits.*
 import com.comcast.ip4s.{Host, Port, host, port}
 import com.suprnation.actor.ActorSystem
 import hydrozoa.config.head.HeadConfig
+import hydrozoa.config.head.network.CardanoNetwork.cardanoNetworkDecoder
 import hydrozoa.config.head.network.{CardanoNetwork, StandardCardanoNetwork}
 import hydrozoa.config.node.NodeConfig
 import hydrozoa.config.node.operation.evacuation.NodeOperationEvacuationConfig
@@ -212,7 +213,7 @@ object Main extends IOApp {
                     network <- {
                         given onlyNetwork: io.circe.Decoder[CardanoNetwork] =
                             io.circe.Decoder.instance(
-                              _.downField("cardanoNetwork").as[CardanoNetwork]
+                              _.downField("cardanoNetwork").as[CardanoNetwork](using cardanoNetworkDecoder)
                             )
                         parser.decode[CardanoNetwork](jsonStr)
                     }

--- a/src/main/scala/hydrozoa/app/Main.scala
+++ b/src/main/scala/hydrozoa/app/Main.scala
@@ -58,7 +58,9 @@ object Main extends IOApp {
         sugarRushPort: String,
         tokenRecoveryAddress: Option[ShelleyAddress],
         adminUsername: String,
-        adminPassword: String
+        adminPassword: String,
+        hydrozoaHost: String,
+        hydrozoaPort: String,
     ) {
         val sugarRushUri: String = s"ws://$sugarRushHost:$sugarRushPort/ws"
     }
@@ -159,6 +161,10 @@ object Main extends IOApp {
             adminUsername <- getMandatoryEnvVar("ADMIN_USERNAME")
             adminPassword <- getMandatoryEnvVar("ADMIN_PASSWORD")
             _ <- logger.info(s"Loaded admin credentials for user: $adminUsername")
+
+            hydrozoaHost <- getMandatoryEnvVar("HTTP_HOST")
+            hydrozoaPort <- getMandatoryEnvVar("HTTP_PORT")
+            _ <- logger.info(s"Loaded HTTP endpoint config: $hydrozoaHost:$hydrozoaPort")
         } yield EnvConfig(
           verificationKey = vKey,
           signingKey = sKey,
@@ -167,7 +173,9 @@ object Main extends IOApp {
           sugarRushPort = sugarRushPort,
           tokenRecoveryAddress = tokenRecoveryAddressOpt,
           adminUsername = adminUsername,
-          adminPassword = adminPassword
+          adminPassword = adminPassword,
+          hydrozoaHost = hydrozoaHost,
+          hydrozoaPort = hydrozoaPort,
         )
 
     /** Parse the `NODE_ID` env (`<head|coil>:<index>`) into a [[NodeIdentity]]. */

--- a/src/main/scala/hydrozoa/app/Main.scala
+++ b/src/main/scala/hydrozoa/app/Main.scala
@@ -11,7 +11,7 @@ import hydrozoa.config.node.operation.evacuation.NodeOperationEvacuationConfig
 import hydrozoa.config.node.operation.multisig.NodeOperationMultisigConfig
 import hydrozoa.lib.cardano.scalus.VerificationKeyExtra.shelleyAddress
 import hydrozoa.lib.logging.{Logging, Slf4jTracer, withCtx}
-import hydrozoa.multisig.backend.cardano.{CardanoBackend, CardanoBackendBlockfrost}
+import hydrozoa.multisig.backend.cardano.CardanoBackendBlockfrost
 import hydrozoa.multisig.consensus.peer.{HeadPeerNumber, PeerId, PeerWallet}
 import hydrozoa.multisig.ledger.remote.RemoteL2Ledger
 import hydrozoa.multisig.persistence.rocksdb.RocksDbBackendStore
@@ -203,15 +203,28 @@ object Main extends IOApp {
         }
 
     /** Load and resolve the shared head config artifact every node shares. */
-    private def loadHeadConfig(path: String, backend: CardanoBackend[IO]): IO[HeadConfig] =
+    private def loadHeadConfig(path: String): IO[HeadConfig] =
         for {
             jsonStr <- IO.blocking(Files.readString(Path.of(path)))
-            headConfig <- HeadConfig.fromJson(jsonStr, backend).value.flatMap {
-                case Right(hc) => IO.pure(hc)
-                case Left(err) =>
-                    IO.raiseError(
-                      new RuntimeException(s"Failed to load head config from $path: $err")
-                    )
+            headConfig <- IO.fromEither {
+                import io.circe.parser
+                val result = for {
+                    network <- {
+                        given onlyNetwork: io.circe.Decoder[CardanoNetwork] =
+                            io.circe.Decoder.instance(
+                              _.downField("cardanoNetwork").as[CardanoNetwork]
+                            )
+                        parser.decode[CardanoNetwork](jsonStr)
+                    }
+                    hc <- {
+                        given hydrozoa.config.ScriptReferenceUtxos =
+                            Bootstrap.fakeScriptReferenceUtxos(network)
+                        parser.decode[HeadConfig](jsonStr)
+                    }
+                } yield hc
+                result.left.map(e =>
+                    new RuntimeException(s"Failed to load head config from $path: $e")
+                )
             }
         } yield headConfig
 
@@ -294,7 +307,7 @@ object Main extends IOApp {
               )
             )
 
-            headConfig <- Resource.eval(loadHeadConfig(headConfigPath, backend))
+            headConfig <- Resource.eval(loadHeadConfig(headConfigPath))
             ownWallet = PeerWallet.scalusWallet(env.verificationKey, env.signingKey)
             nodeConfig <- Resource.eval(
               buildNodeConfig(

--- a/src/main/scala/hydrozoa/app/NodeTransport.scala
+++ b/src/main/scala/hydrozoa/app/NodeTransport.scala
@@ -1,0 +1,104 @@
+package hydrozoa.app
+
+import cats.effect.{IO, Resource}
+import cats.implicits.*
+import com.comcast.ip4s.{Host, Port}
+import hydrozoa.config.head.network.CardanoNetwork
+import hydrozoa.config.node.NodeConfig
+import hydrozoa.multisig.consensus.peer.{CoilPeerNumber, HeadPeerNumber}
+import hydrozoa.multisig.consensus.transport.{CoilPeerWsTransport, HubWsTransport, NodeWsServer, PeerWsTransport}
+import hydrozoa.multisig.{CoilMultisigRegimeManager, HeadMultisigRegimeManager}
+import org.http4s.Uri
+import org.http4s.client.websocket.WSClient
+import org.http4s.server.websocket.WebSocketBuilder2
+
+/** Builds a node's per-process WebSocket transports from the shared head config, binds its server,
+  * dials its peers, and yields the manager wiring carrier ([[HeadMultisigRegimeManager.WsWiring]] /
+  * [[CoilMultisigRegimeManager.WsWiring]]). The bound server and dialer fibers live for the
+  * returned resource's lifetime.
+  *
+  * Each head peer's `webSocketAddress` (e.g. "ws://host:port") is both where that peer binds its
+  * own server and where the other peers dial it: a head mounts the `/head` route, a hub head
+  * additionally `/hub`, and a coil peer binds no server (it only dials its hub's `/hub`).
+  */
+object NodeTransport {
+
+    /** Wire a head (or hub) node: the head-mesh transport toward the other head peers, the hub
+      * transport for any hubbed coils, a bound server, and the mesh dialers.
+      */
+    def headResource(
+        config: NodeConfig,
+        client: WSClient[IO],
+        ownHeadNum: HeadPeerNumber
+    )(using CardanoNetwork.Section): Resource[IO, HeadMultisigRegimeManager.WsWiring] =
+        for {
+            ownHeadPeerId <- Resource.eval(
+              IO.fromOption(config.headPeerIds.find(_.peerNum == ownHeadNum))(
+                new RuntimeException(s"own head peer $ownHeadNum is not in the head config")
+              )
+            )
+            remotes <- Resource.eval(
+              config.headPeerIds.toList
+                  .filterNot(_.peerNum == ownHeadNum)
+                  .traverse(rid => dialUri(config, rid.peerNum, "head").map(rid -> _))
+                  .map(_.toMap)
+            )
+            meshTransport <- Resource.eval(PeerWsTransport.create(ownHeadPeerId, remotes))
+
+            hubbedCoils = config.hubbedCoilPeerNums(ownHeadNum)
+            hubTransport <- Resource.eval(
+              if hubbedCoils.isEmpty then IO.none[HubWsTransport]
+              else HubWsTransport.create(hubbedCoils).map(Some(_))
+            )
+
+            bind <- Resource.eval(bindAddress(config, ownHeadNum))
+            meshRoute = (wsb: WebSocketBuilder2[IO]) => meshTransport.routes(wsb)
+            hubRoute = hubTransport.toList.map(t => (wsb: WebSocketBuilder2[IO]) => t.routes(wsb))
+            _ <- NodeWsServer.resource(bind._1, bind._2, meshRoute :: hubRoute)
+            _ <- meshTransport.startDialers(client)
+        } yield HeadMultisigRegimeManager.WsWiring(meshTransport, hubTransport)
+
+    /** Wire a coil node: the uplink transport toward its hub plus the hub dialer. No server — a
+      * coil peer is never dialed.
+      */
+    def coilResource(
+        config: NodeConfig,
+        client: WSClient[IO],
+        ownCoilNum: CoilPeerNumber
+    )(using CardanoNetwork.Section): Resource[IO, CoilMultisigRegimeManager.WsWiring] =
+        for {
+            hubNum <- Resource.eval(
+              IO.fromOption(config.coilPeerHub(ownCoilNum))(
+                new RuntimeException(s"no hub configured for coil peer $ownCoilNum")
+              )
+            )
+            hubUri <- Resource.eval(dialUri(config, hubNum, "hub"))
+            coilTransport <- Resource.eval(CoilPeerWsTransport.create(ownCoilNum, hubUri))
+            _ <- coilTransport.startDialer(client)
+        } yield CoilMultisigRegimeManager.WsWiring(coilTransport)
+
+    /** A head peer's advertised `webSocketAddress`, or an error if absent. */
+    private def headPeerAddress(config: NodeConfig, num: HeadPeerNumber): IO[String] =
+        IO.fromOption(config.headPeers.headPeerData.lookup(num).map(_.webSocketAddress))(
+          new RuntimeException(s"no webSocketAddress configured for head peer $num")
+        )
+
+    /** Parse a head peer's `webSocketAddress` ("ws://host:port") into a bind (host, port). */
+    private def bindAddress(config: NodeConfig, num: HeadPeerNumber): IO[(Host, Port)] =
+        headPeerAddress(config, num).flatMap(addr =>
+            IO.fromOption(
+              Uri.fromString(addr).toOption.flatMap { u =>
+                  (
+                    u.host.flatMap(h => Host.fromString(h.value)),
+                    u.port.flatMap(Port.fromInt)
+                  ).tupled
+              }
+            )(
+              new RuntimeException(s"head peer $num webSocketAddress must be ws://host:port: $addr")
+            )
+        )
+
+    /** The dial [[Uri]] for a head peer's route, e.g. "ws://host:port/head" or ".../hub". */
+    private def dialUri(config: NodeConfig, num: HeadPeerNumber, path: String): IO[Uri] =
+        headPeerAddress(config, num).flatMap(addr => IO.fromEither(Uri.fromString(s"$addr/$path")))
+}

--- a/src/main/scala/hydrozoa/multisig/CoilMultisigRegimeManager.scala
+++ b/src/main/scala/hydrozoa/multisig/CoilMultisigRegimeManager.scala
@@ -37,7 +37,8 @@ trait CoilMultisigRegimeManager(
     cardanoBackend: CardanoBackend[IO],
     l2Ledger: L2Ledger[IO],
     persistence: Persistence[IO],
-    tracer: ContraTracer[IO, HeadMultisigRegimeManagerEvent]
+    tracer: ContraTracer[IO, HeadMultisigRegimeManagerEvent],
+    wsWiring: CoilMultisigRegimeManager.WsWiring
 ) extends Actor[IO, Request] {
 
     /** Specialize the regime-wide tracer down to per-actor channels, exactly as
@@ -124,8 +125,8 @@ trait CoilMultisigRegimeManager(
             )
 
             // Exactly one liaison, toward the hub head peer (§5.5) [doc-ref]. It projects its connections from
-            // the shared `Connections`; the hub-liaison handle (`remoteHubLiaison`) stays empty in
-            // this production placeholder (in-process wiring fills it).
+            // the shared `Connections`; the hub-liaison handle (`remoteHubLiaison`) is filled below
+            // from this coil's WS uplink transport.
             hubLiaison <- context.actorOf(
               liaison.PeerLiaisonCoilToHub(
                 config,
@@ -134,6 +135,13 @@ trait CoilMultisigRegimeManager(
                 persistence
               )
             )
+
+            // Wire the WS uplink: register the local hub liaison for inbound dispatch and build the
+            // remote hub proxy the coil's SlowConsensusActor broadcasts its hard-ack through.
+            _ <- wsWiring.coilTransport.register(hubLiaison)
+            remoteHubProxy <- transport
+                .RemoteHubProxy(wsWiring.coilTransport)
+                .flatMap(context.actorOf)
 
             // A coil peer never leads, so there is nothing to pace against L1 timing: the limiter
             // slots alias the unthrottled handles directly (no `Limiter` actors spawned). A coil has
@@ -149,6 +157,7 @@ trait CoilMultisigRegimeManager(
               stackComposerLimiter = stackComposer,
               slowConsensusActor = slowConsensusActor,
               coilUplink = Some(hubLiaison),
+              remoteHubLiaison = Some(remoteHubProxy),
             )
 
             // R3 boot replay (§8 step 3, coil path — §10 Q10): before opening the start barrier,
@@ -197,12 +206,19 @@ trait CoilMultisigRegimeManager(
 }
 
 object CoilMultisigRegimeManager {
+
+    /** This coil node's WS uplink transport toward its hub. The manager registers its hub liaison
+      * on it and builds the remote hub proxy handle from it.
+      */
+    final case class WsWiring(coilTransport: transport.CoilPeerWsTransport)
+
     def apply(
         config: NodeConfig,
         cardanoBackend: CardanoBackend[IO],
         virtualLedger: L2Ledger[IO],
         persistence: Persistence[IO],
-        tracer: ContraTracer[IO, HeadMultisigRegimeManagerEvent]
+        tracer: ContraTracer[IO, HeadMultisigRegimeManagerEvent],
+        wsWiring: WsWiring
     ): IO[CoilMultisigRegimeManager] =
         IO(
           new CoilMultisigRegimeManager(
@@ -210,7 +226,8 @@ object CoilMultisigRegimeManager {
             cardanoBackend,
             virtualLedger,
             persistence,
-            tracer
+            tracer,
+            wsWiring
           ) {}
         )
 }

--- a/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManager.scala
+++ b/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManager.scala
@@ -27,7 +27,8 @@ trait HeadMultisigRegimeManager(
     cardanoBackend: CardanoBackend[IO],
     l2Ledger: L2Ledger[IO],
     persistence: Persistence[IO],
-    tracer: ContraTracer[IO, HeadMultisigRegimeManagerEvent]
+    tracer: ContraTracer[IO, HeadMultisigRegimeManagerEvent],
+    wsWiring: HeadMultisigRegimeManager.WsWiring
 ) extends Actor[IO, Request] {
 
     /** Specialize the regime-wide tracer down to per-actor channels. The contramap pushes the
@@ -129,11 +130,12 @@ trait HeadMultisigRegimeManager(
             )
 
             // One peer liaison toward every other head peer (the head mesh). The liaisons project
-            // their connections from the shared `Connections`; the remote-handle maps stay empty in
-            // this production placeholder (in-process wiring fills them — see stage4).
+            // their connections from the shared `Connections`; the remote-handle maps are filled
+            // below from this node's WS transports.
+            remoteHeadIds = config.headPeerIds
+                .filterNot(id => config.ownPeerId == PeerId.Head(id.peerNum))
             headPeerLiaisons <-
-                config.headPeerIds
-                    .filterNot(id => config.ownPeerId == PeerId.Head(id.peerNum))
+                remoteHeadIds
                     .traverse(pid =>
                         context.actorOf(
                           liaison.PeerLiaisonHeadToHead(
@@ -183,6 +185,40 @@ trait HeadMultisigRegimeManager(
                     )
                 )
 
+            // Wire this node's WS transports onto its liaisons: register each local liaison for
+            // inbound dispatch, and build the remote proxy handles the liaisons reach their
+            // counterpart processes through (a hub additionally serves its coil peers).
+            _ <- remoteHeadIds.zip(headPeerLiaisons).traverse_ { case (remoteId, localLiaison) =>
+                wsWiring.meshTransport.register(remoteId, localLiaison)
+            }
+            remoteHeadLiaisons <- remoteHeadIds
+                .zip(headPeerLiaisons)
+                .traverse { case (remoteId, _) =>
+                    transport
+                        .RemotePeerProxy(remoteId, wsWiring.meshTransport)
+                        .flatMap(context.actorOf)
+                        .map(remoteId.peerNum -> _)
+                }
+                .map(_.toMap)
+            _ <- wsWiring.hubTransport.traverse_ { hub =>
+                hubbedCoilPeers.zip(coilPeerLiaisons).traverse_ { case (coilNum, localLiaison) =>
+                    hub.register(coilNum, localLiaison)
+                }
+            }
+            remoteCoilLiaisons <- wsWiring.hubTransport match {
+                case Some(hub) =>
+                    hubbedCoilPeers
+                        .traverse(coilNum =>
+                            transport
+                                .RemoteCoilProxy(coilNum, hub)
+                                .flatMap(context.actorOf)
+                                .map(coilNum -> _)
+                        )
+                        .map(_.toMap)
+                case None =>
+                    IO.pure(Map.empty[CoilPeerNumber, liaison.PeerLiaisonCoilToHub.Handle])
+            }
+
             connections = HeadMultisigRegimeManager.Connections(
               blockWeaver = blockWeaver,
               blockWeaverLimiter = blockWeaverLimiter,
@@ -194,6 +230,8 @@ trait HeadMultisigRegimeManager(
               stackComposerLimiter = stackComposerLimiter,
               slowConsensusActor = slowConsensusActor,
               headPeerLiaisons = headPeerLiaisons,
+              remoteHeadLiaisons = remoteHeadLiaisons,
+              remoteCoilLiaisons = remoteCoilLiaisons,
               coilRelay = coilRelay,
               coilAckSequencer = coilAckSequencer,
               coilPeerLiaisons = coilPeerLiaisons,
@@ -300,12 +338,22 @@ object HeadMultisigRegimeManager {
 
     type PendingConnections = Deferred[IO, Connections]
 
+    /** This head node's per-process WS transports: the head-mesh transport (always) and, on a hub
+      * head peer, the hub transport serving its coil peers. The manager registers its local
+      * liaisons on these and builds the remote proxy handles from them.
+      */
+    final case class WsWiring(
+        meshTransport: transport.PeerWsTransport,
+        hubTransport: Option[transport.HubWsTransport]
+    )
+
     def apply(
         config: NodeConfig,
         cardanoBackend: CardanoBackend[IO],
         virtualLedger: L2Ledger[IO],
         persistence: Persistence[IO],
-        tracer: ContraTracer[IO, HeadMultisigRegimeManagerEvent]
+        tracer: ContraTracer[IO, HeadMultisigRegimeManagerEvent],
+        wsWiring: WsWiring
     ): IO[HeadMultisigRegimeManager] =
         IO(
           new HeadMultisigRegimeManager(
@@ -313,7 +361,8 @@ object HeadMultisigRegimeManager {
             cardanoBackend,
             virtualLedger,
             persistence,
-            tracer
+            tracer,
+            wsWiring
           ) {}
         )
 

--- a/src/main/scala/hydrozoa/multisig/consensus/CardanoLiaison.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/CardanoLiaison.scala
@@ -599,18 +599,28 @@ trait CardanoLiaison(
                                     case Some(fallback) =>
                                         IO.pure(Seq(Action.FallbackToRuleBased(fallback)))
                                     case None => {
-                                        lazy val initAction = {
-                                            if currentTime < config.initializationTx.initializationTxEndTime.convert
-                                            then
-                                                Seq(
-                                                  Action.InitializeHead(
-                                                    state.happyPathEffects.values.map(_.tx).toSeq
+                                        // The init tx is only submittable inside its (config-baked)
+                                        // validity window; once `initializationTxEndTime` passes it
+                                        // can never confirm. Past the window, trace it explicitly
+                                        // rather than silently returning no action.
+                                        val initEndTime =
+                                            config.initializationTx.initializationTxEndTime.convert
+                                        val initAction: IO[Seq[Action]] =
+                                            if currentTime < initEndTime then
+                                                IO.pure(
+                                                  Seq(
+                                                    Action.InitializeHead(
+                                                      state.happyPathEffects.values.map(_.tx).toSeq
+                                                    )
                                                   )
                                                 )
-                                            else {
-                                                Seq.empty
-                                            }
-                                        }
+                                            else
+                                                tracer.traceWith(
+                                                  CardanoLiaisonEvent.InitWindowElapsed(
+                                                    currentTime.toString,
+                                                    initEndTime.toString
+                                                  )
+                                                ) >> IO.pure(Seq.empty)
                                         // TODO: check the rule-based treasury, and if it exists, don't try to initialize the head.
                                         state.targetState match {
                                             case TargetState.Uninitialized =>
@@ -633,7 +643,7 @@ trait CardanoLiaison(
                                                         targetTreasuryUtxoId.toString,
                                                         found = false
                                                       )
-                                                    ) >> IO.pure(initAction)
+                                                    ) >> initAction
 
                                             case TargetState.Finalized(finalizationTxHash) =>
                                                 for {
@@ -656,8 +666,8 @@ trait CardanoLiaison(
                                                                     if isKnown then "known"
                                                                     else "not known"
                                                                   )
-                                                            ) >> IO.pure(
-                                                              if isKnown then Seq.empty
+                                                            ) >> (
+                                                              if isKnown then IO.pure(Seq.empty)
                                                               else initAction
                                                             )
                                                     }

--- a/src/main/scala/hydrozoa/multisig/consensus/CardanoLiaisonEvent.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/CardanoLiaisonEvent.scala
@@ -48,6 +48,15 @@ object CardanoLiaisonEvent:
 
     final case class TargetUtxoStatus(targetId: String, found: Boolean) extends CardanoLiaisonEvent
 
+    /** The hard-confirmed init tx could not be submitted because its (config-baked) validity window
+      * has already elapsed (`currentTime >= initializationTxEndTime`): the head can no longer be
+      * initialized on the happy path. Usually means too much wall-clock passed between head-config
+      * generation (which anchors the window) and stack-0 hard-confirmation — e.g. a long
+      * restart/debug cycle.
+      */
+    final case class InitWindowElapsed(currentTime: String, endTime: String)
+        extends CardanoLiaisonEvent
+
     final case class FinalizationTxStatus(hash: String, isKnown: String) extends CardanoLiaisonEvent
 
     final case class FinalizationTxQueryError(err: String) extends CardanoLiaisonEvent

--- a/src/main/scala/hydrozoa/multisig/consensus/CardanoLiaisonEventFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/CardanoLiaisonEventFormat.scala
@@ -41,6 +41,12 @@ object CardanoLiaisonEventFormat:
                 trace(s"target $targetId found, do nothing")
             case TargetUtxoStatus(targetId, false) =>
                 trace(s"no target $targetId found, submitting init action")
+            case InitWindowElapsed(currentTime, endTime) =>
+                warn(
+                  s"init tx validity window elapsed (currentTime=$currentTime >=" +
+                      s" initializationTxEndTime=$endTime); head can no longer be initialized on the" +
+                      " happy path — regenerate head-config or widen the init window"
+                )
             case FinalizationTxStatus(hash, isKnown) =>
                 trace(s"finalizationTx: hash=$hash known=$isKnown")
             case FinalizationTxQueryError(err) =>

--- a/src/main/scala/hydrozoa/multisig/consensus/SlowConsensusActor.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/SlowConsensusActor.scala
@@ -230,7 +230,15 @@ final case class SlowConsensusActor(
             stateRef.get.flatMap { s =>
                 s.cells.get(h.stackNum) match {
                     case None =>
-                        stateRef.update(_.bufferOrphan(h))
+                        // No cell: either a genuinely early orphan (this peer's handoff for the
+                        // stack hasn't arrived yet — buffer it for replay at cell creation) or a
+                        // late surplus ack for an already hard-confirmed stack. Buffering the latter
+                        // would leak: orphans for a dropped cell are never replayed.
+                        if s.lastConfirmed.exists(Ordering[StackNumber].lteq(h.stackNum, _)) then
+                            tracer.traceWith(
+                              SlowConsensusActorEvent.SurplusHardAckIgnored(h.stackNum, h.peerId)
+                            )
+                        else stateRef.update(_.bufferOrphan(h))
                     case Some(_) =>
                         applyRemote(h) >> tryAdvance(h.stackNum)
                 }
@@ -258,9 +266,12 @@ final case class SlowConsensusActor(
                         IO.raiseError(CellError.UnexpectedPayload(h.stackNum, other.roundLabel))
                 }
             case c: Cell.WaitingRound2 =>
-                // Round-1 is already saturated and the peer-liaison lane delivers each hard-ack
-                // exactly once (next-expected cursors, no resends), so only round-2 is expected
-                // now; any other payload — including a second round-1 — is a protocol violation.
+                // Round 1 is saturated; only round-2 advances the cell now. A late round-1 is NOT a
+                // violation, though: round 1 saturates at the coil quorum, not the full coil set, so
+                // a coil peer beyond the quorum can still have its round-1 ack in flight when the
+                // cell advanced. Its signature is surplus — `selectSigners` keeps only `coilQuorum`
+                // coils — so drop it rather than fail the cell. A `Sole` payload here, by contrast,
+                // is a genuine protocol violation (sole belongs to 1-phase stacks).
                 h.payload match {
                     case p: HardAck.Payload.Round2 =>
                         ackVerifier
@@ -268,6 +279,12 @@ final case class SlowConsensusActor(
                             .as(
                               c.copy(round2 = c.round2.updated(peer, p))
                             )
+                    case _: HardAck.Payload.Round1 =>
+                        tracer
+                            .traceWith(
+                              SlowConsensusActorEvent.SurplusHardAckIgnored(h.stackNum, peer)
+                            )
+                            .as(c)
                     case other =>
                         IO.raiseError(CellError.UnexpectedPayload(h.stackNum, other.roundLabel))
                 }
@@ -529,7 +546,13 @@ object SlowConsensusActor {
 
     final case class State(
         cells: Map[StackNumber, Cell],
-        orphanAcks: Map[StackNumber, List[HardAck]]
+        orphanAcks: Map[StackNumber, List[HardAck]],
+        /** Highest stack number this actor has hard-confirmed (and dropped the cell for). Stacks
+          * confirm strictly in order, so any ack for `stackNum <= lastConfirmed` is a late surplus
+          * for an already-finished stack — it must be dropped, not re-buffered as an orphan, since
+          * orphans are replayed only at cell creation, which never recurs for a dropped stack.
+          */
+        lastConfirmed: Option[StackNumber]
     ) {
         def bufferOrphan(h: HardAck): State =
             copy(orphanAcks =
@@ -537,10 +560,11 @@ object SlowConsensusActor {
             )
         def clearOrphans(stackNum: StackNumber): State =
             copy(orphanAcks = orphanAcks - stackNum)
-        def dropCell(stackNum: StackNumber): State = copy(cells = cells - stackNum)
+        def dropCell(stackNum: StackNumber): State =
+            copy(cells = cells - stackNum, lastConfirmed = Some(stackNum))
     }
     object State {
-        def initial: State = State(Map.empty, Map.empty)
+        def initial: State = State(Map.empty, Map.empty, None)
     }
 
     enum HandoffError extends Throwable:

--- a/src/main/scala/hydrozoa/multisig/consensus/SlowConsensusActorEvent.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/SlowConsensusActorEvent.scala
@@ -1,5 +1,6 @@
 package hydrozoa.multisig.consensus
 
+import hydrozoa.multisig.consensus.peer.PeerId
 import hydrozoa.multisig.ledger.stack.{Stack, StackNumber}
 
 /** Typed events emitted by [[SlowConsensusActor]]. Pure data; formatters in
@@ -23,6 +24,15 @@ object SlowConsensusActorEvent:
       * original is already held locally.
       */
     final case class OwnHardAckEchoIgnored(stackNum: StackNumber) extends SlowConsensusActorEvent
+
+    /** A surplus hard-ack was ignored rather than raised as a protocol violation: a round-1 ack
+      * from a coil peer beyond the round's `coilQuorum` arriving after the cell already advanced
+      * past round 1, or any late ack for a stack already hard-confirmed (its cell dropped). The
+      * signer contributes no witness — `selectSigners` keeps only `coilQuorum` coils — so the ack
+      * is redundant and dropped.
+      */
+    final case class SurplusHardAckIgnored(stackNum: StackNumber, peer: PeerId)
+        extends SlowConsensusActorEvent
 
     /** All acks collected and aggregated; [[Stack.HardConfirmed]] emitted downstream. */
     final case class StackHardConfirmed(stack: Stack.HardConfirmed) extends SlowConsensusActorEvent

--- a/src/main/scala/hydrozoa/multisig/consensus/SlowConsensusActorEventFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/SlowConsensusActorEventFormat.scala
@@ -26,6 +26,11 @@ object SlowConsensusActorEventFormat:
                   s"ignoring echo of own hard-ack for stack $sn",
                   "stackNum" -> s"${sn: Int}"
                 )
+            case SurplusHardAckIgnored(sn, peer) =>
+                debug(
+                  s"ignoring surplus hard-ack from $peer for stack $sn",
+                  "stackNum" -> s"${sn: Int}"
+                )
             case StackHardConfirmed(stack) =>
                 val sn = stack.brief.stackNum
                 info(s"stack $sn HARD-CONFIRMED", "stackNum" -> s"${sn: Int}")

--- a/src/main/scala/hydrozoa/multisig/ledger/remote/RemoteL2Ledger.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/remote/RemoteL2Ledger.scala
@@ -194,12 +194,12 @@ class RemoteL2Ledger private (
         sendRequest(Request.ProxyRequestError(req)).map(_ => ())
     }
 
-    /** Unsupported: the remote ledger owns its own persistence + recovery behind the WebSocket, so
-      * the host does not track or restore its commandNumber (R2b is the EUTXO reference ledger
-      * only).
+    /** The remote ledger owns its own persistence + recovery behind the WebSocket, so the host does
+      * not track its commandNumber (R2b is the EUTXO reference ledger only); always report
+      * [[L2CommandNumber.zero]].
       */
     override def currentCommandNumber: IO[L2CommandNumber] =
-        IO.raiseError(L2LedgerError("currentCommandNumber is not supported by RemoteL2Ledger"))
+        IO.pure(L2CommandNumber.zero)
 
     /** Unsupported — see [[currentCommandNumber]]. */
     override def restoreTo(commandNumber: L2CommandNumber): EitherT[IO, L2LedgerError, Unit] =

--- a/src/main/scala/hydrozoa/multisig/persistence/codec/RefundTxCodec.scala
+++ b/src/main/scala/hydrozoa/multisig/persistence/codec/RefundTxCodec.scala
@@ -19,9 +19,9 @@ import io.circe.{Decoder, Encoder}
   *     `CardanoNetwork.Section`, threaded through from this codec);
   *   - [[DestinationCodec]] — fresh CBOR-hex round-trip (the codec on the type itself is
   *     asymmetric);
-  *   - the `RequestId.i64` codec (packed i64 form) — shadows the companion object's default
-  *     object shape so the on-disk `requestId` field is a plain number, matching the
-  *     SugarRush `u64` expectation.
+  *   - the `RequestId.i64` codec (packed i64 form) — shadows the companion object's default object
+  *     shape so the on-disk `requestId` field is a plain number, matching the SugarRush `u64`
+  *     expectation.
   *
   * `txLens` and `resolvedUtxos = ResolvedUtxos.empty` are derived from the case-class body, not
   * stored in JSON; on decode the case-class default values restore them.

--- a/src/main/scala/hydrozoa/multisig/persistence/codec/RefundTxCodec.scala
+++ b/src/main/scala/hydrozoa/multisig/persistence/codec/RefundTxCodec.scala
@@ -4,6 +4,7 @@ import cats.syntax.functor.*
 import hydrozoa.config.head.network.CardanoNetwork
 import hydrozoa.lib.cardano.scalus.QuantizedTime.{quantizedInstantDecoder, quantizedInstantEncoder}
 import hydrozoa.lib.cardano.scalus.codecs.json.Codecs.{transactionDecoder, transactionEncoder}
+import hydrozoa.multisig.ledger.event.RequestId
 import hydrozoa.multisig.ledger.l1.tx.RefundTx
 import hydrozoa.multisig.persistence.codec.DestinationCodec.given
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
@@ -18,7 +19,9 @@ import io.circe.{Decoder, Encoder}
   *     `CardanoNetwork.Section`, threaded through from this codec);
   *   - [[DestinationCodec]] — fresh CBOR-hex round-trip (the codec on the type itself is
   *     asymmetric);
-  *   - the canonical `RequestId` codec (on its companion, `ledger.event.RequestId`).
+  *   - the `RequestId.i64` codec (packed i64 form) — shadows the companion object's default
+  *     object shape so the on-disk `requestId` field is a plain number, matching the
+  *     SugarRush `u64` expectation.
   *
   * `txLens` and `resolvedUtxos = ResolvedUtxos.empty` are derived from the case-class body, not
   * stored in JSON; on decode the case-class default values restore them.
@@ -26,9 +29,11 @@ import io.circe.{Decoder, Encoder}
 object RefundTxCodec:
 
     given postDatedEncoder(using CardanoNetwork.Section): Encoder[RefundTx.PostDated] =
+        import RequestId.i64.given
         deriveEncoder[RefundTx.PostDated]
 
     given postDatedDecoder(using CardanoNetwork.Section): Decoder[RefundTx.PostDated] =
+        import RequestId.i64.given
         deriveDecoder[RefundTx.PostDated]
 
     given refundTxEncoder(using CardanoNetwork.Section): Encoder[RefundTx] = Encoder.instance {

--- a/src/main/scala/hydrozoa/multisig/server/JsonCodecs.scala
+++ b/src/main/scala/hydrozoa/multisig/server/JsonCodecs.scala
@@ -242,7 +242,11 @@ object JsonCodecs {
         Decoder.decodeInt.map(HeadPeerNumber.apply)
 
     // Response types
-    given requestAcceptedEncoder: Encoder[RequestAccepted] = deriveEncoder[RequestAccepted]
+    given requestAcceptedEncoder: Encoder[RequestAccepted] =
+        (ra: RequestAccepted) => {
+            import RequestId.i64.given
+            Json.obj("requestId" -> ra.requestId.asJson)
+        }
 
 //    given requestAcceptedDecoder: Decoder[RequestAccepted] = deriveDecoder[RequestAccepted]
 

--- a/src/test/scala/hydrozoa/app/BootstrapMembershipTest.scala
+++ b/src/test/scala/hydrozoa/app/BootstrapMembershipTest.scala
@@ -1,0 +1,57 @@
+package hydrozoa.app
+
+import io.circe.parser
+import org.scalatest.funsuite.AnyFunSuite
+
+/** Pins the JSON field names BuildHeadConfig reads, so peers.example.json keeps decoding. A
+  * successful decode proves every field name (verificationKey / webSocketAddress /
+  * hubHeadPeerNumber / coilQuorum / headPeers / coilPeers) matches the [[Bootstrap.Membership]]
+  * decoder.
+  */
+class BootstrapMembershipTest extends AnyFunSuite {
+
+    test("Membership decodes the documented peers.json shape (incl. distributed hubs)") {
+        val json =
+            """{
+              |  "headPeers": [
+              |    { "verificationKey": "0000000000000000000000000000000000000000000000000000000000000000", "webSocketAddress": "ws://hydranth-0:4001" },
+              |    { "verificationKey": "1111111111111111111111111111111111111111111111111111111111111111", "webSocketAddress": "ws://hydranth-1:4001" }
+              |  ],
+              |  "coilPeers": [
+              |    { "verificationKey": "2222222222222222222222222222222222222222222222222222222222222222", "hubHeadPeerNumber": 0 },
+              |    { "verificationKey": "3333333333333333333333333333333333333333333333333333333333333333", "hubHeadPeerNumber": 1 }
+              |  ],
+              |  "coilQuorum": 1
+              |}""".stripMargin
+
+        val membership =
+            parser
+                .decode[Bootstrap.Membership](json)
+                .fold(e => fail(s"decode failed: $e"), identity)
+
+        assert(membership.headPeers.size == 2)
+        assert(membership.coilPeers.size == 2)
+        assert(membership.coilQuorum == 1)
+        assert(membership.headPeers.head.webSocketAddress == "ws://hydranth-0:4001")
+    }
+
+    test("Membership decoding ignores the _comment helper key") {
+        val json =
+            """{
+              |  "_comment": ["this key documents the file and must be ignored by the parser"],
+              |  "headPeers": [
+              |    { "verificationKey": "0000000000000000000000000000000000000000000000000000000000000000", "webSocketAddress": "ws://hydranth-0:4001" }
+              |  ],
+              |  "coilPeers": [],
+              |  "coilQuorum": 0
+              |}""".stripMargin
+
+        val membership =
+            parser
+                .decode[Bootstrap.Membership](json)
+                .fold(e => fail(s"decode failed: $e"), identity)
+
+        assert(membership.headPeers.size == 1)
+        assert(membership.coilPeers.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
Turns the single-peer node entry point into one that runs an **N-head + M-coil** head. Each node is one OS process, told its identity via env (`NODE_ID=<head|coil>:<index>`). All peer verification keys live in a shared `HeadConfig` artifact built once and distributed; nodes never exchange keys at runtime. Init structure is unchanged — **only head peer 0 funds the head**; the others just co-sign stack 0.

## Changes

**Build step — `Bootstrap.scala`**
- `mkNodeConfig` → **`mkSharedHeadConfig`**: builds the shared `HeadConfig` for an N-head + M-coil head from a `Membership` (head peers `vkey`+`webSocketAddress`, coil peers `vkey`+`hubHeadPeerNumber`, `coilQuorum`).
- Head peer 0 is the sole funder: contributes `EQUITY` as L2 equity and covers the whole head's fallback contingency (`collective + N×individual`) from its own L1 address; heads 1..N-1 contribute `Coin.zero`.
- New **`BuildHeadConfig`** CLI: reads `peers.json` + env, writes `head-config.json`.

**Run step — `Main.scala`**
- Loads the shared `head-config.json` (`HeadConfig.fromJson`), parses `NODE_ID`, selects this node's wallet, builds its `NodeConfig` via `mkHeadConfig`/`mkCoilConfig`, and asserts the wallet vkey sits at the declared index.
- Dispatches `HeadMultisigRegimeManager` or `CoilMultisigRegimeManager` on `ownPeerId`.
- User-facing HTTP server runs on **head nodes only**, bound from `HTTP_HOST`/`HTTP_PORT`. Inter-peer comms addresses come from the config, not env.

**Supporting**
- `.env.example`: adds `NODE_ID`, `HEAD_CONFIG_PATH`; scopes `EQUITY` to the build step.
- `peers.example.json`: membership template (coils distributed across hubs).
- `BootstrapMembershipTest`: pins the `peers.json` field names.
- `.gitignore`: generated `head-config.json` and `.hydrozoa-data/`.

## Startup procedure

**1. Generate keys** (once per peer, offline):
```
sbt "runMain hydrozoa.app.GenerateKeyPair"
```

**2. Author `peers.json`** (see `peers.example.json`) — every peer's vkey, head peers' WebSocket addresses, each coil's hub, and `coilQuorum`.

**3. Build the shared config** (once, on head-0/operator machine — needs `BLOCKFROST_API_KEY` + `EQUITY`, and head-0's L1 address funded):
```
sbt "runMain hydrozoa.app.BuildHeadConfig peers.json"   # -> head-config.json
```

**4. Distribute `head-config.json`** to every node (identical file).

**5. Start each node** (its own `.env`: `CARDANO_VERIFICATION_KEY`/`CARDANO_SIGNING_KEY`, `NODE_ID`, `BLOCKFROST_API_KEY`, `SUGAR_RUSH_*`, and for heads `ADMIN_*` + `HTTP_*`):
```
sbt "runMain hydrozoa.app.Main"
```
e.g. `NODE_ID=head:0`, `head:1`, `coil:0`, … — one process each.

## Verification
- Full compile; `ConfigurationCodecTest` (the `HeadConfig` round-trip `BuildHeadConfig` relies on); `BootstrapMembershipTest`.
- **Not yet run live** — needs Blockfrost + a funded head-0 address + SugarRush.

## Known follow-ups (deferred to first live run)
1. Coil peer-liaison log lines label the local side as `Head` (formatter is head-typed; `peer` ctx is overridden to the coil label as a stopgap).
2. `ADMIN_*` still required by shared `loadEnv` even for coil nodes (no HTTP there).
3. Custom-network Blockfrost URL `???` in `NodeConfig.fromJson` untouched (not hit on Preview).