### PR TITLE
Fund14/Project 69: /ready endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,8 @@ Working design and reference docs live in `docs/`:
 **API**
 - [`l2-query-endpoints.md`](docs/l2-query-endpoints.md) — the user-facing server's read-only L2
   queries: `GET /api/l2/utxos/{address}` and `GET /api/l2/transactions` (EUTXO-only).
+- [`observability-endpoints.md`](docs/observability-endpoints.md) — the user-facing server's
+  `/health` (liveness) and `/ready` (readiness) endpoints and the `NodeStatus` behind them.
 
 **Testing**
 - [`integration-stages.md`](docs/integration-stages.md) — the stage1/stage4 integration test

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ PDF). For project-wide conventions, start with the style guide.
 | [integration-stages.md](integration-stages.md) | The two integration test stages under `integration/`: which stage tests what, where to add a test, what each property checks. |
 | [l2-query-endpoints.md](l2-query-endpoints.md) | The user-facing server's read-only L2 queries: `GET /api/l2/utxos/{address}` (CIP-0116 utxos) and `GET /api/l2/transactions` (recent activity); EUTXO-only, empty on a remote-ledger node. |
 | [logging-tracing.md](logging-tracing.md) | Contextual logging and tracing: Tracer, IOLocal-carried context, routing keys, migration off SLF4J MDC. |
+| [observability-endpoints.md](observability-endpoints.md) | The user-facing server's `/health` (liveness) and `/ready` (readiness) endpoints: semantics, status mapping, how `NodeStatus` is maintained. |
 | [rate-limiter.md](rate-limiter.md) | A generic throttling actor that slows the fast/slow cycles (longer block/stack durations) without touching consensus logic. |
 | [slow-consensus.md](slow-consensus.md) | The slow cycle: turning a run of soft-confirmed blocks into a multisigned, L1-submittable set of effect transactions; StackComposer / hard-acks. |
 | [style-guide.md](style-guide.md) | Hydrozoa Scala conventions: opaque-tuple conversions, naming rules (verb functions, `is*`/`has*` predicates), and other house style. |

--- a/docs/observability-endpoints.md
+++ b/docs/observability-endpoints.md
@@ -1,0 +1,92 @@
+# Observability endpoints: /health and /ready
+
+The user-facing HTTP server (`multisig/server/HydrozoaServer.scala`, default port 8080) exposes
+two unauthenticated `GET` endpoints for process supervisors and load balancers. They answer
+different questions for different consumers and must not be conflated:
+
+| | `GET /health` | `GET /ready` |
+|---|---|---|
+| Question | Is this process alive? | Should user traffic be routed here right now? |
+| Consumer | Process supervisor (systemd, container runtime, liveness probe) | Load balancer / proxy / frontend (readiness probe) |
+| On failure | Restart the process | Take the node out of rotation — do **not** restart |
+| Checks | Nothing beyond HTTP serving | The node lifecycle status (see below) |
+| Flaps | Never while the process lives | By design, at lifecycle transitions |
+
+Both endpoints exist only on head peers — coil peers run no user-facing HTTP server
+(`Main.runCoilNode`).
+
+## /health — liveness
+
+Always `200 {"status": "ok"}`.
+
+The response is deliberately static: a liveness probe must only check things a restart would
+fix, so it must never depend on anything external — the L1 backend, peer connections, or head
+state. If Ember answered the request, the process is alive; that is the entire contract.
+
+## /ready — readiness
+
+Reports the node lifecycle status (`multisig/NodeStatus.scala`). The verdict is the HTTP status
+code — `200` = route traffic here, `503` = don't; the JSON body is diagnostic:
+
+| `NodeStatus` | Code | Body | Meaning |
+|---|---|---|---|
+| `Initializing` | 503 | `{"status": "initializing"}` | Stack 0 not hard-confirmed; the head is not on L1 yet. Submits would be accepted but only sit in the mempool. |
+| `Active` | 200 | `{"status": "active"}` | The head is open on L1; the node serves user traffic. |
+| `Finalized` | 503 | `{"status": "finalized"}` | The head has been finalized. Terminal. |
+| `HandedOffToRuleBased` | 503 | `{"status": "handed-off-to-rule-based"}` | The multisig regime handed off to the rule-based regime; the request-processing actors are stopped. Terminal. |
+
+A permanently-503 `/ready` on a node whose `/health` is 200 is a valid, expected end state:
+after finalization or the rule-based handoff the node is alive but must not receive user
+traffic again. That "alive but not serving" pair is exactly what the two endpoints exist to
+distinguish.
+
+## How the status is maintained
+
+The status lives in a plain `Ref[IO, NodeStatus]` owned by `MultisigRegimeManagerBase`
+(next to `connectionsDeferred`); the `/ready` route is a pure `Ref` read — no actor messaging
+and no L1 calls, so it is safe at any probe frequency. Two writers advance it:
+
+- **`CardanoLiaison`** reports the status implied by its L1 `TargetState` at every state
+  write: the live stack-0 hard-confirm path (`Uninitialized → Active`), regular-stack effects
+  carrying a finalization (`→ Finalized`), and the boot recovery fold — so a restarted node
+  whose head is already open reports `active` again as soon as recovery completes.
+- **The regime manager** writes `HandedOffToRuleBased` when it processes the
+  multisig→rule-based handoff.
+
+Writes go through `NodeStatus.advanceTo`, a monotone advance: earlier statuses never overwrite
+later ones and terminal statuses stick, so the two independent writers cannot race the status
+backwards.
+
+Timing notes:
+
+- The server binds only after the regime manager completes `connectionsDeferred`, so during
+  boot probes see connection-refused — which both probe kinds already treat as failure. No
+  special boot handling is needed.
+- On a restart of an already-open head there is a brief `initializing` window between the
+  server binding and `CardanoLiaison` finishing its recovery fold.
+
+## Usage
+
+```bash
+curl -i http://localhost:8080/health
+# HTTP/1.1 200 OK
+# {"status":"ok"}
+
+curl -i http://localhost:8080/ready
+# before stack 0 hard-confirms:  HTTP/1.1 503 Service Unavailable  {"status":"initializing"}
+# while the head is open:        HTTP/1.1 200 OK                   {"status":"active"}
+```
+
+Kubernetes-style probe configuration:
+
+```yaml
+livenessProbe:
+  httpGet: { path: /health, port: 8080 }
+  periodSeconds: 10
+readinessProbe:
+  httpGet: { path: /ready, port: 8080 }
+  periodSeconds: 5
+```
+
+For a plain reverse proxy / load balancer, use `/ready` as the backend health check so the
+node only enters rotation while the head is open.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -78,6 +78,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HealthResponse'
+  /ready:
+    get:
+      description: Readiness — 200 only while the head is Active (open on L1); 503
+        with the lifecycle status otherwise.
+      operationId: getReady
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReadinessResponse'
   /api/admin/finalize:
     post:
       description: Trigger head finalization (admin only).
@@ -162,6 +174,14 @@ components:
           type: string
     HealthResponse:
       title: HealthResponse
+      type: object
+      required:
+      - status
+      properties:
+        status:
+          type: string
+    ReadinessResponse:
+      title: ReadinessResponse
       type: object
       required:
       - status

--- a/integration/src/test/scala/hydrozoa/integration/harness/MultiPeerHeadHarness.scala
+++ b/integration/src/test/scala/hydrozoa/integration/harness/MultiPeerHeadHarness.scala
@@ -28,7 +28,7 @@ import hydrozoa.multisig.ledger.eutxol2.EutxoL2Ledger
 import hydrozoa.multisig.persistence.rocksdb.RocksDbBackendStore
 import hydrozoa.multisig.persistence.{BackendStore, Cf, InMemoryBackendStore, Persistence, PersistenceEvent, PersistenceEventFormat}
 import hydrozoa.multisig.server.{HydrozoaHttpEvent, HydrozoaHttpEventFormat, HydrozoaRoutes, HydrozoaServer, SubmissionClient}
-import hydrozoa.multisig.{CoilMultisigRegimeManager, CoilMultisigRegimeManagerEventFormat, CoilRegimeManagerEvent, HeadMultisigRegimeManager, HeadMultisigRegimeManagerEventFormat, HeadRegimeManagerEvent}
+import hydrozoa.multisig.{CoilMultisigRegimeManager, CoilMultisigRegimeManagerEventFormat, CoilRegimeManagerEvent, HeadMultisigRegimeManager, HeadMultisigRegimeManagerEventFormat, HeadRegimeManagerEvent, NodeStatus}
 import java.nio.file.{Files, Path}
 import java.time.Instant
 import java.util.concurrent.TimeUnit
@@ -956,6 +956,8 @@ object MultiPeerHeadHarness:
             HydrozoaRoutes(
               requestSequencer,
               conns.blockWeaver,
+              // The harness runs no head lifecycle, so readiness is a constant Active.
+              IO.pure(NodeStatus.Active),
               // No EUTXO L2-query reader in the harness — the SubmissionClient uses the write path.
               None,
               nodeConfig.headConfig,

--- a/integration/src/test/scala/hydrozoa/integration/stage1/Suite.scala
+++ b/integration/src/test/scala/hydrozoa/integration/stage1/Suite.scala
@@ -531,6 +531,9 @@ case class Suite(
                     clTracer,
                     persistence,
                     mrmSelf = mrmSelfStub,
+                    // Stage1 runs no user-facing HTTP server, so the readiness status has
+                    // no reader.
+                    advanceNodeStatus = _ => IO.unit,
                   )
                 )
                 // Request sequencer stub

--- a/src/main/scala/hydrozoa/app/Main.scala
+++ b/src/main/scala/hydrozoa/app/Main.scala
@@ -372,6 +372,7 @@ object Main
                             sys.error("RequestSequencer required on head peers")
                           ),
                           connections.blockWeaver,
+                          mrm.nodeStatus.get,
                           // TODO(l2ledger): pass Some(reader) once the head-config l2ledger field
                           // selects cardano-eutxo; a remote-ledger node serves no L2-query endpoints.
                           None,

--- a/src/main/scala/hydrozoa/multisig/MultisigRegimeManagerBase.scala
+++ b/src/main/scala/hydrozoa/multisig/MultisigRegimeManagerBase.scala
@@ -1,7 +1,7 @@
 package hydrozoa.multisig
 
 import cats.*
-import cats.effect.{Deferred, IO}
+import cats.effect.{Deferred, IO, Ref}
 import cats.implicits.*
 import com.suprnation.actor.Actor.{Actor, Receive}
 import com.suprnation.actor.ActorRef.NoSendActorRef
@@ -51,6 +51,12 @@ trait MultisigRegimeManagerBase[E >: LifecycleEvent <: RegimeManagerEvent]
       */
     val connectionsDeferred: Deferred[IO, Connections] = Deferred.unsafe[IO, Connections]
 
+    /** Node lifecycle status backing the user-facing server's `/ready` endpoint. Advanced
+      * monotonically (via [[NodeStatus.advanceTo]]) by [[CardanoLiaison]] as the L1 target state
+      * changes and by this manager on [[HandoffToRuleBased]]; never read here.
+      */
+    val nodeStatus: Ref[IO, NodeStatus] = Ref.unsafe[IO, NodeStatus](NodeStatus.Initializing)
+
     override def supervisorStrategy: SupervisionStrategy[IO] =
         OneForOneStrategy[IO](maxNrOfRetries = 3, withinTimeRange = 1.minute) {
             case _: IllegalArgumentException =>
@@ -70,7 +76,9 @@ trait MultisigRegimeManagerBase[E >: LifecycleEvent <: RegimeManagerEvent]
             tracer.traceWith(LifecycleEvent.TerminatedActor(childType))
         case TerminatedDependency(dependencyType, _) =>
             tracer.traceWith(LifecycleEvent.TerminatedDependency(dependencyType))
-        case HandoffToRuleBased(fallback) => onHandoffToRuleBased(fallback)
+        case HandoffToRuleBased(fallback) =>
+            nodeStatus.update(_.advanceTo(NodeStatus.HandedOffToRuleBased)) *>
+                onHandoffToRuleBased(fallback)
         // TODO: Implement a way to receive a remote comm actor and connect it to its corresponding local comm actor
     }
 
@@ -116,6 +124,7 @@ trait MultisigRegimeManagerBase[E >: LifecycleEvent <: RegimeManagerEvent]
                 tracers.cardanoLiaison,
                 persistence,
                 mrmSelf = context.self,
+                advanceNodeStatus = next => nodeStatus.update(_.advanceTo(next)),
               )
             )
             consensusActor <- context.actorOf(

--- a/src/main/scala/hydrozoa/multisig/NodeStatus.scala
+++ b/src/main/scala/hydrozoa/multisig/NodeStatus.scala
@@ -1,0 +1,39 @@
+package hydrozoa.multisig
+
+/** Node lifecycle status backing the user-facing server's readiness endpoint (`GET /ready`).
+  *
+  * Tracks the head lifecycle as seen by this node: it starts at [[NodeStatus.Initializing]],
+  * becomes [[NodeStatus.Active]] once stack 0 hard-confirms (the head exists on L1), and ends in
+  * one of the terminal statuses — [[NodeStatus.Finalized]] on head finalization or
+  * [[NodeStatus.HandedOffToRuleBased]] on the multisig→rule-based handoff. Only
+  * [[NodeStatus.Active]] means the node should receive user traffic.
+  */
+enum NodeStatus:
+    /** Stack 0 is not hard-confirmed yet: the head is not on L1 and nothing is submittable. */
+    case Initializing
+
+    /** The head is open on L1; the node serves user traffic. */
+    case Active
+
+    /** The head has been finalized; the node takes no further user traffic. Terminal. */
+    case Finalized
+
+    /** The multisig regime handed off to the rule-based regime; the request-processing actors are
+      * stopped and the node takes no further user traffic. Terminal.
+      */
+    case HandedOffToRuleBased
+
+object NodeStatus:
+    extension (current: NodeStatus)
+        /** Monotone advance: move to `next` only if it is further along the lifecycle. Earlier or
+          * equally advanced statuses are ignored, so a terminal status sticks (first writer wins)
+          * and independent writers cannot regress the status.
+          */
+        def advanceTo(next: NodeStatus): NodeStatus =
+            if rank(next) > rank(current) then next else current
+
+    private def rank(status: NodeStatus): Int = status match
+        case NodeStatus.Initializing         => 0
+        case NodeStatus.Active               => 1
+        case NodeStatus.Finalized            => 2
+        case NodeStatus.HandedOffToRuleBased => 2

--- a/src/main/scala/hydrozoa/multisig/consensus/CardanoLiaison.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/CardanoLiaison.scala
@@ -11,7 +11,6 @@ import hydrozoa.config.node.operation.multisig.NodeOperationMultisigConfig
 import hydrozoa.config.node.owninfo.OwnPeerPublic
 import hydrozoa.lib.cardano.scalus.QuantizedTime.{QuantizedInstant, toEpochQuantizedInstant}
 import hydrozoa.lib.logging.ContraTracer
-import hydrozoa.multisig.HeadMultisigRegimeManager
 import hydrozoa.multisig.backend.cardano.CardanoBackend
 import hydrozoa.multisig.consensus.pollresults.PollResults
 import hydrozoa.multisig.ledger.block.BlockVersion
@@ -20,6 +19,7 @@ import hydrozoa.multisig.ledger.l1.tx.*
 import hydrozoa.multisig.ledger.stack.{PartitionEffects, Stack, StackEffects, StackNumber}
 import hydrozoa.multisig.persistence.Persistence
 import hydrozoa.multisig.persistence.recovery.HardConfirmationScan
+import hydrozoa.multisig.{HeadMultisigRegimeManager, NodeStatus}
 import scala.collection.immutable.{Seq, TreeMap}
 import scala.math.Ordered.orderingToOrdered
 import scalus.cardano.ledger.{Block as _, BlockHeader as _, Transaction, TransactionHash, TransactionInput}
@@ -57,6 +57,7 @@ object CardanoLiaison:
         tracer: ContraTracer[IO, CardanoLiaisonEvent],
         persistence: Persistence[IO],
         mrmSelf: ActorRef[IO, HeadMultisigRegimeManager.HandoffToRuleBased],
+        advanceNodeStatus: NodeStatus => IO[Unit],
     ): IO[CardanoLiaison] =
         IO(
           new CardanoLiaison(
@@ -65,7 +66,8 @@ object CardanoLiaison:
             pendingConnections,
             tracer,
             persistence,
-            mrmSelf
+            mrmSelf,
+            advanceNodeStatus
           ) {}
         )
 
@@ -353,6 +355,7 @@ trait CardanoLiaison(
     tracer: ContraTracer[IO, CardanoLiaisonEvent],
     persistence: Persistence[IO],
     mrmSelf: ActorRef[IO, HeadMultisigRegimeManager.HandoffToRuleBased],
+    advanceNodeStatus: NodeStatus => IO[Unit],
 ) extends Actor[IO, CardanoLiaison.Request]:
     import CardanoLiaison.*
 
@@ -419,6 +422,7 @@ trait CardanoLiaison(
             // `runEffects` re-samples L1, so recover restores only the effect index.
             recovered <- State.recover(persistence)(using config)
             _ <- stateRef.set(recovered)
+            _ <- advanceNodeStatus(nodeStatusOf(recovered.targetState))
             // Immediate + periodic Timeout
             _ <- context.self ! CardanoLiaison.Timeout
             _ <- context.setReceiveTimeout(
@@ -451,6 +455,7 @@ trait CardanoLiaison(
         for {
             _ <- tracer.traceWith(CardanoLiaisonEvent.InitialStackEffectsLearned)
             newState <- stateRef.updateAndGet(State.applyInitialEffects(_, eff))
+            _ <- advanceNodeStatus(nodeStatusOf(newState.targetState))
             _ <- tracer.traceWith(CardanoLiaisonEvent.InitialStackEffectsState(newState.prettyDump))
         } yield ()
 
@@ -523,10 +528,19 @@ trait CardanoLiaison(
                   )
                 )
                 newState <- stateRef.updateAndGet(State.applyRegularEffects(_, eff))
+                _ <- advanceNodeStatus(nodeStatusOf(newState.targetState))
                 _ <- tracer.traceWith(CardanoLiaisonEvent.StackEffectsState(newState.prettyDump))
             } yield ()
         }
     }
+
+    /** The node lifecycle status implied by an L1 target state; reported through
+      * `advanceNodeStatus` at every [[stateRef]] write.
+      */
+    private def nodeStatusOf(target: TargetState): NodeStatus = target match
+        case TargetState.Uninitialized => NodeStatus.Initializing
+        case TargetState.Active(_)     => NodeStatus.Active
+        case TargetState.Finalized(_)  => NodeStatus.Finalized
 
     /** The core part of the liaison that decides whether an action is needed and submits them.
       *

--- a/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
+++ b/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
@@ -1,6 +1,7 @@
 package hydrozoa.multisig.server
 
 import hydrozoa.config.head.HeadConfig
+import hydrozoa.multisig.NodeStatus
 import hydrozoa.multisig.ledger.event.RequestId
 import hydrozoa.multisig.ledger.l2.{L2TxKind, L2TxSummary}
 import io.bullet.borer.Cbor
@@ -23,6 +24,22 @@ object ApiDto {
     /** `{ "status": "ok" }` — the liveness body. */
     final case class HealthResponse(status: String)
     given Codec[HealthResponse] = deriveCodec
+
+    /** `{ "status": "<lifecycle>" }` — the readiness diagnostic body for `GET /ready`. The verdict
+      * itself is the HTTP status (200 vs 503); this is only for diagnostics.
+      */
+    final case class ReadinessResponse(status: String)
+    given Codec[ReadinessResponse] = deriveCodec
+
+    /** Map the node lifecycle status to its readiness body (kebab-case label). */
+    def mkReadinessResponse(status: NodeStatus): ReadinessResponse =
+        ReadinessResponse(nodeStatusLabel(status))
+
+    private def nodeStatusLabel(status: NodeStatus): String = status match
+        case NodeStatus.Initializing         => "initializing"
+        case NodeStatus.Active               => "active"
+        case NodeStatus.Finalized            => "finalized"
+        case NodeStatus.HandedOffToRuleBased => "handed-off-to-rule-based"
 
     /** `{ "status": "success", "message": ... }` — the finalize-trigger body. */
     final case class FinalizeResponse(status: String, message: String)

--- a/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
+++ b/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
@@ -3,6 +3,7 @@ package hydrozoa.multisig.server
 import cats.effect.IO
 import hydrozoa.config.head.HeadConfig
 import hydrozoa.lib.logging.ContraTracer
+import hydrozoa.multisig.NodeStatus
 import hydrozoa.multisig.consensus.{BlockWeaver, RequestSequencer}
 import hydrozoa.multisig.ledger.l2.EutxoL2LedgerReader
 import hydrozoa.multisig.server.ApiDto.*
@@ -33,6 +34,7 @@ import sttp.tapir.swagger.bundle.SwaggerInterpreter
 class HydrozoaRoutes(
     requestSequencer: RequestSequencer.Handle,
     blockWeaver: BlockWeaver.Handle,
+    nodeStatus: IO[NodeStatus],
     l2QueryReader: Option[EutxoL2LedgerReader[IO]],
     headConfig: HeadConfig,
     serverConfig: HydrozoaServer.Config,
@@ -158,6 +160,27 @@ class HydrozoaRoutes(
             .description("Liveness — always 200 while the process is serving HTTP.")
             .serverLogicSuccess(_ => IO.pure(HealthResponse("ok")))
 
+    /** Readiness — `200` only while the head is [[NodeStatus.Active]] (open on L1); otherwise
+      * `503`, always with the lifecycle status in the body, so a proxy routes user traffic here
+      * only when the node can serve it. The verdict is the status code; the body is diagnostic.
+      */
+    private val readyEndpoint: ServerEndpoint[Any, IO] =
+        endpoint.get
+            .in("ready")
+            .out(statusCode.and(jsonBody[ReadinessResponse]))
+            .description(
+              "Readiness — 200 only while the head is Active (open on L1); 503 with the lifecycle " +
+                  "status otherwise."
+            )
+            .serverLogicSuccess(_ =>
+                nodeStatus.map { status =>
+                    val code =
+                        if status == NodeStatus.Active then StatusCode.Ok
+                        else StatusCode.ServiceUnavailable
+                    (code, ApiDto.mkReadinessResponse(status))
+                }
+            )
+
     private val finalizeEndpoint: ServerEndpoint[Any, IO] =
         endpoint.post
             // Optional credentials so the security logic runs (and logs) even when the header is
@@ -215,6 +238,7 @@ class HydrozoaRoutes(
           registerDepositEndpoint,
           headInfoEndpoint,
           healthEndpoint,
+          readyEndpoint,
           finalizeEndpoint
         )
 
@@ -306,6 +330,7 @@ object HydrozoaRoutes {
     def apply(
         requestSequencer: RequestSequencer.Handle,
         blockWeaver: BlockWeaver.Handle,
+        nodeStatus: IO[NodeStatus],
         l2QueryReader: Option[EutxoL2LedgerReader[IO]],
         headConfig: HeadConfig,
         serverConfig: HydrozoaServer.Config,
@@ -315,6 +340,7 @@ object HydrozoaRoutes {
           new HydrozoaRoutes(
             requestSequencer,
             blockWeaver,
+            nodeStatus,
             l2QueryReader,
             headConfig,
             serverConfig,

--- a/src/main/scala/hydrozoa/multisig/server/HydrozoaServer.scala
+++ b/src/main/scala/hydrozoa/multisig/server/HydrozoaServer.scala
@@ -4,6 +4,7 @@ import cats.effect.{IO, Resource}
 import com.comcast.ip4s.*
 import hydrozoa.config.head.HeadConfig
 import hydrozoa.lib.logging.ContraTracer
+import hydrozoa.multisig.NodeStatus
 import hydrozoa.multisig.consensus.{BlockWeaver, RequestSequencer}
 import hydrozoa.multisig.ledger.l2.EutxoL2LedgerReader
 import hydrozoa.multisig.server.HydrozoaHttpEvent.ServerStarted
@@ -31,6 +32,9 @@ object HydrozoaServer {
       *   Handle to the RequestSequencer actor
       * @param blockWeaver
       *   Handle to the BlockWeaver actor
+      * @param nodeStatus
+      *   Node lifecycle status behind `GET /ready`, maintained by `MultisigRegimeManagerBase` and
+      *   `CardanoLiaison`
       * @param l2QueryReader
       *   The EUTXO L2-ledger read model behind `GET /api/l2/utxos` and `/api/l2/transactions`, or
       *   `None` on a node that runs a remote ledger (those endpoints are then not mounted)
@@ -46,6 +50,7 @@ object HydrozoaServer {
     def create(
         requestSequencer: RequestSequencer.Handle,
         blockWeaver: BlockWeaver.Handle,
+        nodeStatus: IO[NodeStatus],
         l2QueryReader: Option[EutxoL2LedgerReader[IO]],
         headConfig: HeadConfig,
         config: Config,
@@ -56,6 +61,7 @@ object HydrozoaServer {
               HydrozoaRoutes(
                 requestSequencer,
                 blockWeaver,
+                nodeStatus,
                 l2QueryReader,
                 headConfig,
                 config,
@@ -78,12 +84,13 @@ object HydrozoaServer {
     def run(
         requestSequencer: RequestSequencer.Handle,
         blockWeaver: BlockWeaver.Handle,
+        nodeStatus: IO[NodeStatus],
         l2QueryReader: Option[EutxoL2LedgerReader[IO]],
         headConfig: HeadConfig,
         config: Config,
         tracer: ContraTracer[IO, HydrozoaHttpEvent]
     ): IO[Nothing] = {
-        create(requestSequencer, blockWeaver, l2QueryReader, headConfig, config, tracer)
+        create(requestSequencer, blockWeaver, nodeStatus, l2QueryReader, headConfig, config, tracer)
             .use(_ => IO.never)
     }
 }

--- a/src/test/scala/hydrozoa/multisig/NodeStatusTest.scala
+++ b/src/test/scala/hydrozoa/multisig/NodeStatusTest.scala
@@ -1,0 +1,44 @@
+package hydrozoa.multisig
+
+import hydrozoa.multisig.NodeStatus.advanceTo
+import org.scalacheck.Prop.forAll
+import org.scalacheck.{Gen, Properties}
+
+/** Properties of the monotone [[NodeStatus.advanceTo]] lifecycle advance. With four statuses the
+  * generators cover the full 4×4 transition table, so these properties characterize the function
+  * exhaustively.
+  */
+object NodeStatusTest extends Properties("NodeStatus") {
+
+    private val genStatus: Gen[NodeStatus] = Gen.oneOf(NodeStatus.values.toSeq)
+
+    private val genTerminal: Gen[NodeStatus] =
+        Gen.oneOf(NodeStatus.Finalized, NodeStatus.HandedOffToRuleBased)
+
+    val _ = property("advanceTo yields one of its operands") = forAll(genStatus, genStatus) {
+        (current, next) =>
+            val advanced = current.advanceTo(next)
+            advanced == current || advanced == next
+    }
+
+    val _ = property("advanceTo is idempotent") = forAll(genStatus) { status =>
+        status.advanceTo(status) == status
+    }
+
+    val _ = property("Initializing advances to anything") = forAll(genStatus) { next =>
+        NodeStatus.Initializing.advanceTo(next) == next
+    }
+
+    val _ = property("nothing regresses to Initializing") = forAll(genStatus) { current =>
+        current.advanceTo(NodeStatus.Initializing) == current
+    }
+
+    val _ = property("Active advances to any terminal status") = forAll(genTerminal) { terminal =>
+        NodeStatus.Active.advanceTo(terminal) == terminal
+    }
+
+    val _ = property("terminal statuses absorb every write") = forAll(genTerminal, genStatus) {
+        (terminal, next) =>
+            terminal.advanceTo(next) == terminal
+    }
+}

--- a/src/test/scala/hydrozoa/multisig/server/L2QueryEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/L2QueryEndpointsTest.scala
@@ -7,6 +7,7 @@ import com.suprnation.actor.Actor.{Actor, Receive}
 import com.suprnation.actor.ActorSystem
 import hydrozoa.config.node.MultiNodeConfig
 import hydrozoa.lib.logging.ContraTracer
+import hydrozoa.multisig.NodeStatus
 import hydrozoa.multisig.consensus.peer.HeadPeerNumber
 import hydrozoa.multisig.consensus.{BlockWeaver, RequestSequencer}
 import hydrozoa.multisig.ledger.block.BlockNumber
@@ -88,6 +89,7 @@ class L2QueryEndpointsTest extends AnyFunSuite:
                     routes <- HydrozoaRoutes(
                       requestSequencerStub,
                       blockWeaverStub,
+                      IO.pure(NodeStatus.Active),
                       Some(ledger),
                       multiNodeConfig.headConfig,
                       HydrozoaServer.Config(adminUsername = "admin", adminPassword = "admin"),

--- a/src/test/scala/hydrozoa/multisig/server/OpenApiSchemaTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/OpenApiSchemaTest.scala
@@ -7,6 +7,7 @@ import com.suprnation.actor.ActorSystem
 import hydrozoa.config.GenerateSampleConfig.{defaultSpec, testPeersSpec}
 import hydrozoa.config.node.MultiNodeConfig
 import hydrozoa.lib.logging.ContraTracer
+import hydrozoa.multisig.NodeStatus
 import hydrozoa.multisig.consensus.{BlockWeaver, RequestSequencer}
 import java.nio.file.{Files, Path}
 import org.scalacheck.Gen
@@ -54,6 +55,7 @@ class OpenApiSchemaTest extends AnyFunSuite:
                     routes <- HydrozoaRoutes(
                       requestSequencerStub,
                       blockWeaverStub,
+                      IO.pure(NodeStatus.Active),
                       None,
                       multiNodeConfig.headConfig,
                       HydrozoaServer.Config(adminUsername = "admin", adminPassword = "admin"),

--- a/src/test/scala/hydrozoa/multisig/server/ReadyEndpointTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/ReadyEndpointTest.scala
@@ -1,0 +1,83 @@
+package hydrozoa.multisig.server
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import com.suprnation.actor.Actor.{Actor, Receive}
+import com.suprnation.actor.ActorSystem
+import hydrozoa.config.GenerateSampleConfig.{defaultSpec, testPeersSpec}
+import hydrozoa.config.node.MultiNodeConfig
+import hydrozoa.lib.logging.ContraTracer
+import hydrozoa.multisig.NodeStatus
+import hydrozoa.multisig.consensus.{BlockWeaver, RequestSequencer}
+import io.circe.Json
+import org.http4s.circe.*
+import org.http4s.implicits.*
+import org.http4s.{Method, Request, Status}
+import org.scalacheck.Gen
+import org.scalacheck.rng.Seed
+import org.scalatest.funsuite.AnyFunSuite
+
+/** `GET /ready`: `200` only while the node is [[NodeStatus.Active]], `503` otherwise — and the body
+  * carries the lifecycle status label either way (the verdict is the status code; the body is
+  * diagnostic).
+  */
+class ReadyEndpointTest extends AnyFunSuite:
+
+    private val spec = defaultSpec.copy(nPeers = 1)
+
+    private val multiNodeConfig: MultiNodeConfig =
+        MultiNodeConfig
+            .generate(testPeersSpec(spec))()
+            .pureApply(Gen.Parameters.default, Seed(spec.generationSeed))
+
+    /** Build the routes with the given lifecycle status and run `GET /ready`. */
+    private def getReady(status: NodeStatus): (Status, Json) =
+        ActorSystem[IO]("ReadyEndpointTest")
+            .use { system =>
+                for {
+                    requestSequencerStub <- system.actorOf(
+                      new Actor[IO, RequestSequencer.Request] {
+                          override def receive: Receive[IO, RequestSequencer.Request] =
+                              _ => IO.pure(())
+                      }
+                    )
+                    blockWeaverStub <- system.actorOf(
+                      new Actor[IO, BlockWeaver.Request] {
+                          override def receive: Receive[IO, BlockWeaver.Request] = _ => IO.pure(())
+                      }
+                    )
+                    routes <- HydrozoaRoutes(
+                      requestSequencerStub,
+                      blockWeaverStub,
+                      IO.pure(status),
+                      None,
+                      multiNodeConfig.headConfig,
+                      HydrozoaServer.Config(adminUsername = "admin", adminPassword = "admin"),
+                      ContraTracer[IO, HydrozoaHttpEvent](_ => IO.unit)
+                    )
+                    resp <- routes.routes.orNotFound.run(Request[IO](Method.GET, uri"/ready"))
+                    body <- resp.as[Json]
+                } yield (resp.status, body)
+            }
+            .unsafeRunSync()
+
+    private def statusLabel(body: Json): Option[String] =
+        body.hcursor.downField("status").as[String].toOption
+
+    test("GET /ready is 200 with status \"active\" when the node is Active") {
+        val (status, body) = getReady(NodeStatus.Active)
+        assert(
+          status == Status.Ok && statusLabel(body).contains("active"),
+          s"expected 200 + active, got $status + ${statusLabel(body)}"
+        )
+    }
+
+    test("GET /ready is 503 with the lifecycle status when the node is not Active") {
+        val (status, body) = getReady(NodeStatus.Initializing)
+        assert(
+          status == Status.ServiceUnavailable && statusLabel(body).contains("initializing"),
+          s"expected 503 + initializing, got $status + ${statusLabel(body)}"
+        )
+    }
+
+end ReadyEndpointTest


### PR DESCRIPTION
This PR adds the last missing endpoint `/ready` that provides information on whether a Hydrozoa/Gummiworm head peer can be used to submit queries. Based on the response, a caller may decide which endpoints to use. Please dee `docs/observability-endpoints.md` for the detailed description.