### PR TITLE
rbr: make missing collateral utxo a recoverable error

### DIFF
--- a/src/main/scala/hydrozoa/rulebased/RuleBasedActor.scala
+++ b/src/main/scala/hydrozoa/rulebased/RuleBasedActor.scala
@@ -39,7 +39,7 @@ import hydrozoa.rulebased.ledger.l1.tx.*
 import hydrozoa.rulebased.ledger.l1.utxo.*
 import scala.util.{Failure, Success, Try}
 import scalus.cardano.address.{ShelleyAddress, ShelleyPaymentPart}
-import scalus.cardano.ledger.{Transaction, TransactionHash, TransactionOutput, Utxo, Utxos}
+import scalus.cardano.ledger.{Transaction, TransactionHash, TransactionInput, TransactionOutput, Utxo, Utxos}
 import scalus.uplc.builtin.Data
 import scalus.uplc.builtin.Data.fromData
 
@@ -109,7 +109,7 @@ final case class RuleBasedActor(
 
         def utxosAtPeer(addr: ShelleyAddress): EitherT[IO, Error.RecoverableErrors, Utxos] =
             traced(
-              before = RuleBasedActorEvent.Collateral.Querying(addr.toString),
+              before = RuleBasedActorEvent.Collateral.Querying(addr),
               action = cardanoBackend.utxosAt(addr),
               onError = RuleBasedActorEvent.Backend.ErrorPeerUtxos(_)
             )
@@ -531,7 +531,14 @@ final case class RuleBasedActor(
                 ) match {
                     case x if x.nonEmpty =>
                         pure(x.toList.maxBy(_._2.value.coin.value))
-                    case _ => raiseError(NoSuitableCollateralUtxosFound)
+                    case _ =>
+                        EitherT.left[(TransactionInput, TransactionOutput)](
+                          tracer.traceWith(
+                            RuleBasedActorEvent.Collateral.NotFound(peerAddr)
+                          ) >> IO.pure(
+                            NoSuitableCollateralUtxosFound(peerAddr): Error.RecoverableErrors
+                          )
+                        )
                 }
                 collateralOutput <- collateralUtxoTuple._2 match {
                     case TransactionOutput.Babbage(
@@ -550,12 +557,12 @@ final case class RuleBasedActor(
                           )
                         )
                     case _ =>
-                        EitherT.liftF(
-                          tracer
-                              .traceWith(
-                                RuleBasedActorEvent.Collateral.NotFound(config.ownPeerLabel)
-                              )
-                              .flatMap(_ => IO.raiseError(NoSuitableCollateralUtxosFound))
+                        EitherT.left[CollateralOutput](
+                          tracer.traceWith(
+                            RuleBasedActorEvent.Collateral.NotFound(peerAddr)
+                          ) >> IO.pure(
+                            NoSuitableCollateralUtxosFound(peerAddr): Error.RecoverableErrors
+                          )
                         )
                 }
                 _ <- traceRight(RuleBasedActorEvent.Collateral.Found)
@@ -1077,11 +1084,7 @@ object RuleBasedActor {
             override val getMessage: String = wrapped.getMessage
             override def toString: String = getMessage
         }
-        case object NoSuitableCollateralUtxosFound extends Unrecoverable {
-            override def getMessage: String =
-                "Needed at least one ada-only utxo to use for plutus script collateral" +
-                    " at the peer's head address, but found none."
-        }
+        final case class NoSuitableCollateralUtxosFound(address: ShelleyAddress) extends Recoverable
 
         // Evacuation side
         final case class UnknownResolvedKzg(resolvedKzg: KzgCommitment) extends Unrecoverable {

--- a/src/main/scala/hydrozoa/rulebased/RuleBasedActor.scala
+++ b/src/main/scala/hydrozoa/rulebased/RuleBasedActor.scala
@@ -154,6 +154,13 @@ final case class RuleBasedActor(
     private object Trace {
         def traceRight(event: RuleBasedActorEvent): EitherT[IO, Error.RecoverableErrors, Unit] =
             EitherT.right(tracer.traceWith(event))
+
+        /** Emit `event`, then short-circuit the pipeline with the recoverable `err`. */
+        def traceLeft[A](
+            event: RuleBasedActorEvent,
+            err: Error.RecoverableErrors
+        ): EitherT[IO, Error.RecoverableErrors, A] =
+            EitherT.left[A](tracer.traceWith(event) >> IO.pure(err))
     }
     import Trace.*
 
@@ -532,12 +539,9 @@ final case class RuleBasedActor(
                     case x if x.nonEmpty =>
                         pure(x.toList.maxBy(_._2.value.coin.value))
                     case _ =>
-                        EitherT.left[(TransactionInput, TransactionOutput)](
-                          tracer.traceWith(
-                            RuleBasedActorEvent.Collateral.NotFound(peerAddr)
-                          ) >> IO.pure(
-                            NoSuitableCollateralUtxosFound(peerAddr): Error.RecoverableErrors
-                          )
+                        traceLeft[(TransactionInput, TransactionOutput)](
+                          RuleBasedActorEvent.Collateral.NotFound(peerAddr),
+                          NoSuitableCollateralUtxosFound(peerAddr)
                         )
                 }
                 collateralOutput <- collateralUtxoTuple._2 match {
@@ -557,12 +561,9 @@ final case class RuleBasedActor(
                           )
                         )
                     case _ =>
-                        EitherT.left[CollateralOutput](
-                          tracer.traceWith(
-                            RuleBasedActorEvent.Collateral.NotFound(peerAddr)
-                          ) >> IO.pure(
-                            NoSuitableCollateralUtxosFound(peerAddr): Error.RecoverableErrors
-                          )
+                        traceLeft[CollateralOutput](
+                          RuleBasedActorEvent.Collateral.NotFound(peerAddr),
+                          NoSuitableCollateralUtxosFound(peerAddr)
                         )
                 }
                 _ <- traceRight(RuleBasedActorEvent.Collateral.Found)
@@ -694,11 +695,9 @@ final case class RuleBasedActor(
                 _ <-
                     if toEvacuate.isEmpty
                     then
-                        EitherT.left[Unit](
-                          tracer.traceWith(RuleBasedActorEvent.Evacuation.NoMore) >>
-                              IO.pure(
-                                Error.QueryError.NoEvacuateesRemaining: Error.RecoverableErrors
-                              )
+                        traceLeft[Unit](
+                          RuleBasedActorEvent.Evacuation.NoMore,
+                          Error.QueryError.NoEvacuateesRemaining
                         )
                     else traceRight(RuleBasedActorEvent.Evacuation.PayoutsLeft(toEvacuate.size))
 
@@ -821,21 +820,19 @@ final case class RuleBasedActor(
                 feeUtxos <- Backend.utxosAtFee(walletAddress)
                 collateralUtxo <- feeUtxos.headOption match {
                     case None =>
-                        EitherT.left[CollateralUtxo](
-                          tracer.traceWith(
-                            RuleBasedActorEvent.Collateral.NoFeeCollateralUtxo
-                          ) >>
-                              IO.pure(
-                                Error.QueryError.NoTreasuryFound: Error.RecoverableErrors
-                              )
+                        traceLeft[CollateralUtxo](
+                          RuleBasedActorEvent.Collateral.NotFound(walletAddress),
+                          NoSuitableCollateralUtxosFound(walletAddress)
                         )
                     case Some((input, output)) =>
-                        EitherT.fromEither[IO](
-                          CollateralUtxo
-                              .parse(Utxo(input, output))
-                              .left
-                              .map(_ => Error.QueryError.NoTreasuryFound: Error.RecoverableErrors)
-                        )
+                        CollateralUtxo.parse(Utxo(input, output)) match {
+                            case Right(c) => pure(c)
+                            case Left(_) =>
+                                traceLeft[CollateralUtxo](
+                                  RuleBasedActorEvent.Collateral.NotFound(walletAddress),
+                                  NoSuitableCollateralUtxosFound(walletAddress)
+                                )
+                        }
                 }
             } yield (feeUtxos, collateralUtxo)
         }

--- a/src/main/scala/hydrozoa/rulebased/RuleBasedActorEvent.scala
+++ b/src/main/scala/hydrozoa/rulebased/RuleBasedActorEvent.scala
@@ -2,6 +2,7 @@ package hydrozoa.rulebased
 
 import hydrozoa.multisig.backend.cardano.CardanoBackend
 import hydrozoa.multisig.ledger.l1.tx.EnrichedTx
+import scalus.cardano.address.ShelleyAddress
 
 sealed trait RuleBasedActorEvent
 
@@ -24,9 +25,9 @@ object RuleBasedActorEvent:
         case object ParsedResolved extends RuleBasedActorEvent
 
     object Collateral:
-        final case class Querying(addr: String) extends RuleBasedActorEvent
+        final case class Querying(address: ShelleyAddress) extends RuleBasedActorEvent
         case object Found extends RuleBasedActorEvent
-        final case class NotFound(peerLabel: String) extends RuleBasedActorEvent
+        final case class NotFound(address: ShelleyAddress) extends RuleBasedActorEvent
         case object NoFeeCollateralUtxo extends RuleBasedActorEvent
 
     object Dispute:

--- a/src/main/scala/hydrozoa/rulebased/RuleBasedActorEvent.scala
+++ b/src/main/scala/hydrozoa/rulebased/RuleBasedActorEvent.scala
@@ -28,7 +28,6 @@ object RuleBasedActorEvent:
         final case class Querying(address: ShelleyAddress) extends RuleBasedActorEvent
         case object Found extends RuleBasedActorEvent
         final case class NotFound(address: ShelleyAddress) extends RuleBasedActorEvent
-        case object NoFeeCollateralUtxo extends RuleBasedActorEvent
 
     object Dispute:
         case object Querying extends RuleBasedActorEvent

--- a/src/main/scala/hydrozoa/rulebased/RuleBasedActorEventFormat.scala
+++ b/src/main/scala/hydrozoa/rulebased/RuleBasedActorEventFormat.scala
@@ -38,8 +38,6 @@ object RuleBasedActorEventFormat:
                   s"No ADA-only utxo found at $address. " +
                       "Please send an ADA-only utxo for collateral to this address."
                 )
-            case Collateral.NoFeeCollateralUtxo =>
-                debug("No fee/collateral UTxO found at wallet address, retrying")
 
             case Dispute.Querying          => debug("Querying dispute utxos")
             case Dispute.Parsing           => debug("Parsing dispute utxos")

--- a/src/main/scala/hydrozoa/rulebased/RuleBasedActorEventFormat.scala
+++ b/src/main/scala/hydrozoa/rulebased/RuleBasedActorEventFormat.scala
@@ -30,11 +30,14 @@ object RuleBasedActorEventFormat:
             case Treasury.ParsedUnresolved => info("Treasury is Unresolved")
             case Treasury.ParsedResolved   => info("Treasury is Resolved")
 
-            case Collateral.Querying(addr) =>
-                debug(s"Querying collateral utxos at address $addr")
+            case Collateral.Querying(address) =>
+                debug(s"Querying collateral utxos at address $address")
             case Collateral.Found => debug("Found collateral utxo")
-            case Collateral.NotFound(peerLabel) =>
-                error(s"Could not find a collateral utxo for peer $peerLabel")
+            case Collateral.NotFound(address) =>
+                error(
+                  s"No ADA-only utxo found at $address. " +
+                      "Please send an ADA-only utxo for collateral to this address."
+                )
             case Collateral.NoFeeCollateralUtxo =>
                 debug("No fee/collateral UTxO found at wallet address, retrying")
 


### PR DESCRIPTION
## Summary
- `NoSuitableCollateralUtxosFound` moves from `Unrecoverable` to `Recoverable`, carrying the peer address. Both branches in `getCollateral` now emit `Collateral.NotFound(peerAddr)` and return `EitherT.left` instead of raising, so the tick loop retries instead of crashing.
- `Collateral.Querying` / `Collateral.NotFound` now carry `ShelleyAddress` instead of a stringified label.
- Human trace for `NotFound`: "No ADA-only utxo found at \$address. Please send an ADA-only utxo for collateral to this address."

## Test plan
- [x] \`sbtn compile\`
- [x] \`sbtn Test/compile\`
- [x] \`just fmt\` / \`just lint\`