### PR TITLE
feat(handoff): wire multisig→rule-based regime transition

### DIFF
--- a/integration/src/test/scala/hydrozoa/integration/harness/MultiPeerHeadHarness.scala
+++ b/integration/src/test/scala/hydrozoa/integration/harness/MultiPeerHeadHarness.scala
@@ -15,7 +15,7 @@ import hydrozoa.multisig.consensus.transport.*
 import hydrozoa.multisig.ledger.eutxol2.EutxoL2Ledger
 import hydrozoa.multisig.persistence.rocksdb.RocksDbBackendStore
 import hydrozoa.multisig.persistence.{BackendStore, Cf, InMemoryBackendStore, Persistence, PersistenceEvent, PersistenceEventFormat}
-import hydrozoa.multisig.{CoilMultisigRegimeManager, CoilMultisigRegimeManagerEvent, CoilMultisigRegimeManagerEventFormat, HeadMultisigRegimeManager, HeadMultisigRegimeManagerEvent, HeadMultisigRegimeManagerEventFormat}
+import hydrozoa.multisig.{CoilMultisigRegimeManager, CoilMultisigRegimeManagerEvent, CoilMultisigRegimeManagerEventFormat, HeadMultisigRegimeManager, HeadRegimeManagerEvent, HeadMultisigRegimeManagerEventFormat}
 import java.nio.file.{Files, Path}
 import java.time.Instant
 import java.util.concurrent.TimeUnit
@@ -59,7 +59,7 @@ object MultiPeerHeadHarness:
     /** Roll-up of every event emitted by the regime managers the harness owns.
       */
     enum Event:
-        case Head(peerNum: HeadPeerNumber, event: HeadMultisigRegimeManagerEvent)
+        case Head(peerNum: HeadPeerNumber, event: HeadRegimeManagerEvent)
         case Coil(coilNum: CoilPeerNumber, event: CoilMultisigRegimeManagerEvent)
 
     /** Test-side wiring injected into each MRM. The [[Event]]-typed projects down to Head/Coil-specific tracers
@@ -661,10 +661,10 @@ object MultiPeerHeadHarness:
             multiNodeConfig: MultiNodeConfig,
             backendMode: StorageBackend.Mode,
             network: Transport.HeadNetwork,
-            callerTracer: ContraTracer[IO, HeadMultisigRegimeManagerEvent],
+            callerTracer: ContraTracer[IO, HeadRegimeManagerEvent],
         ): Resource[IO, Peer] =
             val nodeConfig = multiNodeConfig.nodeConfigs(peerNum)
-            val slf4jMrm: ContraTracer[IO, HeadMultisigRegimeManagerEvent] =
+            val slf4jMrm: ContraTracer[IO, HeadRegimeManagerEvent] =
                 Slf4jTracer.sink.contramap(
                   HeadMultisigRegimeManagerEventFormat.humanFormat(peerNum)
                 )

--- a/integration/src/test/scala/hydrozoa/integration/stage1/Suite.scala
+++ b/integration/src/test/scala/hydrozoa/integration/stage1/Suite.scala
@@ -25,6 +25,7 @@ import hydrozoa.lib.logging.{ContraTracer, Slf4jMsg, Slf4jMsgFormat, Slf4jTracer
 import hydrozoa.multisig.backend.cardano.CardanoBackendBlockfrost.URL
 import hydrozoa.multisig.backend.cardano.{CardanoBackend, CardanoBackendBlockfrost, CardanoBackendEventFormat, CardanoBackendMock, MockState, yaciTestSauceGenesis}
 import hydrozoa.multisig.consensus.peer.HeadPeerNumber
+import hydrozoa.multisig.HeadMultisigRegimeManager
 import hydrozoa.multisig.consensus.{BlockWeaver, CardanoLiaison, CardanoLiaisonEvent, CardanoLiaisonEventFormat, FastConsensusActor, FastConsensusActorEvent, FastConsensusActorEventFormat, RequestSequencer, StackComposer}
 import hydrozoa.multisig.ledger.block.{Block, BlockNumber, BlockVersion}
 import hydrozoa.multisig.ledger.eutxol2.{EutxoL2Ledger, toUtxos}
@@ -510,6 +511,16 @@ case class Suite(
                     nodeConfig.headPeers.nHeadPeers: Int
                   )
                 )
+                // No HMRM in stage1 — provide a stub actor that swallows any HandoffToRuleBased
+                // signal. Stage 1 doesn't exercise fallback-to-rule-based (single-peer / happy
+                // path only), so the ref is a required-but-inert construction parameter.
+                mrmSelfStub <- system.actorOf(
+                  new Actor[IO, HeadMultisigRegimeManager.HandoffToRuleBased] {
+                      override def receive
+                          : Receive[IO, HeadMultisigRegimeManager.HandoffToRuleBased] =
+                          _ => IO.unit
+                  }
+                )
                 // Cardano liaison
                 cardanoLiaison <- system.actorOf(
                   CardanoLiaison(
@@ -517,7 +528,8 @@ case class Suite(
                     cardanoBackend,
                     CardanoLiaison.Connections(blockWeaver),
                     clTracer,
-                    persistence
+                    persistence,
+                    mrmSelf = mrmSelfStub,
                   )
                 )
                 // Request sequencer stub

--- a/integration/src/test/scala/hydrozoa/integration/stage1/Suite.scala
+++ b/integration/src/test/scala/hydrozoa/integration/stage1/Suite.scala
@@ -31,6 +31,7 @@ import hydrozoa.multisig.ledger.block.{Block, BlockNumber, BlockVersion}
 import hydrozoa.multisig.ledger.eutxol2.{EutxoL2Ledger, toUtxos}
 import hydrozoa.multisig.ledger.event.RequestNumber
 import hydrozoa.multisig.ledger.joint.{JointLedger, JointLedgerEventFormat}
+import hydrozoa.multisig.ledger.l1.tx.RawTx
 import hydrozoa.multisig.persistence.{InMemoryBackendStore, Persistence, PersistenceEventFormat}
 import java.util.concurrent.TimeUnit
 import org.scalacheck.commands.{ModelBasedSuite, ScenarioGen}
@@ -185,7 +186,7 @@ case class Suite(
                              s"mixSplitTxSigned = ${HexUtil.encodeHexString(mixSplitTxSigned.toCbor)}"
                            )
                          )
-                    ret <- run(backend.submitTx(mixSplitTxSigned))
+                    ret <- run(backend.submitTx(RawTx(mixSplitTxSigned)))
                     _ <- run(log.trace(s"submission response: $ret"))
 
                     // TODO: await tx
@@ -224,7 +225,7 @@ case class Suite(
                              s"splitTxSigned = ${HexUtil.encodeHexString(splitTxSigned.toCbor)}"
                            )
                          )
-                    ret <- run(backend.submitTx(splitTxSigned))
+                    ret <- run(backend.submitTx(RawTx(splitTxSigned)))
                     _ <- run(log.trace(s"submission response: $ret"))
 
                     // TODO: await tx

--- a/integration/src/test/scala/hydrozoa/integration/stage1/Sut.scala
+++ b/integration/src/test/scala/hydrozoa/integration/stage1/Sut.scala
@@ -21,6 +21,7 @@ import hydrozoa.multisig.ledger.block.{BlockBrief, BlockNumber}
 import hydrozoa.multisig.ledger.joint
 import hydrozoa.multisig.ledger.joint.JointLedger
 import hydrozoa.multisig.ledger.joint.JointLedger.Requests.{CompleteBlockFinal, CompleteBlockRegular, StartBlock}
+import hydrozoa.multisig.ledger.l1.tx.RawTx
 import org.scalacheck.commands.SutCommand
 import scala.concurrent.duration.DurationInt
 import scalus.cardano.address.ShelleyAddress
@@ -227,7 +228,9 @@ object SutCommands:
                     val id = cmd.request.requestId
                     val tx = cmd.depositTxBytesSigned
 
-                    sut.cardanoBackend.submitTx(tx) >>= (ret => IO.pure((id, tx) -> ret))
+                    sut.cardanoBackend.submitTx(RawTx(tx)) >>= (ret =>
+                        IO.pure((id, tx) -> ret)
+                    )
                 })
 
                 submissionErrors = ret.filter(_._2.isLeft)

--- a/integration/src/test/scala/hydrozoa/integration/stage4/Sut.scala
+++ b/integration/src/test/scala/hydrozoa/integration/stage4/Sut.scala
@@ -13,6 +13,7 @@ import hydrozoa.multisig.consensus.{RequestSequencer, UserRequest, UserRequestWi
 import hydrozoa.multisig.ledger.block.BlockBrief
 import hydrozoa.multisig.ledger.event.RequestId
 import hydrozoa.multisig.ledger.event.RequestId.ValidityFlag
+import hydrozoa.multisig.ledger.l1.tx.RawTx
 import hydrozoa.multisig.ledger.stack.Stack
 import hydrozoa.multisig.persistence.BackendStore
 import org.scalacheck.commands.SutCommand
@@ -167,7 +168,7 @@ object Stage4SutCommands:
                 reqId <- sut.static.peers(cmd.peerNum).requestSequencer ?: cmd.request.asUserRequest
                 _ <- sut.static.log.trace(s"reqId=$reqId, cmd.request.requestId=${cmd.request.requestId}")
                 _ <- sut.mutable.submittedRequestIds.update(_ :+ cmd.request.requestId)
-                _ <- sut.static.cardanoBackend.submitTx(cmd.depositTxBytesSigned)
+                _ <- sut.static.cardanoBackend.submitTx(RawTx(cmd.depositTxBytesSigned))
             } yield ValidityFlag.Valid
         }
     }

--- a/src/main/scala/hydrozoa/app/Bootstrap.scala
+++ b/src/main/scala/hydrozoa/app/Bootstrap.scala
@@ -30,6 +30,7 @@ import hydrozoa.multisig.consensus.peer.HeadPeerNumber
 import hydrozoa.multisig.ledger.block.{Block, BlockBrief, BlockEffects, BlockHeader}
 import hydrozoa.multisig.ledger.joint.obligation.Payout
 import hydrozoa.multisig.ledger.joint.{EvacuationKey, EvacuationMap, evacuationKeyOrdering}
+import hydrozoa.multisig.ledger.l1.tx.RawTx
 import hydrozoa.multisig.ledger.l1.txseq.InitializationTxSeq
 import hydrozoa.rulebased.ledger.l1.script.plutus.RuleBasedTreasuryValidator.evacuationKeyToData
 import io.circe.generic.semiauto.deriveDecoder
@@ -566,7 +567,7 @@ object Migrate
                         )
 
                         _ <- log.info("Submitting transaction...")
-                        submitResult <- backend.submitTx(signed)
+                        submitResult <- backend.submitTx(RawTx(signed))
                         _ <- IO.fromEither(
                           submitResult.left.map(err =>
                               new RuntimeException(s"Failed to submit transaction: $err")

--- a/src/main/scala/hydrozoa/app/Main.scala
+++ b/src/main/scala/hydrozoa/app/Main.scala
@@ -20,7 +20,7 @@ import hydrozoa.multisig.ledger.remote.{RemoteL2Ledger, RemoteL2LedgerEventForma
 import hydrozoa.multisig.persistence.rocksdb.RocksDbBackendStore
 import hydrozoa.multisig.persistence.{Cf, Persistence, PersistenceEventFormat}
 import hydrozoa.multisig.server.{HydrozoaHttpEvent, HydrozoaHttpEventFormat, HydrozoaServer}
-import hydrozoa.multisig.{CoilMultisigRegimeManager, CoilMultisigRegimeManagerEvent, CoilMultisigRegimeManagerEventFormat, HeadMultisigRegimeManager, HeadMultisigRegimeManagerEvent, HeadMultisigRegimeManagerEventFormat, MrmTracers}
+import hydrozoa.multisig.{CoilMultisigRegimeManager, CoilMultisigRegimeManagerEvent, CoilMultisigRegimeManagerEventFormat, HeadMultisigRegimeManager, HeadMultisigRegimeManagerEventFormat, HeadRegimeManagerEvent, MrmTracers}
 import java.nio.file.Path
 import org.http4s.Uri
 import org.http4s.jdkhttpclient.JdkWSClient
@@ -185,7 +185,7 @@ object Main
         backend: CardanoBackend[IO],
         remoteL2Ledger: RemoteL2Ledger,
         persistence: Persistence[IO],
-        mrmTracer: ContraTracer[IO, HeadMultisigRegimeManagerEvent],
+        mrmTracer: ContraTracer[IO, HeadRegimeManagerEvent],
         wsClient: org.http4s.client.websocket.WSClient[IO],
         ownHeadNum: HeadPeerNumber,
     ): Resource[IO, NodeRun.HeadNode] = {

--- a/src/main/scala/hydrozoa/multisig/CoilMultisigRegimeManager.scala
+++ b/src/main/scala/hydrozoa/multisig/CoilMultisigRegimeManager.scala
@@ -11,6 +11,7 @@ import hydrozoa.multisig.consensus.*
 import hydrozoa.multisig.consensus.peer.PeerId
 import hydrozoa.multisig.consensus.peer.PeerId.{Coil, Head}
 import hydrozoa.multisig.consensus.transport.{CoilTransport, RemoteHubProxy}
+import hydrozoa.multisig.ledger.l1.tx.FallbackTx
 import hydrozoa.multisig.ledger.l2.L2Ledger
 import hydrozoa.multisig.persistence.Persistence
 
@@ -130,6 +131,16 @@ trait CoilMultisigRegimeManager(
               core.slowConsensusActor -> Actors.SlowConsensus,
             )
         } yield ()
+
+    // TODO(coil-handoff): coil-side rule-based regime not yet implemented. Raising here on
+    // purpose so the gap is loud — a silent no-op would drop the handoff signal from CL.
+    override protected def onHandoffToRuleBased(fallback: FallbackTx): IO[Unit] =
+        IO.raiseError(
+          new NotImplementedError(
+            s"CoilMultisigRegimeManager.onHandoffToRuleBased(${fallback.tx.id}) — " +
+                "coil-side handoff to the rule-based regime is not yet wired"
+          )
+        )
 }
 
 object CoilMultisigRegimeManager {

--- a/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManager.scala
+++ b/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManager.scala
@@ -1,7 +1,7 @@
 package hydrozoa.multisig
 
 import cats.*
-import cats.effect.{Deferred, IO, Resource}
+import cats.effect.{Deferred, IO, Ref, Resource}
 import cats.implicits.*
 import com.suprnation.actor.ActorContext
 import com.suprnation.actor.ActorRef.NoSendActorRef
@@ -15,23 +15,32 @@ import hydrozoa.multisig.consensus.limiter.Limiter
 import hydrozoa.multisig.consensus.peer.{CoilPeerNumber, HeadPeerNumber, PeerId}
 import hydrozoa.multisig.consensus.transport.{HubTransport, PeerTransport, RemoteCoilProxy, RemotePeerProxy}
 import hydrozoa.multisig.ledger.joint.JointLedger
+import hydrozoa.multisig.ledger.l1.tx.FallbackTx
 import hydrozoa.multisig.ledger.l2.L2Ledger
 import hydrozoa.multisig.persistence.Persistence
+import hydrozoa.rulebased.RuleBasedRegimeManager
 
 trait HeadMultisigRegimeManager(
     config: NodeConfig,
     cardanoBackend: CardanoBackend[IO],
     l2Ledger: L2Ledger[IO],
     persistence: Persistence[IO],
-    override protected val tracer: ContraTracer[IO, HeadMultisigRegimeManagerEvent],
+    override protected val tracer: ContraTracer[IO, HeadRegimeManagerEvent],
     peerTransport: ActorContext[IO, Request, Any] => PeerTransport,
     /** Hub-side coil transport, populated iff this peer hubs any coil peers; required when
       * `config.hubbedCoilPeerNums(ownHeadNum)` is non-empty.
       */
     hubCoilTransport: Option[ActorContext[IO, Request, Any] => HubTransport],
-) extends MultisigRegimeManagerBase[HeadMultisigRegimeManagerEvent] {
+) extends MultisigRegimeManagerBase[HeadRegimeManagerEvent] {
 
     override protected lazy val tracers: MrmTracers = MrmTracers.fromRoot(tracer)
+
+    /** Non-CL child refs, populated once every actor is spawned in [[preStartLocal]]. On
+      * [[HandoffToRuleBased]], `onHandoffToRuleBased` reads them and issues `context.stop` to each;
+      * CL stays alive to process refunds and finish rollouts.
+      */
+    private val nonClChildren: Ref[IO, List[NoSendActorRef[IO]]] =
+        Ref.unsafe(List.empty)
 
     override protected def preStartLocal: IO[Unit] =
         for {
@@ -232,6 +241,40 @@ trait HeadMultisigRegimeManager(
             )
             _ <- (headPeerLiaisons.toList ++ coilPeerLiaisons)
                 .traverse_(r => watchChildren(r -> Actors.PeerLiaisonHeadToHead))
+
+            // Record everything the handoff needs to stop. CL is deliberately excluded — it
+            // stays alive across the multisig→rule-based transition to process refunds and
+            // finish rollouts.
+            _ <- nonClChildren.set(
+              List[NoSendActorRef[IO]](
+                core.blockWeaver,
+                core.consensusActor,
+                core.jointLedger,
+                core.stackComposer,
+                core.slowConsensusActor,
+                blockWeaverLimiter,
+                stackComposerLimiter,
+                requestSequencer,
+              ) ++ headPeerLiaisons.toList
+                  ++ coilPeerLiaisons
+                  ++ remoteHeadProxies.values.toList
+                  ++ coilAckSequencer.toList
+                  ++ coilRelay.toList
+                  ++ remoteCoilLiaisons.values.toList
+            )
+        } yield ()
+
+    override protected def onHandoffToRuleBased(fallback: FallbackTx): IO[Unit] =
+        for {
+            refs <- nonClChildren.getAndSet(Nil)
+            _ <- refs.traverse_(context.stop)
+            _ <- context.actorOf(
+              RuleBasedRegimeManager(
+                cardanoBackend = cardanoBackend,
+                persistence = persistence,
+                tracer = tracers.ruleBasedActor,
+              )(using config)
+            )
         } yield ()
 }
 
@@ -290,7 +333,7 @@ object HeadMultisigRegimeManager {
         cardanoBackend: CardanoBackend[IO],
         virtualLedger: L2Ledger[IO],
         persistence: Persistence[IO],
-        tracer: ContraTracer[IO, HeadMultisigRegimeManagerEvent],
+        tracer: ContraTracer[IO, HeadRegimeManagerEvent],
         peerTransport: Resource[IO, ActorContext[IO, Request, Any] => PeerTransport],
         hubCoilTransport: Option[Resource[IO, ActorContext[IO, Request, Any] => HubTransport]] =
             None,
@@ -322,7 +365,7 @@ object HeadMultisigRegimeManager {
             StackComposer, SlowConsensus
 
     /** Requests received by the multisig regime manager. */
-    type Request = PreStart.type | TerminatedChild | TerminatedDependency
+    type Request = PreStart.type | TerminatedChild | TerminatedDependency | HandoffToRuleBased
 
     type Children = Actors
 
@@ -338,4 +381,10 @@ object HeadMultisigRegimeManager {
     final case class TerminatedChild(childType: Actors, ref: NoSendActorRef[IO])
 
     final case class TerminatedDependency(dependencyType: Dependencies, ref: NoSendActorRef[IO])
+
+    /** Sent by [[CardanoLiaison]] once a `FallbackToRuleBased` action has been dispatched. HMRM
+      * responds by gracefully stopping every multisig child except CL (which stays up to process
+      * refunds and finish rollouts) and spawning [[hydrozoa.rulebased.RuleBasedRegimeManager]].
+      */
+    final case class HandoffToRuleBased(fallback: FallbackTx)
 }

--- a/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManagerEvent.scala
+++ b/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManagerEvent.scala
@@ -9,6 +9,7 @@ import hydrozoa.multisig.consensus.peer.PeerId
 import hydrozoa.multisig.consensus.transport.{HubWsTransportEvent, NodeWsServerEvent, PeerTransportEvent}
 import hydrozoa.multisig.consensus.{BlockWeaverEvent, CardanoLiaisonEvent, CoilAckSequencerEvent, EventSequencerEvent, FastConsensusActorEvent, SlowConsensusActorEvent, StackComposerEvent}
 import hydrozoa.multisig.ledger.joint.JointLedgerEvent
+import hydrozoa.rulebased.RuleBasedActorEvent
 
 /** The (head, multisig) cell of the regime-event grid. A union over the category traits from
   * [[RegimeManagerEvent]] that apply to a head peer running the multisig regime:
@@ -20,6 +21,12 @@ import hydrozoa.multisig.ledger.joint.JointLedgerEvent
   */
 type HeadMultisigRegimeManagerEvent =
     LifecycleEvent | CommonChildEvent | HeadOnlyChildEvent | MultisigOnlyChildEvent
+
+/** The full head-side regime-event surface: the (head, multisig) cell plus the rule-based children
+  * the head may spawn after the multisig→rule-based handoff. HMRM's tracer is typed against this so
+  * the same manager can trace across both regime phases without a re-cast.
+  */
+type HeadRegimeManagerEvent = HeadMultisigRegimeManagerEvent | RuleBasedOnlyChildEvent
 
 /** Per-producer tracers shared by every regime+role — what
   * [[MultisigRegimeManagerBase .spawnCoreActors]] needs. Subclasses' cell-specific tracer carriers
@@ -53,6 +60,7 @@ final case class MrmTracers(
     hubWsTransport: ContraTracer[IO, HubWsTransportEvent],
     nodeWsServer: ContraTracer[IO, NodeWsServerEvent],
     peerLiaison: PeerId => ContraTracer[IO, PeerLiaisonEvent],
+    ruleBasedActor: ContraTracer[IO, RuleBasedActorEvent],
 ) extends HasCoreTracers
 
 object MrmTracers:
@@ -61,7 +69,7 @@ object MrmTracers:
       * routing is the only piece of wiring that has to know the [[RegimeManagerEvent]] category
       * constructors — every consumer downstream sees the narrow event type.
       */
-    def fromRoot(tracer: ContraTracer[IO, HeadMultisigRegimeManagerEvent]): MrmTracers =
+    def fromRoot(tracer: ContraTracer[IO, HeadRegimeManagerEvent]): MrmTracers =
         MrmTracers(
           blockWeaver = tracer.contramap(CommonChildEvent.BlockWeaver.apply),
           jointLedger = tracer.contramap(CommonChildEvent.JointLedger.apply),
@@ -78,4 +86,5 @@ object MrmTracers:
           hubWsTransport = tracer.contramap(HeadOnlyChildEvent.HubWsTransport.apply),
           nodeWsServer = tracer.contramap(HeadOnlyChildEvent.NodeWsServer.apply),
           peerLiaison = pid => tracer.contramap(CommonChildEvent.PeerLiaison(pid, _)),
+          ruleBasedActor = tracer.contramap(RuleBasedOnlyChildEvent.RuleBasedActor.apply),
         )

--- a/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManagerEventFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManagerEventFormat.scala
@@ -7,11 +7,14 @@ import hydrozoa.multisig.consensus.peer.{HeadPeerNumber, PeerId}
 import hydrozoa.multisig.consensus.transport.{HubWsTransportEventFormat, NodeWsServerEventFormat, PeerTransportEventFormat}
 import hydrozoa.multisig.consensus.{BlockWeaverEventFormat, CardanoLiaisonEventFormat, CoilAckSequencerEventFormat, EventSequencerEventFormat, FastConsensusActorEventFormat, SlowConsensusActorEventFormat, StackComposerEventFormat}
 import hydrozoa.multisig.ledger.joint.JointLedgerEventFormat
+import hydrozoa.rulebased.RuleBasedActorEventFormat
 
-/** Top-level formatter delegating by category trait, then by per-actor format. */
+/** Top-level formatter delegating by category trait, then by per-actor format. Handles the full
+  * [[HeadRegimeManagerEvent]] surface (multisig phase + post-handoff rule-based phase).
+  */
 object HeadMultisigRegimeManagerEventFormat:
 
-    def humanFormat(peerNum: HeadPeerNumber)(e: HeadMultisigRegimeManagerEvent): LogEvent = {
+    def humanFormat(peerNum: HeadPeerNumber)(e: HeadRegimeManagerEvent): LogEvent = {
         val ev = LogEvent.From.forPeer("HeadMultisigRegimeManager", peerNum)
         import ev.*
         e match
@@ -47,4 +50,6 @@ object HeadMultisigRegimeManagerEventFormat:
                 LimiterEventFormat.humanFormat("BlockWeaver")(bwl)
             case MultisigOnlyChildEvent.StackComposerLimiter(scl) =>
                 LimiterEventFormat.humanFormat("StackComposer")(scl)
+            case RuleBasedOnlyChildEvent.RuleBasedActor(rba) =>
+                RuleBasedActorEventFormat.humanFormat(peerNum)(rba)
     }

--- a/src/main/scala/hydrozoa/multisig/MultisigRegimeManagerBase.scala
+++ b/src/main/scala/hydrozoa/multisig/MultisigRegimeManagerBase.scala
@@ -14,6 +14,7 @@ import hydrozoa.multisig.MultisigRegimeManagerBase.CoreActors
 import hydrozoa.multisig.backend.cardano.CardanoBackend
 import hydrozoa.multisig.consensus.*
 import hydrozoa.multisig.ledger.joint.JointLedger
+import hydrozoa.multisig.ledger.l1.tx.FallbackTx
 import hydrozoa.multisig.ledger.l2.L2Ledger
 import hydrozoa.multisig.persistence.Persistence
 import scala.concurrent.duration.DurationInt
@@ -69,6 +70,7 @@ trait MultisigRegimeManagerBase[E >: LifecycleEvent <: RegimeManagerEvent]
             tracer.traceWith(LifecycleEvent.TerminatedActor(childType))
         case TerminatedDependency(dependencyType, _) =>
             tracer.traceWith(LifecycleEvent.TerminatedDependency(dependencyType))
+        case HandoffToRuleBased(fallback) => onHandoffToRuleBased(fallback)
         // TODO: Implement a way to receive a remote comm actor and connect it to its corresponding local comm actor
     }
 
@@ -76,6 +78,13 @@ trait MultisigRegimeManagerBase[E >: LifecycleEvent <: RegimeManagerEvent]
       * then complete the `pendingConnections` + [[connectionsDeferred]] barriers.
       */
     protected def preStartLocal: IO[Unit]
+
+    /** React to [[HandoffToRuleBased]] by stopping the multisig actors (except the still-live
+      * [[CardanoLiaison]]) and spawning the rule-based regime manager. Subclass-supplied per role:
+      * HMRM spawns [[hydrozoa.rulebased.RuleBasedRegimeManager]]; CMRM will spawn the coil-side
+      * equivalent. Abstract on purpose — a silent default would swallow the handoff.
+      */
+    protected def onHandoffToRuleBased(fallback: FallbackTx): IO[Unit]
 
     /** Fan a list of (actorRef, actor-kind) pairs into per-child death watches that fire
       * `TerminatedChild` back to this manager.
@@ -105,7 +114,8 @@ trait MultisigRegimeManagerBase[E >: LifecycleEvent <: RegimeManagerEvent]
                 cardanoBackend,
                 pendingConnections,
                 tracers.cardanoLiaison,
-                persistence
+                persistence,
+                mrmSelf = context.self,
               )
             )
             consensusActor <- context.actorOf(

--- a/src/main/scala/hydrozoa/multisig/RegimeManagerEvent.scala
+++ b/src/main/scala/hydrozoa/multisig/RegimeManagerEvent.scala
@@ -7,6 +7,7 @@ import hydrozoa.multisig.consensus.peer.PeerId
 import hydrozoa.multisig.consensus.transport.{CoilPeerWsTransportEvent, HubWsTransportEvent, NodeWsServerEvent, PeerTransportEvent}
 import hydrozoa.multisig.consensus.{BlockWeaverEvent, CardanoLiaisonEvent, CoilAckSequencerEvent, EventSequencerEvent, FastConsensusActorEvent, SlowConsensusActorEvent, StackComposerEvent}
 import hydrozoa.multisig.ledger.joint.JointLedgerEvent
+import hydrozoa.rulebased.RuleBasedActorEvent
 
 /** Top of a 2-dim event hierarchy for the regime managers, sliced along the two axes the regime
   * managers themselves are sliced on:
@@ -81,6 +82,7 @@ object MultisigOnlyChildEvent:
     final case class BlockWeaverLimiter(event: LimiterEvent) extends MultisigOnlyChildEvent
     final case class StackComposerLimiter(event: LimiterEvent) extends MultisigOnlyChildEvent
 
-/** Children only the rule-based regime spawns (in any role). Populated when PR 2 lands. */
+/** Children only the rule-based regime spawns (in any role). */
 sealed trait RuleBasedOnlyChildEvent extends RegimeManagerEvent
-object RuleBasedOnlyChildEvent
+object RuleBasedOnlyChildEvent:
+    final case class RuleBasedActor(event: RuleBasedActorEvent) extends RuleBasedOnlyChildEvent

--- a/src/main/scala/hydrozoa/multisig/backend/cardano/CardanoBackend.scala
+++ b/src/main/scala/hydrozoa/multisig/backend/cardano/CardanoBackend.scala
@@ -1,8 +1,9 @@
 package hydrozoa.multisig.backend.cardano
 
 import hydrozoa.lib.logging.ContraTracer
+import hydrozoa.multisig.ledger.l1.tx.EnrichedTx
 import scalus.cardano.address.ShelleyAddress
-import scalus.cardano.ledger.{AssetName, PolicyId, ProtocolParams, Transaction, TransactionHash, TransactionInput, Utxo, Utxos}
+import scalus.cardano.ledger.{AssetName, PolicyId, ProtocolParams, TransactionHash, TransactionInput, Utxo, Utxos}
 import scalus.uplc.builtin.Data
 
 /** Notes:
@@ -61,10 +62,11 @@ trait CardanoBackend[F[_]]:
         after: TransactionHash
     ): F[Either[CardanoBackend.Error, List[(TransactionHash, Data, Data)]]]
 
-    /** Submits a transaction.
-      * @return
+    /** Submits a transaction. The caller passes an [[EnrichedTx]] so wrappers (e.g. the firewall)
+      * can statically dispatch on the tx family — implementations extract `etx.tx` before hitting
+      * the chain.
       */
-    def submitTx(tx: Transaction): F[Either[Error, Unit]]
+    def submitTx(etx: EnrichedTx[?]): F[Either[Error, Unit]]
 
     /** Retrieve the latest protocol parameters.
       */

--- a/src/main/scala/hydrozoa/multisig/backend/cardano/CardanoBackendBlockfrost.scala
+++ b/src/main/scala/hydrozoa/multisig/backend/cardano/CardanoBackendBlockfrost.scala
@@ -13,6 +13,7 @@ import hydrozoa.config.head.network.{CardanoNetwork, StandardCardanoNetwork}
 import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.backend.cardano.CardanoBackend.Error
 import hydrozoa.multisig.backend.cardano.CardanoBackend.Error.*
+import hydrozoa.multisig.ledger.l1.tx.EnrichedTx
 import io.bullet.borer.Cbor
 import scala.collection.mutable
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -518,9 +519,9 @@ class CardanoBackendBlockfrost private (
             )
         )
 
-    override def submitTx(tx: Transaction): IO[Either[CardanoBackend.Error, Unit]] =
+    override def submitTx(etx: EnrichedTx[?]): IO[Either[CardanoBackend.Error, Unit]] =
         IO {
-            val result = backendService.getTransactionService.submitTransaction(tx.toCbor)
+            val result = backendService.getTransactionService.submitTransaction(etx.tx.toCbor)
             if result.isSuccessful
             then Right(())
             else Left(Unexpected(result.getResponse))

--- a/src/main/scala/hydrozoa/multisig/backend/cardano/FirewalledCardanoBackend.scala
+++ b/src/main/scala/hydrozoa/multisig/backend/cardano/FirewalledCardanoBackend.scala
@@ -3,17 +3,21 @@ package hydrozoa.multisig.backend.cardano
 import cats.effect.IO
 import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.backend.cardano.CardanoBackend.Error
+import hydrozoa.multisig.ledger.l1.tx.EnrichedTx
 import scalus.cardano.address.ShelleyAddress
-import scalus.cardano.ledger.{AssetName, PolicyId, ProtocolParams, Transaction, TransactionHash, TransactionInput, Utxo, Utxos}
+import scalus.cardano.ledger.{AssetName, PolicyId, ProtocolParams, TransactionHash, TransactionInput, Utxo, Utxos}
 import scalus.uplc.builtin.Data
 
 /** Wraps a [[CardanoBackend]] and drops outbound [[submitTx]] calls when `shouldDrop` says so.
   * Every other method delegates unchanged. Emits
   * [[FirewalledCardanoBackendEvent.DroppedOutboundTx]] on drop.
+  *
+  * The predicate receives the full [[EnrichedTx]] so callers can dispatch on tx family / payload
+  * (e.g. "drop only `FallbackTx` at major version 2") without resorting to tx-id observation.
   */
 final class FirewalledCardanoBackend(
     underlying: CardanoBackend[IO],
-    shouldDrop: Transaction => IO[Boolean],
+    shouldDrop: EnrichedTx[?] => IO[Boolean],
     firewallTracer: ContraTracer[IO, FirewalledCardanoBackendEvent],
 ) extends CardanoBackend[IO]:
 
@@ -43,14 +47,14 @@ final class FirewalledCardanoBackend(
     ): IO[Either[Error, List[(TransactionHash, Data, Data)]]] =
         underlying.lastContinuingTxs(asset, after)
 
-    override def submitTx(tx: Transaction): IO[Either[Error, Unit]] =
-        shouldDrop(tx).flatMap {
+    override def submitTx(etx: EnrichedTx[?]): IO[Either[Error, Unit]] =
+        shouldDrop(etx).flatMap {
             case true =>
                 firewallTracer
-                    .traceWith(FirewalledCardanoBackendEvent.DroppedOutboundTx(tx.id))
+                    .traceWith(FirewalledCardanoBackendEvent.DroppedOutboundTx(etx.tx.id))
                     .as(Right(()))
             case false =>
-                underlying.submitTx(tx)
+                underlying.submitTx(etx)
         }
 
     override def fetchLatestParams: IO[Either[Error, ProtocolParams]] =

--- a/src/main/scala/hydrozoa/multisig/consensus/CardanoLiaison.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/CardanoLiaison.scala
@@ -55,10 +55,18 @@ object CardanoLiaison:
         pendingConnections: HeadMultisigRegimeManager.PendingConnections |
             CardanoLiaison.Connections,
         tracer: ContraTracer[IO, CardanoLiaisonEvent],
-        persistence: Persistence[IO]
+        persistence: Persistence[IO],
+        mrmSelf: ActorRef[IO, HeadMultisigRegimeManager.HandoffToRuleBased],
     ): IO[CardanoLiaison] =
         IO(
-          new CardanoLiaison(config, cardanoBackend, pendingConnections, tracer, persistence) {}
+          new CardanoLiaison(
+            config,
+            cardanoBackend,
+            pendingConnections,
+            tracer,
+            persistence,
+            mrmSelf
+          ) {}
         )
 
     type Config = CardanoNetwork.Section & NodeOperationMultisigConfig.Section &
@@ -344,6 +352,7 @@ trait CardanoLiaison(
     pendingConnections: HeadMultisigRegimeManager.PendingConnections | CardanoLiaison.Connections,
     tracer: ContraTracer[IO, CardanoLiaisonEvent],
     persistence: Persistence[IO],
+    mrmSelf: ActorRef[IO, HeadMultisigRegimeManager.HandoffToRuleBased],
 ) extends Actor[IO, CardanoLiaison.Request]:
     import CardanoLiaison.*
 
@@ -726,8 +735,8 @@ trait CardanoLiaison(
                         )
                     }
 
-                    fallbackTxId = actionsToSubmit.collectFirst {
-                        case Action.FallbackToRuleBased(tx) => tx.tx.id
+                    fallbackAction = actionsToSubmit.collectFirst {
+                        case a: Action.FallbackToRuleBased => a
                     }
 
                     submitRet <-
@@ -748,19 +757,23 @@ trait CardanoLiaison(
                       tracer.traceWith(CardanoLiaisonEvent.SubmissionErrors(submissionErrors.size))
                     )
 
-                    // Post-submission: fire FallbackToRuleBasedDispatched only after the fallback
-                    // tx was accepted by the backend. "Dispatched" denotes confirmed submission, not
-                    // intent — pre-effect intent is logged earlier as ActionsDispatched.
-                    _ <- fallbackTxId match {
+                    // Post-submission: fire FallbackToRuleBasedDispatched and signal the regime
+                    // manager only after the fallback tx was accepted by the backend. "Dispatched"
+                    // denotes confirmed submission, not intent — pre-effect intent is logged
+                    // earlier as ActionsDispatched.
+                    _ <- fallbackAction match {
                         case None => IO.unit
-                        case Some(id) =>
+                        case Some(action) =>
+                            val id = action.tx.tx.id
                             val submittedOk = submitRet.exists { case (etx, ret) =>
                                 etx.tx.id == id && ret.isRight
                             }
                             IO.whenA(submittedOk)(
                               tracer.traceWith(
                                 CardanoLiaisonEvent.FallbackToRuleBasedDispatched(id)
-                              )
+                              ) >> (mrmSelf ! HeadMultisigRegimeManager.HandoffToRuleBased(
+                                action.tx
+                              ))
                             )
                     }
 
@@ -788,7 +801,7 @@ trait CardanoLiaison(
     object Action {
 
         /** Switching into the rule-based regime. */
-        final case class FallbackToRuleBased(tx: EnrichedTx[?]) extends DirectAction
+        final case class FallbackToRuleBased(tx: FallbackTx) extends DirectAction
 
         /** Pushing the existing state in the multisig regime forward. */
         final case class PushForwardMultisig(txs: Seq[EnrichedTx[?]]) extends DirectAction

--- a/src/main/scala/hydrozoa/multisig/consensus/CardanoLiaison.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/CardanoLiaison.scala
@@ -746,7 +746,7 @@ trait CardanoLiaison(
                                     _ <- tracer.traceWith(
                                       CardanoLiaisonEvent.TxSubmitting(etx.tx.id)
                                     )
-                                    ret <- cardanoBackend.submitTx(etx.tx)
+                                    ret <- cardanoBackend.submitTx(etx)
                                 } yield (etx, ret)
                             )
                         else IO.pure(List.empty)

--- a/src/main/scala/hydrozoa/multisig/ledger/l1/tx/RawTx.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/l1/tx/RawTx.scala
@@ -1,0 +1,18 @@
+package hydrozoa.multisig.ledger.l1.tx
+
+import monocle.{Focus, Lens}
+import scalus.cardano.ledger.Transaction
+import scalus.cardano.txbuilder.TransactionBuilder.ResolvedUtxos
+
+/** [[EnrichedTx]] escape hatch for submissions that don't belong to any hydrozoa protocol family —
+  * user-facing wallet moves, bootstrap-time admin txs, and test probes that submit raw bytes.
+  */
+final case class RawTx(
+    override val tx: Transaction,
+    override val txLens: Lens[RawTx, Transaction] = Focus[RawTx](_.tx),
+    override val resolvedUtxos: ResolvedUtxos = ResolvedUtxos.empty,
+) extends EnrichedTx[RawTx]
+
+object RawTx {
+    given TxFamily[RawTx] = TxFamily.of("RawTx")
+}

--- a/src/main/scala/hydrozoa/rulebased/RuleBasedActor.scala
+++ b/src/main/scala/hydrozoa/rulebased/RuleBasedActor.scala
@@ -46,6 +46,14 @@ extension (tx: Transaction) {
     def selfSigned(using config: Config): Transaction = config.ruleBasedWallet.signTx(tx)
 }
 
+extension [T <: EnrichedTx[T]](etx: T) {
+
+    /** Sign the enriched tx with the rule-based actor's own wallet, preserving family info so
+      * downstream wrappers (e.g. the firewall) can dispatch statically on it.
+      */
+    def selfSigned(using config: Config): T = config.ruleBasedWallet.signTx(etx)
+}
+
 /** Single actor that drives the rule-based regime end to end: while the treasury is Unresolved it
   * runs the dispute branch (vote/abstain → tally → resolve); once Resolved it runs the evacuation
   * branch (chained `lastContinuingTxs` reads + evacuation tx submissions). Each tick parses the
@@ -118,8 +126,8 @@ final case class RuleBasedActor(
               RuleBasedActorEvent.Backend.ErrorContinuingTxs(_)
             )
 
-        def submit(tx: Transaction): EitherT[IO, Error.RecoverableErrors, Unit] =
-            run(cardanoBackend.submitTx(tx), RuleBasedActorEvent.Backend.ErrorSubmittingTx(_))
+        def submit(etx: EnrichedTx[?]): EitherT[IO, Error.RecoverableErrors, Unit] =
+            run(cardanoBackend.submitTx(etx), RuleBasedActorEvent.Backend.ErrorSubmittingTx(_))
 
         /** Emit `before` (a "Querying" event), then run + wrap error per [[run]]. */
         private def traced[A](
@@ -168,11 +176,11 @@ final case class RuleBasedActor(
         } yield ()
 
     private def signAndSubmitTx[TxType <: EnrichedTx[TxType]](
-        tx: EnrichedTx[TxType],
+        tx: TxType,
     ): EitherT[IO, Error.RecoverableErrors, Unit] = {
         for {
             _ <- traceRight(RuleBasedActorEvent.Tx.Submitting(tx))
-            res <- Backend.submit(tx.tx.selfSigned)
+            res <- Backend.submit(tx.selfSigned)
             _ <- traceRight(RuleBasedActorEvent.Tx.SubmitSuccess(tx))
         } yield res
     }

--- a/src/main/scala/hydrozoa/rulebased/RuleBasedRegimeManager.scala
+++ b/src/main/scala/hydrozoa/rulebased/RuleBasedRegimeManager.scala
@@ -5,14 +5,13 @@ import cats.data.NonEmptyList
 import cats.effect.*
 import cats.syntax.all.*
 import com.suprnation.actor.Actor.*
-import hydrozoa.lib.cardano.scalus.QuantizedTime.QuantizedInstant
 import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.backend.cardano.CardanoBackend
 import hydrozoa.multisig.consensus.peer.PeerId
 import hydrozoa.multisig.ledger.block.BlockHeader
 import hydrozoa.multisig.ledger.l1.tx.FallbackTx
 import hydrozoa.multisig.ledger.stack.{PartitionEffects, StackEffects, StandaloneEvacuationCommitment}
-import hydrozoa.multisig.persistence.{BackendStore, Markers, Persistence, StoreKey}
+import hydrozoa.multisig.persistence.{Markers, Persistence, StoreKey}
 import hydrozoa.rulebased.RuleBasedRegimeManager.DisputeAction
 import hydrozoa.rulebased.ledger.l1.state.VoteState.secFromData
 import scalus.uplc.builtin.Data
@@ -24,8 +23,6 @@ import scalus.uplc.builtin.Data.fromData
 case class RuleBasedRegimeManager(
     cardanoBackend: CardanoBackend[IO],
     persistence: Persistence[IO],
-    backend: BackendStore[IO],
-    votingDeadline: QuantizedInstant,
     tracer: ContraTracer[IO, RuleBasedActorEvent],
 )(using config: RuleBasedRegimeManager.Config)
     extends Actor[IO, Unit] {
@@ -57,7 +54,7 @@ case class RuleBasedRegimeManager(
                       )
                     )
             }
-            markers <- Markers.derive(backend, PeerId.Head(ownHeadPeerNum))
+            markers <- Markers.derive(persistence.backend, PeerId.Head(ownHeadPeerNum))
             stackNum <- markers.hardConfirmed.liftTo[IO](
               RuleBasedRegimeManager.MissingState("no hard-confirmed stack on disk")
             )
@@ -96,7 +93,7 @@ case class RuleBasedRegimeManager(
                       )
                     )
             }
-            markers <- Markers.derive(backend, PeerId.Head(ownHeadPeerNum))
+            markers <- Markers.derive(persistence.backend, PeerId.Head(ownHeadPeerNum))
             stackNum <- markers.hardConfirmed.liftTo[IO](
               RuleBasedRegimeManager.MissingState("no hard-confirmed stack on disk")
             )

--- a/src/test/scala/hydrozoa/multisig/backend/cardano/CardanoBackendBlockfrostTest.scala
+++ b/src/test/scala/hydrozoa/multisig/backend/cardano/CardanoBackendBlockfrostTest.scala
@@ -5,6 +5,7 @@ import cats.effect.unsafe.implicits.global
 import cats.syntax.contravariant.*
 import hydrozoa.config.head.network.CardanoNetwork
 import hydrozoa.lib.logging.Slf4jTracer
+import hydrozoa.multisig.ledger.l1.tx.RawTx
 import io.github.cdimascio.dotenv.Dotenv
 import org.scalatest.Tag
 import org.scalatest.funsuite.AnyFunSuite
@@ -220,7 +221,7 @@ class CardanoBackendBlockfrostTest extends AnyFunSuite {
                   key,
                   tracer = tracer
                 )
-                ret <- backend.submitTx(Transaction.empty)
+                ret <- backend.submitTx(RawTx(Transaction.empty))
             } yield ret
         )
         print(ret)

--- a/src/test/scala/hydrozoa/multisig/backend/cardano/CardanoBackendMock.scala
+++ b/src/test/scala/hydrozoa/multisig/backend/cardano/CardanoBackendMock.scala
@@ -11,6 +11,7 @@ import com.bloxbean.cardano.client.util.HexUtil
 import hydrozoa.lib.cardano.scalus.QuantizedTime.QuantizedInstant
 import hydrozoa.lib.logging.{ContraTracer, LogEvent, Slf4jTracer}
 import hydrozoa.multisig.backend.cardano.CardanoBackend.Error
+import hydrozoa.multisig.ledger.l1.tx.EnrichedTx
 import monocle.Focus.focus
 import scalus.cardano.address.ShelleyAddress
 import scalus.cardano.ledger.rules.STS.Mutator
@@ -151,7 +152,8 @@ class CardanoBackendMock private (
         } yield Right(result)
     }
 
-    override def submitTx(tx: Transaction): MockStateF[Either[CardanoBackend.Error, Unit]] =
+    override def submitTx(etx: EnrichedTx[?]): MockStateF[Either[CardanoBackend.Error, Unit]] =
+        val tx = etx.tx
         for {
             _ <- log.traceWith(CardanoBackendEvent.SubmitTxReceived(tx.id))
             _ <- log.traceWith(
@@ -288,8 +290,8 @@ object CardanoBackendMock {
                 ): IO[Either[CardanoBackend.Error, List[(TransactionHash, Data, Data)]]] =
                     transformer(mock.lastContinuingTxs(asset, after))
 
-                override def submitTx(tx: Transaction): IO[Either[CardanoBackend.Error, Unit]] =
-                    transformer(mock.submitTx(tx))
+                override def submitTx(etx: EnrichedTx[?]): IO[Either[CardanoBackend.Error, Unit]] =
+                    transformer(mock.submitTx(etx))
 
                 def fetchLatestParams: IO[Either[Error, ProtocolParams]] =
                     transformer(mock.fetchLatestParams)

--- a/src/test/scala/hydrozoa/multisig/backend/cardano/FirewalledCardanoBackendTest.scala
+++ b/src/test/scala/hydrozoa/multisig/backend/cardano/FirewalledCardanoBackendTest.scala
@@ -3,6 +3,7 @@ package hydrozoa.multisig.backend.cardano
 import cats.effect.unsafe.implicits.global
 import cats.effect.{IO, Ref}
 import hydrozoa.lib.logging.ContraTracer
+import hydrozoa.multisig.ledger.l1.tx.RawTx
 import org.scalatest.funsuite.AnyFunSuite
 import scalus.cardano.ledger.Transaction
 
@@ -19,7 +20,7 @@ class FirewalledCardanoBackendTest extends AnyFunSuite:
             captured <- Ref[IO].of(List.empty[FirewalledCardanoBackendEvent])
             sink = ContraTracer[IO, FirewalledCardanoBackendEvent](e => captured.update(e :: _))
             firewalled = new FirewalledCardanoBackend(underlying, _ => IO.pure(false), sink)
-            result <- firewalled.submitTx(Transaction.empty)
+            result <- firewalled.submitTx(RawTx(Transaction.empty))
             droppedEvents <- captured.get
         yield
             val _ = assert(
@@ -36,7 +37,7 @@ class FirewalledCardanoBackendTest extends AnyFunSuite:
             captured <- Ref[IO].of(List.empty[FirewalledCardanoBackendEvent])
             sink = ContraTracer[IO, FirewalledCardanoBackendEvent](e => captured.update(e :: _))
             firewalled = new FirewalledCardanoBackend(underlying, _ => IO.pure(true), sink)
-            result <- firewalled.submitTx(Transaction.empty)
+            result <- firewalled.submitTx(RawTx(Transaction.empty))
             droppedEvents <- captured.get
         yield
             val _ = assert(result == Right(()), s"expected Right(()) short-circuit, got $result")


### PR DESCRIPTION
CL sends HandoffToRuleBased(fallback) to HMRM on successful fallback submit; HMRM stops non-CL children and spawns RuleBasedRegimeManager. CL stays alive to process refunds and finish rollouts.

- HMRM.Request gains HandoffToRuleBased(fallback: FallbackTx)
- Base's onHandoffToRuleBased is abstract; CMRM raises NotImplementedError as a loud TODO until coil-side handoff lands
- RuleBasedOnlyChildEvent populated with RuleBasedActor(event)
- HeadRegimeManagerEvent = HeadMultisigRegimeManagerEvent | RuleBasedOnlyChildEvent
- MrmTracers gains ruleBasedActor projection
- Action.FallbackToRuleBased.tx narrowed EnrichedTx[?] → FallbackTx
- RRM drops stale votingDeadline + separate BackendStore (uses persistence.backend)
- Stage 1 CL construction gets an inert HMRM stub since it has no HMRM