### PR TITLE
test(rulebased): dispute resolution-safety & vote-attack scenarios (test A)

### DIFF
--- a/src/test/scala/hydrozoa/rulebased/ledger/l1/DisputeActorTest.scala
+++ b/src/test/scala/hydrozoa/rulebased/ledger/l1/DisputeActorTest.scala
@@ -49,7 +49,14 @@ object DisputeActorTestHelpers {
         txIn: TransactionInput,
         nVoteTokens: BigInt = 1,
     ): scalus.cardano.ledger.Utxo =
-        DisputeTestFixtures.mkBallotBoxUtxoPure(headConfig, key, link, voteStatus, txIn, nVoteTokens)
+        DisputeTestFixtures.mkBallotBoxUtxoPure(
+          headConfig,
+          key,
+          link,
+          voteStatus,
+          txIn,
+          nVoteTokens
+        )
 
     def mkBallotBoxUtxo(
         key: BigInt,

--- a/src/test/scala/hydrozoa/rulebased/ledger/l1/DisputeActorTest.scala
+++ b/src/test/scala/hydrozoa/rulebased/ledger/l1/DisputeActorTest.scala
@@ -6,6 +6,7 @@ import cats.effect.unsafe.implicits.global
 import cats.syntax.all.*
 import hydrozoa.*
 import hydrozoa.config.*
+import hydrozoa.config.head.HeadConfig
 import hydrozoa.config.node.MultiNodeConfig
 import hydrozoa.lib.cardano.scalus.QuantizedTime.QuantizedInstant.realTimeQuantizedInstant
 import hydrozoa.lib.cardano.scalus.VerificationKeyExtra.{addrKeyHash, pubKeyHash}
@@ -13,11 +14,11 @@ import hydrozoa.lib.logging.{ContraTracer, Slf4jTracer}
 import hydrozoa.multisig.backend.cardano.{CardanoBackendMock, MockState}
 import hydrozoa.multisig.ledger.commitment.TrustedSetup
 import hydrozoa.multisig.ledger.joint.EvacuationMap
+import hydrozoa.rulebased.ledger.l1.state.StandaloneEvacuationCommitmentOnchain
 import hydrozoa.rulebased.ledger.l1.state.TreasuryState.RuleBasedTreasuryDatum
 import hydrozoa.rulebased.ledger.l1.state.TreasuryState.RuleBasedTreasuryDatum.Unresolved
 import hydrozoa.rulebased.ledger.l1.state.VoteState.VoteStatus.Voted
-import hydrozoa.rulebased.ledger.l1.state.VoteState.{VoteDatum, VoteStatus}
-import hydrozoa.rulebased.ledger.l1.state.{StandaloneEvacuationCommitmentOnchain, TreasuryState, VoteState}
+import hydrozoa.rulebased.ledger.l1.state.VoteState.{KzgCommitment, VoteDatum, VoteStatus}
 import hydrozoa.rulebased.ledger.l1.tx.CommonGenerators.genCollateralUtxo
 import hydrozoa.rulebased.ledger.l1.tx.EvacuationTx
 import hydrozoa.rulebased.ledger.l1.utxo.{BallotBox, RuleBasedTreasuryOutput, RuleBasedTreasuryUtxo}
@@ -40,6 +41,38 @@ import test.Generators.Hydrozoa.{genEvacuationMap, genPositiveValue}
 object DisputeActorTestHelpers {
     import MultiNodeConfig.*
 
+    /** Build a ballot-box UTxO at the dispute address directly from a [[HeadConfig]] (no test
+      * monad). The [[MultiNodeConfigTestM]] variant below just supplies the env's head config.
+      */
+    def mkBallotBoxUtxoPure(
+        headConfig: HeadConfig,
+        key: BigInt,
+        link: BigInt,
+        voteStatus: VoteStatus,
+        // Careful, these can't conflict!
+        txIn: TransactionInput,
+        nVoteTokens: BigInt = 1,
+    ): scalus.cardano.ledger.Utxo = {
+        val disputeResAddress = HydrozoaBlueprint.mkDisputeAddress(headConfig.network)
+        val ownVoteUtxoOutput = Babbage(
+          address = disputeResAddress,
+          value = Value.assets(
+            lovelace = Coin.ada(5),
+            assets = Map(
+              (
+                headConfig.headMultisigScript.policyId,
+                Map((headConfig.headTokenNames.voteTokenName, nVoteTokens.toLong))
+              )
+            )
+          ),
+          datumOption = Some(
+            Inline(toData(VoteDatum(key = key, link = link, voteStatus = voteStatus)))
+          ),
+          scriptRef = None
+        )
+        scalus.cardano.ledger.Utxo((txIn, ownVoteUtxoOutput))
+    }
+
     def mkBallotBoxUtxo(
         key: BigInt,
         link: BigInt,
@@ -48,27 +81,28 @@ object DisputeActorTestHelpers {
         txIn: TransactionInput,
         nVoteTokens: BigInt = 1,
     ): MultiNodeConfigTestM[scalus.cardano.ledger.Utxo] =
-        for {
-            env <- ask
-            disputeResAddress = HydrozoaBlueprint.mkDisputeAddress(env.headConfig.network)
-            ownVoteUtxoOutput = Babbage(
-              address = disputeResAddress,
-              value = Value.assets(
-                lovelace = Coin.ada(5),
-                assets = Map(
-                  (
-                    env.headConfig.headMultisigScript.policyId,
-                    Map((env.headConfig.headTokenNames.voteTokenName, nVoteTokens.toLong))
-                  )
-                )
-              ),
-              datumOption = Some(
-                Inline(toData(VoteState.VoteDatum(key = key, link = link, voteStatus = voteStatus)))
-              ),
-              scriptRef = None
-            )
-            ownVoteUtxo = (txIn, ownVoteUtxoOutput)
-        } yield scalus.cardano.ledger.Utxo(ownVoteUtxo)
+        asks(env => mkBallotBoxUtxoPure(env.headConfig, key, link, voteStatus, txIn, nVoteTokens))
+
+    /** Build an Unresolved rule-based treasury UTxO (no test monad). */
+    def mkRuleBasedTreasuryPure(
+        versionMajor: BigInt,
+        value: Value,
+        txIn: TransactionInput,
+        votingDeadline: PosixTime
+    ): RuleBasedTreasuryUtxo = {
+        val datum = Unresolved(
+          deadlineVoting = votingDeadline,
+          versionMajor = versionMajor,
+          // this is cribbed from the CommonGenerators.scala test
+          setupG2 = TrustedSetup
+              .takeSrsG2(EvacuationTx.Assumptions.maxEvacuationsPerTx + 1)
+              .map(p2 => G2Element(p2).toCompressedByteString)
+        )
+        RuleBasedTreasuryUtxo(
+          utxoId = txIn,
+          treasuryOutput = RuleBasedTreasuryOutput(datum, value)
+        )
+    }
 
     def mkRuleBasedTreasury(
         versionMajor: BigInt,
@@ -76,26 +110,7 @@ object DisputeActorTestHelpers {
         txIn: TransactionInput,
         votingDeadline: PosixTime
     ): MultiNodeConfigTestM[RuleBasedTreasuryUtxo] =
-        for {
-            _ <- ask
-
-            datum = Unresolved(
-              deadlineVoting = votingDeadline,
-              versionMajor = versionMajor,
-              // this is cribbed from the CommonGenerators.scala test
-              setupG2 = TrustedSetup
-                  .takeSrsG2(EvacuationTx.Assumptions.maxEvacuationsPerTx + 1)
-                  .map(p2 => G2Element(p2).toCompressedByteString)
-            )
-            treasuryUtxo = RuleBasedTreasuryUtxo(
-              utxoId = txIn,
-              treasuryOutput = RuleBasedTreasuryOutput(
-                datum,
-                value
-              )
-            )
-
-        } yield treasuryUtxo
+        pure(mkRuleBasedTreasuryPure(versionMajor, value, txIn, votingDeadline))
 
     /** Given a pre-initialized TestM with a TestHeadConfig environment and an initial L2 UTxO set,
       * create a (pure) DisputeActor.
@@ -135,7 +150,7 @@ object DisputeActorTestHelpers {
                   .label("collateral utxo")
             )
 
-            initialCommitment: VoteState.KzgCommitment = initialEvacuationMap.kzgCommitment
+            initialCommitment: KzgCommitment = initialEvacuationMap.kzgCommitment
 
             now <- lift(realTimeQuantizedInstant(env.slotConfig))
             currentSlot = now.toSlot

--- a/src/test/scala/hydrozoa/rulebased/ledger/l1/DisputeActorTest.scala
+++ b/src/test/scala/hydrozoa/rulebased/ledger/l1/DisputeActorTest.scala
@@ -12,16 +12,12 @@ import hydrozoa.lib.cardano.scalus.QuantizedTime.QuantizedInstant.realTimeQuanti
 import hydrozoa.lib.cardano.scalus.VerificationKeyExtra.{addrKeyHash, pubKeyHash}
 import hydrozoa.lib.logging.{ContraTracer, Slf4jTracer}
 import hydrozoa.multisig.backend.cardano.{CardanoBackendMock, MockState}
-import hydrozoa.multisig.ledger.commitment.TrustedSetup
 import hydrozoa.multisig.ledger.joint.EvacuationMap
 import hydrozoa.rulebased.ledger.l1.state.StandaloneEvacuationCommitmentOnchain
-import hydrozoa.rulebased.ledger.l1.state.TreasuryState.RuleBasedTreasuryDatum
-import hydrozoa.rulebased.ledger.l1.state.TreasuryState.RuleBasedTreasuryDatum.Unresolved
 import hydrozoa.rulebased.ledger.l1.state.VoteState.VoteStatus.Voted
 import hydrozoa.rulebased.ledger.l1.state.VoteState.{KzgCommitment, VoteDatum, VoteStatus}
 import hydrozoa.rulebased.ledger.l1.tx.CommonGenerators.genCollateralUtxo
-import hydrozoa.rulebased.ledger.l1.tx.EvacuationTx
-import hydrozoa.rulebased.ledger.l1.utxo.{BallotBox, RuleBasedTreasuryOutput, RuleBasedTreasuryUtxo}
+import hydrozoa.rulebased.ledger.l1.utxo.{BallotBox, RuleBasedTreasuryUtxo}
 import hydrozoa.rulebased.{DisputeActor, DisputeActorEvent, DisputeActorEventFormat, RuleBasedRegimeManager}
 import org.scalacheck.{Arbitrary, Gen, Properties}
 import scalus.cardano.ledger.*
@@ -31,8 +27,7 @@ import scalus.cardano.ledger.EvaluatorMode.EvaluateAndComputeCost
 import scalus.cardano.ledger.TransactionOutput.Babbage
 import scalus.cardano.ledger.rules.{Context, State, UtxoEnv}
 import scalus.cardano.onchain.plutus.v3.PosixTime
-import scalus.uplc.builtin.Data.{fromData, toData}
-import scalus.uplc.builtin.bls12_381.G2Element
+import scalus.uplc.builtin.Data.fromData
 import test.Generators.Hydrozoa.{genEvacuationMap, genPositiveValue}
 
 // Note: If the vote status is unresolved, the dispute resolution script will fail unless the tx hash matches
@@ -43,6 +38,7 @@ object DisputeActorTestHelpers {
 
     /** Build a ballot-box UTxO at the dispute address directly from a [[HeadConfig]] (no test
       * monad). The [[MultiNodeConfigTestM]] variant below just supplies the env's head config.
+      * Delegates to the shared [[DisputeTestFixtures]] constructor.
       */
     def mkBallotBoxUtxoPure(
         headConfig: HeadConfig,
@@ -52,26 +48,8 @@ object DisputeActorTestHelpers {
         // Careful, these can't conflict!
         txIn: TransactionInput,
         nVoteTokens: BigInt = 1,
-    ): scalus.cardano.ledger.Utxo = {
-        val disputeResAddress = HydrozoaBlueprint.mkDisputeAddress(headConfig.network)
-        val ownVoteUtxoOutput = Babbage(
-          address = disputeResAddress,
-          value = Value.assets(
-            lovelace = Coin.ada(5),
-            assets = Map(
-              (
-                headConfig.headMultisigScript.policyId,
-                Map((headConfig.headTokenNames.voteTokenName, nVoteTokens.toLong))
-              )
-            )
-          ),
-          datumOption = Some(
-            Inline(toData(VoteDatum(key = key, link = link, voteStatus = voteStatus)))
-          ),
-          scriptRef = None
-        )
-        scalus.cardano.ledger.Utxo((txIn, ownVoteUtxoOutput))
-    }
+    ): scalus.cardano.ledger.Utxo =
+        DisputeTestFixtures.mkBallotBoxUtxoPure(headConfig, key, link, voteStatus, txIn, nVoteTokens)
 
     def mkBallotBoxUtxo(
         key: BigInt,
@@ -83,26 +61,16 @@ object DisputeActorTestHelpers {
     ): MultiNodeConfigTestM[scalus.cardano.ledger.Utxo] =
         asks(env => mkBallotBoxUtxoPure(env.headConfig, key, link, voteStatus, txIn, nVoteTokens))
 
-    /** Build an Unresolved rule-based treasury UTxO (no test monad). */
+    /** Build an Unresolved rule-based treasury UTxO (no test monad). Delegates to the shared
+      * [[DisputeTestFixtures]] constructor.
+      */
     def mkRuleBasedTreasuryPure(
         versionMajor: BigInt,
         value: Value,
         txIn: TransactionInput,
         votingDeadline: PosixTime
-    ): RuleBasedTreasuryUtxo = {
-        val datum = Unresolved(
-          deadlineVoting = votingDeadline,
-          versionMajor = versionMajor,
-          // this is cribbed from the CommonGenerators.scala test
-          setupG2 = TrustedSetup
-              .takeSrsG2(EvacuationTx.Assumptions.maxEvacuationsPerTx + 1)
-              .map(p2 => G2Element(p2).toCompressedByteString)
-        )
-        RuleBasedTreasuryUtxo(
-          utxoId = txIn,
-          treasuryOutput = RuleBasedTreasuryOutput(datum, value)
-        )
-    }
+    ): RuleBasedTreasuryUtxo =
+        DisputeTestFixtures.mkRuleBasedTreasuryPure(versionMajor, value, txIn, votingDeadline)
 
     def mkRuleBasedTreasury(
         versionMajor: BigInt,

--- a/src/test/scala/hydrozoa/rulebased/ledger/l1/script/plutus/DisputeResolutionScenarioTest.scala
+++ b/src/test/scala/hydrozoa/rulebased/ledger/l1/script/plutus/DisputeResolutionScenarioTest.scala
@@ -1,0 +1,323 @@
+package hydrozoa.rulebased.ledger.l1.script.plutus
+
+import cats.effect.unsafe.implicits.global
+import cps.*
+import hydrozoa.*
+import hydrozoa.config.HydrozoaBlueprint
+import hydrozoa.config.node.{MultiNodeConfig, NodeConfig}
+import hydrozoa.lib.cardano.scalus.QuantizedTime.QuantizedInstant.realTimeQuantizedInstant
+import hydrozoa.lib.cardano.scalus.VerificationKeyExtra.{addrKeyHash, pubKeyHash}
+import hydrozoa.lib.cardano.scalus.ledger.CollateralUtxo
+import hydrozoa.multisig.consensus.peer.PeerWallet
+import hydrozoa.rulebased.ledger.l1.DisputeActorTestHelpers.{mkBallotBoxUtxoPure, mkRuleBasedTreasuryPure}
+import hydrozoa.rulebased.ledger.l1.state.StandaloneEvacuationCommitmentOnchain
+import hydrozoa.rulebased.ledger.l1.state.TreasuryState.RuleBasedTreasuryDatum
+import hydrozoa.rulebased.ledger.l1.state.VoteState.VoteStatus
+import hydrozoa.rulebased.ledger.l1.state.VoteState.VoteStatus.Voted
+import hydrozoa.rulebased.ledger.l1.tx.CommonGenerators.genCollateralUtxo
+import hydrozoa.rulebased.ledger.l1.tx.{ResolutionTx, TallyTx, VoteTx}
+import hydrozoa.rulebased.ledger.l1.utxo.BallotBox
+import org.scalacheck.rng.Seed
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest.funsuite.AnyFunSuite
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+import scalus.cardano.address.Address
+import scalus.cardano.ledger.*
+import scalus.cardano.ledger.ArbitraryInstances.{genByteStringOfN, given}
+import scalus.cardano.ledger.EvaluatorMode.EvaluateAndComputeCost
+import scalus.cardano.ledger.rules.{CardanoMutator, State, UtxoEnv}
+import scalus.testing.{ImmutableEmulator, Scenario}
+
+/** Resolution-safety check for the rule-based dispute (test "A").
+  *
+  * Invariant: the dispute resolves to the **highest version actually voted, regardless of tally
+  * order and regardless of which peers vote**. The ballot-box ring starts with key 0 carrying a
+  * default `Voted(X1, v1)` (so a `Voted` survivor — and thus a resolvable head — always exists),
+  * and keys 1..N-1 all start as `AwaitingVote`. The decision *whether each peer votes* is made
+  * **inside the scenario**: for every awaiting box the `Scenario` monad branches (`choices(true,
+  * false)`) — `true` submits a real [[VoteTx]] (`AwaitingVote -> Voted(X2, v2)`), `false` is the
+  * peer that never calls submit, leaving its box `AwaitingVote` (it loses under `maxVote`: Voted >
+  * AwaitingVote > Abstain).
+  *
+  * After voting, the scenario advances past the voting deadline (`Scenario.sleep`) — votes need
+  * `to <= deadline`, the tally needs `from >= deadline` — re-reads the boxes, tallies the ring down
+  * to one box (`tallyDown`, branching over every legal `(continuing, removed)` pair), and resolves.
+  * The resolved treasury must commit to **X2 if any peer voted in that branch, else the default
+  * X1** — asserted on **every** leaf.
+  *
+  * One scenario therefore explores all `2^(N-1)` vote subsets × `(N-1)!` tally orders. This is a
+  * deterministic example test (not generative): the multi-peer fixture is materialized once from a
+  * fixed seed — the house pattern for non-property tests that still need a [[MultiNodeConfig]] (cf.
+  * `StackComposerRecoveryTest`); branching lives in the `Scenario` monad, not in ScalaCheck.
+  *
+  * Box count is `min(3, nHeadPeers + 1)` (capped low to keep the exhaustive fan-out cheap — 8
+  * leaves; the 4+ box space is covered by a bounded-trace ScalaCheck Commands test). The final
+  * tallied box must hold exactly `nHeadPeers + 1` vote tokens (Resolve checks it). Each vote
+  * consumes-and-recreates its collateral (unlike `TallyTx`, which only references it), so every
+  * awaiting box gets its **own** collateral utxo; the tally/resolve chain reuses one separate
+  * collateral.
+  */
+class DisputeResolutionScenarioTest extends AnyFunSuite {
+
+    /** A single, deterministic multi-peer fixture (seeded). */
+    private val env =
+        MultiNodeConfig.generateWithCoil().pureApply(Gen.Parameters.default, Seed(0L))
+
+    /** Materialize a generator deterministically from a fixed seed. */
+    private def fixed[A](gen: Gen[A], seed: Long): A =
+        gen.pureApply(Gen.Parameters.default, Seed(seed))
+
+    private val config: NodeConfig = env.nodeConfigs.head._2
+    private val ownWallet: PeerWallet = env.nodePrivateConfigs.head._2.ownWallet
+    private val ownKeyHash = ownWallet.exportVerificationKey.addrKeyHash
+    private val peerPkh = ownWallet.exportVerificationKey.pubKeyHash
+    private val disputeAddr: Address = HydrozoaBlueprint.mkDisputeAddress(env.headConfig.network)
+
+    private val treasuryToken = Value.asset(
+      env.headConfig.headMultisigScript.policyId,
+      env.headConfig.headTokenNames.treasuryTokenName,
+      1
+    )
+    private val fallbackTxId = fixed(Arbitrary.arbitrary[TransactionHash], 1)
+    private val x1Commitment = fixed(genByteStringOfN(48), 2)
+    private val x2Commitment = fixed(genByteStringOfN(48).suchThat(_ != x1Commitment), 3)
+    private val versionMajor = BigInt(100)
+    private val x2Minor = BigInt(2)
+    private val now = realTimeQuantizedInstant(env.headConfig.slotConfig).unsafeRunSync()
+
+    // Final tallied box must hold exactly nHeadPeers + 1 vote tokens (Resolve checks this), so the
+    // box count is bounded by the token budget (each box needs >= 1 token).
+    private val totalTokens = BigInt(env.headConfig.nHeadPeers.convert + 1)
+    // Capped at 3 boxes to keep the exhaustive fan-out cheap: 2^2 vote subsets × 2! tally orders =
+    // 8 leaves. The 4+ box space is covered by a bounded-trace ScalaCheck Commands test instead.
+    private val numBoxes = math.min(3, totalTokens.toInt)
+
+    // Treasury (Unresolved). Deadline in the FUTURE so votes (to <= deadline) are valid now and the
+    // tally (from >= deadline) becomes valid once the scenario sleeps past it.
+    private val treasury = mkRuleBasedTreasuryPure(
+      versionMajor,
+      treasuryToken + Value(Coin.ada(100)),
+      TransactionInput(fallbackTxId, 0),
+      votingDeadline = now.toPosixTime + 600_000
+    )
+    private val deadlineSlot: Slot = treasury.parseVotingDeadline(using config).toOption.get
+
+    // One collateral per awaiting box (each vote consumes its own) plus one for the tally/resolve
+    // chain (TallyTx only references collateral, so the chain can reuse a single one).
+    private val voteCollaterals: List[CollateralUtxo] =
+        (0 until numBoxes - 1).toList.map(i =>
+            fixed(genCollateralUtxo(ownKeyHash)(using env.headConfig), 10L + i)
+        )
+    private val collateral = fixed(genCollateralUtxo(ownKeyHash)(using env.headConfig), 4)
+
+    // The standalone evacuation commitment every voter signs (version X2 = (versionMajor, 2),
+    // committing to x2Commitment). The on-chain Vote check verifies the all-peer multisig over it.
+    private val sec = StandaloneEvacuationCommitmentOnchain(
+      headId = env.headConfig.headTokenNames.treasuryTokenName.bytes,
+      versionMajor = versionMajor,
+      versionMinor = x2Minor,
+      commitment = x2Commitment
+    )
+    private val signatures = env.multisignHeader(sec).toList
+    private val coilSignatures = env.multisignHeaderCoil(sec)
+
+    // Ring 0 -> 1 -> ... -> (numBoxes-1) -> 0.
+    //  - key 0 = default Voted(X1, 1) (guarantees a Voted survivor; absorbs the token slack).
+    //  - keys 1.. = AwaitingVote (each may or may not vote, decided inside the scenario).
+    private val boxStatuses: List[VoteStatus] =
+        Voted(x1Commitment, 1) :: List.fill(numBoxes - 1)(VoteStatus.AwaitingVote(peerPkh))
+    private val boxTokens: List[BigInt] =
+        (totalTokens - (numBoxes - 1)) :: List.fill(numBoxes - 1)(BigInt(1))
+
+    private val boxUtxos: List[Utxo] = (0 until numBoxes).toList.map { i =>
+        mkBallotBoxUtxoPure(
+          env.headConfig,
+          BigInt(i),
+          BigInt((i + 1) % numBoxes),
+          boxStatuses(i),
+          TransactionInput(fallbackTxId, i + 1),
+          nVoteTokens = boxTokens(i)
+        )
+    }
+
+    private val initialUtxos: Utxos = (
+      Map(
+        (treasury.utxoId, treasury.treasuryOutput.toOutput(using config)),
+        (collateral.input, collateral.collateralOutput.toOutput(using env))
+      )
+          ++ voteCollaterals.map(c => c.input -> c.collateralOutput.toOutput(using env))
+          ++ boxUtxos.map(u => u.input -> u.output)
+          ++ config.scriptReferenceUtxos.toList.map(_.toTuple)
+    )
+
+    /** The awaiting boxes (keys 1..), each paired with its own collateral for voting. */
+    private val awaitingBoxes: List[(BallotBox[VoteStatus.AwaitingVote], CollateralUtxo)] =
+        boxUtxos.tail
+            .map { u =>
+                BallotBox
+                    .parse(u)(using config)
+                    .fold(e => throw new AssertionError(e.toString), identity)
+                    .asInstanceOf[BallotBox[VoteStatus.AwaitingVote]]
+            }
+            .zip(voteCollaterals)
+
+    /** Voting phase: for each awaiting box, branch on vote / don't-vote. A vote submits a real
+      * [[VoteTx]] (signed by the box's peer, spending the box's own collateral), turning it into
+      * `Voted(X2)`; not voting leaves it `AwaitingVote`. Returns whether *any* box voted on this
+      * branch.
+      */
+    private def voteEach(
+        boxes: List[(BallotBox[VoteStatus.AwaitingVote], CollateralUtxo)],
+        anyVoted: Boolean
+    ): Scenario[Boolean] =
+        async[Scenario] {
+            boxes match {
+                case Nil => anyVoted
+                case (box, voteCollateral) :: rest =>
+                    val doVote = Scenario.choices(true, false).await
+                    val votedNow =
+                        if doVote then {
+                            val voteTx = VoteTx
+                                .Build(
+                                  box,
+                                  treasury,
+                                  voteCollateral,
+                                  sec,
+                                  signatures,
+                                  coilSignatures
+                                )
+                                .result(using config)
+                                .toOption
+                                .get
+                            val r = Scenario.submit(ownWallet.signTx(voteTx.tx)).await
+                            Scenario.guard(r.isRight).await
+                            true
+                        } else false
+                    voteEach(rest, anyVoted || votedNow).await
+            }
+        }
+
+    /** The full scenario: vote (branched) -> sleep past the deadline -> tally down (branched) ->
+      * resolve. Yields the resolved datum paired with whether this branch cast any vote.
+      */
+    private val scenario: Scenario[(RuleBasedTreasuryDatum, Boolean)] =
+        async[Scenario] {
+            val anyVoted = voteEach(awaitingBoxes, false).await
+            val cur = Scenario.now.await
+            val target = deadlineSlot.slot + 1
+            if target > cur then Scenario.sleep(target - cur).await
+            val emu = Scenario.currentEmulator.await
+            val datum = tallyDown(allBoxesAt(emu, disputeAddr)).await
+            (datum, anyVoted)
+        }
+
+    test("resolution resolves to highest voted version, any tally order and any vote subset") {
+        val emulator0 = mkEmulator(initialUtxos, now.toSlot)
+        val results =
+            Await.result(Scenario.runAll(emulator0.toEmulator)(scenario), Duration(600, "s"))
+
+        // 2^(N-1) vote subsets × (N-1)! tally orders.
+        val expectedBranches = (1 << (numBoxes - 1)) * (1 until numBoxes).product
+        val _ = assert(
+          results.size == expectedBranches,
+          s"expected $expectedBranches leaves (2^${numBoxes - 1} vote subsets × " +
+              s"${numBoxes - 1}! tally orders), got ${results.size}"
+        )
+        val _ = assert(
+          results.forall { case (_, (datum, anyVoted)) =>
+              datum match {
+                  case RuleBasedTreasuryDatum.Resolved(c, (_, m), _) =>
+                      if anyVoted then c == x2Commitment && m == x2Minor
+                      else c == x1Commitment && m == BigInt(1)
+                  case _ => false
+              }
+          },
+          "each leaf must resolve to X2 iff it cast any vote, else the default X1; " +
+              s"got ${results.map(_._2._2).groupBy(identity).view.mapValues(_.size).toMap}"
+        )
+    }
+
+    /** Mirror the Mock execution model: single CardanoMutator under EvaluateAndComputeCost. */
+    private def mkEmulator(initialUtxos: Utxos, slot: Slot): ImmutableEmulator =
+        ImmutableEmulator(
+          state = State(utxos = initialUtxos),
+          env = UtxoEnv(
+            slot.slot,
+            env.headConfig.cardanoProtocolParams,
+            certState = CertState.empty,
+            env.headConfig.network
+          ),
+          slotConfig = env.headConfig.slotConfig,
+          evaluatorMode = EvaluateAndComputeCost,
+          validators = Seq.empty,
+          mutators = Seq(CardanoMutator)
+        )
+
+    /** All ballot boxes currently at `address` in the emulator's UTxO set. */
+    private def allBoxesAt(
+        emulator: ImmutableEmulator,
+        address: Address
+    ): List[BallotBox[VoteStatus]] =
+        emulator.utxos.toList
+            .filter((_, o) => o.address == address)
+            .flatMap((i, o) => BallotBox.parse(Utxo(i, o))(using config).toOption)
+
+    /** The ballot box with the given `key` currently at `address` in the emulator's UTxO set. */
+    private def findBoxByKey(
+        emulator: ImmutableEmulator,
+        address: Address,
+        key: BigInt
+    ): Option[BallotBox[VoteStatus]] =
+        allBoxesAt(emulator, address).find(_.ballotBoxOutput.key == key)
+
+    /** Valid `(continuing, removed)` tally pairs among `boxes`: the removed box's key must equal
+      * the continuing box's link and be strictly greater (the linked-list contraction rule). The
+      * Scenario branches over these — so the choice is *which boxes to tally*, not a label, and it
+      * enumerates every valid tally order by construction.
+      */
+    private def tallyPairs(
+        boxes: List[BallotBox[VoteStatus]]
+    ): List[(BallotBox[VoteStatus], BallotBox[VoteStatus])] =
+        for {
+            cont <- boxes
+            rem <- boxes
+            if rem.ballotBoxOutput.key == cont.ballotBoxOutput.link
+                && rem.ballotBoxOutput.key > cont.ballotBoxOutput.key
+        } yield (cont, rem)
+
+    /** Recursive contraction: branch over every legal tally pair at each step, thread the emulator
+      * forward, and resolve the single survivor. Returns the resolved datum on each branch.
+      */
+    private def tallyDown(bs: List[BallotBox[VoteStatus]]): Scenario[RuleBasedTreasuryDatum] =
+        async[Scenario] {
+            if bs.size == 1 then {
+                val resolution = ResolutionTx
+                    .Build(bs.head.asInstanceOf[BallotBox[Voted]], treasury, collateral)(using
+                      config
+                    )
+                    .result
+                    .toOption
+                    .get
+                val r = Scenario.submit(ownWallet.signTx(resolution.tx)).await
+                Scenario.guard(r.isRight).await
+                resolution.treasuryResolvedUtxoProduced.treasuryOutput.datum
+            } else {
+                val (cont, rem) = Scenario.fromCollection(tallyPairs(bs)).await
+                val tally = TallyTx
+                    .Build(cont, rem, treasury, collateral)(using config)
+                    .result
+                    .toOption
+                    .get
+                val r = Scenario.submit(ownWallet.signTx(tally.tx)).await
+                Scenario.guard(r.isRight).await
+                val emu = Scenario.currentEmulator.await
+                val survivor = findBoxByKey(emu, disputeAddr, cont.ballotBoxOutput.key).get
+                val rest = bs.filterNot { b =>
+                    b.ballotBoxOutput.key == cont.ballotBoxOutput.key ||
+                    b.ballotBoxOutput.key == rem.ballotBoxOutput.key
+                }
+                tallyDown(survivor :: rest).await
+            }
+        }
+}

--- a/src/test/scala/hydrozoa/rulebased/ledger/l1/script/plutus/DisputeVoteAttackTest.scala
+++ b/src/test/scala/hydrozoa/rulebased/ledger/l1/script/plutus/DisputeVoteAttackTest.scala
@@ -1,0 +1,186 @@
+package hydrozoa.rulebased.ledger.l1.script.plutus
+
+import cats.effect.unsafe.implicits.global
+import hydrozoa.*
+import hydrozoa.config.node.MultiNodeConfig
+import hydrozoa.lib.cardano.scalus.QuantizedTime.QuantizedInstant.realTimeQuantizedInstant
+import hydrozoa.lib.cardano.scalus.VerificationKeyExtra.{addrKeyHash, pubKeyHash}
+import hydrozoa.rulebased.ledger.l1.DisputeActorTestHelpers.{mkBallotBoxUtxo, mkRuleBasedTreasury}
+import hydrozoa.rulebased.ledger.l1.state.StandaloneEvacuationCommitmentOnchain
+import hydrozoa.rulebased.ledger.l1.state.VoteState.VoteStatus
+import hydrozoa.rulebased.ledger.l1.tx.CommonGenerators.genCollateralUtxo
+import hydrozoa.rulebased.ledger.l1.tx.VoteTx
+import hydrozoa.rulebased.ledger.l1.utxo.BallotBox
+import org.scalacheck.{Arbitrary, Gen, Properties, Test}
+import scalus.cardano.ledger.*
+import scalus.cardano.ledger.ArbitraryInstances.given
+import scalus.cardano.ledger.EvaluatorMode.EvaluateAndComputeCost
+import scalus.cardano.ledger.rules.{CardanoMutator, Context, State, UtxoEnv}
+
+/** Negative tests for [[DisputeResolutionValidator]]: two malformed votes the validator must
+  * reject.
+  *
+  * Each is a single transaction, so there is no need for an emulator or the `Scenario` monad — we
+  * run the tx straight through [[CardanoMutator]] (the ledger rule that executes the Plutus script)
+  * and check it's rejected. Each builds an otherwise-valid vote via [[VoteTx.Build]], then mutates
+  * one field to make it illegal and re-signs:
+  *
+  *   - E1 vote on another peer's reserved box → VoteMustBeSignedByPeer
+  *   - E2 vote past deadlineVoting → VoteTimeValidityCheck
+  *
+  * Each assertion checks the rejection is a *script* failure mentioning the validator's own
+  * message, so a reject cannot pass for an incidental ledger reason.
+  */
+object DisputeVoteAttackTest extends Properties("Dispute Vote Attack") {
+
+    import MultiNodeConfig.*
+
+    override def overrideParameters(p: Test.Parameters): Test.Parameters =
+        p.withMinSuccessfulTests(5)
+
+    /** Replace the tx's required signers (to model a vote signed by the wrong peer). */
+    private def withRequiredSigners(tx: Transaction, signers: Set[AddrKeyHash]): Transaction =
+        tx.copy(body = KeepRaw(tx.body.value.copy(requiredSigners = TaggedSortedSet.from(signers))))
+
+    /** Push the tx's validity upper bound to `slot` (to model a vote past the deadline). */
+    private def withValidityEnd(tx: Transaction, slot: Long): Transaction =
+        tx.copy(body = KeepRaw(tx.body.value.copy(ttl = Some(slot))))
+
+    /** True iff the tx was rejected by Plutus script evaluation with a message mentioning `needle`
+      * — i.e. the validator (not an incidental ledger rule) caught the attack.
+      */
+    private def rejectedByValidator(
+        result: Either[TransactionException, State],
+        needle: String
+    ): Boolean =
+        result match {
+            case Left(e: TransactionException.PlutusScriptValidationException) =>
+                (e.explain + " " + e.logs.mkString(" ")).contains(needle)
+            case _ => false
+        }
+
+    def voteAttacks: MultiNodeConfigTestM[Boolean] = for {
+        env <- ask
+
+        treasuryToken = Value.asset(
+          env.headConfig.headMultisigScript.policyId,
+          env.headConfig.headTokenNames.treasuryTokenName,
+          1
+        )
+        fallbackTxId <- pick(Arbitrary.arbitrary[TransactionHash])
+        nEvacs <- pick(Gen.choose(0, 10))
+        evacMap <- pick(test.Generators.Hydrozoa.genEvacuationMap(nEvacs)(using env))
+        versionMajor = BigInt(100)
+        versionMinor = BigInt(2)
+        now <- lift(realTimeQuantizedInstant(env.headConfig.slotConfig))
+
+        ruleBasedTreasury <- mkRuleBasedTreasury(
+          versionMajor,
+          evacMap.totalValue + treasuryToken,
+          TransactionInput(fallbackTxId, 0),
+          votingDeadline = now.toPosixTime + 600_000
+        )
+
+        config = env.nodeConfigs.head._2
+        ownWallet = env.nodePrivateConfigs.head._2.ownWallet
+        ownKeyHash = ownWallet.exportVerificationKey.addrKeyHash
+        otherWallet = env.nodePrivateConfigs.values
+            .filter(_.ownWallet.exportVerificationKey != ownWallet.exportVerificationKey)
+            .head
+            .ownWallet
+
+        ownVoteUtxo <- mkBallotBoxUtxo(
+          1,
+          2,
+          VoteStatus.AwaitingVote(ownWallet.exportVerificationKey.pubKeyHash),
+          TransactionInput(fallbackTxId, env.headConfig.nHeadPeers + 1)
+        )
+        otherVoteUtxo <- mkBallotBoxUtxo(
+          2,
+          3,
+          VoteStatus.AwaitingVote(otherWallet.exportVerificationKey.pubKeyHash),
+          TransactionInput(fallbackTxId, env.headConfig.nHeadPeers + 2)
+        )
+
+        collateralUtxo <- pick(genCollateralUtxo(ownKeyHash)(using env.headConfig))
+
+        sec = StandaloneEvacuationCommitmentOnchain(
+          headId = env.headConfig.headTokenNames.treasuryTokenName.bytes,
+          versionMajor = versionMajor,
+          versionMinor = versionMinor,
+          commitment = evacMap.kzgCommitment
+        )
+        signatures = env.multisignHeader(sec).toList
+        coilSignatures = env.multisignHeaderCoil(sec)
+
+        ownBallotBox <- failLeft(
+          BallotBox
+              .parse(ownVoteUtxo)(using config)
+              .map(_.asInstanceOf[BallotBox[VoteStatus.AwaitingVote]])
+        )
+        otherBallotBox <- failLeft(
+          BallotBox
+              .parse(otherVoteUtxo)(using config)
+              .map(_.asInstanceOf[BallotBox[VoteStatus.AwaitingVote]])
+        )
+
+        buildVote = (box: BallotBox[VoteStatus.AwaitingVote]) =>
+            VoteTx
+                .Build(
+                  uncastBallotBox = box,
+                  treasuryUtxo = ruleBasedTreasury,
+                  collateralUtxo = collateralUtxo,
+                  sec = sec,
+                  signatures = signatures,
+                  coilSignatures = coilSignatures
+                )
+                .result(using config)
+
+        ownVoteTx <- failLeft(buildVote(ownBallotBox))
+        otherVoteTx <- failLeft(buildVote(otherBallotBox))
+
+        initialUtxos: Utxos = Map(
+          (ruleBasedTreasury.utxoId, ruleBasedTreasury.treasuryOutput.toOutput(using config)),
+          (ownVoteUtxo.input, ownVoteUtxo.output),
+          (otherVoteUtxo.input, otherVoteUtxo.output),
+          (collateralUtxo.input, collateralUtxo.collateralOutput.toOutput(using env))
+        ) ++ config.scriptReferenceUtxos.toList.map(_.toTuple)
+
+        // The validator runs in CardanoMutator.transit under EvaluateAndComputeCost. Both attacks
+        // are checked against this same base state (each is independent — no state threading).
+        state = State(utxos = initialUtxos)
+        context = Context(
+          fee = Coin.zero,
+          env = UtxoEnv(
+            now.toSlot.slot,
+            env.headConfig.cardanoProtocolParams,
+            certState = CertState.empty,
+            env.headConfig.network
+          ),
+          slotConfig = env.headConfig.slotConfig,
+          evaluatorMode = EvaluateAndComputeCost
+        )
+
+        // E1: a peer votes on ANOTHER peer's reserved box. We set the required signer to ourselves
+        // and sign — so the ledger's witness check passes, but the validator's AwaitingVote(peer)
+        // check must reject it.
+        e1Tx = ownWallet.signTx(withRequiredSigners(otherVoteTx.tx, Set(ownKeyHash)))
+        e1Result = CardanoMutator.transit(context, state, e1Tx)
+        _ <- assertWith(
+          msg =
+              s"E1: voting on another peer's box must be rejected by the validator, got $e1Result",
+          condition = rejectedByValidator(e1Result, "signed by peer")
+        )
+
+        // E2: vote past deadlineVoting — push the validity upper bound beyond the deadline.
+        honestTtl = ownVoteTx.tx.body.value.ttl.getOrElse(now.toSlot.slot)
+        e2Tx = ownWallet.signTx(withValidityEnd(ownVoteTx.tx, honestTtl + 100))
+        e2Result = CardanoMutator.transit(context, state, e2Tx)
+        _ <- assertWith(
+          msg = s"E2: vote past deadlineVoting must be rejected by the validator, got $e2Result",
+          condition = rejectedByValidator(e2Result, "deadlineVoting")
+        )
+    } yield true
+
+    val _ = property("dispute vote attacks (negative)") = runWithCoil()(voteAttacks)
+}

--- a/src/test/scala/hydrozoa/rulebased/ledger/l1/script/plutus/DisputeVoteAttackTest.scala
+++ b/src/test/scala/hydrozoa/rulebased/ledger/l1/script/plutus/DisputeVoteAttackTest.scala
@@ -26,10 +26,15 @@ import scalus.cardano.ledger.rules.{CardanoMutator, Context, State, UtxoEnv}
   * one field to make it illegal and re-signs:
   *
   *   - E1 vote on another peer's reserved box → VoteMustBeSignedByPeer
-  *   - E2 vote past deadlineVoting → VoteTimeValidityCheck
+  *   - E2 vote past deadlineVoting (finite-but-too-late upper bound) → VoteTimeValidityCheck
+  *   - E3 vote with an OPEN validity interval (no upper bound) → VoteTimeValidityCheck (the
+  *     distinct non-finite `case _ => fail` path; you can't dodge the deadline with an unbounded
+  *     range)
+  *   - E4 re-vote a box that is already Voted (terminal-state re-entry) → the builder's
+  *     VoteAlreadyCast (refused before a transaction is even formed)
   *
-  * Each assertion checks the rejection is a *script* failure mentioning the validator's own
-  * message, so a reject cannot pass for an incidental ledger reason.
+  * Each script-level assertion checks the rejection is a *script* failure mentioning the
+  * validator's own message, so a reject cannot pass for an incidental ledger reason.
   */
 object DisputeVoteAttackTest extends Properties("Dispute Vote Attack") {
 
@@ -45,6 +50,12 @@ object DisputeVoteAttackTest extends Properties("Dispute Vote Attack") {
     /** Push the tx's validity upper bound to `slot` (to model a vote past the deadline). */
     private def withValidityEnd(tx: Transaction, slot: Long): Transaction =
         tx.copy(body = KeepRaw(tx.body.value.copy(ttl = Some(slot))))
+
+    /** Remove the tx's validity upper bound entirely (an open/unbounded interval — to model
+      * crafting the validity range so no finite `to` can be checked against the deadline).
+      */
+    private def withoutValidityEnd(tx: Transaction): Transaction =
+        tx.copy(body = KeepRaw(tx.body.value.copy(ttl = None)))
 
     /** True iff the tx was rejected by Plutus script evaluation with a message mentioning `needle`
       * — i.e. the validator (not an incidental ledger rule) caught the attack.
@@ -179,6 +190,39 @@ object DisputeVoteAttackTest extends Properties("Dispute Vote Attack") {
         _ <- assertWith(
           msg = s"E2: vote past deadlineVoting must be rejected by the validator, got $e2Result",
           condition = rejectedByValidator(e2Result, "deadlineVoting")
+        )
+
+        // E3: craft an OPEN validity interval (no upper bound). The validator needs a finite upper
+        // bound to compare against deadlineVoting, so an unbounded `to` hits the `case _ => fail`
+        // path — you cannot dodge the deadline check with an open validity range.
+        e3Tx = ownWallet.signTx(withoutValidityEnd(ownVoteTx.tx))
+        e3Result = CardanoMutator.transit(context, state, e3Tx)
+        _ <- assertWith(
+          msg =
+              s"E3: a vote with an open (unbounded) validity range must be rejected, got $e3Result",
+          condition = rejectedByValidator(e3Result, "deadlineVoting")
+        )
+
+        // E4: re-vote a box that is already Voted (terminal-state re-entry). The builder's
+        // parseAndVote sees a non-AwaitingVote status and refuses with VoteAlreadyCast before a
+        // transaction is even formed.
+        votedUtxo <- mkBallotBoxUtxo(
+          3,
+          4,
+          VoteStatus.Voted(evacMap.kzgCommitment, versionMinor),
+          TransactionInput(fallbackTxId, env.headConfig.nHeadPeers + 3)
+        )
+        votedBox <- failLeft(
+          BallotBox
+              .parse(votedUtxo)(using config)
+              .map(_.asInstanceOf[BallotBox[VoteStatus.AwaitingVote]])
+        )
+        _ <- assertWith(
+          msg = "E4: re-voting an already-Voted box must be refused (VoteAlreadyCast)",
+          condition = buildVote(votedBox) match {
+              case Left(VoteTx.Build.Error.VoteAlreadyCast) => true
+              case _                                        => false
+          }
         )
     } yield true
 

--- a/src/test/scala/hydrozoa/rulebased/ledger/l1/script/plutus/DisputeVoteAttackTest.scala
+++ b/src/test/scala/hydrozoa/rulebased/ledger/l1/script/plutus/DisputeVoteAttackTest.scala
@@ -12,13 +12,14 @@ import hydrozoa.rulebased.ledger.l1.tx.CommonGenerators.genCollateralUtxo
 import hydrozoa.rulebased.ledger.l1.tx.VoteTx
 import hydrozoa.rulebased.ledger.l1.utxo.BallotBox
 import org.scalacheck.{Arbitrary, Gen, Properties, Test}
+import scalus.cardano.address.{ShelleyAddress, ShelleyDelegationPart}
 import scalus.cardano.ledger.*
 import scalus.cardano.ledger.ArbitraryInstances.given
 import scalus.cardano.ledger.EvaluatorMode.EvaluateAndComputeCost
 import scalus.cardano.ledger.rules.{CardanoMutator, Context, State, UtxoEnv}
 
-/** Negative tests for [[DisputeResolutionValidator]]: two malformed votes the validator must
-  * reject.
+/** Negative tests for [[DisputeResolutionValidator]]: malformed votes the validator (or the
+  * builder) must reject.
   *
   * Each is a single transaction, so there is no need for an emulator or the `Scenario` monad — we
   * run the tx straight through [[CardanoMutator]] (the ledger rule that executes the Plutus script)
@@ -32,6 +33,10 @@ import scalus.cardano.ledger.rules.{CardanoMutator, Context, State, UtxoEnv}
   *     range)
   *   - E4 re-vote a box that is already Voted (terminal-state re-entry) → the builder's
   *     VoteAlreadyCast (refused before a transaction is even formed)
+  *   - E5 swap ONLY the staking part of the continuing vote output's address (same payment script,
+  *     the attacker's stake key) → VoteVoteOutputExists. The on-chain `Eq[Address]` ANDs the
+  *     payment AND staking credential, so the address is checked in full — a redirect that keeps
+  *     the payment part but captures staking rights on the locked utxo is still rejected.
   *
   * Each script-level assertion checks the rejection is a *script* failure mentioning the
   * validator's own message, so a reject cannot pass for an incidental ledger reason.
@@ -56,6 +61,40 @@ object DisputeVoteAttackTest extends Properties("Dispute Vote Attack") {
       */
     private def withoutValidityEnd(tx: Transaction): Transaction =
         tx.copy(body = KeepRaw(tx.body.value.copy(ttl = None)))
+
+    /** Swap ONLY the staking (delegation) part of the continuing vote output's address: keep its
+      * value and payment script, but attach the attacker's own stake key. The honest vote output
+      * has no delegation part (Null), so attaching one grows the output by ~28 bytes — pay that
+      * extra size out of the attacker's own change output (index 0, the collateral return) and bump
+      * the fee, so the *script* rejects the staking mismatch rather than a phase-1 fee check.
+      * Models capturing staking rights/rewards on the locked ballot-box utxo without touching its
+      * payment credential.
+      */
+    private def withSwappedStakingPart(
+        tx: Transaction,
+        voteValue: Value,
+        stake: AddrKeyHash,
+        feeBump: Coin
+    ): Transaction = {
+        val body = tx.body.value
+        val delegation = ShelleyDelegationPart.Key(StakeKeyHash.fromByteString(stake))
+        val newOutputs = body.outputs.zipWithIndex.map { case (sized, idx) =>
+            val out = sized.value
+            out.address match {
+                case sh: ShelleyAddress if out.value == voteValue =>
+                    val withStake = sh.copy(delegation = delegation)
+                    Sized(out match {
+                        case b: TransactionOutput.Babbage => b.copy(address = withStake)
+                        case s: TransactionOutput.Shelley => s.copy(address = withStake)
+                    })
+                case _ if idx == 0 => Sized(out.withValue(out.value - Value(feeBump)))
+                case _             => sized
+            }
+        }
+        tx.copy(body =
+            KeepRaw(body.copy(outputs = newOutputs, fee = Coin(body.fee.value + feeBump.value)))
+        )
+    }
 
     /** True iff the tx was rejected by Plutus script evaluation with a message mentioning `needle`
       * — i.e. the validator (not an incidental ledger rule) caught the attack.
@@ -223,6 +262,21 @@ object DisputeVoteAttackTest extends Properties("Dispute Vote Attack") {
               case Left(VoteTx.Build.Error.VoteAlreadyCast) => true
               case _                                        => false
           }
+        )
+
+        // E5: swap ONLY the staking part of the continuing vote output's address (same payment
+        // script, attacker's stake key). The on-chain Eq[Address] ANDs payment AND staking
+        // credential, so this subtle redirect — payment matches, staking differs — must still be
+        // caught by the continuing-output check rather than slip through.
+        e5Tx = ownWallet.signTx(
+          withSwappedStakingPart(ownVoteTx.tx, ownVoteUtxo.output.value, ownKeyHash, Coin(5000))
+        )
+        e5Result = CardanoMutator.transit(context, state, e5Tx)
+        _ <- assertWith(
+          msg =
+              s"E5: a staking-credential-only swap on the vote output must be rejected, got $e5Result",
+          condition =
+              rejectedByValidator(e5Result, "one continuing vote output with the same value")
         )
     } yield true
 


### PR DESCRIPTION
Test "A" of the rule-based L1 dispute regime — adversarial Scenario/emulator tests (scalus-testkit `ImmutableEmulator`/`Scenario`).

- **`DisputeResolutionScenarioTest`** — resolution safety. Per-peer vote/no-vote decided *inside* the Scenario monad (real `VoteTx` submits), then sleep past the deadline, then tally + resolve. Explores vote subsets × tally orders (capped to 3 boxes); each leaf resolves to X2 iff it voted, else X1.
- **`DisputeVoteAttackTest`** — negative: E1 (vote on another peer's box), E2 (vote past the deadline) rejected by `CardanoMutator.transit`.
- **`DisputeActorTest`** — pure-helper refactor (`mkBallotBoxUtxoPure`/`mkRuleBasedTreasuryPure`); no behaviour change.

Based on the **`scalus-0.18.1-updated`** branch (#486), so the diff is exactly these three test files. Retarget to `main` once #486 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)