### PR TITLE
feat(server): L2 utxo + recent-transactions query endpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,10 @@ Working design and reference docs live in `docs/`:
 - [`rate-limiter.md`](docs/rate-limiter.md) — generic throttling actor that slows the consensus
   cycles without changing consensus logic.
 
+**API**
+- [`l2-query-endpoints.md`](docs/l2-query-endpoints.md) — the user-facing server's read-only L2
+  queries: `GET /api/l2/utxos/{address}` and `GET /api/l2/transactions` (EUTXO-only).
+
 **Testing**
 - [`integration-stages.md`](docs/integration-stages.md) — the stage1/stage4 integration test
   levels: what each exercises and where to add a test.

--- a/build.sbt
+++ b/build.sbt
@@ -40,6 +40,7 @@ dockerCommands := dockerCommands.value.flatMap {
 val scalusVersion = "0.18.1"
 val bloxbeanVersion = "0.7.1"
 val http4sVersion = "0.23.32"
+val tapirVersion = "1.13.25"
 
 // Cardano on-chain validators and shared on-chain types
 lazy val cardanoOnchain: Project = (project in file("cardano-onchain"))
@@ -90,6 +91,12 @@ lazy val core: Project = (project in file("."))
         "org.http4s" %% "http4s-dsl" % http4sVersion,
         "org.http4s" %% "http4s-circe" % http4sVersion,
         "com.comcast" %% "ip4s-core" % "3.6.0",
+        // tapir - endpoints-as-values, self-documenting REST API + Swagger UI (CE3 / http4s 0.23)
+        "com.softwaremill.sttp.tapir" %% "tapir-http4s-server" % tapirVersion,
+        "com.softwaremill.sttp.tapir" %% "tapir-json-circe" % tapirVersion,
+        "com.softwaremill.sttp.tapir" %% "tapir-swagger-ui-bundle" % tapirVersion,
+        "com.softwaremill.sttp.tapir" %% "tapir-openapi-docs" % tapirVersion,
+        "com.softwaremill.sttp.apispec" %% "openapi-circe-yaml" % "0.11.10",
         // circe for JSON
         "io.circe" %% "circe-core" % "0.14.10",
         "io.circe" %% "circe-generic" % "0.14.10",

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ PDF). For project-wide conventions, start with the style guide.
 | [codecs.md](codecs.md) | Conventions for wire/storage codecs (working notes). |
 | [fast-consensus.md](fast-consensus.md) | The fast cycle: per-peer soft-confirmation of block headers, eager signature collection, BlockWeaver / JointLedger / FastConsensusActor roles. |
 | [integration-stages.md](integration-stages.md) | The two integration test stages under `integration/`: which stage tests what, where to add a test, what each property checks. |
+| [l2-query-endpoints.md](l2-query-endpoints.md) | The user-facing server's read-only L2 queries: `GET /api/l2/utxos/{address}` (CIP-0116 utxos) and `GET /api/l2/transactions` (recent activity); EUTXO-only, empty on a remote-ledger node. |
 | [logging-tracing.md](logging-tracing.md) | Contextual logging and tracing: Tracer, IOLocal-carried context, routing keys, migration off SLF4J MDC. |
 | [rate-limiter.md](rate-limiter.md) | A generic throttling actor that slows the fast/slow cycles (longer block/stack durations) without touching consensus logic. |
 | [slow-consensus.md](slow-consensus.md) | The slow cycle: turning a run of soft-confirmed blocks into a multisigned, L1-submittable set of effect transactions; StackComposer / hard-acks. |

--- a/docs/l2-query-endpoints.md
+++ b/docs/l2-query-endpoints.md
@@ -1,0 +1,77 @@
+# L2 query endpoints: /api/l2/utxos and /api/l2/transactions
+
+The user-facing HTTP server (`multisig/server/HydrozoaServer.scala`) exposes two read-only `GET`
+endpoints for inspecting the L2 ledger's current state and recent activity. They are the
+read counterpart to the existing write path (`POST /api/l2/submit`, `POST /api/deposit/register`).
+
+| | `GET /api/l2/utxos/{address}` | `GET /api/l2/transactions` |
+|---|---|---|
+| Answers | what does this address control on L2 now? | what happened on L2 recently? |
+| Shape | array of CIP-0116 utxos | array of transaction summaries, newest first |
+| Source | live L2 utxo set | the L2 ledger's own command log |
+
+## EUTXO-only
+
+These queries are served by the **EUTXO reference ledger** (`EutxoL2Ledger`), which holds its
+state locally. A node wired to the **remote** L2 ledger (`RemoteL2Ledger`, the SugarRush
+WebSocket) owns its state behind the black box and exposes no query channel, so on such a node
+both endpoints return an **empty array** (a valid, non-error response). This mirrors how the
+ledger already stubs its other read/recovery methods on the remote path. The queries live on
+the shared `L2LedgerReader` trait (a narrow, read-only view of `L2Ledger`), so the HTTP layer
+can read L2 state without being able to issue ledger commands.
+
+## GET /api/l2/utxos/{address}
+
+The current L2 utxos controlled by a bech32 `address`, serialized with the repo's CIP-0116
+codecs. A malformed address is a `400`; an unknown-but-well-formed address is `200 []`.
+
+```bash
+curl http://localhost:8080/api/l2/utxos/addr_test1vryvgass5dsrf2kxl3vgfz76uhp83kv5lagzcp29tcana6q4a064h
+```
+```json
+[
+  {
+    "input": { "transaction_id": "808aff…4aff", "index": 1 },
+    "output": {
+      "address": "addr_test1vryvgass5dsrf2kxl3vgfz76uhp83kv5lagzcp29tcana6q4a064h",
+      "value": {
+        "coin": "1782598159115561",
+        "assets": { "8001ac…1c": { "fdff00": "2005921964837086207" } }
+      },
+      "datum": null
+    }
+  }
+]
+```
+
+`datum` is `null` when absent, `{ "inline": "<cbor-hex>" }` for an inline datum, or
+`{ "hash": "<hex>" }` for a datum-hash reference — CIP-0116 keeps the two kinds distinct.
+
+## GET /api/l2/transactions
+
+The most recent applied L2 transactions, newest first, as lightweight summaries. `?count=N`
+bounds the number of **summaries** returned (default 50); a non-integer `count` is a `400`.
+
+```bash
+curl "http://localhost:8080/api/l2/transactions?count=10"
+```
+```json
+[
+  { "requestId": { "headPeerNumber": 0, "requestNumber": 3 },
+    "blockNumber": 3, "kind": "depositRefunded" },
+  { "requestId": { "headPeerNumber": 0, "requestNumber": 2 },
+    "blockNumber": 2, "kind": "transaction" }
+]
+```
+
+`kind` is one of `transaction`, `depositRegistered`, `depositAbsorbed`, `depositRefunded` — the
+log records applied transactions and the steps of a deposit's lifecycle. Each entry is a command
+that committed; `count` measures returned summaries (one logged command can expand to several, a
+no-op deposit decision to none), so the ledger widens its log window until it has `count`
+summaries or the log is exhausted.
+
+## Demo
+
+`multisig/server/L2QueryEndpointsTest` boots an in-memory `EutxoL2Ledger`, seeds it, builds the
+real routes, and drives both endpoints over HTTP — asserting the responses and printing the JSON,
+so the flow can be shown in a screen recording.

--- a/docs/l2-query-endpoints.md
+++ b/docs/l2-query-endpoints.md
@@ -44,8 +44,8 @@ curl http://localhost:8080/api/l2/utxos/addr_test1vryvgass5dsrf2kxl3vgfz76uhp83k
 ]
 ```
 
-`datum` is `null` when absent, `{ "inline": "<cbor-hex>" }` for an inline datum, or
-`{ "hash": "<hex>" }` for a datum-hash reference — CIP-0116 keeps the two kinds distinct.
+`datum` is `null` when the output has none; otherwise it is an object with `inline` (the datum's
+CBOR hex) or `hash` (a datum-hash reference), whichever applies — the two kinds are kept distinct.
 
 ## GET /api/l2/transactions
 
@@ -69,6 +69,18 @@ log records applied transactions and the steps of a deposit's lifecycle. Each en
 that committed; `count` measures returned summaries (one logged command can expand to several, a
 no-op deposit decision to none), so the ledger widens its log window until it has `count`
 summaries or the log is exhausted.
+
+## OpenAPI schema & Swagger UI
+
+The whole HTTP API is described as [tapir](https://tapir.softwaremill.com) endpoint values in
+`multisig/server/HydrozoaRoutes.scala`, so the OpenAPI schema is **generated from the same
+definitions that serve traffic** — it cannot drift from the routes. The running node serves:
+
+- **Swagger UI** at `GET /docs` — interactive docs for every endpoint;
+- the **raw spec** at `GET /docs/docs.yaml`.
+
+A committed snapshot lives at [`openapi.yaml`](openapi.yaml); `OpenApiSchemaTest` regenerates it
+from the endpoints and fails if the checked-in copy is stale, so the snapshot stays in sync.
 
 ## Demo
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,329 @@
+openapi: 3.1.0
+info:
+  title: Hydrozoa node API
+  version: 0.1.0
+paths:
+  /api/l2/submit:
+    post:
+      description: Submit a signed L2 transaction (a JSON UserRequest with a COSE
+        signature).
+      operationId: postApiL2Submit
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+        required: true
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RequestAcceptedResponse'
+        default:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/deposit/register:
+    post:
+      description: Register an L1 deposit (a JSON UserRequest with a COSE signature).
+      operationId: postApiDepositRegister
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+        required: true
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RequestAcceptedResponse'
+        default:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/head-info:
+    get:
+      description: Head parameters plus the current node time.
+      operationId: getApiHead-info
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HeadInfoResponse'
+        default:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/l2/utxos/{address}:
+    get:
+      description: Current L2 utxos controlled by a bech32 address (EUTXO ledger only;
+        empty otherwise).
+      operationId: getApiL2UtxosAddress
+      parameters:
+      - name: address
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/L2UtxoView'
+        default:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/l2/transactions:
+    get:
+      description: Recent applied L2 transactions, newest first (EUTXO ledger only;
+        empty otherwise).
+      operationId: getApiL2Transactions
+      parameters:
+      - name: count
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int32
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/L2TxSummaryView'
+        default:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /health:
+    get:
+      description: Liveness — always 200 while the process is serving HTTP.
+      operationId: getHealth
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthResponse'
+  /api/admin/finalize:
+    post:
+      description: Trigger head finalization (admin only).
+      operationId: postApiAdminFinalize
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FinalizeResponse'
+        default:
+          description: ''
+          headers:
+            WWW-Authenticate:
+              required: false
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      security:
+      - {}
+      - httpAuth: []
+components:
+  schemas:
+    DatumView:
+      title: DatumView
+      type: object
+      properties:
+        inline:
+          type: string
+        hash:
+          type: string
+    ErrorResponse:
+      title: ErrorResponse
+      type: object
+      required:
+      - error
+      properties:
+        error:
+          type: string
+    FinalizeResponse:
+      title: FinalizeResponse
+      type: object
+      required:
+      - status
+      - message
+      properties:
+        status:
+          type: string
+        message:
+          type: string
+    HeadInfoResponse:
+      title: HeadInfoResponse
+      type: object
+      required:
+      - headId
+      - headAddress
+      - multisigRegimeUtxo
+      - treasuryBeaconToken
+      - submissionDurationSeconds
+      - absorptionStartOffsetSeconds
+      - refundStartOffsetSeconds
+      - currentTimePosixSeconds
+      - maxNonPlutusTxFee
+      properties:
+        headId:
+          type: string
+        headAddress:
+          type: string
+        multisigRegimeUtxo:
+          $ref: '#/components/schemas/TxInputView'
+        treasuryBeaconToken:
+          type: string
+        submissionDurationSeconds:
+          type: integer
+          format: int64
+        absorptionStartOffsetSeconds:
+          type: integer
+          format: int64
+        refundStartOffsetSeconds:
+          type: integer
+          format: int64
+        currentTimePosixSeconds:
+          type: integer
+          format: int64
+        maxNonPlutusTxFee:
+          type: string
+    HealthResponse:
+      title: HealthResponse
+      type: object
+      required:
+      - status
+      properties:
+        status:
+          type: string
+    L2OutputView:
+      title: L2OutputView
+      type: object
+      required:
+      - address
+      - value
+      properties:
+        address:
+          type: string
+        value:
+          $ref: '#/components/schemas/ValueView'
+        datum:
+          $ref: '#/components/schemas/DatumView'
+    L2TxSummaryView:
+      title: L2TxSummaryView
+      type: object
+      required:
+      - requestId
+      - blockNumber
+      - kind
+      properties:
+        requestId:
+          $ref: '#/components/schemas/RequestIdView'
+        blockNumber:
+          type: integer
+          format: int32
+        kind:
+          type: string
+    L2UtxoView:
+      title: L2UtxoView
+      type: object
+      required:
+      - input
+      - output
+      properties:
+        input:
+          $ref: '#/components/schemas/TxInputView'
+        output:
+          $ref: '#/components/schemas/L2OutputView'
+    Map_Map_String_String:
+      title: Map_Map_String_String
+      type: object
+      additionalProperties:
+        $ref: '#/components/schemas/Map_String'
+    Map_String:
+      title: Map_String
+      type: object
+      additionalProperties:
+        type: string
+    RequestAcceptedResponse:
+      title: RequestAcceptedResponse
+      type: object
+      required:
+      - requestId
+      properties:
+        requestId:
+          type: integer
+          format: int64
+    RequestIdView:
+      title: RequestIdView
+      type: object
+      required:
+      - headPeerNumber
+      - requestNumber
+      properties:
+        headPeerNumber:
+          type: integer
+          format: int32
+        requestNumber:
+          type: integer
+          format: int64
+    TxInputView:
+      title: TxInputView
+      type: object
+      required:
+      - transaction_id
+      - index
+      properties:
+        transaction_id:
+          type: string
+        index:
+          type: integer
+          format: int32
+    ValueView:
+      title: ValueView
+      type: object
+      required:
+      - coin
+      - assets
+      properties:
+        coin:
+          type: string
+        assets:
+          $ref: '#/components/schemas/Map_Map_String_String'
+  securitySchemes:
+    httpAuth:
+      type: http
+      scheme: basic

--- a/src/main/scala/hydrozoa/app/Main.scala
+++ b/src/main/scala/hydrozoa/app/Main.scala
@@ -16,6 +16,7 @@ import hydrozoa.lib.logging.{ContraTracer, Slf4jMsg, Slf4jMsgFormat, Slf4jTracer
 import hydrozoa.multisig.backend.cardano.CardanoBackend
 import hydrozoa.multisig.consensus.peer.{CoilPeerNumber, HeadPeerId, HeadPeerNumber, PeerId}
 import hydrozoa.multisig.consensus.transport.{CoilPeerWsTransport, CoilPeerWsTransportEventFormat, CoilTransport, HubTransport, HubWsTransport, NodeWsServer, WsPeerTransport}
+import hydrozoa.multisig.ledger.l2.L2LedgerReader
 import hydrozoa.multisig.ledger.remote.{RemoteL2Ledger, RemoteL2LedgerEventFormat}
 import hydrozoa.multisig.persistence.rocksdb.RocksDbBackendStore
 import hydrozoa.multisig.persistence.{Cf, Persistence, PersistenceEventFormat}
@@ -169,8 +170,8 @@ object Main
 
         resource.use { case (nodeConfig, system, nodeRun) =>
             nodeRun match {
-                case NodeRun.HeadNode(mrm) =>
-                    runHeadNode(nodeConfig, system, mrm, httpExtraTracer)
+                case NodeRun.HeadNode(mrm, l2LedgerReader) =>
+                    runHeadNode(nodeConfig, system, mrm, l2LedgerReader, httpExtraTracer)
                 case NodeRun.CoilNode(mrm) =>
                     runCoilNode(system, mrm)
             }
@@ -279,7 +280,7 @@ object Main
               peerFactory,
               hubFactory,
             )
-        } yield NodeRun.HeadNode(mrm)
+        } yield NodeRun.HeadNode(mrm, remoteL2Ledger)
     }
 
     /** Build the coil-node uplink dialer (no inbound server) and allocate the
@@ -335,6 +336,7 @@ object Main
         nodeConfig: NodeConfig,
         system: ActorSystem[IO],
         mrm: HeadMultisigRegimeManager,
+        l2LedgerReader: L2LedgerReader[IO],
         httpExtraTracer: ContraTracer[IO, HydrozoaHttpEvent],
     ): IO[ExitCode] =
         for {
@@ -372,6 +374,7 @@ object Main
                             sys.error("RequestSequencer required on head peers")
                           ),
                           connections.blockWeaver,
+                          l2LedgerReader,
                           nodeConfig.headConfig,
                           serverConfig,
                           httpTracer,
@@ -396,7 +399,10 @@ object Main
 
     private sealed trait NodeRun
     private object NodeRun {
-        final case class HeadNode(mrm: HeadMultisigRegimeManager) extends NodeRun
+        final case class HeadNode(
+            mrm: HeadMultisigRegimeManager,
+            l2LedgerReader: L2LedgerReader[IO],
+        ) extends NodeRun
         final case class CoilNode(mrm: CoilMultisigRegimeManager) extends NodeRun
     }
 }

--- a/src/main/scala/hydrozoa/multisig/ledger/eutxol2/EutxoL2Ledger.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/eutxol2/EutxoL2Ledger.scala
@@ -23,6 +23,7 @@ import io.bullet.borer.Cbor
 import monocle.syntax.all.*
 import scala.collection.immutable.TreeMap
 import scala.util.Try
+import scalus.cardano.address.Address
 import scalus.cardano.ledger.*
 import scalus.uplc.builtin.ByteString
 
@@ -258,6 +259,45 @@ case class EutxoL2Ledger private (
         commitReal(req).void
 
     override def currentCommandNumber: IO[L2CommandNumber] = state.get.map(_.commandNumber)
+
+    /** The committed L2 utxos this address controls — a live filter over `activeUtxos`. Concurrent
+      * with the JointLedger-driven command path (a plain `Ref` read), so it observes the state as
+      * of the last committed command.
+      */
+    override def utxosByAddress(address: Address): IO[Utxos] =
+        state.get.map(_.activeUtxos.filter((_, output) => output.address == address))
+
+    /** The most recent `limit` applied L2 transactions, newest first, projected to
+      * [[L2TxSummary]]s. Reads the tail of the store's own command log, so it needs no separate
+      * history: for the EUTXO ledger the logged command *is* the record of what happened.
+      *
+      * `limit` counts returned summaries, not commands scanned — one command can expand to several
+      * summaries and a no-op deposit decision to none — so the log window is widened backward until
+      * `limit` summaries are collected or the log is exhausted. Each earlier batch is strictly
+      * older, so accumulating preserves newest-first order.
+      */
+    override def recentTransactions(limit: Int): IO[Vector[L2TxSummary]] =
+        if limit <= 0 then IO.pure(Vector.empty)
+        else
+            state.get.map(_.commandNumber).flatMap { current =>
+                def collect(
+                    upTo: L2CommandNumber,
+                    acc: Vector[L2TxSummary]
+                ): IO[Vector[L2TxSummary]] =
+                    if acc.sizeIs >= limit || upTo.value <= 0L then IO.pure(acc)
+                    else
+                        val fromExclusive =
+                            L2CommandNumber(math.max(0L, upTo.value - limit.toLong))
+                        store
+                            .logRange(fromExclusive, upTo)
+                            .flatMap(commands =>
+                                collect(
+                                  fromExclusive,
+                                  acc ++ commands.reverse.flatMap(L2TxSummary.fromCommand)
+                                )
+                            )
+                collect(current, Vector.empty).map(_.take(limit))
+            }
 
     /** Read the full in-memory state — package-private, for recovery tests that assert a restored
       * ledger matches the live one. Not part of the [[L2Ledger]] interface.

--- a/src/main/scala/hydrozoa/multisig/ledger/l2/L2Ledger.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/l2/L2Ledger.scala
@@ -65,7 +65,7 @@ object L2LedgerState:
   *   A monad in which the "transport" runs. This will be IO for most implementations (for network
   *   or unix socket access, etc), but can also be something like [[State]] for pure implementations
   */
-trait L2Ledger[F[_]] {
+trait L2Ledger[F[_]] extends L2LedgerReader[F] {
     implicit def monadF: Monad[F]
 
     /** See:

--- a/src/main/scala/hydrozoa/multisig/ledger/l2/L2LedgerReader.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/l2/L2LedgerReader.scala
@@ -1,0 +1,24 @@
+package hydrozoa.multisig.ledger.l2
+
+import scalus.cardano.address.Address
+import scalus.cardano.ledger.Utxos
+
+/** The read-only L2-ledger queries the user-facing HTTP server exposes (`GET /api/l2/utxos`,
+  * `GET /api/l2/transactions`). A narrow view of [[L2Ledger]] — the server is handed only this, so
+  * it can read L2 state but cannot issue ledger commands.
+  *
+  * These reads are meaningful only for a ledger that holds its state locally (the EUTXO reference
+  * ledger, [[hydrozoa.multisig.ledger.eutxol2.EutxoL2Ledger]]); an implementation that owns its
+  * state elsewhere (a remote black box) returns empty results.
+  */
+trait L2LedgerReader[F[_]]:
+    /** The current L2 utxo set restricted to `address` — the outputs that address controls right
+      * now. A live read of the ledger's committed state (no consensus round-trip).
+      */
+    def utxosByAddress(address: Address): F[Utxos]
+
+    /** The most recently applied L2 commands, newest first, at most `limit` — a window over the
+      * ledger's own command log projected to lightweight [[L2TxSummary]]s. Every entry is a command
+      * that committed.
+      */
+    def recentTransactions(limit: Int): F[Vector[L2TxSummary]]

--- a/src/main/scala/hydrozoa/multisig/ledger/l2/L2TxSummary.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/l2/L2TxSummary.scala
@@ -1,0 +1,36 @@
+package hydrozoa.multisig.ledger.l2
+
+import hydrozoa.multisig.ledger.block.BlockNumber
+import hydrozoa.multisig.ledger.event.RequestId
+
+/** A lightweight record of one applied L2 command, as surfaced by
+  * [[L2LedgerReader.recentTransactions]]. Derived from the L2 ledger's own command log, so every
+  * summary corresponds to a command that committed.
+  */
+final case class L2TxSummary(
+    requestId: RequestId,
+    blockNumber: BlockNumber,
+    kind: L2TxKind
+)
+
+/** What an [[L2TxSummary]] records: an applied L2 transaction, or a step in a deposit's lifecycle.
+  */
+enum L2TxKind:
+    case Transaction, DepositRegistered, DepositAbsorbed, DepositRefunded
+
+object L2TxSummary:
+    /** Expand one logged real command into its summaries, in the order they appear to a reader. A
+      * transaction or a deposit registration is a single summary; a deposit-decisions command is
+      * one summary per absorbed deposit followed by one per refunded deposit (so a no-op decisions
+      * command with empty lists yields none).
+      */
+    def fromCommand(command: L2LedgerCommand.Real): Vector[L2TxSummary] = command match
+        case c: L2LedgerCommand.ApplyTransaction =>
+            Vector(L2TxSummary(c.requestId, c.blockNumber, L2TxKind.Transaction))
+        case c: L2LedgerCommand.RegisterDeposit =>
+            Vector(L2TxSummary(c.requestId, c.blockNumber, L2TxKind.DepositRegistered))
+        case c: L2LedgerCommand.ApplyDepositDecisions =>
+            c.absorbedDeposits.toVector
+                .map(id => L2TxSummary(id, c.blockNumber, L2TxKind.DepositAbsorbed))
+                ++ c.refundedDeposits.toVector
+                    .map(id => L2TxSummary(id, c.blockNumber, L2TxKind.DepositRefunded))

--- a/src/main/scala/hydrozoa/multisig/ledger/remote/RemoteL2Ledger.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/remote/RemoteL2Ledger.scala
@@ -7,7 +7,7 @@ import hydrozoa.config.head.network.CardanoNetwork
 import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.ledger.joint.EvacuationDiff
 import hydrozoa.multisig.ledger.joint.obligation.Payout
-import hydrozoa.multisig.ledger.l2.{L2CommandNumber, L2Ledger, L2LedgerCommand, L2LedgerError}
+import hydrozoa.multisig.ledger.l2.{L2CommandNumber, L2Ledger, L2LedgerCommand, L2LedgerError, L2TxSummary}
 import hydrozoa.multisig.ledger.remote
 import hydrozoa.multisig.ledger.remote.RemoteL2Ledger.{Request, Response}
 import hydrozoa.multisig.ledger.remote.RemoteL2LedgerEvent.*
@@ -18,6 +18,8 @@ import org.http4s.Uri
 import org.http4s.client.websocket.{WSConnectionHighLevel, WSFrame, WSRequest}
 import org.http4s.jdkhttpclient.JdkWSClient
 import scala.concurrent.duration.*
+import scalus.cardano.address.Address
+import scalus.cardano.ledger.Utxos
 
 /** A remote L2Ledger implementation that communicates with a black-box ledger over WebSocket.
   *
@@ -168,6 +170,15 @@ class RemoteL2Ledger private (
     /** Unsupported — see [[currentCommandNumber]]. */
     override def restoreTo(commandNumber: L2CommandNumber): EitherT[IO, L2LedgerError, Unit] =
         EitherT.leftT(L2LedgerError("restoreTo is not supported by RemoteL2Ledger"))
+
+    /** The remote black-box ledger owns its state behind the WebSocket and exposes no query
+      * channel, so the L2-query endpoints have nothing to read here; return an empty utxo set (the
+      * queries are meaningful only against the local EUTXO ledger). See [[currentCommandNumber]].
+      */
+    override def utxosByAddress(address: Address): IO[Utxos] = IO.pure(Map.empty)
+
+    /** Unsupported — see [[utxosByAddress]]; returns no transactions. */
+    override def recentTransactions(limit: Int): IO[Vector[L2TxSummary]] = IO.pure(Vector.empty)
 }
 
 object RemoteL2Ledger {

--- a/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
+++ b/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
@@ -1,0 +1,171 @@
+package hydrozoa.multisig.server
+
+import hydrozoa.config.head.HeadConfig
+import hydrozoa.multisig.ledger.event.RequestId
+import hydrozoa.multisig.ledger.l2.{L2TxKind, L2TxSummary}
+import io.bullet.borer.Cbor
+import io.circe.Codec
+import io.circe.generic.semiauto.deriveCodec
+import scalus.cardano.address.{Address, ShelleyAddress}
+import scalus.cardano.ledger.{DatumOption, TransactionInput, TransactionOutput, Value}
+import scalus.uplc.builtin.ByteString
+
+/** Flat data-transfer objects for the HTTP API responses.
+  *
+  * These exist so the endpoints have a single self-documenting contract: every field is a
+  * primitive, string, list, or map, so both the circe JSON codecs and the tapir OpenAPI schemas
+  * derive from them automatically — no hand-written encoder can drift from the generated schema.
+  * The handlers map the domain types onto these; the string forms match the project's CIP-0116
+  * conventions (bech32 addresses, hex hashes, decimal-string coins/quantities).
+  */
+object ApiDto {
+
+    /** `{ "status": "ok" }` — the liveness body. */
+    final case class HealthResponse(status: String)
+    given Codec[HealthResponse] = deriveCodec
+
+    /** `{ "status": "success", "message": ... }` — the finalize-trigger body. */
+    final case class FinalizeResponse(status: String, message: String)
+    given Codec[FinalizeResponse] = deriveCodec
+
+    /** `{ "requestId": <i64> }` — a write request's assigned id, packed as the SugarRush i64 form.
+      */
+    final case class RequestAcceptedResponse(requestId: Long)
+    given Codec[RequestAcceptedResponse] = deriveCodec
+
+    /** Map an accepted write request's id to its i64 response body. */
+    def mkRequestAcceptedResponse(id: RequestId): RequestAcceptedResponse =
+        RequestAcceptedResponse(id.asI64)
+
+    /** `{ "error": ... }` — the error body used across the API. */
+    final case class ErrorResponse(error: String)
+    given Codec[ErrorResponse] = deriveCodec
+
+    /** A request id in object form, `{ headPeerNumber, requestNumber }`. */
+    final case class RequestIdView(headPeerNumber: Int, requestNumber: Long)
+
+    /** Map a request id to its object-form view. */
+    def mkRequestIdView(id: RequestId): RequestIdView =
+        val (headPeerNumber, requestNumber) = id.convert
+        RequestIdView(headPeerNumber, requestNumber)
+
+    /** One entry of the recent-transactions feed. */
+    final case class L2TxSummaryView(
+        requestId: RequestIdView,
+        blockNumber: Int,
+        kind: String
+    )
+    given Codec[RequestIdView] = deriveCodec
+    given Codec[L2TxSummaryView] = deriveCodec
+
+    /** Map an applied-command summary to its recent-transactions feed entry. */
+    def mkL2TxSummaryView(summary: L2TxSummary): L2TxSummaryView =
+        L2TxSummaryView(
+          requestId = mkRequestIdView(summary.requestId),
+          blockNumber = summary.blockNumber.convert,
+          kind = kindName(summary.kind)
+        )
+
+    private def kindName(kind: L2TxKind): String = kind match
+        case L2TxKind.Transaction       => "transaction"
+        case L2TxKind.DepositRegistered => "depositRegistered"
+        case L2TxKind.DepositAbsorbed   => "depositAbsorbed"
+        case L2TxKind.DepositRefunded   => "depositRefunded"
+
+    /** A utxo reference, `{ transaction_id, index }` (CIP-0116). */
+    final case class TxInputView(transaction_id: String, index: Int)
+
+    /** A Cardano value: ADA in `coin`, native assets nested policy → asset → quantity. */
+    final case class ValueView(coin: String, assets: Map[String, Map[String, String]])
+
+    /** An output's datum: at most one of `inline` (CBOR hex) or `hash` (hex); absent when none. */
+    final case class DatumView(inline: Option[String], hash: Option[String])
+
+    /** One L2 output: address, value, and (optional) datum. */
+    final case class L2OutputView(address: String, value: ValueView, datum: Option[DatumView])
+
+    /** One L2 utxo: its input reference and the output it holds. */
+    final case class L2UtxoView(input: TxInputView, output: L2OutputView)
+
+    given Codec[TxInputView] = deriveCodec
+    given Codec[ValueView] = deriveCodec
+    given Codec[DatumView] = deriveCodec
+    given Codec[L2OutputView] = deriveCodec
+    given Codec[L2UtxoView] = deriveCodec
+
+    /** Map an L2 utxo (its input reference and output) to its API view. */
+    def mkL2UtxoView(input: TransactionInput, output: TransactionOutput): L2UtxoView =
+        L2UtxoView(mkTxInputView(input), mkL2OutputView(output))
+
+    private def mkTxInputView(input: TransactionInput): TxInputView =
+        TxInputView(input.transactionId.toHex, input.index.toInt)
+
+    private def mkL2OutputView(output: TransactionOutput): L2OutputView =
+        L2OutputView(addressBech32(output.address), mkValueView(output.value), mkDatumView(output))
+
+    private def addressBech32(address: Address): String =
+        address match
+            case shelley: ShelleyAddress => shelley.toBech32.getOrElse(shelley.toHex)
+            case other                   => other.toString
+
+    private def mkValueView(value: Value): ValueView =
+        val assets = value.assets.assets.map { (policyId, byName) =>
+            policyId.toHex -> byName.map { (assetName, quantity) =>
+                assetName.bytes.toHex -> java.lang.Long.toUnsignedString(quantity)
+            }.toMap
+        }.toMap
+        ValueView(java.lang.Long.toUnsignedString(value.coin.value), assets)
+
+    private def mkDatumView(output: TransactionOutput): Option[DatumView] =
+        output match
+            case TransactionOutput.Shelley(_, _, datumHash) =>
+                datumHash.map(hash => DatumView(inline = None, hash = Some(hash.toHex)))
+            case TransactionOutput.Babbage(_, _, datumOption, _) =>
+                datumOption.map {
+                    case DatumOption.Inline(data) =>
+                        DatumView(
+                          inline = Some(ByteString.fromArray(Cbor.encode(data).toByteArray).toHex),
+                          hash = None
+                        )
+                    case DatumOption.Hash(hash) =>
+                        DatumView(inline = None, hash = Some(hash.toHex))
+                }
+
+    /** The head-parameters body. All hashes/ids are hex; the address is bech32; coins are decimal
+      * strings; the beacon token is `policyIdHex.assetNameHex`.
+      */
+    final case class HeadInfoResponse(
+        headId: String,
+        headAddress: String,
+        multisigRegimeUtxo: TxInputView,
+        treasuryBeaconToken: String,
+        submissionDurationSeconds: Long,
+        absorptionStartOffsetSeconds: Long,
+        refundStartOffsetSeconds: Long,
+        currentTimePosixSeconds: Long,
+        maxNonPlutusTxFee: String
+    )
+    given Codec[HeadInfoResponse] = deriveCodec
+
+    /** Map the head config plus the current node time to the head-parameters response. */
+    def mkHeadInfoResponse(
+        headConfig: HeadConfig,
+        currentTimePosixSeconds: Long
+    ): HeadInfoResponse =
+        HeadInfoResponse(
+          headId = headConfig.headId.bytes.toHex,
+          headAddress = headConfig.headMultisigAddress.toBech32
+              .getOrElse(headConfig.headMultisigAddress.toHex),
+          multisigRegimeUtxo = mkTxInputView(headConfig.multisigRegimeUtxo.input),
+          treasuryBeaconToken =
+              s"${headConfig.headMultisigScript.policyId.toHex}.${headConfig.headTokenNames.treasuryTokenName.bytes.toHex}",
+          submissionDurationSeconds =
+              headConfig.txTiming.depositSubmissionDuration.finiteDuration.toSeconds,
+          absorptionStartOffsetSeconds =
+              headConfig.txTiming.absorptionStartOffsetDuration.finiteDuration.toSeconds,
+          refundStartOffsetSeconds =
+              headConfig.txTiming.refundStartOffsetDuration.finiteDuration.toSeconds,
+          currentTimePosixSeconds = currentTimePosixSeconds,
+          maxNonPlutusTxFee = java.lang.Long.toUnsignedString(headConfig.maxNonPlutusTxFee.value)
+        )
+}

--- a/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
+++ b/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
@@ -1,27 +1,34 @@
 package hydrozoa.multisig.server
 
-import cats.data.Validated.Invalid
 import cats.effect.IO
-import fs2.Stream
 import hydrozoa.config.head.HeadConfig
-import hydrozoa.config.head.network.CardanoNetwork
 import hydrozoa.lib.logging.ContraTracer
-import hydrozoa.multisig.consensus.{BlockWeaver, RequestSequencer, UserRequest}
+import hydrozoa.multisig.consensus.{BlockWeaver, RequestSequencer}
 import hydrozoa.multisig.ledger.l2.L2LedgerReader
-import hydrozoa.multisig.server.ApiResponse.{CardanoNativeToken, Error, HeadInfo, RequestAccepted}
+import hydrozoa.multisig.server.ApiDto.*
 import hydrozoa.multisig.server.HydrozoaHttpEvent.*
-import hydrozoa.multisig.server.JsonCodecs.{UserRequestDecoder, given}
-import io.circe.syntax.*
-import org.http4s.circe.*
-import org.http4s.dsl.io.*
-import org.http4s.headers.Authorization
-import org.http4s.{BasicCredentials, EntityDecoder, HttpRoutes}
+import hydrozoa.multisig.server.JsonCodecs.UserRequestDecoder
+import hydrozoa.multisig.server.TapirJson.*
+import org.http4s.HttpRoutes
 import scala.util.Try
 import scalus.cardano.address.Address
-import scalus.cardano.ledger.Utxo
+import sttp.apispec.openapi.circe.yaml.*
+import sttp.model.StatusCode
+import sttp.model.headers.WWWAuthenticateChallenge
+import sttp.tapir.*
+import sttp.tapir.docs.openapi.{OpenAPIDocsInterpreter, OpenAPIDocsOptions}
+import sttp.tapir.generic.auto.*
+import sttp.tapir.model.UsernamePassword
+import sttp.tapir.server.ServerEndpoint
+import sttp.tapir.server.http4s.Http4sServerInterpreter
+import sttp.tapir.swagger.bundle.SwaggerInterpreter
 
-/** HTTP routes for the Hydrozoa server. These routes are what get called by the frontend (or a
-  * proxy -- load-balancer, unified api).
+/** The Hydrozoa node's user-facing HTTP API, described as tapir endpoint values.
+  *
+  * Endpoints-as-data is what makes the OpenAPI schema (and Swagger UI) genuinely *generated* from
+  * the same definitions that serve traffic — there is one source of truth, so the docs cannot drift
+  * from the routes. The tapir http4s interpreter stays inside cats-effect: handlers are `IO`, the
+  * result is a plain `HttpRoutes[IO]`, and it mounts on the same Ember server.
   */
 class HydrozoaRoutes(
     requestSequencer: RequestSequencer.Handle,
@@ -31,212 +38,248 @@ class HydrozoaRoutes(
     serverConfig: HydrozoaServer.Config,
     tracer: ContraTracer[IO, HydrozoaHttpEvent]
 ) {
-    private given HeadConfig = headConfig
+    import HydrozoaRoutes.{apiTitle, apiVersion}
 
-    /** Optional `?count=` on `GET /api/l2/transactions`; absent ⇒ [[defaultRecentTxCount]], present
-      * but non-integer ⇒ a 400 (like a malformed address), rather than falling through to a 404.
-      */
-    private object CountQueryParam extends OptionalValidatingQueryParamDecoderMatcher[Int]("count")
+    private given HeadConfig = headConfig
 
     /** How many recent L2 transactions to return when `?count=` is omitted. */
     private val defaultRecentTxCount = 50
 
-    /** Parse a bech32 address from the request path, or a message describing why it is malformed.
+    /** The COSE-validating decoder for user requests (deposit registrations and L2 transactions).
       */
+    private val userRequestDecoder: UserRequestDecoder = UserRequestDecoder()
+
+    /** The shared error output: an HTTP status plus an `{ error }` body. */
+    private val errorOut: EndpointOutput[(StatusCode, ErrorResponse)] =
+        statusCode.and(jsonBody[ErrorResponse])
+
+    private def fail(code: StatusCode, message: String): (StatusCode, ErrorResponse) =
+        (code, ErrorResponse(message))
+
+    /** The admin realm advertised on a `401` from the finalize endpoint. */
+    private val adminChallenge: WWWAuthenticateChallenge =
+        WWWAuthenticateChallenge.basic("Hydrozoa Admin")
+
+    /** Finalize's error output — like [[errorOut]], but carrying an optional `WWW-Authenticate`
+      * header so a `401` re-advertises the Basic challenge (as the old route did).
+      */
+    private val finalizeErrorOut: EndpointOutput[(StatusCode, Option[String], ErrorResponse)] =
+        statusCode.and(header[Option[String]]("WWW-Authenticate")).and(jsonBody[ErrorResponse])
+
+    // ---- Endpoint definitions (the single source of truth for routes + schema) ----
+
+    private val submitEndpoint: ServerEndpoint[Any, IO] =
+        endpoint.post
+            .in("api" / "l2" / "submit")
+            .in(stringJsonBody)
+            .out(jsonBody[RequestAcceptedResponse])
+            .errorOut(errorOut)
+            .description(
+              "Submit a signed L2 transaction (a JSON UserRequest with a COSE signature)."
+            )
+            .serverLogic(body => acceptUserRequest("POST /api/l2/submit", body))
+
+    private val registerDepositEndpoint: ServerEndpoint[Any, IO] =
+        endpoint.post
+            .in("api" / "deposit" / "register")
+            .in(stringJsonBody)
+            .out(jsonBody[RequestAcceptedResponse])
+            .errorOut(errorOut)
+            .description("Register an L1 deposit (a JSON UserRequest with a COSE signature).")
+            .serverLogic(body => acceptUserRequest("POST /api/deposit/register", body))
+
+    private val headInfoEndpoint: ServerEndpoint[Any, IO] =
+        endpoint.get
+            .in("api" / "head-info")
+            .out(jsonBody[HeadInfoResponse])
+            .errorOut(errorOut)
+            .description("Head parameters plus the current node time.")
+            .serverLogic(_ =>
+                IO.realTimeInstant
+                    .map(_.getEpochSecond)
+                    .map(now => Right(ApiDto.mkHeadInfoResponse(headConfig, now)))
+                    .handleError(err => Left(fail(StatusCode.InternalServerError, err.getMessage)))
+            )
+
+    private val l2UtxosEndpoint: ServerEndpoint[Any, IO] =
+        endpoint.get
+            .in("api" / "l2" / "utxos" / path[String]("address"))
+            .out(jsonBody[List[L2UtxoView]])
+            .errorOut(errorOut)
+            .description(
+              "Current L2 utxos controlled by a bech32 address (EUTXO ledger only; empty otherwise)."
+            )
+            .serverLogic(address =>
+                parseAddress(address) match {
+                    case Left(message) => IO.pure(Left(fail(StatusCode.BadRequest, message)))
+                    case Right(addr) =>
+                        l2LedgerReader
+                            .utxosByAddress(addr)
+                            .map(utxos =>
+                                Right(utxos.toList.map((in, out) => ApiDto.mkL2UtxoView(in, out)))
+                            )
+                            .handleError(err =>
+                                Left(fail(StatusCode.InternalServerError, err.getMessage))
+                            )
+                }
+            )
+
+    private val l2TransactionsEndpoint: ServerEndpoint[Any, IO] =
+        endpoint.get
+            .in("api" / "l2" / "transactions")
+            .in(query[Option[Int]]("count"))
+            .out(jsonBody[List[L2TxSummaryView]])
+            .errorOut(errorOut)
+            .description(
+              "Recent applied L2 transactions, newest first (EUTXO ledger only; empty otherwise)."
+            )
+            .serverLogic(count =>
+                l2LedgerReader
+                    .recentTransactions(count.getOrElse(defaultRecentTxCount))
+                    .map(summaries => Right(summaries.map(ApiDto.mkL2TxSummaryView).toList))
+                    .handleError(err => Left(fail(StatusCode.InternalServerError, err.getMessage)))
+            )
+
+    private val healthEndpoint: ServerEndpoint[Any, IO] =
+        endpoint.get
+            .in("health")
+            .out(jsonBody[HealthResponse])
+            .description("Liveness — always 200 while the process is serving HTTP.")
+            .serverLogicSuccess(_ => IO.pure(HealthResponse("ok")))
+
+    private val finalizeEndpoint: ServerEndpoint[Any, IO] =
+        endpoint.post
+            // Optional credentials so the security logic runs (and logs) even when the header is
+            // absent, rather than tapir short-circuiting the missing-header case.
+            .securityIn(auth.basic[Option[UsernamePassword]](adminChallenge))
+            .in("api" / "admin" / "finalize")
+            .out(jsonBody[FinalizeResponse])
+            .errorOut(finalizeErrorOut)
+            .description("Trigger head finalization (admin only).")
+            .serverSecurityLogic {
+                case Some(credentials)
+                    if credentials.username == serverConfig.adminUsername
+                        && credentials.password.contains(serverConfig.adminPassword) =>
+                    IO.pure(Right(()))
+                case _ =>
+                    tracer
+                        .traceWith(UnauthorizedAdmin("POST /api/admin/finalize"))
+                        .as(
+                          Left(
+                            (
+                              StatusCode.Unauthorized,
+                              Some(adminChallenge.toString),
+                              ErrorResponse("Unauthorized")
+                            )
+                          )
+                        )
+            }
+            .serverLogic(_ =>
+                _ =>
+                    (for {
+                        _ <- tracer.traceWith(FinalizeTriggered)
+                        _ <- blockWeaver ! BlockWeaver.LocalFinalizationTrigger.Triggered
+                        _ <- tracer.traceWith(FinalizeSignalSent)
+                    } yield Right(
+                      FinalizeResponse("success", "Head finalization triggered")
+                    )).handleErrorWith(err =>
+                        tracer
+                            .traceWith(RequestFailed("POST /api/admin/finalize", err))
+                            .as(
+                              Left(
+                                (
+                                  StatusCode.InternalServerError,
+                                  None,
+                                  ErrorResponse(err.getMessage)
+                                )
+                              )
+                            )
+                    )
+            )
+
+    /** Every API endpoint, in the order they appear in the docs. */
+    private val apiEndpoints: List[ServerEndpoint[Any, IO]] =
+        List(
+          submitEndpoint,
+          registerDepositEndpoint,
+          headInfoEndpoint,
+          l2UtxosEndpoint,
+          l2TransactionsEndpoint,
+          healthEndpoint,
+          finalizeEndpoint
+        )
+
+    /** Don't auto-document a body/param decode-failure response: our JSON bodies are raw strings
+      * whose codec never fails, so tapir's default would advertise an unreachable `text/plain` 400
+      * that contradicts the real JSON `ErrorResponse`. The genuine errors are on each endpoint's
+      * declared error output.
+      */
+    private val docsOptions: OpenAPIDocsOptions =
+        OpenAPIDocsOptions.default.copy(defaultDecodeFailureOutput = _ => None)
+
+    /** Swagger UI (served at `/docs`) + the raw OpenAPI document, derived from [[apiEndpoints]]. */
+    private val docsEndpoints: List[ServerEndpoint[Any, IO]] =
+        SwaggerInterpreter(openAPIInterpreterOptions = docsOptions)
+            .fromServerEndpoints[IO](apiEndpoints, apiTitle, apiVersion)
+
+    /** The full route set: the API plus the self-generated docs. */
+    val routes: HttpRoutes[IO] =
+        Http4sServerInterpreter[IO]().toRoutes(apiEndpoints ++ docsEndpoints)
+
+    /** The generated OpenAPI document as YAML — the artifact the golden test pins. */
+    def openApiYaml: String =
+        OpenAPIDocsInterpreter(docsOptions)
+            .toOpenAPI(apiEndpoints.map(_.endpoint), apiTitle, apiVersion)
+            .toYaml
+
+    // ---- Handlers ----
+
+    /** Parse + COSE-validate a user request, forward it to the sequencer, and return the assigned
+      * id — preserving the body / decode-error / failure tracing. Any failure is a 400.
+      */
+    private def acceptUserRequest(
+        path: String,
+        bodyText: String
+    ): IO[Either[(StatusCode, ErrorResponse), RequestAcceptedResponse]] =
+        val handled =
+            for {
+                _ <- tracer.traceWith(RequestBody(path, bodyText))
+                json <- io.circe.parser.parse(bodyText) match {
+                    case Left(parseError) =>
+                        tracer.traceWith(JsonParseError(path, parseError)) *>
+                            IO.raiseError(parseError)
+                    case Right(json) => IO.pure(json)
+                }
+                userRequest <- userRequestDecoder.decodeJson(json) match {
+                    case Left(decodeError) =>
+                        tracer.traceWith(JsonDecodeError(path, decodeError)) *>
+                            tracer.traceWith(
+                              JsonDecodeErrorHistory(path, decodeError.history.toString)
+                            ) *> IO.raiseError(decodeError)
+                    case Right(request) => IO.pure(request)
+                }
+                _ <- tracer.traceWith(RequestDecoded(path, userRequest.toString))
+                requestId <- requestSequencer ?: userRequest
+            } yield ApiDto.mkRequestAcceptedResponse(requestId)
+
+        handled
+            .map(Right(_))
+            .handleErrorWith(err =>
+                tracer
+                    .traceWith(RequestFailed(path, err))
+                    .as(Left(fail(StatusCode.BadRequest, err.getMessage)))
+            )
+
+    /** Parse a bech32 address, or a message describing why it is malformed. */
     private def parseAddress(bech32: String): Either[String, Address] =
         Try(Address.fromBech32(bech32)).toEither.left
             .map(err => s"Invalid bech32 address '$bech32': ${err.getMessage}")
-
-    /** Check if the provided credentials match the configured admin credentials */
-    private def checkAuth(req: org.http4s.Request[IO]): Boolean =
-        req.headers.get[Authorization] match {
-            case Some(Authorization(BasicCredentials(username, password))) =>
-                username == serverConfig.adminUsername && password == serverConfig.adminPassword
-            case _ => false
-        }
-
-    // Implicit decoders for request bodies
-    given depositRequestEntityDecoder(using
-        CardanoNetwork.Section
-    ): EntityDecoder[IO, UserRequest] =
-        jsonOf[IO, UserRequest]
-
-    private val userRequestDecoder: JsonCodecs.UserRequestDecoder = UserRequestDecoder()
-
-    val routes: HttpRoutes[IO] = HttpRoutes.of[IO] {
-
-        // POST /api/l2/submit - Submit an L2 transaction
-        case req @ POST -> Root / "api" / "l2" / "submit" =>
-            val path = "POST /api/l2/submit"
-            val result: IO[org.http4s.Response[IO]] = for {
-                bodyText <- req.bodyText.compile.string
-                _ <- tracer.traceWith(RequestHeaders(path, req.headers.toString))
-                _ <- tracer.traceWith(RequestBody(path, bodyText))
-                // Try to parse as JSON to get better error messages
-                _ <- io.circe.parser.parse(bodyText) match {
-                    case Left(parseError) =>
-                        tracer.traceWith(JsonParseError(path, parseError))
-                    case Right(json) =>
-                        userRequestDecoder.decodeJson(json) match {
-                            case Left(decodeError) =>
-                                tracer.traceWith(JsonDecodeError(path, decodeError)) *>
-                                    tracer.traceWith(
-                                      JsonDecodeErrorHistory(path, decodeError.history.toString)
-                                    )
-                            case Right(_) =>
-                                IO.unit
-                        }
-                }
-                // Re-create request with the body we just read
-                newReq = req.withBodyStream(Stream.emits(bodyText.getBytes))
-                transactionRequest <- newReq.as[UserRequest]
-                _ <- tracer.traceWith(RequestDecoded(path, transactionRequest.toString))
-                // Send synchronous request to RequestSequencer and get back RequestId
-                requestId <- requestSequencer ?: transactionRequest
-                response = RequestAccepted(requestId = requestId)
-                resp <- Ok(response.asJson)
-            } yield resp
-
-            result.handleErrorWith { err =>
-                tracer.traceWith(RequestFailed(path, err)) *>
-                    BadRequest(Error(error = err.getMessage).asJson)
-            }
-
-        // POST /api/deposit/register - Register a deposit
-        case req @ POST -> Root / "api" / "deposit" / "register" =>
-            val path = "POST /api/deposit/register"
-            val result: IO[org.http4s.Response[IO]] = for {
-                bodyText <- req.bodyText.compile.string
-                _ <- tracer.traceWith(RequestHeaders(path, req.headers.toString))
-                _ <- tracer.traceWith(RequestBody(path, bodyText))
-                _ <- io.circe.parser.parse(bodyText) match {
-                    case Left(parseError) =>
-                        tracer.traceWith(JsonParseError(path, parseError))
-                    case Right(json) =>
-                        io.circe.Decoder[UserRequest].decodeJson(json) match {
-                            case Left(decodeError) =>
-                                tracer.traceWith(JsonDecodeError(path, decodeError)) *>
-                                    tracer.traceWith(
-                                      JsonDecodeErrorHistory(path, decodeError.history.toString)
-                                    )
-                            case Right(_) =>
-                                IO.unit
-                        }
-                }
-                newReq = req.withBodyStream(Stream.emits(bodyText.getBytes))
-                depositRequest <- newReq.as[UserRequest]
-                _ <- tracer.traceWith(RequestDecoded(path, depositRequest.toString))
-                requestId <- requestSequencer ?: depositRequest
-                response = RequestAccepted(requestId)
-                resp <- Ok(response.asJson)
-            } yield resp
-
-            result.handleErrorWith { err =>
-                tracer.traceWith(RequestFailed(path, err)) *>
-                    BadRequest(Error(error = err.getMessage).asJson)
-            }
-
-        // GET /api/head-info
-        case GET -> Root / "api" / "head-info" =>
-            val result: IO[org.http4s.Response[IO]] = for {
-                currentTimePosixSeconds <- IO.realTimeInstant.map(_.getEpochSecond)
-                resp <- Ok(
-                  HeadInfo(
-                    headId = headConfig.headId,
-                    headAddress = headConfig.headMultisigAddress,
-                    multisigRegimeUtxo = headConfig.multisigRegimeUtxo.input,
-                    treasuryBeaconToken = CardanoNativeToken(
-                      headConfig.headMultisigScript.policyId,
-                      headConfig.headTokenNames.treasuryTokenName
-                    ),
-                    submissionDurationSeconds =
-                        headConfig.txTiming.depositSubmissionDuration.finiteDuration.toSeconds,
-                    absorptionStartOffsetSeconds =
-                        headConfig.txTiming.absorptionStartOffsetDuration.finiteDuration.toSeconds,
-                    refundStartOffsetSeconds =
-                        headConfig.txTiming.refundStartOffsetDuration.finiteDuration.toSeconds,
-                    currentTimePosixSeconds = currentTimePosixSeconds,
-                    maxNonPlutusTxFee = headConfig.maxNonPlutusTxFee
-                  ).asJson
-                )
-            } yield resp
-
-            result.handleErrorWith { err =>
-                InternalServerError(Error(error = err.getMessage).asJson)
-            }
-
-        // GET /api/l2/utxos/{address} - current L2 utxos controlled by an address, CIP-0116-style.
-        // Returns data only on an EUTXO-backed node; empty otherwise (see L2LedgerReader).
-        case GET -> Root / "api" / "l2" / "utxos" / address =>
-            parseAddress(address) match {
-                case Left(err) => BadRequest(Error(error = err).asJson)
-                case Right(addr) =>
-                    l2LedgerReader
-                        .utxosByAddress(addr)
-                        .flatMap(utxos =>
-                            Ok(utxos.toList.map((input, output) => Utxo(input, output)).asJson)
-                        )
-                        .handleErrorWith(err =>
-                            InternalServerError(Error(error = err.getMessage).asJson)
-                        )
-            }
-
-        // GET /api/l2/transactions?count=N - recent applied L2 transactions, newest first.
-        // Returns data only on an EUTXO-backed node; empty otherwise (see L2LedgerReader).
-        case GET -> Root / "api" / "l2" / "transactions" :? CountQueryParam(count) =>
-            count match {
-                case Some(Invalid(errs)) =>
-                    BadRequest(
-                      Error(error =
-                          s"Invalid 'count' parameter: ${errs.toList.map(_.sanitized).mkString(", ")}"
-                      ).asJson
-                    )
-                case validated =>
-                    l2LedgerReader
-                        .recentTransactions(
-                          validated.flatMap(_.toOption).getOrElse(defaultRecentTxCount)
-                        )
-                        .flatMap(summaries => Ok(summaries.asJson))
-                        .handleErrorWith(err =>
-                            InternalServerError(Error(error = err.getMessage).asJson)
-                        )
-            }
-
-        // GET /health - Health check endpoint
-        case GET -> Root / "health" =>
-            Ok(io.circe.Json.obj("status" -> "ok".asJson))
-
-        // POST /api/admin/finalize - Trigger head finalization (admin only)
-        case req @ POST -> Root / "api" / "admin" / "finalize" =>
-            val path = "POST /api/admin/finalize"
-            if !checkAuth(req) then
-                tracer.traceWith(UnauthorizedAdmin(path)) *>
-                    Unauthorized(
-                      org.http4s.headers.`WWW-Authenticate`(
-                        org.http4s.Challenge("Basic", "Hydrozoa Admin")
-                      )
-                    )
-            else
-                val result: IO[org.http4s.Response[IO]] = for {
-                    _ <- tracer.traceWith(FinalizeTriggered)
-                    _ <- blockWeaver ! BlockWeaver.LocalFinalizationTrigger.Triggered
-                    _ <- tracer.traceWith(FinalizeSignalSent)
-                    resp <- Ok(
-                      io.circe.Json.obj(
-                        "status" -> "success".asJson,
-                        "message" -> "Head finalization triggered".asJson
-                      )
-                    )
-                } yield resp
-
-                result.handleErrorWith { err =>
-                    tracer.traceWith(RequestFailed(path, err)) *>
-                        InternalServerError(Error(error = err.getMessage).asJson)
-                }
-    }
 }
 
 object HydrozoaRoutes {
+    val apiTitle: String = "Hydrozoa node API"
+    val apiVersion: String = "0.1.0"
+
     def apply(
         requestSequencer: RequestSequencer.Handle,
         blockWeaver: BlockWeaver.Handle,

--- a/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
+++ b/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
@@ -1,11 +1,13 @@
 package hydrozoa.multisig.server
 
+import cats.data.Validated.Invalid
 import cats.effect.IO
 import fs2.Stream
 import hydrozoa.config.head.HeadConfig
 import hydrozoa.config.head.network.CardanoNetwork
 import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.consensus.{BlockWeaver, RequestSequencer, UserRequest}
+import hydrozoa.multisig.ledger.l2.L2LedgerReader
 import hydrozoa.multisig.server.ApiResponse.{CardanoNativeToken, Error, HeadInfo, RequestAccepted}
 import hydrozoa.multisig.server.HydrozoaHttpEvent.*
 import hydrozoa.multisig.server.JsonCodecs.{UserRequestDecoder, given}
@@ -14,6 +16,9 @@ import org.http4s.circe.*
 import org.http4s.dsl.io.*
 import org.http4s.headers.Authorization
 import org.http4s.{BasicCredentials, EntityDecoder, HttpRoutes}
+import scala.util.Try
+import scalus.cardano.address.Address
+import scalus.cardano.ledger.Utxo
 
 /** HTTP routes for the Hydrozoa server. These routes are what get called by the frontend (or a
   * proxy -- load-balancer, unified api).
@@ -21,11 +26,26 @@ import org.http4s.{BasicCredentials, EntityDecoder, HttpRoutes}
 class HydrozoaRoutes(
     requestSequencer: RequestSequencer.Handle,
     blockWeaver: BlockWeaver.Handle,
+    l2LedgerReader: L2LedgerReader[IO],
     headConfig: HeadConfig,
     serverConfig: HydrozoaServer.Config,
     tracer: ContraTracer[IO, HydrozoaHttpEvent]
 ) {
     private given HeadConfig = headConfig
+
+    /** Optional `?count=` on `GET /api/l2/transactions`; absent ⇒ [[defaultRecentTxCount]], present
+      * but non-integer ⇒ a 400 (like a malformed address), rather than falling through to a 404.
+      */
+    private object CountQueryParam extends OptionalValidatingQueryParamDecoderMatcher[Int]("count")
+
+    /** How many recent L2 transactions to return when `?count=` is omitted. */
+    private val defaultRecentTxCount = 50
+
+    /** Parse a bech32 address from the request path, or a message describing why it is malformed.
+      */
+    private def parseAddress(bech32: String): Either[String, Address] =
+        Try(Address.fromBech32(bech32)).toEither.left
+            .map(err => s"Invalid bech32 address '$bech32': ${err.getMessage}")
 
     /** Check if the provided credentials match the configured admin credentials */
     private def checkAuth(req: org.http4s.Request[IO]): Boolean =
@@ -145,6 +165,43 @@ class HydrozoaRoutes(
                 InternalServerError(Error(error = err.getMessage).asJson)
             }
 
+        // GET /api/l2/utxos/{address} - current L2 utxos controlled by an address, CIP-0116-style.
+        // Returns data only on an EUTXO-backed node; empty otherwise (see L2LedgerReader).
+        case GET -> Root / "api" / "l2" / "utxos" / address =>
+            parseAddress(address) match {
+                case Left(err) => BadRequest(Error(error = err).asJson)
+                case Right(addr) =>
+                    l2LedgerReader
+                        .utxosByAddress(addr)
+                        .flatMap(utxos =>
+                            Ok(utxos.toList.map((input, output) => Utxo(input, output)).asJson)
+                        )
+                        .handleErrorWith(err =>
+                            InternalServerError(Error(error = err.getMessage).asJson)
+                        )
+            }
+
+        // GET /api/l2/transactions?count=N - recent applied L2 transactions, newest first.
+        // Returns data only on an EUTXO-backed node; empty otherwise (see L2LedgerReader).
+        case GET -> Root / "api" / "l2" / "transactions" :? CountQueryParam(count) =>
+            count match {
+                case Some(Invalid(errs)) =>
+                    BadRequest(
+                      Error(error =
+                          s"Invalid 'count' parameter: ${errs.toList.map(_.sanitized).mkString(", ")}"
+                      ).asJson
+                    )
+                case validated =>
+                    l2LedgerReader
+                        .recentTransactions(
+                          validated.flatMap(_.toOption).getOrElse(defaultRecentTxCount)
+                        )
+                        .flatMap(summaries => Ok(summaries.asJson))
+                        .handleErrorWith(err =>
+                            InternalServerError(Error(error = err.getMessage).asJson)
+                        )
+            }
+
         // GET /health - Health check endpoint
         case GET -> Root / "health" =>
             Ok(io.circe.Json.obj("status" -> "ok".asJson))
@@ -183,9 +240,19 @@ object HydrozoaRoutes {
     def apply(
         requestSequencer: RequestSequencer.Handle,
         blockWeaver: BlockWeaver.Handle,
+        l2LedgerReader: L2LedgerReader[IO],
         headConfig: HeadConfig,
         serverConfig: HydrozoaServer.Config,
         tracer: ContraTracer[IO, HydrozoaHttpEvent]
     ): IO[HydrozoaRoutes] =
-        IO.pure(new HydrozoaRoutes(requestSequencer, blockWeaver, headConfig, serverConfig, tracer))
+        IO.pure(
+          new HydrozoaRoutes(
+            requestSequencer,
+            blockWeaver,
+            l2LedgerReader,
+            headConfig,
+            serverConfig,
+            tracer
+          )
+        )
 }

--- a/src/main/scala/hydrozoa/multisig/server/HydrozoaServer.scala
+++ b/src/main/scala/hydrozoa/multisig/server/HydrozoaServer.scala
@@ -5,6 +5,7 @@ import com.comcast.ip4s.*
 import hydrozoa.config.head.HeadConfig
 import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.consensus.{BlockWeaver, RequestSequencer}
+import hydrozoa.multisig.ledger.l2.L2LedgerReader
 import hydrozoa.multisig.server.HydrozoaHttpEvent.ServerStarted
 import org.http4s.ember.server.EmberServerBuilder
 import org.http4s.server.Server
@@ -30,6 +31,8 @@ object HydrozoaServer {
       *   Handle to the RequestSequencer actor
       * @param blockWeaver
       *   Handle to the BlockWeaver actor
+      * @param l2LedgerReader
+      *   Read-only L2-ledger queries behind `GET /api/l2/utxos` and `/api/l2/transactions`
       * @param headConfig
       *   Head configuration
       * @param config
@@ -42,13 +45,21 @@ object HydrozoaServer {
     def create(
         requestSequencer: RequestSequencer.Handle,
         blockWeaver: BlockWeaver.Handle,
+        l2LedgerReader: L2LedgerReader[IO],
         headConfig: HeadConfig,
         config: Config,
         tracer: ContraTracer[IO, HydrozoaHttpEvent]
     ): Resource[IO, Server] =
         for {
             hydrozoaRoutes <- Resource.eval(
-              HydrozoaRoutes(requestSequencer, blockWeaver, headConfig, config, tracer)
+              HydrozoaRoutes(
+                requestSequencer,
+                blockWeaver,
+                l2LedgerReader,
+                headConfig,
+                config,
+                tracer
+              )
             )
             server <- EmberServerBuilder
                 .default[IO]
@@ -66,11 +77,12 @@ object HydrozoaServer {
     def run(
         requestSequencer: RequestSequencer.Handle,
         blockWeaver: BlockWeaver.Handle,
+        l2LedgerReader: L2LedgerReader[IO],
         headConfig: HeadConfig,
         config: Config,
         tracer: ContraTracer[IO, HydrozoaHttpEvent]
     ): IO[Nothing] = {
-        create(requestSequencer, blockWeaver, headConfig, config, tracer)
+        create(requestSequencer, blockWeaver, l2LedgerReader, headConfig, config, tracer)
             .use(_ => IO.never)
     }
 }

--- a/src/main/scala/hydrozoa/multisig/server/JsonCodecs.scala
+++ b/src/main/scala/hydrozoa/multisig/server/JsonCodecs.scala
@@ -10,7 +10,9 @@ import hydrozoa.multisig.consensus.UserRequestBody.{DepositRequestBody, Transact
 import hydrozoa.multisig.consensus.peer.HeadPeerNumber
 import hydrozoa.multisig.consensus.{UserRequest, UserRequestBody, UserRequestHeader}
 import hydrozoa.multisig.ledger.event.{RequestId, RequestNumber}
+import hydrozoa.multisig.ledger.l2.{L2TxKind, L2TxSummary}
 import hydrozoa.multisig.server.ApiResponse.{Error, HeadInfo, RequestAccepted}
+import io.bullet.borer.Cbor
 import io.circe.generic.semiauto.*
 import io.circe.syntax.*
 import io.circe.{Decoder, DecodingFailure, Encoder, Json}
@@ -287,4 +289,62 @@ object JsonCodecs {
     given headInfoEncoder: Encoder[HeadInfo] = deriveEncoder[HeadInfo]
 
     given headInfoDecoder: Decoder[HeadInfo] = deriveDecoder[HeadInfo]
+
+    // ---- L2 query endpoints (GET /api/l2/utxos, /api/l2/transactions) ----
+    // CIP-0116-structured utxo encoding. `transactionInputEncoder` and `valueEncoder` come from the
+    // CIP-0116 givens imported above; only the output object is assembled here, since CIP-0116
+    // defines no `TransactionOutput` encoder.
+
+    /** One L2 output as `{ address, value, datum }`: bech32 address, CIP-0116 value, and a tagged
+      * datum — `{ "inline": <cbor-hex> }`, `{ "hash": <hex> }`, or `null` when absent — so a
+      * consumer can tell an inline datum from a datum-hash reference (CIP-0116 keeps them
+      * distinct).
+      */
+    private def encodeL2Output(output: TransactionOutput): Json =
+        val addressJson = output.address match
+            case shelley: ShelleyAddress =>
+                Json.fromString(shelley.toBech32.getOrElse(shelley.toHex))
+            case other => Json.fromString(other.toString)
+        def datumHashJson(hash: DataHash): Json = Json.obj("hash" -> Json.fromString(hash.toHex))
+        val datumJson = output match
+            case TransactionOutput.Shelley(_, _, datumHash) =>
+                datumHash.fold(Json.Null)(datumHashJson)
+            case TransactionOutput.Babbage(_, _, datumOption, _) =>
+                datumOption match
+                    case Some(DatumOption.Inline(data)) =>
+                        Json.obj(
+                          "inline" -> Json.fromString(
+                            ByteString.fromArray(Cbor.encode(data).toByteArray).toHex
+                          )
+                        )
+                    case Some(DatumOption.Hash(hash)) => datumHashJson(hash)
+                    case None                         => Json.Null
+        Json.obj(
+          "address" -> addressJson,
+          "value" -> output.value.asJson,
+          "datum" -> datumJson
+        )
+
+    given l2UtxoEncoder: Encoder[Utxo] =
+        (utxo: Utxo) =>
+            Json.obj(
+              "input" -> utxo.input.asJson,
+              "output" -> encodeL2Output(utxo.output)
+            )
+
+    given l2TxKindEncoder: Encoder[L2TxKind] =
+        Encoder.encodeString.contramap {
+            case L2TxKind.Transaction       => "transaction"
+            case L2TxKind.DepositRegistered => "depositRegistered"
+            case L2TxKind.DepositAbsorbed   => "depositAbsorbed"
+            case L2TxKind.DepositRefunded   => "depositRefunded"
+        }
+
+    given l2TxSummaryEncoder: Encoder[L2TxSummary] =
+        (summary: L2TxSummary) =>
+            Json.obj(
+              "requestId" -> summary.requestId.asJson,
+              "blockNumber" -> summary.blockNumber.asJson,
+              "kind" -> summary.kind.asJson
+            )
 }

--- a/src/main/scala/hydrozoa/multisig/server/TapirJson.scala
+++ b/src/main/scala/hydrozoa/multisig/server/TapirJson.scala
@@ -1,0 +1,16 @@
+package hydrozoa.multisig.server
+
+import io.circe.Printer
+import sttp.tapir.json.circe.TapirJsonCirce
+
+/** tapir's circe `jsonBody`, but serializing with null values dropped.
+  *
+  * The API DTOs use `Option` fields for genuinely-absent data (e.g. an output's datum). tapir
+  * derives their OpenAPI schema with those fields simply *not required*; circe's default printer,
+  * however, emits an explicit `null` for a `None`. That mismatch means an absent optional would be
+  * sent as `"field": null`, which does not validate against the "not required" schema. Dropping
+  * nulls omits the key instead, so the wire JSON matches the generated schema.
+  */
+object TapirJson extends TapirJsonCirce {
+    override def jsonPrinter: Printer = Printer.noSpaces.copy(dropNullValues = true)
+}

--- a/src/test/scala/hydrozoa/multisig/server/L2QueryEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/L2QueryEndpointsTest.scala
@@ -134,8 +134,8 @@ class L2QueryEndpointsTest extends AnyFunSuite:
                     s"expected ${expected.size} utxos, got ${body.asArray.map(_.size)}"
                   )
                 )
-                // Every entry carries the full CIP-0116 shape: structured input, and an output
-                // with address, value {coin, assets}, and a (possibly null) datum field.
+                // Every entry carries the full CIP-0116 shape: a structured input, and an output
+                // with address and value {coin, assets}. `datum` is optional (omitted when absent).
                 _ <- IO(
                   assert(
                     body.asArray.forall(_.forall { utxo =>
@@ -144,9 +144,8 @@ class L2QueryEndpointsTest extends AnyFunSuite:
                         && c.downField("input").downField("index").succeeded
                         && c.downField("output").downField("address").succeeded
                         && c.downField("output").downField("value").downField("coin").succeeded
-                        && c.downField("output").downField("datum").succeeded
                     }),
-                    "each utxo must have the CIP-0116 input/output/value/datum shape"
+                    "each utxo must have the CIP-0116 input/output/value shape"
                   )
                 )
             } yield ()
@@ -240,12 +239,57 @@ class L2QueryEndpointsTest extends AnyFunSuite:
         }
     }
 
-    test("GET /api/l2/transactions?count=abc is a 400, not a 404") {
+    test("the generated OpenAPI spec is served under /docs") {
         withSeededRoutes { (app, _) =>
             for {
-                result <- get(app, "/api/l2/transactions?count=abc")
-                (status, _) = result
-                _ <- IO(assert(status == Status.BadRequest, s"expected 400, got $status"))
+                resp <- app.run(Request[IO](Method.GET, Uri.unsafeFromString("/docs/docs.yaml")))
+                body <- resp.bodyText.compile.string
+                _ <- IO(
+                  assert(resp.status == Status.Ok, s"expected 200 for the spec, got ${resp.status}")
+                )
+                _ <- IO(
+                  assert(body.contains("openapi"), s"spec body unexpected: ${body.take(60)}")
+                )
+            } yield ()
+        }
+    }
+
+    test("GET /api/l2/transactions?count=abc is a 400, not a 404") {
+        withSeededRoutes { (app, _) =>
+            // tapir rejects an un-decodable query param with a 400 and a plain-text body, so check
+            // the status directly rather than through the JSON helper.
+            for {
+                resp <- app.run(
+                  Request[IO](Method.GET, Uri.unsafeFromString("/api/l2/transactions?count=abc"))
+                )
+                _ <- IO(
+                  assert(resp.status == Status.BadRequest, s"expected 400, got ${resp.status}")
+                )
+            } yield ()
+        }
+    }
+
+    test(
+      "POST /api/admin/finalize with wrong credentials is 401 with a WWW-Authenticate challenge"
+    ) {
+        withSeededRoutes { (app, _) =>
+            // The harness configures admin/admin; send a wrong password.
+            val badAuth =
+                org.http4s.headers.Authorization(org.http4s.BasicCredentials("admin", "wrong"))
+            for {
+                resp <- app.run(
+                  Request[IO](Method.POST, Uri.unsafeFromString("/api/admin/finalize"))
+                      .putHeaders(badAuth)
+                )
+                _ <- IO(
+                  assert(resp.status == Status.Unauthorized, s"expected 401, got ${resp.status}")
+                )
+                hasChallenge = resp.headers.headers.exists(
+                  _.name.toString.equalsIgnoreCase("WWW-Authenticate")
+                )
+                _ <- IO(
+                  assert(hasChallenge, "a 401 from the admin endpoint must carry WWW-Authenticate")
+                )
             } yield ()
         }
     }

--- a/src/test/scala/hydrozoa/multisig/server/L2QueryEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/L2QueryEndpointsTest.scala
@@ -1,0 +1,253 @@
+package hydrozoa.multisig.server
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import cats.syntax.all.*
+import com.suprnation.actor.Actor.{Actor, Receive}
+import com.suprnation.actor.ActorSystem
+import hydrozoa.config.node.MultiNodeConfig
+import hydrozoa.lib.logging.ContraTracer
+import hydrozoa.multisig.consensus.peer.HeadPeerNumber
+import hydrozoa.multisig.consensus.{BlockWeaver, RequestSequencer}
+import hydrozoa.multisig.ledger.block.BlockNumber
+import hydrozoa.multisig.ledger.eutxol2.EutxoL2Ledger
+import hydrozoa.multisig.ledger.eutxol2.store.InMemoryL2Store
+import hydrozoa.multisig.ledger.event.RequestId
+import hydrozoa.multisig.ledger.l2.L2LedgerCommand
+import io.circe.{Json, Printer}
+import org.http4s.circe.*
+import org.http4s.implicits.*
+import org.http4s.{HttpApp, Method, Request, Status, Uri}
+import org.scalacheck.Gen
+import org.scalacheck.rng.Seed
+import org.scalatest.funsuite.AnyFunSuite
+import scalus.cardano.address.ShelleyAddress
+
+/** End-to-end demo + test for the L2 query endpoints (`GET /api/l2/utxos/{address}`,
+  * `GET /api/l2/transactions`). Boots an in-memory [[EutxoL2Ledger]], seeds it (genesis utxos plus
+  * a few applied commands), builds the real [[HydrozoaRoutes]] against it with stub consensus
+  * actors, and drives both endpoints through the HTTP layer — asserting the responses and printing
+  * the JSON so the flow can be shown in a screen recording.
+  */
+class L2QueryEndpointsTest extends AnyFunSuite:
+
+    private val printer = Printer.spaces2.copy(dropNullValues = false)
+
+    /** A deterministic single-generator config; nodeConfig is the EUTXO ledger config, headConfig
+      * feeds the routes.
+      */
+    private val multiNodeConfig: MultiNodeConfig =
+        MultiNodeConfig.generateDefault
+            .pureApply(Gen.Parameters.default, Seed(0L))
+    private val nodeConfig = multiNodeConfig.nodeConfigs(HeadPeerNumber.zero)
+
+    /** A refunded-deposit decision at `blockNum` — a real command that logs (so it shows up in
+      * `/api/l2/transactions`) without needing a constructed deposit/tx payload: `refundedDeposits`
+      * are only removed from the pending set, which tolerates ids that were never registered.
+      */
+    private def refundDecision(
+        blockNum: Int,
+        refunded: RequestId
+    ): L2LedgerCommand.ApplyDepositDecisions =
+        L2LedgerCommand.ApplyDepositDecisions(
+          blockNumber = BlockNumber(blockNum),
+          blockCreationEndTime = BigInt(blockNum),
+          absorbedDeposits = Nil,
+          refundedDeposits = List(refunded)
+        )
+
+    /** Build the routes against a seeded ledger + stub actors, then run `check` with the HTTP app
+      * and the ledger's genesis utxo addresses.
+      */
+    private def withSeededRoutes(
+        check: (HttpApp[IO], EutxoL2Ledger) => IO[Unit]
+    ): Unit =
+        ActorSystem[IO]("L2QueryEndpointsTest")
+            .use { system =>
+                for {
+                    store <- InMemoryL2Store.create
+                    ledger <- EutxoL2Ledger(nodeConfig, store)
+                    // Seed a small transaction log: three refunded-deposit decisions, blocks 1..3.
+                    _ <- List(1, 2, 3).traverse_ { n =>
+                        ledger
+                            .sendApplyDepositDecisions(refundDecision(n, RequestId(0, n.toLong)))
+                            .value
+                            .flatMap(IO.fromEither)
+                    }
+                    requestSequencerStub <- system.actorOf(
+                      new Actor[IO, RequestSequencer.Request] {
+                          override def receive: Receive[IO, RequestSequencer.Request] =
+                              _ => IO.pure(())
+                      }
+                    )
+                    blockWeaverStub <- system.actorOf(
+                      new Actor[IO, BlockWeaver.Request] {
+                          override def receive: Receive[IO, BlockWeaver.Request] = _ => IO.pure(())
+                      }
+                    )
+                    routes <- HydrozoaRoutes(
+                      requestSequencerStub,
+                      blockWeaverStub,
+                      ledger,
+                      multiNodeConfig.headConfig,
+                      HydrozoaServer.Config(adminUsername = "admin", adminPassword = "admin"),
+                      ContraTracer[IO, HydrozoaHttpEvent](_ => IO.unit)
+                    )
+                    _ <- check(routes.routes.orNotFound, ledger)
+                } yield ()
+            }
+            .unsafeRunSync()
+
+    private def get(app: HttpApp[IO], path: String): IO[(Status, Json)] =
+        for {
+            resp <- app.run(Request[IO](Method.GET, Uri.unsafeFromString(path)))
+            body <- resp.as[Json]
+        } yield (resp.status, body)
+
+    /** The Shelley addresses present in the genesis L2 utxo set (deterministic under `Seed(0L)`).
+      */
+    private val genesisShelleyAddresses: List[ShelleyAddress] =
+        EutxoL2Ledger.State
+            .genesis(nodeConfig)
+            .activeUtxos
+            .values
+            .map(_.address)
+            .collect { case s: ShelleyAddress => s }
+            .toList
+
+    test("GET /api/l2/utxos/{address} returns the address's current L2 utxos, CIP-0116-style") {
+        val shelley = genesisShelleyAddresses.headOption
+            .getOrElse(fail("genesis produced no Shelley L2 utxos to query"))
+        val bech32 = shelley.toBech32.getOrElse(shelley.toHex)
+        withSeededRoutes { (app, ledger) =>
+            for {
+                expected <- ledger.utxosByAddress(shelley)
+                result <- get(app, s"/api/l2/utxos/$bech32")
+                (status, body) = result
+                _ <- IO.println(s"[demo] GET /api/l2/utxos/$bech32")
+                _ <- IO.println(printer.print(body))
+                _ <- IO(assert(status == Status.Ok))
+                _ <- IO(assert(expected.nonEmpty, "the chosen genesis address controls no utxos"))
+                _ <- IO(
+                  assert(
+                    body.asArray.exists(_.size == expected.size),
+                    s"expected ${expected.size} utxos, got ${body.asArray.map(_.size)}"
+                  )
+                )
+                // Every entry carries the full CIP-0116 shape: structured input, and an output
+                // with address, value {coin, assets}, and a (possibly null) datum field.
+                _ <- IO(
+                  assert(
+                    body.asArray.forall(_.forall { utxo =>
+                        val c = utxo.hcursor
+                        c.downField("input").downField("transaction_id").succeeded
+                        && c.downField("input").downField("index").succeeded
+                        && c.downField("output").downField("address").succeeded
+                        && c.downField("output").downField("value").downField("coin").succeeded
+                        && c.downField("output").downField("datum").succeeded
+                    }),
+                    "each utxo must have the CIP-0116 input/output/value/datum shape"
+                  )
+                )
+            } yield ()
+        }
+    }
+
+    test("GET /api/l2/utxos/{valid address with no utxos} returns an empty array") {
+        // A well-formed bech32 address the ledger holds nothing for: the head's own L1 multisig
+        // address, which is never an L2 output address.
+        val unfunded = multiNodeConfig.headConfig.headMultisigAddress.toBech32
+            .getOrElse(fail("head multisig address is not bech32-encodable"))
+        withSeededRoutes { (app, _) =>
+            for {
+                result <- get(app, s"/api/l2/utxos/$unfunded")
+                (status, body) = result
+                _ <- IO(assert(status == Status.Ok))
+                _ <- IO(assert(body.asArray.exists(_.isEmpty), s"expected [], got $body"))
+            } yield ()
+        }
+    }
+
+    test("GET /api/l2/utxos/{malformed} is a 400, not a 500") {
+        withSeededRoutes { (app, _) =>
+            for {
+                result <- get(app, "/api/l2/utxos/not-a-real-address")
+                (status, _) = result
+                _ <- IO(assert(status == Status.BadRequest))
+            } yield ()
+        }
+    }
+
+    test("GET /api/l2/transactions returns recent applied L2 transactions, newest first") {
+        withSeededRoutes { (app, _) =>
+            for {
+                result <- get(app, "/api/l2/transactions?count=10")
+                (status, body) = result
+                _ <- IO.println("[demo] GET /api/l2/transactions?count=10")
+                _ <- IO.println(printer.print(body))
+                _ <- IO(assert(status == Status.Ok))
+                entries = body.asArray.getOrElse(Vector.empty)
+                _ <- IO(assert(entries.size == 3, s"expected 3 entries, got ${entries.size}"))
+                // Newest first: block numbers descend 3, 2, 1; every entry is a deposit refund.
+                blockNums = entries.flatMap(_.hcursor.downField("blockNumber").as[Int].toOption)
+                _ <- IO(assert(blockNums == Vector(3, 2, 1), s"block order was $blockNums"))
+                kinds = entries.flatMap(_.hcursor.downField("kind").as[String].toOption)
+                _ <- IO(assert(kinds.forall(_ == "depositRefunded"), s"kinds were $kinds"))
+                // requestId is the object shape {headPeerNumber, requestNumber} (the HTTP default).
+                _ <- IO(
+                  assert(
+                    entries.forall { e =>
+                        e.hcursor.downField("requestId").downField("headPeerNumber").succeeded
+                        && e.hcursor.downField("requestId").downField("requestNumber").succeeded
+                    },
+                    "requestId must be the object shape"
+                  )
+                )
+            } yield ()
+        }
+    }
+
+    test("GET /api/l2/transactions?count=1 honors the limit") {
+        withSeededRoutes { (app, _) =>
+            for {
+                result <- get(app, "/api/l2/transactions?count=1")
+                (status, body) = result
+                _ <- IO(assert(status == Status.Ok))
+                _ <- IO(assert(body.asArray.exists(_.size == 1)))
+            } yield ()
+        }
+    }
+
+    test("GET /api/l2/transactions with no ?count returns all seeded entries (default limit)") {
+        withSeededRoutes { (app, _) =>
+            for {
+                result <- get(app, "/api/l2/transactions")
+                (status, body) = result
+                _ <- IO(assert(status == Status.Ok))
+                _ <- IO(assert(body.asArray.exists(_.size == 3)))
+            } yield ()
+        }
+    }
+
+    test("GET /api/l2/transactions?count=0 returns an empty array") {
+        withSeededRoutes { (app, _) =>
+            for {
+                result <- get(app, "/api/l2/transactions?count=0")
+                (status, body) = result
+                _ <- IO(assert(status == Status.Ok))
+                _ <- IO(assert(body.asArray.exists(_.isEmpty)))
+            } yield ()
+        }
+    }
+
+    test("GET /api/l2/transactions?count=abc is a 400, not a 404") {
+        withSeededRoutes { (app, _) =>
+            for {
+                result <- get(app, "/api/l2/transactions?count=abc")
+                (status, _) = result
+                _ <- IO(assert(status == Status.BadRequest, s"expected 400, got $status"))
+            } yield ()
+        }
+    }
+
+end L2QueryEndpointsTest

--- a/src/test/scala/hydrozoa/multisig/server/OpenApiSchemaTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/OpenApiSchemaTest.scala
@@ -1,0 +1,80 @@
+package hydrozoa.multisig.server
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import com.suprnation.actor.Actor.{Actor, Receive}
+import com.suprnation.actor.ActorSystem
+import hydrozoa.config.GenerateSampleConfig.{defaultSpec, testPeersSpec}
+import hydrozoa.config.node.MultiNodeConfig
+import hydrozoa.lib.logging.ContraTracer
+import hydrozoa.multisig.consensus.{BlockWeaver, RequestSequencer}
+import hydrozoa.multisig.ledger.l2.{L2LedgerReader, L2TxSummary}
+import java.nio.file.{Files, Path}
+import org.scalacheck.Gen
+import org.scalacheck.rng.Seed
+import org.scalatest.funsuite.AnyFunSuite
+import scalus.cardano.address.Address
+import scalus.cardano.ledger.Utxos
+
+/** Golden test pinning the committed `docs/openapi.yaml` to the schema generated from the tapir
+  * endpoint definitions. It regenerates the document and fails if the committed copy is stale, so
+  * the checked-in schema can never silently drift from the routes. Regenerate by re-running this
+  * test (a stale run overwrites the file) and committing the result.
+  */
+class OpenApiSchemaTest extends AnyFunSuite:
+
+    private val committedSchema: Path = Path.of("docs/openapi.yaml")
+
+    private val spec = defaultSpec.copy(nPeers = 1)
+
+    private val multiNodeConfig: MultiNodeConfig =
+        MultiNodeConfig
+            .generate(testPeersSpec(spec))()
+            .pureApply(Gen.Parameters.default, Seed(spec.generationSeed))
+
+    /** A no-op reader — the schema depends only on the endpoint descriptions, not the handlers. */
+    private val emptyReader: L2LedgerReader[IO] = new L2LedgerReader[IO] {
+        override def utxosByAddress(address: Address): IO[Utxos] = IO.pure(Map.empty)
+        override def recentTransactions(limit: Int): IO[Vector[L2TxSummary]] = IO.pure(Vector.empty)
+    }
+
+    private def generatedYaml: String =
+        ActorSystem[IO]("OpenApiSchemaTest")
+            .use { system =>
+                for {
+                    requestSequencerStub <- system.actorOf(
+                      new Actor[IO, RequestSequencer.Request] {
+                          override def receive: Receive[IO, RequestSequencer.Request] =
+                              _ => IO.pure(())
+                      }
+                    )
+                    blockWeaverStub <- system.actorOf(
+                      new Actor[IO, BlockWeaver.Request] {
+                          override def receive: Receive[IO, BlockWeaver.Request] = _ => IO.pure(())
+                      }
+                    )
+                    routes <- HydrozoaRoutes(
+                      requestSequencerStub,
+                      blockWeaverStub,
+                      emptyReader,
+                      multiNodeConfig.headConfig,
+                      HydrozoaServer.Config(adminUsername = "admin", adminPassword = "admin"),
+                      ContraTracer[IO, HydrozoaHttpEvent](_ => IO.unit)
+                    )
+                } yield routes.openApiYaml
+            }
+            .unsafeRunSync()
+
+    test("docs/openapi.yaml is up to date with the tapir endpoint definitions") {
+        val generated = generatedYaml
+        val committed =
+            if Files.exists(committedSchema) then Files.readString(committedSchema) else ""
+        if committed != generated then
+            Files.writeString(committedSchema, generated)
+            fail(
+              "docs/openapi.yaml was out of date with the endpoint definitions and has been " +
+                  "regenerated. Review and commit the updated docs/openapi.yaml."
+            )
+    }
+
+end OpenApiSchemaTest


### PR DESCRIPTION
## What

Two read-only L2 query endpoints on the user-facing HTTP server (Fund14 proj68, MS1):

- **`GET /api/l2/utxos/{address}`** — current L2 utxos an address controls, CIP-0116-structured JSON. `400` on a malformed address, `[]` on an unknown-but-well-formed one.
- **`GET /api/l2/transactions?count=N`** — recent applied L2 transactions, newest first. `count` defaults to 50; a non-integer `count` is a `400`.

## Design

- A narrow **`L2LedgerReader[F]`** trait (`utxosByAddress`, `recentTransactions`) that `L2Ledger[F]` extends. `EutxoL2Ledger` implements it (a live `Ref` filter for utxos; a tail-scan of its own command log for recent transactions — **no new RocksDB storage**). `RemoteL2Ledger` **stubs both** (returns empty), following its existing `currentCommandNumber`/`restoreTo` stub pattern.
- The HTTP route holds only the reader, not the writable ledger (least-knowledge).
- Utxos serialize via the repo's existing **CIP-0116** codecs plus one new structured `TransactionOutput` encoder (`{address, value, datum}`; datum tagged `{inline:…}` / `{hash:…}` / `null`). Transaction summaries are `{requestId, blockNumber, kind}` with `kind ∈ transaction | depositRegistered | depositAbsorbed | depositRefunded`.

## EUTXO-only

The queries are answered by the **EUTXO reference ledger**, which holds its state locally. A production node currently wires **`RemoteL2Ledger`** (the SugarRush WebSocket), which owns its state behind the black box — so on such a node both endpoints return an empty array (a valid, non-error response). This matches the milestone's "formally works only with the EUTXO ledger."

## Demo / tests

`multisig/server/L2QueryEndpointsTest` (8 tests) boots an in-memory `EutxoL2Ledger`, seeds it, builds the real routes, and drives both endpoints over HTTP — asserting the responses and printing the JSON, so the flow can be shown in a screen recording. Covers the populated case, empty-address `[]`, malformed-address `400`, `count` limit / default / `0`, malformed `count` `400`, and the CIP-0116 shape.

## Verification

- Main + integration compile clean; `just fmt` / `just lint` clean.
- 67 ledger / recovery / server / smoke tests pass (0 failures), plus the 8 new endpoint tests.
- An 18-agent adversarial review found only convention/nit issues (no correctness bugs); 6 were applied (404→400 count validation, count-by-summary windowing, tagged datum, `toBech32.getOrElse(toHex)`, expanded test coverage).

## Docs

`docs/l2-query-endpoints.md`, indexed in `docs/README.md` and `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
