### PR TITLE
rbr: review followups

### DIFF
--- a/integration/src/test/scala/hydrozoa/integration/fallbackhandoff/VoteVersionMismatchTest.scala
+++ b/integration/src/test/scala/hydrozoa/integration/fallbackhandoff/VoteVersionMismatchTest.scala
@@ -183,14 +183,18 @@ object VoteVersionMismatchTest extends Properties("Vote Version Mismatch"):
 
             coilNodeConfigs = multiNodeConfig.mkCoilNodeConfigs(coilWallets)
 
-            hooks = MultiPeerHeadHarness.Hooks[Option[RequestSequencer.Handle]](
-              tracer = humanFormatTracer |+| observerTracer(
+            observer <- Resource.eval(
+              observerTracer(
                 bothPeersConfirmedMajor2,
                 fallbackDispatched,
                 allHeadsBuildingVote,
                 allHeadsVoteSubmittedOk,
                 allCoilsHandledDispute,
-              ),
+              )
+            )
+
+            hooks = MultiPeerHeadHarness.Hooks[Option[RequestSequencer.Handle]](
+              tracer = humanFormatTracer |+| observer,
               handle = {
                   case (PeerId.Head(peerNum), conns) =>
                       IO.fromOption(conns.requestSequencer)(
@@ -340,12 +344,7 @@ object VoteVersionMismatchTest extends Properties("Vote Version Mismatch"):
         allHeadsBuildingVote: Deferred[IO, Unit],
         allHeadsVoteSubmittedOk: Deferred[IO, Unit],
         allCoilsHandledDispute: Deferred[IO, Unit],
-    ): ContraTracer[IO, MultiPeerHeadHarness.Event] =
-        val peersAtMajor2: Ref[IO, Set[HeadPeerNumber]] = Ref.unsafe(Set.empty)
-        val headsBuildingVote: Ref[IO, Set[HeadPeerNumber]] = Ref.unsafe(Set.empty)
-        val headsVoteSubmittedOk: Ref[IO, Set[HeadPeerNumber]] = Ref.unsafe(Set.empty)
-        val coilsHandledDispute: Ref[IO, Set[Int]] = Ref.unsafe(Set.empty)
-
+    ): IO[ContraTracer[IO, MultiPeerHeadHarness.Event]] =
         def lastMajorVersion(effects: StackEffects.HardConfirmed): Option[Int] =
             effects match {
                 case _: StackEffects.HardConfirmed.Initial => None
@@ -358,7 +357,12 @@ object VoteVersionMismatchTest extends Properties("Vote Version Mismatch"):
                     }
             }
 
-        ContraTracer[IO, MultiPeerHeadHarness.Event] {
+        for
+            peersAtMajor2       <- Ref[IO].of(Set.empty[HeadPeerNumber])
+            headsBuildingVote   <- Ref[IO].of(Set.empty[HeadPeerNumber])
+            headsVoteSubmittedOk <- Ref[IO].of(Set.empty[HeadPeerNumber])
+            coilsHandledDispute <- Ref[IO].of(Set.empty[Int])
+        yield ContraTracer[IO, MultiPeerHeadHarness.Event] {
             case MultiPeerHeadHarness.Event.Head(peerNum, evt) =>
                 evt match {
                     case CommonChildEvent.SlowConsensusActor(

--- a/integration/src/test/scala/hydrozoa/integration/fallbackhandoff/VoteVersionMismatchTest.scala
+++ b/integration/src/test/scala/hydrozoa/integration/fallbackhandoff/VoteVersionMismatchTest.scala
@@ -1,14 +1,16 @@
 package hydrozoa.integration.fallbackhandoff
 
+import cats.data.ReaderT
 import cats.effect.*
 import cats.effect.unsafe.implicits.global
 import cats.syntax.all.*
 import hydrozoa.config.head.multisig.timing.TxTiming.RequestTimes.{RequestValidityEndTime, RequestValidityStartTime}
 import hydrozoa.config.head.network.CardanoNetwork
+import hydrozoa.config.head.rulebased.dispute.DisputeResolutionConfig
 import hydrozoa.config.node.MultiNodeConfig
 import hydrozoa.integration.harness.MultiPeerHeadHarness
 import hydrozoa.integration.harness.MultiPeerHeadHarness.Transport.Mode as TransportMode
-import hydrozoa.lib.cardano.scalus.QuantizedTime.QuantizedInstant
+import hydrozoa.lib.cardano.scalus.QuantizedTime.{QuantizedFiniteDuration, QuantizedInstant}
 import hydrozoa.lib.logging.{ContraTracer, Slf4jTracer}
 import hydrozoa.multisig.backend.cardano.{CardanoBackend as L1Backend, FirewalledCardanoBackend, FirewalledCardanoBackendEvent, yaciTestSauceGenesis}
 import hydrozoa.multisig.consensus.peer.{HeadPeerNumber, PeerId}
@@ -18,7 +20,7 @@ import hydrozoa.multisig.ledger.l1.tx.SettlementTx
 import hydrozoa.multisig.ledger.stack.{PartitionEffects, StackEffects}
 import hydrozoa.multisig.{CoilMultisigRegimeManagerEventFormat, CommonChildEvent, HeadMultisigRegimeManagerEventFormat, RuleBasedOnlyChildEvent}
 import hydrozoa.rulebased.RuleBasedActorEvent
-import org.scalacheck.{Prop, Properties}
+import org.scalacheck.{Gen, Prop, Properties}
 import scala.concurrent.duration.*
 import scalus.uplc.builtin.ByteString
 import test.{SeedPhrase, TestPeers}
@@ -65,11 +67,28 @@ object VoteVersionMismatchTest extends Properties("Vote Version Mismatch"):
         val coilPeersConfig = testPeers.coilPeersConfig(hub = HeadPeerNumber(0))
         val testPeerToUtxos = yaciTestSauceGenesis(cardanoNetwork.network)(testPeers)
 
+        // Fast voting deadline so the deadline-gated tally path in RuleBasedActor unblocks well
+        // inside `scenarioTimeout`. The default generator picks 1h..5d; the coil peer's RBA
+        // would sit on `TallyBlockedByAwaitingVote` for that entire window and time the scenario
+        // out. Same pattern as `EvacuationPropertyTest.fastDisputeResolutionConfig`.
+        val fastDisputeResolutionConfig: test.GenWithTestPeers[DisputeResolutionConfig] =
+            ReaderT { network =>
+                Gen.const(
+                  DisputeResolutionConfig(
+                    votingDuration = QuantizedFiniteDuration(
+                      slotConfig = network.slotConfig,
+                      finiteDuration = 5.seconds,
+                    )
+                  )
+                )
+            }
+
         val resource = MultiPeerHeadHarness.mkResource(
           transportMode = transportMode,
           testPeers = testPeers,
           testPeerToUtxos = testPeerToUtxos,
           takeoffOffset = 10.seconds,
+          disputeResolutionConfig = fastDisputeResolutionConfig,
           coilPeers = coilPeersConfig,
         ) { (takeoffTime, mnc) =>
             buildCtxResource(transportMode, mnc, testPeers, coilWallets, takeoffTime)

--- a/integration/src/test/scala/hydrozoa/integration/harness/MultiPeerHeadHarness.scala
+++ b/integration/src/test/scala/hydrozoa/integration/harness/MultiPeerHeadHarness.scala
@@ -27,11 +27,14 @@ import hydrozoa.multisig.consensus.transport.*
 import hydrozoa.multisig.ledger.eutxol2.EutxoL2Ledger
 import hydrozoa.multisig.persistence.rocksdb.RocksDbBackendStore
 import hydrozoa.multisig.persistence.{BackendStore, Cf, InMemoryBackendStore, Persistence, PersistenceEvent, PersistenceEventFormat}
+import hydrozoa.multisig.server.{HydrozoaHttpEvent, HydrozoaHttpEventFormat, HydrozoaRoutes, HydrozoaServer, SubmissionClient}
 import hydrozoa.multisig.{CoilMultisigRegimeManager, CoilMultisigRegimeManagerEventFormat, CoilRegimeManagerEvent, HeadMultisigRegimeManager, HeadMultisigRegimeManagerEventFormat, HeadRegimeManagerEvent}
 import java.nio.file.{Files, Path}
 import java.time.Instant
 import java.util.concurrent.TimeUnit
+import org.http4s.client.Client as Http4sClient
 import org.http4s.client.websocket.WSClient
+import org.http4s.implicits.*
 import org.http4s.jdkhttpclient.JdkWSClient
 import org.http4s.server.websocket.WebSocketBuilder2
 import org.http4s.{HttpRoutes, Uri}
@@ -227,12 +230,14 @@ object MultiPeerHeadHarness:
         wrapBackend: (PeerId, L1Backend[IO]) => L1Backend[IO] = (_, b) => b,
     )
 
-    /** Per-node artifacts exposed to callers: resolved connections, persistence backend, and the
-      * caller-derived handle. Used for both head peers and coil peers.
+    /** Per-head-peer artifacts exposed to callers: resolved connections, persistence backend, the
+      * in-process [[SubmissionClient]] (bound to this peer's [[HydrozoaRoutes]] via
+      * `Client.fromHttpApp`), and the caller-derived handle.
       */
     case class Peer[H](
         connections: HeadMultisigRegimeManager.Connections,
         backendStore: BackendStore[IO],
+        submissionClient: SubmissionClient,
         handle: H,
     )
 
@@ -354,13 +359,19 @@ object MultiPeerHeadHarness:
                  )
             peerEntries <- Resource.eval(
                                peerConnections.toList.traverse { case (peerNum, conns) =>
-                                   hooks.handle(PeerId.Head(peerNum), conns).map { h =>
-                                       peerNum -> Peer(
-                                         connections = conns,
-                                         backendStore = peerMrms(peerNum).backendStore,
-                                         handle = h,
-                                       )
-                                   }
+                                   for
+                                       submissionClient <- Http.mkPeerSubmissionClient(
+                                                               peerNum,
+                                                               conns,
+                                                               multiNodeConfig,
+                                                           )
+                                       h <- hooks.handle(PeerId.Head(peerNum), conns)
+                                   yield peerNum -> Peer(
+                                     connections = conns,
+                                     backendStore = peerMrms(peerNum).backendStore,
+                                     submissionClient = submissionClient,
+                                     handle = h,
+                                   )
                                }
                            )
             coilEntries <- Resource.eval(
@@ -906,6 +917,49 @@ object MultiPeerHeadHarness:
                            )
                     _ <- Resource.eval(system.actorOf(mrm, s"cmrm-${coilNum.convert}"))
                 yield Coil(mrm, backendStore, coilConfig)
+            }
+
+    // ===================================
+    // Http — per-peer in-memory HydrozoaRoutes + SubmissionClient
+    // ===================================
+
+    object Http:
+        /** Placeholder authority for the in-process HTTP client. `Client.fromHttpApp` dispatches
+          * by path against the wrapped `HttpApp`, so the authority never hits a socket.
+          */
+        private val InProcBaseUri: Uri = uri"http://harness"
+
+        /** Build a peer's [[HydrozoaRoutes]] and wrap it in an in-memory http4s
+          * [[org.http4s.client.Client]] via `Client.fromHttpApp`, then return a
+          * [[SubmissionClient]] that signs each request with the peer's own wallet.
+          */
+        def mkPeerSubmissionClient(
+            peerNum: HeadPeerNumber,
+            conns: HeadMultisigRegimeManager.Connections,
+            multiNodeConfig: MultiNodeConfig,
+        ): IO[SubmissionClient] =
+            val nodeConfig = multiNodeConfig.nodeConfigs(peerNum)
+            val requestSequencer = conns.requestSequencer.getOrElse(
+              throw new IllegalStateException(
+                s"head peer $peerNum missing RequestSequencer; cannot build SubmissionClient"
+              )
+            )
+            val serverConfig = HydrozoaServer.Config(
+              adminUsername = "harness-admin",
+              adminPassword = "harness-admin",
+            )
+            val httpTracer: ContraTracer[IO, HydrozoaHttpEvent] =
+                Slf4jTracer.sink.contramap(HydrozoaHttpEventFormat.humanFormat)
+            HydrozoaRoutes(
+              requestSequencer,
+              conns.blockWeaver,
+              nodeConfig.headConfig,
+              serverConfig,
+              httpTracer,
+            ).map { hydrozoaRoutes =>
+                val client: Http4sClient[IO] =
+                    Http4sClient.fromHttpApp(hydrozoaRoutes.routes.orNotFound)
+                SubmissionClient.http(client, InProcBaseUri, nodeConfig.ownWallet)
             }
 
     // ===================================

--- a/integration/src/test/scala/hydrozoa/integration/rbr/property/EvacuationPropertyTest.scala
+++ b/integration/src/test/scala/hydrozoa/integration/rbr/property/EvacuationPropertyTest.scala
@@ -13,6 +13,7 @@ import hydrozoa.integration.harness.MultiPeerHeadHarness
 import hydrozoa.integration.harness.MultiPeerHeadHarness.Transport.Mode as TransportMode
 import hydrozoa.lib.cardano.scalus.QuantizedTime.QuantizedInstant
 import hydrozoa.lib.logging.{ContraTracer, Slf4jTracer}
+import scala.annotation.unused
 import hydrozoa.multisig.backend.cardano.{CardanoBackend as L1Backend, FirewalledCardanoBackend, FirewalledCardanoBackendEvent, yaciTestSauceGenesis}
 import hydrozoa.multisig.consensus.peer.{HeadPeerNumber, PeerId}
 import hydrozoa.multisig.consensus.{CardanoLiaisonEvent, RequestSequencer, UserRequest, UserRequestBody, UserRequestHeader}
@@ -410,6 +411,7 @@ object EvacuationPropertyTest extends Properties("RBR Evacuation Property"):
       * cardinality shifts. Toggle by uncommenting the `logAmbientUtxos(...)` call site in
       * [[runClassifier]]. Not on the happy path so callers pay nothing when commented out.
       */
+    @unused
     private def logAmbientUtxos(classifier: RBRClassifier, utxos: List[Utxo]): IO[Unit] =
         val ambient = utxos.filter(u => classifier.classify(u).contains(AmbientPlaceId))
         val lines = ambient.zipWithIndex.map { case (u, idx) =>

--- a/integration/src/test/scala/hydrozoa/integration/rbr/property/EvacuationPropertyTest.scala
+++ b/integration/src/test/scala/hydrozoa/integration/rbr/property/EvacuationPropertyTest.scala
@@ -41,12 +41,9 @@ import test.{SeedPhrase, TestPeers}
   *   4. RBA's persistence-backed `loadAction` walks backward, finds the SEC matching the
   *      on-chain treasury's `versionMajor = 1`, and submits a Vote that Plutus accepts.
   *   5. Voting deadline elapses → TallyTx → ResolutionTx.
-  *   6. Test asserts a ResolutionTx submitted successfully (i.e. the dispute resolved).
-  *
-  * Full evacuation (`RuleBasedActorEvent.Evacuation.NoMore`) is not asserted: the EvacuationTx
-  * builder trips the treasury validator's `Trusted setup in the treasury is not big enough`
-  * check because [[FallbackTx.scala]] sets `setupG2 = SList.empty` (TODO there). Wiring the
-  * KZG G2 trusted setup through fallback construction is separate follow-up work.
+  *   6. Every peer's RBA builds and submits an [[EvacuationTx]] until its `Evacuation.NoMore`
+  *      terminal event fires.
+  *   7. Test asserts the shared-L1 UTxO histogram matches the expected terminal cardinalities.
   */
 object EvacuationPropertyTest extends Properties("RBR Evacuation Property"):
 
@@ -55,10 +52,10 @@ object EvacuationPropertyTest extends Properties("RBR Evacuation Property"):
     ): org.scalacheck.Test.Parameters = p.withMinSuccessfulTests(1)
 
     private val nHeadPeers: Int              = 2
-    private val scenarioTimeout: FiniteDuration = 3.minutes
+    private val scenarioTimeout: FiniteDuration = 5.minutes
     private val cardanoNetwork: CardanoNetwork = CardanoNetwork.Preprod
 
-    val _ = property("ws: fallback→RRM→vote→tally→resolve dispute completes") =
+    val _ = property("ws: fallback→RRM→vote→tally→resolve→evacuate happy path") =
         testProperty(TransportMode.WebSocket)
 
     private def testProperty(transportMode: TransportMode): Prop =
@@ -106,7 +103,8 @@ object EvacuationPropertyTest extends Properties("RBR Evacuation Property"):
             _ <- step1b_startPeriodicRequestLoop
             _ <- step2_awaitFallbackToRuleBasedHandoff
             _ <- step3_awaitResolutionSubmitted
-            _ <- step4_assertTerminalHistogram
+            _ <- step4_awaitEvacuationDone
+            _ <- step5_assertTerminalHistogram
         yield true
 
     /** State + handles threaded between steps. */
@@ -116,6 +114,15 @@ object EvacuationPropertyTest extends Properties("RBR Evacuation Property"):
         harness: MultiPeerHeadHarness.Harness[Option[RequestSequencer.Handle]],
         fallbackDispatched: Deferred[IO, Unit],
         resolutionSubmitted: Deferred[IO, Unit],
+        // Set of peers whose RBA has fired `Evacuation.NoMore`. `evacuationDone` is only
+        // completed once every head peer has fired — waiting for the first NoMore is racy: the
+        // winning-drain peer fires while others may still be mid-submission.
+        peersEvacuationDone: Ref[IO, Set[HeadPeerNumber]],
+        evacuationDone: Deferred[IO, Unit],
+        // First `PayoutsLeft(n)` observed on any peer — the KZG-committed evacuation count at
+        // the RBA's read of the resolved treasury. Subsequent PayoutsLeft values are strictly
+        // smaller as drain progresses; taking the first captures the pre-drain total.
+        firstPayoutsLeft: Ref[IO, Option[Int]],
         periodicRequestFiber: Ref[IO, Option[FiberIO[Nothing]]],
     )
 
@@ -149,18 +156,31 @@ object EvacuationPropertyTest extends Properties("RBR Evacuation Property"):
             _   <- lift(ctx.resolutionSubmitted.get.timeout(scenarioTimeout))
         yield ()
 
-    /** After resolution lands, cancel the periodic-request loop, wait a beat for any in-flight
-      * tx to settle, snapshot the shared mock L1, and check the UTxO distribution matches the
-      * expected terminal buckets.
+    private def step4_awaitEvacuationDone: test.TestM[Ctx, Unit] =
+        for
+            ctx <- ask
+            _   <- lift(ctx.evacuationDone.get.timeout(scenarioTimeout))
+        yield ()
+
+    /** After evacuation completes, cancel the periodic-request loop, wait a beat for any
+      * in-flight tx to settle, snapshot the shared mock L1, and check the UTxO distribution
+      * matches the expected terminal buckets.
       */
-    private def step4_assertTerminalHistogram: test.TestM[Ctx, Unit] =
+    private def step5_assertTerminalHistogram: test.TestM[Ctx, Unit] =
         for
             ctx    <- ask
             _      <- lift(ctx.periodicRequestFiber.get.flatMap(_.traverse_(_.cancel)))
             _      <- lift(IO.sleep(quiescenceDelay))
             utxos  <- lift(ctx.harness.l1Snapshot)
             actual <- lift(runClassifier(utxos)(using ctx.multiNodeConfig))
-            expected = expectedCardinalities
+            expectedEvacCount <- lift(ctx.firstPayoutsLeft.get.flatMap(
+              IO.fromOption(_)(
+                new IllegalStateException(
+                  "no `Evacuation.PayoutsLeft` observed; RBA never entered the drain loop"
+                )
+              )
+            ))
+            expected = expectedCardinalities(expectedEvacCount)
             _ <- assertWith(
               actual == expected,
               s"Cardinality mismatch:\n  expected: $expected\n  actual:   $actual",
@@ -184,6 +204,9 @@ object EvacuationPropertyTest extends Properties("RBR Evacuation Property"):
         for
             fallbackDispatched   <- Resource.eval(Deferred[IO, Unit])
             resolutionSubmitted  <- Resource.eval(Deferred[IO, Unit])
+            peersEvacuationDone  <- Resource.eval(Ref[IO].of(Set.empty[HeadPeerNumber]))
+            evacuationDone       <- Resource.eval(Deferred[IO, Unit])
+            firstPayoutsLeft     <- Resource.eval(Ref[IO].of(Option.empty[Int]))
             periodicRequestFiber <- Resource.eval(Ref[IO].of(Option.empty[FiberIO[Nothing]]))
 
             preinitPeerUtxosL1 = yaciTestSauceGenesis(cardanoNetwork.network)(testPeers)
@@ -196,6 +219,9 @@ object EvacuationPropertyTest extends Properties("RBR Evacuation Property"):
               tracer = humanFormatTracer |+| observerTracer(
                 fallbackDispatched,
                 resolutionSubmitted,
+                peersEvacuationDone,
+                evacuationDone,
+                firstPayoutsLeft,
               ),
               handle = {
                   case (PeerId.Head(peerNum), conns) =>
@@ -235,6 +261,9 @@ object EvacuationPropertyTest extends Properties("RBR Evacuation Property"):
           harness = harness,
           fallbackDispatched = fallbackDispatched,
           resolutionSubmitted = resolutionSubmitted,
+          peersEvacuationDone = peersEvacuationDone,
+          evacuationDone = evacuationDone,
+          firstPayoutsLeft = firstPayoutsLeft,
           periodicRequestFiber = periodicRequestFiber,
         )
 
@@ -315,9 +344,12 @@ object EvacuationPropertyTest extends Properties("RBR Evacuation Property"):
     private def observerTracer(
         fallbackDispatched: Deferred[IO, Unit],
         resolutionSubmitted: Deferred[IO, Unit],
+        peersEvacuationDone: Ref[IO, Set[HeadPeerNumber]],
+        evacuationDone: Deferred[IO, Unit],
+        firstPayoutsLeft: Ref[IO, Option[Int]],
     ): ContraTracer[IO, MultiPeerHeadHarness.Event] =
         ContraTracer[IO, MultiPeerHeadHarness.Event] {
-            case MultiPeerHeadHarness.Event.Head(_, evt) =>
+            case MultiPeerHeadHarness.Event.Head(peerNum, evt) =>
                 evt match {
                     case CommonChildEvent.CardanoLiaison(
                           _: CardanoLiaisonEvent.FallbackToRuleBasedDispatched
@@ -328,6 +360,22 @@ object EvacuationPropertyTest extends Properties("RBR Evacuation Property"):
                           RuleBasedActorEvent.Tx.SubmitSuccess(tx)
                         ) if tx.transactionFamily == "Resolution" =>
                         resolutionSubmitted.complete(()).void
+
+                    case RuleBasedOnlyChildEvent.RuleBasedActor(
+                          RuleBasedActorEvent.Evacuation.PayoutsLeft(n)
+                        ) =>
+                        firstPayoutsLeft.update(_.orElse(Some(n)))
+
+                    case RuleBasedOnlyChildEvent.RuleBasedActor(
+                          RuleBasedActorEvent.Evacuation.NoMore
+                        ) =>
+                        peersEvacuationDone
+                            .updateAndGet(_ + peerNum)
+                            .flatMap { seen =>
+                                IO.whenA(seen.size == nHeadPeers)(
+                                  evacuationDone.complete(()).void
+                                )
+                            }
 
                     case _ => IO.unit
                 }
@@ -347,16 +395,42 @@ object EvacuationPropertyTest extends Properties("RBR Evacuation Property"):
         utxos: Utxos
     )(using MultiNodeConfig): IO[Map[RBRPlaceId, Int]] =
         val classifier = new RBRClassifier
-        Histogram.empty(classifier).addAll(utxos.toList.map { case (i, o) => Utxo(i, o) }).toEither match
+        val allUtxos   = utxos.toList.map { case (i, o) => Utxo(i, o) }
+        Histogram.empty(classifier).addAll(allUtxos).toEither match
             case Left(errs) =>
                 IO.raiseError(
                   new RuntimeException(s"Ambiguous UTxO classification: ${errs.toList}")
                 )
             case Right(hist) =>
+                // logAmbientUtxos(classifier, allUtxos) *>
                 IO.pure(RBRPlaceId.values.toList.map(k => k -> hist(k)).toMap)
 
-    /** Expected terminal cardinalities: init → settle-v1 → fallback → vote → tally → resolve on
-      * the happy path (no evacuation — blocked by the KZG G2 TODO in [[FallbackTx]]).
+    /** Diagnostic helper: emit each ambient-bucket UTxO (input / address / value / datum) via
+      * Slf4j so the composition of [[AmbientPlaceId]] can be identified when the terminal
+      * cardinality shifts. Toggle by uncommenting the `logAmbientUtxos(...)` call site in
+      * [[runClassifier]]. Not on the happy path so callers pay nothing when commented out.
+      */
+    private def logAmbientUtxos(classifier: RBRClassifier, utxos: List[Utxo]): IO[Unit] =
+        val ambient = utxos.filter(u => classifier.classify(u).contains(AmbientPlaceId))
+        val lines = ambient.zipWithIndex.map { case (u, idx) =>
+            s"  [$idx] input=${u.input} addr=${u.output.address} value=${u.output.value} datum=${u.output.datumOption}"
+        }.mkString("\n")
+        Slf4jTracer.sink.traceWith(
+          hydrozoa.lib.logging.LogEvent
+              .From(Map.empty, "AmbientDiagnostic")
+              .info(s"AmbientPlaceId utxos (${ambient.size}):\n$lines")
+        )
+
+    /** Expected terminal cardinalities: init → settle-v1 → fallback → vote → tally → resolve →
+      * evacuate on the happy path. `evacuationCount` is the first `PayoutsLeft(n)` observed
+      * from any peer's RBA — exactly the size of the resolved treasury's evacuation map before
+      * drain begins (see `RuleBasedActor.Evacuation.handle`).
+      *   - `EvacuationOutputPlaceId -> evacuationCount`: every L2 output was drained to L1 via
+      *     the RBA's `EvacuationTx` loop; each output carries the `"evacuation"` inline-datum
+      *     sentinel stamped by [[InitializationParametersGen.generatePeerContribution]], which
+      *     survives the KZG membership hash and so appears on the L1 evacuation outputs.
+      *   - `PayoutObligationsPlaceId -> 0`: no in-flight payout obligations remain on the
+      *     resolved treasury.
       *   - `CollateralPlaceId -> 0`: the [[RBRClassifier]] identifies collateral by the
       *     `"collateral"` datum sentinel, which only exists in the synthetic
       *     [[InitialDisputeUtxos]] fixture — the real tx builders draw collateral from plain
@@ -365,10 +439,14 @@ object EvacuationPropertyTest extends Properties("RBR Evacuation Property"):
       *     scenario is to walk the tx graph and mark any output that is later consumed as a
       *     `collateral_input` of some downstream tx — i.e. classify by role in tx history
       *     rather than by content sentinel.
-      *   - `AmbientPlaceId -> 4`: `nHeadPeers = 2` (2 collateral + 2 change/genesis leftovers);
-      *     fixed for this scenario, observed via instrumentation run.
+      *   - `AmbientPlaceId -> nHeadPeers * 2`: each peer maintains two parallel wallet-ADA
+      *     streams at their shelley address — an [[InitializationTx]] change output and a
+      *     [[FallbackTx]] equity payout. Every RBR-side script tx that pays its fee from
+      *     collateral (Vote/Resolution/Evacuation) picks one of these as its collateral
+      *     input and returns it (fee-subtracted) at the same address, so no utxo is
+      *     destroyed — the two streams persist for the full flow.
       */
-    private val expectedCardinalities: Map[RBRPlaceId, Int] =
+    private def expectedCardinalities(evacuationCount: Int): Map[RBRPlaceId, Int] =
         Map(
           TreasuryRefPlaceId        -> 1,
           DisputeRefPlaceId         -> 1,
@@ -377,7 +455,7 @@ object EvacuationPropertyTest extends Properties("RBR Evacuation Property"):
           VotedPlaceId              -> 0,
           UnvotedPlaceId            -> 0,
           CollateralPlaceId         -> 0,
-          EvacuationOutputPlaceId   -> 0,
+          EvacuationOutputPlaceId   -> evacuationCount,
           PayoutObligationsPlaceId  -> 0,
-          AmbientPlaceId            -> 4,
+          AmbientPlaceId            -> nHeadPeers * 2,
         )

--- a/integration/src/test/scala/hydrozoa/integration/stage4/Suite.scala
+++ b/integration/src/test/scala/hydrozoa/integration/stage4/Suite.scala
@@ -28,6 +28,7 @@ import hydrozoa.multisig.ledger.event.RequestId.ValidityFlag
 import hydrozoa.multisig.ledger.event.{RequestId, RequestNumber}
 import hydrozoa.multisig.ledger.stack.{PartitionEffects, Stack, StackEffects}
 import hydrozoa.multisig.persistence.{BackendStore, Cf}
+import hydrozoa.multisig.server.SubmissionClient
 import org.scalacheck.commands.{AnyCommand, ModelBasedSuite, ScenarioGen}
 import org.scalacheck.{Gen, Prop, PropertyM}
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
@@ -147,8 +148,10 @@ case class Stage4Suite(
                               IO.pure(
                                 Some(
                                   Stage4PeerHandle(
-                                    conns.requestSequencer.getOrElse(
-                                      sys.error(s"head peer $peerNum missing RequestSequencer")
+                                    SubmissionClient.direct(
+                                      conns.requestSequencer.getOrElse(
+                                        sys.error(s"head peer $peerNum missing RequestSequencer")
+                                      )
                                     )
                                   )
                                 )

--- a/integration/src/test/scala/hydrozoa/integration/stage4/Suite.scala
+++ b/integration/src/test/scala/hydrozoa/integration/stage4/Suite.scala
@@ -28,7 +28,6 @@ import hydrozoa.multisig.ledger.event.RequestId.ValidityFlag
 import hydrozoa.multisig.ledger.event.{RequestId, RequestNumber}
 import hydrozoa.multisig.ledger.stack.{PartitionEffects, Stack, StackEffects}
 import hydrozoa.multisig.persistence.{BackendStore, Cf}
-import hydrozoa.multisig.server.SubmissionClient
 import org.scalacheck.commands.{AnyCommand, ModelBasedSuite, ScenarioGen}
 import org.scalacheck.{Gen, Prop, PropertyM}
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
@@ -133,7 +132,9 @@ case class Stage4Suite(
             // SUT-command-fed Ref (not a plugin — written by commands, not tracer arms)
             submittedRequestIds <- Resource.eval(Ref[IO].of(Vector.empty[RequestId]))
 
-            hooks = MultiPeerHeadHarness.Hooks[Option[Stage4PeerHandle]](
+            // Hooks.handle is unused now — each head peer's SubmissionClient is built by the
+            // harness against its in-process HydrozoaRoutes and exposed on Peer[H].submissionClient.
+            hooks = MultiPeerHeadHarness.Hooks[Unit](
                       tracer = Plugin.tracerOf(
                         perPeer,
                         perCoil,
@@ -143,21 +144,7 @@ case class Stage4Suite(
                         effectsLandedSignal,
                         fallbackEnteredSignal,
                       ),
-                      handle = {
-                          case (PeerId.Head(peerNum), conns) =>
-                              IO.pure(
-                                Some(
-                                  Stage4PeerHandle(
-                                    SubmissionClient.direct(
-                                      conns.requestSequencer.getOrElse(
-                                        sys.error(s"head peer $peerNum missing RequestSequencer")
-                                      )
-                                    )
-                                  )
-                                )
-                              )
-                          case (_: PeerId.Coil, _) => IO.pure(None)
-                      },
+                      handle = (_, _) => IO.unit,
                     )
             harness <- MultiPeerHeadHarness.resource(
                            MultiPeerHeadHarness.Inputs(
@@ -175,13 +162,7 @@ case class Stage4Suite(
           static = Stage4SutStatic(
             system = harness.system,
             cardanoBackend = harness.cardanoBackend,
-            // Head peers always yield `Some` (see the `Hooks.handle` above); crash loudly if the
-            // invariant is violated so downstream doesn't silently drop peers.
-            peers = harness.peers.map { case (n, p) =>
-                n -> p.handle.getOrElse(
-                  sys.error(s"head peer $n missing Stage4PeerHandle after harness bring-up")
-                )
-            },
+            peers = harness.peers.map { case (n, p) => n -> p.submissionClient },
             backendStores = harness.peers.map { case (n, p) => n -> p.backendStore },
             log = Slf4jTracer.sink.contramap(Slf4jMsgFormat.humanFormat("Stage4.Sut")),
           ),

--- a/integration/src/test/scala/hydrozoa/integration/stage4/Sut.scala
+++ b/integration/src/test/scala/hydrozoa/integration/stage4/Sut.scala
@@ -24,20 +24,17 @@ import scalus.cardano.ledger.TransactionHash
 // Stage 4 SUT
 // ===================================
 
-/** Per-peer submission handle exposed to SUT commands. Routes a [[UserRequest]] through the
-  * transport the harness chose (direct actor send today; in-memory http4s round-trip once wired).
-  */
-case class Stage4PeerHandle(
-    submissionClient: SubmissionClient,
-)
-
 /** Immutable, set-once resources of a running stage4 SUT. Allocated during `sutResource`,
   * referenced from anywhere thereafter — no field on this case class ever changes.
+  *
+  * `peers` holds each head peer's [[SubmissionClient]] — built by the harness against that peer's
+  * in-process [[hydrozoa.multisig.server.HydrozoaRoutes]] via `Client.fromHttpApp`, so submissions
+  * exercise the real HTTP/JSON codec surface without binding a socket.
   */
 case class Stage4SutStatic(
     system: ActorSystem[IO],
     cardanoBackend: CardanoBackend[IO],
-    peers: Map[HeadPeerNumber, Stage4PeerHandle],
+    peers: Map[HeadPeerNumber, SubmissionClient],
     /** Per-peer persistence backend store — used by `analyzePersistence` to assert SC + SCA
       * writes (Treasury + EvacuationMap + HardConfirmation) landed during the scenario.
       */
@@ -150,25 +147,26 @@ object Stage4SutCommands:
         override def run(cmd: DelayCommand, sut: Stage4Sut): IO[Unit] = IO.unit
     }
 
-    // L2 tx: submit via the peer's SubmissionClient (direct actor send today; HTTP round-trip
-    // once wired). Result is always Valid (trivial); oracle check in shutdownSut compares model
-    // predictions against actual block-brief outcomes.
+    // L2 tx: submit via the peer's SubmissionClient (in-memory http4s round-trip through the
+    // harness's HydrozoaRoutes). Result is always Valid (trivial); oracle check in shutdownSut
+    // compares model predictions against actual block-brief outcomes.
     given SutCommand[L2TxCommand, ValidityFlag, Stage4Sut] with {
         override def run(cmd: L2TxCommand, sut: Stage4Sut): IO[ValidityFlag] = {
             for {
-                reqId <- sut.static.peers(cmd.peerNum).submissionClient.submit(cmd.request.asUserRequest)
+                reqId <- sut.static.peers(cmd.peerNum).submit(cmd.request.asUserRequest)
                 _ <- sut.static.log.trace(s"reqId=$reqId, cmd.request.requestId=${cmd.request.requestId}")
                 _ <- sut.mutable.submittedRequestIds.update(_ :+ cmd.request.requestId)
             } yield ValidityFlag.Valid
         }
     }
 
-    // Deposit: register with the peer's SubmissionClient AND submit the signed deposit tx to the
-    // shared mock L1 backend so CardanoLiaison can observe it on-chain at the correct time.
+    // Deposit: submit via the peer's SubmissionClient (in-memory http4s round-trip) AND submit
+    // the signed deposit tx to the shared mock L1 backend so CardanoLiaison can observe it
+    // on-chain at the correct time.
     given SutCommand[RegisterAndSubmitDepositCommand, ValidityFlag, Stage4Sut] with {
         override def run(cmd: RegisterAndSubmitDepositCommand, sut: Stage4Sut): IO[ValidityFlag] = {
             for {
-                reqId <- sut.static.peers(cmd.peerNum).submissionClient.submit(cmd.request.asUserRequest)
+                reqId <- sut.static.peers(cmd.peerNum).submit(cmd.request.asUserRequest)
                 _ <- sut.static.log.trace(s"reqId=$reqId, cmd.request.requestId=${cmd.request.requestId}")
                 _ <- sut.mutable.submittedRequestIds.update(_ :+ cmd.request.requestId)
                 _ <- sut.static.cardanoBackend.submitTx(RawTx(cmd.depositTxBytesSigned))

--- a/integration/src/test/scala/hydrozoa/integration/stage4/Sut.scala
+++ b/integration/src/test/scala/hydrozoa/integration/stage4/Sut.scala
@@ -9,13 +9,14 @@ import hydrozoa.integration.stage4.EffectsLanded.BlockExpectation
 import hydrozoa.lib.logging.{ContraTracer, Slf4jMsg, trace}
 import hydrozoa.multisig.backend.cardano.CardanoBackend
 import hydrozoa.multisig.consensus.peer.{CoilPeerNumber, HeadPeerNumber}
-import hydrozoa.multisig.consensus.{RequestSequencer, UserRequest, UserRequestWithId}
+import hydrozoa.multisig.consensus.{UserRequest, UserRequestWithId}
 import hydrozoa.multisig.ledger.block.BlockBrief
 import hydrozoa.multisig.ledger.event.RequestId
 import hydrozoa.multisig.ledger.event.RequestId.ValidityFlag
 import hydrozoa.multisig.ledger.l1.tx.RawTx
 import hydrozoa.multisig.ledger.stack.Stack
 import hydrozoa.multisig.persistence.BackendStore
+import hydrozoa.multisig.server.SubmissionClient
 import org.scalacheck.commands.SutCommand
 import scalus.cardano.ledger.TransactionHash
 
@@ -23,9 +24,11 @@ import scalus.cardano.ledger.TransactionHash
 // Stage 4 SUT
 // ===================================
 
-/** Per-peer actor handles exposed to SUT commands. */
+/** Per-peer submission handle exposed to SUT commands. Routes a [[UserRequest]] through the
+  * transport the harness chose (direct actor send today; in-memory http4s round-trip once wired).
+  */
 case class Stage4PeerHandle(
-    requestSequencer: RequestSequencer.Handle,
+    submissionClient: SubmissionClient,
 )
 
 /** Immutable, set-once resources of a running stage4 SUT. Allocated during `sutResource`,
@@ -147,25 +150,25 @@ object Stage4SutCommands:
         override def run(cmd: DelayCommand, sut: Stage4Sut): IO[Unit] = IO.unit
     }
 
-    // L2 tx: submit directly to the peer's RequestSequencer.
-    // Result is always Valid (trivial); oracle check in shutdownSut compares model
+    // L2 tx: submit via the peer's SubmissionClient (direct actor send today; HTTP round-trip
+    // once wired). Result is always Valid (trivial); oracle check in shutdownSut compares model
     // predictions against actual block-brief outcomes.
     given SutCommand[L2TxCommand, ValidityFlag, Stage4Sut] with {
         override def run(cmd: L2TxCommand, sut: Stage4Sut): IO[ValidityFlag] = {
             for {
-                reqId <- sut.static.peers(cmd.peerNum).requestSequencer ?: cmd.request.asUserRequest
+                reqId <- sut.static.peers(cmd.peerNum).submissionClient.submit(cmd.request.asUserRequest)
                 _ <- sut.static.log.trace(s"reqId=$reqId, cmd.request.requestId=${cmd.request.requestId}")
                 _ <- sut.mutable.submittedRequestIds.update(_ :+ cmd.request.requestId)
             } yield ValidityFlag.Valid
         }
     }
 
-    // Deposit: register with RequestSequencer AND submit the signed deposit tx to the shared
-    // mock L1 backend so CardanoLiaison can observe it on-chain at the correct time.
+    // Deposit: register with the peer's SubmissionClient AND submit the signed deposit tx to the
+    // shared mock L1 backend so CardanoLiaison can observe it on-chain at the correct time.
     given SutCommand[RegisterAndSubmitDepositCommand, ValidityFlag, Stage4Sut] with {
         override def run(cmd: RegisterAndSubmitDepositCommand, sut: Stage4Sut): IO[ValidityFlag] = {
             for {
-                reqId <- sut.static.peers(cmd.peerNum).requestSequencer ?: cmd.request.asUserRequest
+                reqId <- sut.static.peers(cmd.peerNum).submissionClient.submit(cmd.request.asUserRequest)
                 _ <- sut.static.log.trace(s"reqId=$reqId, cmd.request.requestId=${cmd.request.requestId}")
                 _ <- sut.mutable.submittedRequestIds.update(_ :+ cmd.request.requestId)
                 _ <- sut.static.cardanoBackend.submitTx(RawTx(cmd.depositTxBytesSigned))

--- a/src/main/scala/hydrozoa/lib/cardano/wallet/Cip30SignedData.scala
+++ b/src/main/scala/hydrozoa/lib/cardano/wallet/Cip30SignedData.scala
@@ -1,0 +1,9 @@
+package hydrozoa.lib.cardano.wallet
+
+/** CIP-30 `signData()` output: COSE_Key + COSE_Sign1 as CBOR hex. Constructor is `private[wallet]`
+  * — only [[WalletModule]] impls produce values.
+  */
+final case class Cip30SignedData private[wallet] (
+    coseKeyCborHex: String,
+    coseSignatureCborHex: String,
+)

--- a/src/main/scala/hydrozoa/lib/cardano/wallet/WalletModule.scala
+++ b/src/main/scala/hydrozoa/lib/cardano/wallet/WalletModule.scala
@@ -1,6 +1,8 @@
 package hydrozoa.lib.cardano.wallet
 
+import com.bloxbean.cardano.client.address.{AddressProvider, Credential}
 import com.bloxbean.cardano.client.cip.cip30.CIP30DataSigner
+import com.bloxbean.cardano.client.common.model.Networks
 import com.bloxbean.cardano.client.crypto.Blake2bUtil
 import com.bloxbean.cardano.client.crypto.api.SigningProvider
 import com.bloxbean.cardano.client.crypto.bip32.key.{HdPrivateKey, HdPublicKey}
@@ -69,12 +71,12 @@ trait WalletModule:
 
     /** Sign `payload` as a CIP-30 `signData()` COSE_Sign1, returning the (coseKey, coseSignature)
       * pair as CBOR-encoded hex strings — the shape [[hydrozoa.multisig.server.JsonCodecs]] expects
-      * on the request wire. The `addressBytes` argument goes into the COSE protected headers and is
-      * not otherwise validated by the server-side verifier.
+      * on the request wire. The COSE "address" header is derived internally as an enterprise
+      * address of `verificationKey`'s payment credential; bloxbean's `CIP30DataSigner.verify` walks
+      * back to that credential when validating the signature.
       */
     def signCoseCip30(
         payload: Array[Byte],
-        addressBytes: Array[Byte],
         verificationKey: VerificationKey,
         signingKey: SigningKey
     ): (String, String)
@@ -122,10 +124,13 @@ object WalletModule {
 
         override def signCoseCip30(
             payload: Array[Byte],
-            addressBytes: Array[Byte],
             verificationKey: VerificationKey,
             signingKey: SigningKey
         ): (String, String) =
+            val keyHash = Blake2bUtil.blake2bHash224(verificationKey.getKeyData)
+            val addressBytes = AddressProvider
+                .getEntAddress(Credential.fromKey(keyHash), Networks.testnet())
+                .getBytes
             val ds = CIP30DataSigner.INSTANCE.signData(
               addressBytes,
               payload,
@@ -157,10 +162,13 @@ object WalletModule {
 
         override def signCoseCip30(
             payload: Array[Byte],
-            addressBytes: Array[Byte],
             verificationKey: VerificationKey,
             signingKey: SigningKey
         ): (String, String) =
+            val keyHash = Blake2bUtil.blake2bHash224(verificationKey.bytes)
+            val addressBytes = AddressProvider
+                .getEntAddress(Credential.fromKey(keyHash), Networks.testnet())
+                .getBytes
             val ds = CIP30DataSigner.INSTANCE.signData(
               addressBytes,
               payload,

--- a/src/main/scala/hydrozoa/lib/cardano/wallet/WalletModule.scala
+++ b/src/main/scala/hydrozoa/lib/cardano/wallet/WalletModule.scala
@@ -1,5 +1,6 @@
 package hydrozoa.lib.cardano.wallet
 
+import com.bloxbean.cardano.client.cip.cip30.CIP30DataSigner
 import com.bloxbean.cardano.client.crypto.Blake2bUtil
 import com.bloxbean.cardano.client.crypto.api.SigningProvider
 import com.bloxbean.cardano.client.crypto.bip32.key.{HdPrivateKey, HdPublicKey}
@@ -66,6 +67,18 @@ trait WalletModule:
         signingKey: SigningKey
     ): IArray[Byte]
 
+    /** Sign `payload` as a CIP-30 `signData()` COSE_Sign1, returning the (coseKey, coseSignature)
+      * pair as CBOR-encoded hex strings — the shape [[hydrozoa.multisig.server.JsonCodecs]] expects
+      * on the request wire. The `addressBytes` argument goes into the COSE protected headers and is
+      * not otherwise validated by the server-side verifier.
+      */
+    def signCoseCip30(
+        payload: Array[Byte],
+        addressBytes: Array[Byte],
+        verificationKey: VerificationKey,
+        signingKey: SigningKey
+    ): (String, String)
+
 object WalletModule {
     // TODO: this may be moved to test
     object BloxBean extends WalletModule:
@@ -107,6 +120,20 @@ object WalletModule {
             )
             IArray.from(signature)
 
+        override def signCoseCip30(
+            payload: Array[Byte],
+            addressBytes: Array[Byte],
+            verificationKey: VerificationKey,
+            signingKey: SigningKey
+        ): (String, String) =
+            val ds = CIP30DataSigner.INSTANCE.signData(
+              addressBytes,
+              payload,
+              signingKey.getKeyData,
+              verificationKey.getKeyData
+            )
+            (ds.key(), ds.signature())
+
     object Scalus extends WalletModule:
         override type VerificationKey = ScalusVerificationKey
         override type SigningKey = ScalusSigningKey
@@ -127,4 +154,18 @@ object WalletModule {
             val msgBs = ByteString.fromArray(IArray.genericWrapArray(msg).toArray)
             IArray.from(signEd25519(signingKey, msgBs).bytes)
         }
+
+        override def signCoseCip30(
+            payload: Array[Byte],
+            addressBytes: Array[Byte],
+            verificationKey: VerificationKey,
+            signingKey: SigningKey
+        ): (String, String) =
+            val ds = CIP30DataSigner.INSTANCE.signData(
+              addressBytes,
+              payload,
+              signingKey.bytes,
+              verificationKey.bytes
+            )
+            (ds.key(), ds.signature())
 }

--- a/src/main/scala/hydrozoa/lib/cardano/wallet/WalletModule.scala
+++ b/src/main/scala/hydrozoa/lib/cardano/wallet/WalletModule.scala
@@ -69,17 +69,18 @@ trait WalletModule:
         signingKey: SigningKey
     ): IArray[Byte]
 
-    /** Sign `payload` as a CIP-30 `signData()` COSE_Sign1, returning the (coseKey, coseSignature)
-      * pair as CBOR-encoded hex strings — the shape [[hydrozoa.multisig.server.JsonCodecs]] expects
-      * on the request wire. The COSE "address" header is derived internally as an enterprise
-      * address of `verificationKey`'s payment credential; bloxbean's `CIP30DataSigner.verify` walks
-      * back to that credential when validating the signature.
+    /** Sign `payload` as a CIP-30 `signData()` COSE_Sign1, returning a [[Cip30SignedData]] wrapping
+      * the (coseKey, coseSignature) CBOR-hex pair — the shape
+      * [[hydrozoa.multisig.server.JsonCodecs]] expects on the request wire. The COSE "address"
+      * header is derived internally as an enterprise address of `verificationKey`'s payment
+      * credential; bloxbean's `CIP30DataSigner.verify` walks back to that credential when
+      * validating the signature.
       */
     def signCoseCip30(
         payload: Array[Byte],
         verificationKey: VerificationKey,
         signingKey: SigningKey
-    ): (String, String)
+    ): Cip30SignedData
 
 object WalletModule {
     // TODO: this may be moved to test
@@ -126,7 +127,7 @@ object WalletModule {
             payload: Array[Byte],
             verificationKey: VerificationKey,
             signingKey: SigningKey
-        ): (String, String) =
+        ): Cip30SignedData =
             val keyHash = Blake2bUtil.blake2bHash224(verificationKey.getKeyData)
             val addressBytes = AddressProvider
                 .getEntAddress(Credential.fromKey(keyHash), Networks.testnet())
@@ -137,7 +138,7 @@ object WalletModule {
               signingKey.getKeyData,
               verificationKey.getKeyData
             )
-            (ds.key(), ds.signature())
+            Cip30SignedData(coseKeyCborHex = ds.key(), coseSignatureCborHex = ds.signature())
 
     object Scalus extends WalletModule:
         override type VerificationKey = ScalusVerificationKey
@@ -164,7 +165,7 @@ object WalletModule {
             payload: Array[Byte],
             verificationKey: VerificationKey,
             signingKey: SigningKey
-        ): (String, String) =
+        ): Cip30SignedData =
             val keyHash = Blake2bUtil.blake2bHash224(verificationKey.bytes)
             val addressBytes = AddressProvider
                 .getEntAddress(Credential.fromKey(keyHash), Networks.testnet())
@@ -175,5 +176,5 @@ object WalletModule {
               signingKey.bytes,
               verificationKey.bytes
             )
-            (ds.key(), ds.signature())
+            Cip30SignedData(coseKeyCborHex = ds.key(), coseSignatureCborHex = ds.signature())
 }

--- a/src/main/scala/hydrozoa/multisig/consensus/peer/PeerWallet.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/peer/PeerWallet.scala
@@ -76,7 +76,7 @@ final class PeerWallet(
       * coseSignatureCborHex)` — the shape the request-side JSON codec unpacks in
       * [[hydrozoa.multisig.server.JsonCodecs.UserRequestDecoder.validateCoseSignature]].
       */
-    def signCoseCip30(payload: Array[Byte]): (String, String) =
+    def signCoseCip30(payload: Array[Byte]): Cip30SignedData =
         walletModule.signCoseCip30(payload, verificationKey, signingKey)
 }
 

--- a/src/main/scala/hydrozoa/multisig/consensus/peer/PeerWallet.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/peer/PeerWallet.scala
@@ -71,6 +71,15 @@ final class PeerWallet(
         headerSerialized: IArray[Byte]
     ): BlockHeader.HeaderSignature =
         BlockHeader.Minor.HeaderSignature(walletModule.signMsg(headerSerialized, signingKey))
+
+    /** Sign `payload` as a CIP-30 `signData()` COSE_Sign1. Returns `(coseKeyCborHex,
+      * coseSignatureCborHex)` — the shape the request-side JSON codec unpacks in
+      * [[hydrozoa.multisig.server.JsonCodecs.UserRequestDecoder.validateCoseSignature]]. The
+      * "address" bytes required by CIP-30 are stubbed with the exported 32-byte public key, which
+      * the server-side verifier doesn't check against a Cardano address anyway.
+      */
+    def signCoseCip30(payload: Array[Byte]): (String, String) =
+        walletModule.signCoseCip30(payload, exportVerificationKey.bytes, verificationKey, signingKey)
 }
 
 object PeerWallet:

--- a/src/main/scala/hydrozoa/multisig/consensus/peer/PeerWallet.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/peer/PeerWallet.scala
@@ -74,12 +74,10 @@ final class PeerWallet(
 
     /** Sign `payload` as a CIP-30 `signData()` COSE_Sign1. Returns `(coseKeyCborHex,
       * coseSignatureCborHex)` — the shape the request-side JSON codec unpacks in
-      * [[hydrozoa.multisig.server.JsonCodecs.UserRequestDecoder.validateCoseSignature]]. The
-      * "address" bytes required by CIP-30 are stubbed with the exported 32-byte public key, which
-      * the server-side verifier doesn't check against a Cardano address anyway.
+      * [[hydrozoa.multisig.server.JsonCodecs.UserRequestDecoder.validateCoseSignature]].
       */
     def signCoseCip30(payload: Array[Byte]): (String, String) =
-        walletModule.signCoseCip30(payload, exportVerificationKey.bytes, verificationKey, signingKey)
+        walletModule.signCoseCip30(payload, verificationKey, signingKey)
 }
 
 object PeerWallet:

--- a/src/main/scala/hydrozoa/multisig/ledger/l1/tx/FallbackTx.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/l1/tx/FallbackTx.scala
@@ -156,7 +156,8 @@ private object FallbackTxOps {
 
                     // TODO: Partial, hacked in during a refactor
                     private val output = {
-                        val v = treasuryUtxoSpent.value - Value(treasuryUtxoSpent.equity.coin)
+                        val v = treasuryUtxoSpent.value - Value(treasuryUtxoSpent.equity.coin) +
+                            Value(config.collectiveContingency.minAdaForTreasury)
                         RuleBasedTreasuryOutput(
                           value = v,
                           datum = datum,
@@ -185,7 +186,6 @@ private object FallbackTxOps {
                             mkBallotBox(
                               VD.public(treasuryUtxoSpent.kzgCommitment).toData,
                               config.collectiveContingency.publicVoteDeposit
-                                  + config.collectiveContingency.minAdaForTreasury
                             )
                         }
                     }
@@ -248,7 +248,8 @@ private object FallbackTxOps {
                 // FIXME: Partial, introduced during a refactor where RuleBasedTreasuryOutput began to verify
                 // that the constructed output did indeed have a valid treasury token
                 val treasuryOutputProduced = {
-                    val value = treasuryUtxoSpent.value - Value(treasuryUtxoSpent.equity.coin)
+                    val value = treasuryUtxoSpent.value - Value(treasuryUtxoSpent.equity.coin) +
+                        Value(config.collectiveContingency.minAdaForTreasury)
                     RuleBasedTreasuryOutput(
                       datum = Steps.Sends.Treasury.datum,
                       value = value

--- a/src/main/scala/hydrozoa/multisig/ledger/l1/tx/FallbackTx.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/l1/tx/FallbackTx.scala
@@ -7,12 +7,14 @@ import hydrozoa.config.head.multisig.timing.TxTiming.BlockTimes.FallbackTxStartT
 import hydrozoa.lib.cardano.scalus.contextualscalus.Change
 import hydrozoa.lib.cardano.scalus.contextualscalus.TransactionBuilder.{addExpectedSigners, build, finalizeContext}
 import hydrozoa.multisig.consensus.peer.HeadPeerNumber
+import hydrozoa.multisig.ledger.commitment.TrustedSetup
 import hydrozoa.multisig.ledger.l1.script.multisig.HeadMultisigScript
 import hydrozoa.multisig.ledger.l1.tx.Metadata.Fallback
 import hydrozoa.multisig.ledger.l1.utxo.{MultisigRegimeOutput, MultisigRegimeUtxo, MultisigTreasuryUtxo}
 import hydrozoa.rulebased.ledger.l1.state.TreasuryState.RuleBasedTreasuryDatum.Unresolved
 import hydrozoa.rulebased.ledger.l1.state.VoteDatum as VD
 import hydrozoa.rulebased.ledger.l1.state.VoteState.VoteDatum
+import hydrozoa.rulebased.ledger.l1.tx.EvacuationTx
 import hydrozoa.rulebased.ledger.l1.utxo.{RuleBasedTreasuryOutput, RuleBasedTreasuryUtxo}
 import io.circe.*
 import monocle.{Focus, Lens}
@@ -20,13 +22,13 @@ import scalus.cardano.address.ShelleyAddress
 import scalus.cardano.ledger.DatumOption.Inline
 import scalus.cardano.ledger.TransactionOutput.Babbage
 import scalus.cardano.ledger.{Mint as _, TransactionOutput, *}
-import scalus.cardano.onchain.plutus.prelude.List as SList
 import scalus.cardano.onchain.plutus.v1.PubKeyHash
 import scalus.cardano.txbuilder.*
 import scalus.cardano.txbuilder.TransactionBuilder.ResolvedUtxos
 import scalus.cardano.txbuilder.TransactionBuilderStep.*
 import scalus.uplc.builtin.Builtins.blake2b_224
 import scalus.uplc.builtin.Data.toData
+import scalus.uplc.builtin.bls12_381.G2Element
 import scalus.uplc.builtin.{ByteString, Data}
 import scalus.|>
 
@@ -143,8 +145,12 @@ private object FallbackTxOps {
                               config.slotConfig.slotToTime(validityStartTime.toSlot.slot) +
                                   config.votingDuration.finiteDuration.toMillis,
                           versionMajor = Steps.Spends.Treasury.datum.versionMajor.toInt,
-                          // TODO: pull the onchain G2 prefix from the head's TrustedSetup
-                          setupG2 = SList.empty
+                          // Size the G2 prefix to cover the largest EvacuationTx the treasury will
+                          // ever validate (evacuatedUtxos.length + 1 elements per tx, capped at
+                          // maxEvacuationsPerTx).
+                          setupG2 = TrustedSetup
+                              .takeSrsG2(EvacuationTx.Assumptions.maxEvacuationsPerTx + 1)
+                              .map(p2 => G2Element(p2).toCompressedByteString)
                         )
                     }
 

--- a/src/main/scala/hydrozoa/multisig/server/JsonCodecs.scala
+++ b/src/main/scala/hydrozoa/multisig/server/JsonCodecs.scala
@@ -248,7 +248,10 @@ object JsonCodecs {
             Json.obj("requestId" -> ra.requestId.asJson)
         }
 
-//    given requestAcceptedDecoder: Decoder[RequestAccepted] = deriveDecoder[RequestAccepted]
+    given requestAcceptedDecoder: Decoder[RequestAccepted] = c => {
+        import RequestId.i64.given
+        c.downField("requestId").as[RequestId].map(RequestAccepted.apply)
+    }
 
     given errorEncoder: Encoder[Error] = deriveEncoder[Error]
 

--- a/src/main/scala/hydrozoa/multisig/server/SubmissionClient.scala
+++ b/src/main/scala/hydrozoa/multisig/server/SubmissionClient.scala
@@ -1,8 +1,17 @@
 package hydrozoa.multisig.server
 
 import cats.effect.IO
-import hydrozoa.multisig.consensus.{RequestSequencer, UserRequest}
+import hydrozoa.multisig.consensus.peer.PeerWallet
+import hydrozoa.multisig.consensus.{RequestSequencer, UserRequest, UserRequestBody}
 import hydrozoa.multisig.ledger.event.RequestId
+import hydrozoa.multisig.server.ApiResponse.RequestAccepted
+import hydrozoa.multisig.server.JsonCodecs.given
+import io.circe.Json
+import io.circe.syntax.*
+import org.http4s.circe.CirceEntityDecoder.*
+import org.http4s.circe.CirceEntityEncoder.*
+import org.http4s.client.Client
+import org.http4s.{Method, Request as Http4sRequest, Uri}
 
 /** A client-side handle for submitting [[UserRequest]]s to a Hydrozoa peer and awaiting its
   * assigned [[RequestId]]. Abstracts over the transport: an in-process actor send, an in-memory
@@ -20,3 +29,42 @@ object SubmissionClient:
         new SubmissionClient:
             def submit(userRequest: UserRequest): IO[RequestId] =
                 handle ?: userRequest
+
+    /** http4s-based impl: signs the [[UserRequestHeader]] with `wallet` as a CIP-30 COSE_Sign1,
+      * routes the request to the deposit-register or l2-submit endpoint by variant, and expects a
+      * [[RequestAccepted]] JSON response. `client` can be a real http4s `Client[IO]` or an
+      * in-memory `Client.fromHttpApp` — the harness uses the latter so no socket is bound.
+      */
+    def http(
+        client: Client[IO],
+        baseUri: Uri,
+        wallet: PeerWallet,
+    ): SubmissionClient =
+        new SubmissionClient:
+            def submit(userRequest: UserRequest): IO[RequestId] =
+                val (coseKey, coseSignature) = wallet.signCoseCip30(userRequest.header.bytes)
+                val bodyJson                 = signedRequestJson(userRequest, coseKey, coseSignature)
+                val path                     = pathFor(userRequest)
+                val req = Http4sRequest[IO](Method.POST, baseUri.withPath(path))
+                    .withEntity(bodyJson)
+                client.expect[RequestAccepted](req).map(_.requestId)
+
+    private def pathFor(request: UserRequest): Uri.Path =
+        request match
+            case _: UserRequest.DepositRequest     => Uri.Path.unsafeFromString("/api/deposit/register")
+            case _: UserRequest.TransactionRequest => Uri.Path.unsafeFromString("/api/l2/submit")
+
+    private def signedRequestJson(
+        request: UserRequest,
+        coseKey: String,
+        coseSignature: String,
+    ): Json =
+        val bodyField: (String, Json) = request.body match
+            case b: UserRequestBody.DepositRequestBody     => "deposit"     -> b.asJson
+            case b: UserRequestBody.TransactionRequestBody => "transaction" -> b.asJson
+        Json.obj(
+          "header"        -> request.header.asJson,
+          bodyField,
+          "coseKey"       -> Json.fromString(coseKey),
+          "coseSignature" -> Json.fromString(coseSignature),
+        )

--- a/src/main/scala/hydrozoa/multisig/server/SubmissionClient.scala
+++ b/src/main/scala/hydrozoa/multisig/server/SubmissionClient.scala
@@ -1,0 +1,22 @@
+package hydrozoa.multisig.server
+
+import cats.effect.IO
+import hydrozoa.multisig.consensus.{RequestSequencer, UserRequest}
+import hydrozoa.multisig.ledger.event.RequestId
+
+/** A client-side handle for submitting [[UserRequest]]s to a Hydrozoa peer and awaiting its
+  * assigned [[RequestId]]. Abstracts over the transport: an in-process actor send, an in-memory
+  * http4s round-trip against [[HydrozoaRoutes]], or a real over-the-wire HTTP call.
+  */
+trait SubmissionClient:
+    def submit(userRequest: UserRequest): IO[RequestId]
+
+object SubmissionClient:
+
+    /** In-process impl that forwards to a peer's [[RequestSequencer]] actor via `?:`. Matches the
+      * pre-HTTP integration path used by the multipeer harness.
+      */
+    def direct(handle: RequestSequencer.Handle): SubmissionClient =
+        new SubmissionClient:
+            def submit(userRequest: UserRequest): IO[RequestId] =
+                handle ?: userRequest

--- a/src/main/scala/hydrozoa/multisig/server/SubmissionClient.scala
+++ b/src/main/scala/hydrozoa/multisig/server/SubmissionClient.scala
@@ -1,6 +1,7 @@
 package hydrozoa.multisig.server
 
 import cats.effect.IO
+import hydrozoa.lib.cardano.wallet.Cip30SignedData
 import hydrozoa.multisig.consensus.peer.PeerWallet
 import hydrozoa.multisig.consensus.{RequestSequencer, UserRequest, UserRequestBody}
 import hydrozoa.multisig.ledger.event.RequestId
@@ -42,8 +43,8 @@ object SubmissionClient:
     ): SubmissionClient =
         new SubmissionClient:
             def submit(userRequest: UserRequest): IO[RequestId] =
-                val (coseKey, coseSignature) = wallet.signCoseCip30(userRequest.header.bytes)
-                val bodyJson = signedRequestJson(userRequest, coseKey, coseSignature)
+                val signed = wallet.signCoseCip30(userRequest.header.bytes)
+                val bodyJson = signedRequestJson(userRequest, signed)
                 val path = pathFor(userRequest)
                 val req = Http4sRequest[IO](Method.POST, baseUri.withPath(path))
                     .withEntity(bodyJson)
@@ -56,8 +57,7 @@ object SubmissionClient:
 
     private def signedRequestJson(
         request: UserRequest,
-        coseKey: String,
-        coseSignature: String,
+        signed: Cip30SignedData,
     ): Json =
         val bodyField: (String, Json) = request.body match
             case b: UserRequestBody.DepositRequestBody     => "deposit" -> b.asJson
@@ -65,6 +65,6 @@ object SubmissionClient:
         Json.obj(
           "header" -> request.header.asJson,
           bodyField,
-          "coseKey" -> Json.fromString(coseKey),
-          "coseSignature" -> Json.fromString(coseSignature),
+          "coseKey" -> Json.fromString(signed.coseKeyCborHex),
+          "coseSignature" -> Json.fromString(signed.coseSignatureCborHex),
         )

--- a/src/main/scala/hydrozoa/multisig/server/SubmissionClient.scala
+++ b/src/main/scala/hydrozoa/multisig/server/SubmissionClient.scala
@@ -43,15 +43,15 @@ object SubmissionClient:
         new SubmissionClient:
             def submit(userRequest: UserRequest): IO[RequestId] =
                 val (coseKey, coseSignature) = wallet.signCoseCip30(userRequest.header.bytes)
-                val bodyJson                 = signedRequestJson(userRequest, coseKey, coseSignature)
-                val path                     = pathFor(userRequest)
+                val bodyJson = signedRequestJson(userRequest, coseKey, coseSignature)
+                val path = pathFor(userRequest)
                 val req = Http4sRequest[IO](Method.POST, baseUri.withPath(path))
                     .withEntity(bodyJson)
                 client.expect[RequestAccepted](req).map(_.requestId)
 
     private def pathFor(request: UserRequest): Uri.Path =
         request match
-            case _: UserRequest.DepositRequest     => Uri.Path.unsafeFromString("/api/deposit/register")
+            case _: UserRequest.DepositRequest => Uri.Path.unsafeFromString("/api/deposit/register")
             case _: UserRequest.TransactionRequest => Uri.Path.unsafeFromString("/api/l2/submit")
 
     private def signedRequestJson(
@@ -60,11 +60,11 @@ object SubmissionClient:
         coseSignature: String,
     ): Json =
         val bodyField: (String, Json) = request.body match
-            case b: UserRequestBody.DepositRequestBody     => "deposit"     -> b.asJson
+            case b: UserRequestBody.DepositRequestBody     => "deposit" -> b.asJson
             case b: UserRequestBody.TransactionRequestBody => "transaction" -> b.asJson
         Json.obj(
-          "header"        -> request.header.asJson,
+          "header" -> request.header.asJson,
           bodyField,
-          "coseKey"       -> Json.fromString(coseKey),
+          "coseKey" -> Json.fromString(coseKey),
           "coseSignature" -> Json.fromString(coseSignature),
         )

--- a/src/main/scala/hydrozoa/rulebased/RuleBasedActor.scala
+++ b/src/main/scala/hydrozoa/rulebased/RuleBasedActor.scala
@@ -708,13 +708,12 @@ final case class RuleBasedActor(
                         )
                     else traceRight(RuleBasedActorEvent.Evacuation.PayoutsLeft(toEvacuate.size))
 
-                feeAndCollateral <- getFeeAndCollateral
+                collateralUtxo <- getEvacuationCollateral
                 evacBuilder = EvacuationTx.Build(
                   inputTreasuryUtxo = treasuryUtxo,
                   evacuateesToTryNext = toEvacuate,
                   allRemainingEvacuatees = toEvacuate,
-                  feeUtxos = feeAndCollateral._1,
-                  collateralUtxo = feeAndCollateral._2
+                  collateralUtxo = collateralUtxo
                 )
                 // NoEvacuatees is recoverable (poll-then-retry), not a fatal build failure — peel
                 // it off before delegating to the generic buildAndSubmit which raises on Left.
@@ -821,7 +820,7 @@ final case class RuleBasedActor(
             }
 
         /** Query the evacuation wallet's utxos and derive collateral from the first one. */
-        def getFeeAndCollateral: EitherT[IO, Error.RecoverableErrors, (Utxos, CollateralUtxo)] = {
+        def getEvacuationCollateral: EitherT[IO, Error.RecoverableErrors, CollateralUtxo] = {
             val walletAddress = config.ruleBasedWallet.exportVerificationKey.shelleyAddress()
             for {
                 feeUtxos <- Backend.utxosAtFee(walletAddress)
@@ -841,7 +840,7 @@ final case class RuleBasedActor(
                                 )
                         }
                 }
-            } yield (feeUtxos, collateralUtxo)
+            } yield collateralUtxo
         }
     }
 

--- a/src/main/scala/hydrozoa/rulebased/RuleBasedActor.scala
+++ b/src/main/scala/hydrozoa/rulebased/RuleBasedActor.scala
@@ -14,6 +14,7 @@ import hydrozoa.config.node.NodePrivateConfig
 import hydrozoa.config.node.operation.evacuation.NodeOperationEvacuationConfig
 import hydrozoa.config.node.owninfo.OwnPeerPublic
 import hydrozoa.config.{HydrozoaBlueprint, ScriptReferenceUtxos}
+import hydrozoa.lib.cardano.scalus.QuantizedTime.QuantizedInstant.realTimeQuantizedInstant
 import hydrozoa.lib.cardano.scalus.VerificationKeyExtra.{pubKeyHash, shelleyAddress}
 import hydrozoa.lib.cardano.scalus.ledger.{CollateralOutput, CollateralUtxo}
 import hydrozoa.lib.logging.ContraTracer
@@ -115,7 +116,11 @@ final case class RuleBasedActor(
             )
 
         def utxosAtFee(addr: ShelleyAddress): EitherT[IO, Error.RecoverableErrors, Utxos] =
-            run(cardanoBackend.utxosAt(addr), RuleBasedActorEvent.Backend.ErrorFeeUtxos(_))
+            traced(
+              before = RuleBasedActorEvent.Fee.Querying(addr),
+              action = cardanoBackend.utxosAt(addr),
+              onError = RuleBasedActorEvent.Backend.ErrorFeeUtxos(_)
+            )
 
         def continuingTreasuryTxsAfter(
             after: TransactionHash
@@ -464,12 +469,16 @@ final case class RuleBasedActor(
             parsed: List[BallotBox[VoteStatus]],
             targetVersionMinor: BigInt
         ): Option[BallotBox[Voted | Abstain.type]] = {
-            val openBoxes: List[(BallotBox[Voted | Abstain.type], BigInt)] = parsed.collect {
-                case bb if bb.ballotBoxOutput.status.isInstanceOf[Voted] =>
-                    val v = bb.ballotBoxOutput.status.asInstanceOf[Voted]
-                    (bb.asInstanceOf[BallotBox[Voted | Abstain.type]], v.versionMinor)
-                case bb if bb.ballotBoxOutput.status == Abstain =>
-                    (bb.asInstanceOf[BallotBox[Voted | Abstain.type]], BigInt(0))
+            // BallotBox is invariant in its Status parameter, so the narrowed type has to be
+            // recovered by cast — the match itself is the check that keeps it sound.
+            val openBoxes: List[(BallotBox[Voted | Abstain.type], BigInt)] = parsed.flatMap { bb =>
+                bb.ballotBoxOutput.status match {
+                    case v: Voted =>
+                        List((bb.asInstanceOf[BallotBox[Voted | Abstain.type]], v.versionMinor))
+                    case Abstain =>
+                        List((bb.asInstanceOf[BallotBox[Voted | Abstain.type]], BigInt(0)))
+                    case _: AwaitingVote => Nil
+                }
             }
             openBoxes.filter(_._2 < targetVersionMinor).sortBy(_._2).headOption.map(_._1)
         }
@@ -495,11 +504,14 @@ final case class RuleBasedActor(
                                   treasuryUtxo,
                                   collateralUtxo
                                 )
-                        case _ => raiseError(Error.NonVotedUtxoAtResolve(x))
+                        case _ =>
+                            EitherT.leftT[IO, Unit](
+                              Error.NonVotedUtxoAtResolve(x): Error.RecoverableErrors
+                            )
                     }
-                case xs =>
+                case x :: y :: rest =>
                     traceRight(RuleBasedActorEvent.Dispute.ParsingTally) >>
-                        tally(xs, treasuryUtxo, collateralUtxo)
+                        tally(NonEmptyList(x, y :: rest), treasuryUtxo, collateralUtxo)
             }
 
         /** Parse the treasury's `versionMajor` from an Unresolved datum. `Dispute.handle` is only
@@ -621,17 +633,27 @@ final case class RuleBasedActor(
                 }
             } yield ()
 
-        /** Branch: deadline passed; merge two ballot boxes via TallyTx. The continuing input must
-          * have a key strictly less than the removed input, so we sort.
+        /** Merge two ballot boxes via TallyTx. The continuing input must have a key strictly less
+          * than the removed input, so we sort. If any residual is still `AwaitingVote`, we defer
+          * until the voting deadline elapses — on-chain the tally would still succeed (maxVote
+          * treats AwaitingVote < Voted), but pre-deadline we don't want to submit txs whose
+          * validity range starts in the future and just park in the mempool.
           */
         def tally(
-            otherUtxos: Seq[BallotBox[VoteStatus]],
+            otherUtxos: NonEmptyList[BallotBox[VoteStatus]],
             treasuryUtxo: RuleBasedTreasuryUtxo,
             collateralUtxo: CollateralUtxo
         ): EitherT[IO, Error.RecoverableErrors, Unit] = {
+            val hasAwaitingVote = otherUtxos.exists(_.ballotBoxOutput.status match {
+                case _: AwaitingVote => true
+                case _               => false
+            })
             val keySorted = otherUtxos.sortBy(_.ballotBoxOutput.key)
             val continuing = keySorted.head
             for {
+                _ <-
+                    if hasAwaitingVote then gateOnVotingDeadline(treasuryUtxo)
+                    else pure(())
                 _ <- traceRight(RuleBasedActorEvent.Tx.Tallying)
                 removed <- keySorted.tail.find(ballotBox =>
                     ballotBox.ballotBoxOutput.key == continuing.ballotBoxOutput.link
@@ -652,6 +674,31 @@ final case class RuleBasedActor(
                 )
             } yield ()
         }
+
+        /** Recoverable Left when wall-clock time hasn't crossed the treasury's voting deadline;
+          * Right otherwise. `parseVotingDeadline` failure escalates as an unrecoverable spec
+          * violation (we only reach here on an Unresolved treasury).
+          */
+        private def gateOnVotingDeadline(
+            treasuryUtxo: RuleBasedTreasuryUtxo
+        ): EitherT[IO, Error.RecoverableErrors, Unit] =
+            for {
+                deadline <- treasuryUtxo.parseVotingDeadline match {
+                    case Right(s) => pure(s)
+                    case Left(e) =>
+                        raiseError(Error.ParseError.Treasury.WrappedTreasuryParseError(e))
+                }
+                now <- EitherT.right[Error.RecoverableErrors](
+                  realTimeQuantizedInstant(config.slotConfig)
+                )
+                _ <-
+                    if now.toSlot.slot <= deadline.slot then
+                        traceRight(RuleBasedActorEvent.Dispute.WaitingForVotesBeforeDeadline) >>
+                            EitherT.leftT[IO, Unit](
+                              Error.TallyBlockedByAwaitingVote: Error.RecoverableErrors
+                            )
+                    else pure(())
+            } yield ()
 
         /** Branch: only a single Voted ballot box remains. Submit ResolutionTx to flip the treasury
           * datum to `Resolved`.
@@ -727,14 +774,16 @@ final case class RuleBasedActor(
                 ](loadEvacuationInputs)
 
                 // The resolution tx is the last (oldest) tx after the fallback that spends the
-                // treasury; the preceding entries are withdrawal transactions.
+                // treasury; the preceding entries are withdrawal transactions. `parsePastRedeemers`
+                // gates non-empty, parses each withdrawal's redeemer, and extracts the
+                // resolution-time kzg from the oldest datum in one pass.
                 treasuryTxs <- Backend.continuingTreasuryTxsAfter(inputs.fallbackTxHash)
-                pastEvacuateRedeemers <- parsePastRedeemers(treasuryTxs)
+                parsed <- parsePastRedeemers(treasuryTxs)
+                (pastEvacuateRedeemers, resolutionKzg) = parsed
 
                 // The treasury's current `evacuationActive` commits to the REMAINING map after
                 // past withdrawals; the original resolution-time map is committed by the oldest
                 // treasury tx's output datum, which is what `candidateEvacMaps` is keyed by.
-                resolutionKzg <- parseResolutionKzg(treasuryTxs)
                 evacuationMapAtResolution <- lookupMap(resolutionKzg, inputs.candidateEvacMaps)
 
                 previouslyEvacuated: Set[EvacuationKey] = pastEvacuateRedeemers.foldLeft(
@@ -742,60 +791,52 @@ final case class RuleBasedActor(
                 )((acc, redeemer) => acc ++ redeemer.evacuationKeys.toScalaList)
             } yield evacuationMapAtResolution.removedAll(previouslyEvacuated)
 
-        /** Parse the redeemers of past withdrawal transactions. The list's last entry is the
-          * resolution tx (no evacuate redeemer); everything before is a withdrawal whose redeemer
-          * names the keys evacuated by that tx.
+        /** Parse the past withdrawal redeemers and the resolution-time evacuation kzg from
+          * `treasuryTxs`. The list's last (oldest) entry is the resolution tx: no evacuate
+          * redeemer, and its output datum commits to the kzg the candidate maps are keyed by.
+          * Everything before is a withdrawal whose redeemer names the keys evacuated by that tx. An
+          * empty list means the backend hasn't surfaced the resolution tx yet (race vs the resolved
+          * datum we already parsed, or a rollback) — recoverable.
           */
         def parsePastRedeemers(
             treasuryTxs: List[(TransactionHash, Data, Data)]
-        ): EitherT[IO, Error.RecoverableErrors, List[EvacuateRedeemer]] =
-            treasuryTxs.length match {
-                // Backend hasn't surfaced the resolution tx yet — race vs the resolved datum we
-                // already parsed, or a rollback. The recoverable Left propagates; no extra trace.
-                case 0 =>
-                    EitherT.leftT[IO, List[EvacuateRedeemer]](
+        ): EitherT[IO, Error.RecoverableErrors, (List[EvacuateRedeemer], KzgCommitment)] =
+            NonEmptyList.fromList(treasuryTxs) match {
+                case None =>
+                    EitherT.leftT[IO, (List[EvacuateRedeemer], KzgCommitment)](
                       Error.QueryError.NoTreasuryFound: Error.RecoverableErrors
                     )
-                // Resolution only, no withdrawals processed yet.
-                case 1 => pure(List.empty[EvacuateRedeemer])
-                case _ =>
-                    treasuryTxs.init.traverse { case (_, redeemerData, _) =>
-                        Try(fromData[TreasuryRedeemer](redeemerData)) match {
-                            case Failure(t) =>
-                                raiseError(
-                                  Error.ParseError.TreasuryEvacuationRedeemerParseError(t)
-                                )
-                            case Success(TreasuryRedeemer.Evacuate(r)) => pure(r)
-                            case Success(_) =>
-                                EitherT.leftT[IO, EvacuateRedeemer](
-                                  Error.ParseError.TreasuryDeinitialized: Error.RecoverableErrors
-                                )
+                case Some(nel) =>
+                    val resolutionDatum = nel.last._3
+                    val withdrawalTxs = nel.init
+                    for {
+                        redeemers <- withdrawalTxs.traverse { case (_, redeemerData, _) =>
+                            Try(fromData[TreasuryRedeemer](redeemerData)) match {
+                                case Failure(t) =>
+                                    raiseError(
+                                      Error.ParseError.TreasuryEvacuationRedeemerParseError(t)
+                                    )
+                                case Success(TreasuryRedeemer.Evacuate(r)) => pure(r)
+                                case Success(_) =>
+                                    EitherT.leftT[IO, EvacuateRedeemer](
+                                      Error.ParseError.TreasuryDeinitialized: Error.RecoverableErrors
+                                    )
+                            }
                         }
-                    }
+                        kzg <- Try(
+                          fromData[TreasuryState.RuleBasedTreasuryDatumOnchain](resolutionDatum)
+                        ) match {
+                            case Failure(t) =>
+                                raiseError(Error.ParseError.TreasuryResolveRedeemerParseError(t))
+                            case Success(
+                                  r: TreasuryState.RuleBasedTreasuryDatumOnchain.ResolvedOnchain
+                                ) =>
+                                pure(r.evacuationActive)
+                            case Success(_) =>
+                                raiseError(Error.ParseError.TreasuryNotResolved)
+                        }
+                    } yield (redeemers, kzg)
             }
-
-        /** Parse the resolution-time evacuation kzg from the oldest entry of `treasuryTxs` (the
-          * resolution tx's output datum). This is the kzg the candidate maps are keyed by — it
-          * differs from the current treasury's `evacuationActive` once any withdrawals have
-          * occurred.
-          */
-        def parseResolutionKzg(
-            treasuryTxs: List[(TransactionHash, Data, Data)]
-        ): EitherT[IO, Error.RecoverableErrors, KzgCommitment] = {
-            val resolutionTreasuryOutputDatum = treasuryTxs.last._3
-            Try(
-              fromData[TreasuryState.RuleBasedTreasuryDatumOnchain](
-                resolutionTreasuryOutputDatum
-              )
-            ) match {
-                case Failure(t) =>
-                    raiseError(Error.ParseError.TreasuryResolveRedeemerParseError(t))
-                case Success(r: TreasuryState.RuleBasedTreasuryDatumOnchain.ResolvedOnchain) =>
-                    pure(r.evacuationActive)
-                case Success(_) =>
-                    raiseError(Error.ParseError.TreasuryNotResolved)
-            }
-        }
 
         /** Look up the evacuation-map preimage that the resolution committed to. */
         def lookupMap(
@@ -848,6 +889,9 @@ final case class RuleBasedActor(
         et.value
     }
 
+    // preStart runs in the actor's lifecycle callback, outside the receive loop; posting a
+    // PreStart message defers initialization (`preStartLocal`) into the receive loop, matching
+    // the codebase-wide idiom used across the multisig actors.
     override def preStart: IO[Unit] =
         context.self ! Requests.PreStart
 
@@ -859,24 +903,11 @@ final case class RuleBasedActor(
         case _: Requests.Tick.type     => handleTick.void
     }
 
-    /** Queries the cardano backend for all utxos at the dispute resolution address, and then parses
-      * them.
-      *
-      * Assumptions
-      *   - We don't have any extra vote utxos that will validly parse, i.e., we don't check the
-      *     number of utxos given to this function. This is an invariant of the system and needs to
-      *     be established elsewhere
-      *     - We assume the CardanoBackend is correctly implemented such that
-      *       - We receive all the vote utxos that exist at the time of the query; we're not missing
-      *         any.
-      *       - Each utxo has a correct transaction input according to the results of the query.
-      *       - Each utxo has the correct vote token in it and sits at the correct adddress.
-      */
-    /** Query the dispute address utxos, parse each into a [[BallotBox]], and classify the set into
-      * the appropriate [[DisputeUtxos]] case. Traces each phase (Querying / Parsing / Parsed*).
-      */
     /** Query and parse the dispute address's utxos into a flat list of `BallotBox[VoteStatus]`,
       * emitting the shared `Dispute.Parsing` trace. Head and coil paths classify on top.
+      *
+      * Assumes the backend returns every vote utxo that exists at query time (each with the correct
+      * input, vote token, and address); parse failures raise via `IO.fromEither`.
       */
     private def parseDisputeUtxos
         : EitherT[IO, Error.RecoverableErrors, List[BallotBox[VoteStatus]]] =
@@ -918,11 +949,14 @@ final case class RuleBasedActor(
                                             x.asInstanceOf[BallotBox[Voted]]
                                           ): DisputeUtxos
                                         )
-                                case _ => raiseError(Error.NonVotedUtxoAtResolve(x))
+                                case _ =>
+                                    EitherT.leftT[IO, DisputeUtxos](
+                                      Error.NonVotedUtxoAtResolve(x): Error.RecoverableErrors
+                                    )
                             }
-                        case xs =>
+                        case x :: y :: rest =>
                             traceRight(RuleBasedActorEvent.Dispute.ParsingTally)
-                                .as(DisputeUtxos.Tally(xs): DisputeUtxos)
+                                .as(DisputeUtxos.Tally(NonEmptyList(x, y :: rest)): DisputeUtxos)
                     }
             }
         } yield result
@@ -942,7 +976,7 @@ object RuleBasedActor {
       */
     enum DisputeUtxos:
         case CastVote(ownVoteUtxo: BallotBox[AwaitingVote])
-        case Tally(utxos: Seq[BallotBox[VoteStatus]])
+        case Tally(utxos: NonEmptyList[BallotBox[VoteStatus]])
         case Resolve(finalVoteUtxo: BallotBox[Voted])
         case EmptyVotes
 
@@ -1053,24 +1087,28 @@ object RuleBasedActor {
             wrapped: CardanoBackend.Error
         ) extends Recoverable
 
+        // Tally deferred: residuals contain an AwaitingVote and the voting deadline hasn't
+        // elapsed. On-chain the tally would still succeed (maxVote treats AwaitingVote < Voted),
+        // but pre-deadline we prefer to wait so the tx-builder isn't submitting future-validity
+        // txs that just park in the mempool.
+        case object TallyBlockedByAwaitingVote extends Recoverable
+
         type UnrecoverableErrors = Unrecoverable | Membership.MembershipCheckError
         sealed trait Unrecoverable extends Exception
 
         // Dispute side
         case object TreasuryUnresolvedButNoVotes extends Unrecoverable
-        case class NoCompatibleVoteForTallyingFound(voteUtxos: Seq[BallotBox[VoteStatus]])
-            extends Unrecoverable {
+        case class NoCompatibleVoteForTallyingFound(
+            voteUtxos: NonEmptyList[BallotBox[VoteStatus]]
+        ) extends Unrecoverable {
             override def getMessage: String =
-                s"No compatible ballot box with key ${voteUtxos.head._2.link} found. Datums found: " +
-                    s"${voteUtxos.map { _._2 }}"
+                s"No compatible ballot box with key ${voteUtxos.head.ballotBoxOutput.link} " +
+                    s"found. Datums found: ${voteUtxos.map(_.ballotBoxOutput).toList}"
         }
         // Treasury is unresolved, exactly one vote utxo remains, but its status isn't Voted.
-        // The spec says the final tally output is always Voted — Abstain/AwaitingVote here
-        // means the on-chain state has diverged from what we expect, so we escalate.
-        case class NonVotedUtxoAtResolve(voteUtxo: BallotBox[VoteStatus]) extends Unrecoverable {
-            override def getMessage: String =
-                s"Single remaining vote utxo at resolve time is not Voted: $voteUtxo"
-        }
+        // On a coil peer running before the deadline this is legitimate — the head peer just
+        // hasn't voted yet. Poll and retry.
+        case class NonVotedUtxoAtResolve(voteUtxo: BallotBox[VoteStatus]) extends Recoverable
         case class UnrecoverableCardanoBackendError(
             wrapped: CardanoBackend.Error
         ) extends Unrecoverable {

--- a/src/main/scala/hydrozoa/rulebased/RuleBasedActorEvent.scala
+++ b/src/main/scala/hydrozoa/rulebased/RuleBasedActorEvent.scala
@@ -2,6 +2,7 @@ package hydrozoa.rulebased
 
 import hydrozoa.multisig.backend.cardano.CardanoBackend
 import hydrozoa.multisig.ledger.l1.tx.EnrichedTx
+import scalus.cardano.address.ShelleyAddress
 
 sealed trait RuleBasedActorEvent
 
@@ -29,6 +30,9 @@ object RuleBasedActorEvent:
         final case class NotFound(peerLabel: String) extends RuleBasedActorEvent
         case object NoFeeCollateralUtxo extends RuleBasedActorEvent
 
+    object Fee:
+        final case class Querying(address: ShelleyAddress) extends RuleBasedActorEvent
+
     object Dispute:
         case object Querying extends RuleBasedActorEvent
         case object Parsing extends RuleBasedActorEvent
@@ -36,6 +40,11 @@ object RuleBasedActorEvent:
         case object ParsingTally extends RuleBasedActorEvent
         case object ParsingResolve extends RuleBasedActorEvent
         case object ParsingEmptyVotes extends RuleBasedActorEvent
+
+        /** Residual set still contains an AwaitingVote ballot and the voting deadline has not
+          * elapsed; tally is deferred until on-chain time crosses the deadline.
+          */
+        case object WaitingForVotesBeforeDeadline extends RuleBasedActorEvent
 
         /** Coil-peer classifier outcomes for the coil ratchet path (see
           * [[RuleBasedActor.Dispute.handleCoil]]).

--- a/src/main/scala/hydrozoa/rulebased/RuleBasedActorEventFormat.scala
+++ b/src/main/scala/hydrozoa/rulebased/RuleBasedActorEventFormat.scala
@@ -38,12 +38,17 @@ object RuleBasedActorEventFormat:
             case Collateral.NoFeeCollateralUtxo =>
                 debug("No fee/collateral UTxO found at wallet address, retrying")
 
+            case Fee.Querying(address) =>
+                debug(s"Querying fee utxos at address $address")
+
             case Dispute.Querying          => debug("Querying dispute utxos")
             case Dispute.Parsing           => debug("Parsing dispute utxos")
             case Dispute.ParsingCastVote   => info("Dispute state: own ballot awaits a vote")
             case Dispute.ParsingTally      => info("Dispute state: ready to tally")
             case Dispute.ParsingResolve    => info("Dispute state: ready to resolve")
             case Dispute.ParsingEmptyVotes => warn("Dispute state: no vote utxos (unexpected)")
+            case Dispute.WaitingForVotesBeforeDeadline =>
+                info("Dispute state: awaiting peer votes; deadline not yet elapsed")
 
             case Dispute.Coil.ParsingRatchet =>
                 info("Coil dispute state: ratcheting a public ballot box")

--- a/src/main/scala/hydrozoa/rulebased/ledger/l1/tx/EvacuationTx.scala
+++ b/src/main/scala/hydrozoa/rulebased/ledger/l1/tx/EvacuationTx.scala
@@ -86,8 +86,8 @@ private object EvacuationTxOps {
       *   The map of all evacuations that still need to be processed
       * @param collateralUtxo
       *   Wallet UTxO used both as Plutus collateral and as the fee-paying regular input; the
-      *   returned collateral output absorbs the fee via the diff handler, matching the
-      *   pattern used by [[VoteTx]], [[ResolutionTx]], [[DeinitTx]] et al.
+      *   returned collateral output absorbs the fee via the diff handler, matching the pattern used
+      *   by [[VoteTx]], [[ResolutionTx]], [[DeinitTx]] et al.
       */
     final case class Build(
         inputTreasuryUtxo: RuleBasedTreasuryUtxo,

--- a/src/main/scala/hydrozoa/rulebased/ledger/l1/tx/EvacuationTx.scala
+++ b/src/main/scala/hydrozoa/rulebased/ledger/l1/tx/EvacuationTx.scala
@@ -22,7 +22,7 @@ import scalus.cardano.ledger.TransactionException.{ExUnitsExceedMaxException, In
 import scalus.cardano.onchain.plutus.prelude.List as SList
 import scalus.cardano.txbuilder.*
 import scalus.cardano.txbuilder.TransactionBuilder.ResolvedUtxos
-import scalus.cardano.txbuilder.TransactionBuilderStep.{Send, Spend}
+import scalus.cardano.txbuilder.TransactionBuilderStep.Send
 
 final case class EvacuationTx(
     treasuryUtxoSpent: RuleBasedTreasuryUtxo,
@@ -84,15 +84,16 @@ private object EvacuationTxOps {
       *   The sub-map of evacuations to try in this transaction
       * @param allRemainingEvacuatees
       *   The map of all evacuations that still need to be processed
-      * @param feeUtxos
-      *   Utxos to use to pay the fees
+      * @param collateralUtxo
+      *   Wallet UTxO used both as Plutus collateral and as the fee-paying regular input; the
+      *   returned collateral output absorbs the fee via the diff handler, matching the
+      *   pattern used by [[VoteTx]], [[ResolutionTx]], [[DeinitTx]] et al.
       */
     final case class Build(
         inputTreasuryUtxo: RuleBasedTreasuryUtxo,
         evacuateesToTryNext: EvacuationMap,
         allRemainingEvacuatees: EvacuationMap,
         collateralUtxo: CollateralUtxo,
-        feeUtxos: Utxos,
     ) {
 
         private def halveEvacuation(evacuatees: EvacuationMap): EvacuationMap = {
@@ -190,17 +191,16 @@ private object EvacuationTxOps {
                   List(
                     config.referenceTreasury,
                     inputTreasuryUtxo.spendAttached(evacuationRedeemer),
+                    // Spend the collateral utxo as a regular input; the returned
+                    // collateral output absorbs the tx fee via the index-0 diff handler.
                     collateralUtxo.add,
-                    collateralUtxo.send,
+                    collateralUtxo.spend,
+                    collateralUtxo.collateralOutput.send,
                     residualTreasury.send
                   )
                       ++
                           // Outputs for withdrawals
                           evacuationOutputs.map(Send(_))
-                          // Spend the fee utxos
-                          ++ feeUtxos.toList.map((ti, to) =>
-                              Spend(scalus.cardano.ledger.Utxo(ti, to), PubKeyWitness)
-                          )
                 )
                     .explainConst("Building evacuation tx failed")
                     .left

--- a/src/test/scala/hydrozoa/config/head/initialization/InitializationParametersGen.scala
+++ b/src/test/scala/hydrozoa/config/head/initialization/InitializationParametersGen.scala
@@ -270,16 +270,25 @@ object InitializationParametersGenTopDown {
                         for {
                             next <- generateCappedValue(cardanoNetwork)(capValue = rest)
                             address <- Gen.oneOf(peerAddresses)
-                            acc_ = acc :+ Babbage(
+                            // The datum bumps the output's min-ADA above what generateCappedValue
+                            // budgeted for `next`; top up here and advance the loop using the
+                            // actually-consumed value.
+                            output = Babbage(
                               address = address,
                               value = next,
                               datumOption =
                                   Some(Inline(toData(ByteString.fromString("evacuation")))),
-                            )
+                            ).ensureMinAda(cardanoNetwork)
                         } yield
-                            if next == rest
-                            then Right(acc_)
-                            else Left(acc_ -> (rest - next))
+                            if (rest - output.value).coin.value < 0L
+                            then Right(acc)
+                            else {
+                                val acc_ = acc :+ output
+                                val newRest = rest - output.value
+                                if next == rest || newRest.coin.value == 0L
+                                then Right(acc_)
+                                else Left(acc_ -> newRest)
+                            }
                     )
                 else Gen.const(List.empty)
 

--- a/src/test/scala/hydrozoa/config/head/initialization/InitializationParametersGen.scala
+++ b/src/test/scala/hydrozoa/config/head/initialization/InitializationParametersGen.scala
@@ -26,7 +26,10 @@ import scala.collection.immutable.{SortedMap, TreeMap}
 import scala.concurrent.duration.DurationInt
 import scalus.cardano.address.Address
 import scalus.cardano.ledger.*
+import scalus.cardano.ledger.DatumOption.Inline
 import scalus.cardano.ledger.TransactionOutput.Babbage
+import scalus.uplc.builtin.ByteString
+import scalus.uplc.builtin.Data.toData
 import scalus.|>
 import spire.math.{Rational, SafeLong}
 import test.Generators.Hydrozoa.*
@@ -258,12 +261,21 @@ object InitializationParametersGenTopDown {
             l2TransactionOutputs <-
                 if rest == ensureMinAdaLenient(cardanoNetwork)(rest)
                 then
-                    // Generate L2 utxos from the rest (if present)
+                    // Generate L2 utxos from the rest (if present). Each output carries an
+                    // "evacuation" inline-datum sentinel so `RBRClassifier` can bucket the
+                    // eventual L1 evacuation outputs by content — the sentinel is committed
+                    // to the KZG at obligation-creation time, so `RuleBasedTreasuryScript`'s
+                    // membership check reproduces the same hash and accepts the L1 output.
                     Gen.tailRecM(List.empty[Babbage] -> rest)((acc, rest) =>
                         for {
                             next <- generateCappedValue(cardanoNetwork)(capValue = rest)
                             address <- Gen.oneOf(peerAddresses)
-                            acc_ = acc :+ Babbage(address, next)
+                            acc_ = acc :+ Babbage(
+                              address = address,
+                              value = next,
+                              datumOption =
+                                  Some(Inline(toData(ByteString.fromString("evacuation")))),
+                            )
                         } yield
                             if next == rest
                             then Right(acc_)

--- a/src/test/scala/hydrozoa/lib/cardano/wallet/WalletModuleTest.scala
+++ b/src/test/scala/hydrozoa/lib/cardano/wallet/WalletModuleTest.scala
@@ -1,0 +1,90 @@
+package hydrozoa.lib.cardano.wallet
+
+import com.bloxbean.cardano.client.cip.cip30.{CIP30DataSigner, DataSignature}
+import com.bloxbean.cardano.client.crypto.bip32.HdKeyGenerator
+import com.bloxbean.cardano.client.crypto.bip32.key.{HdPrivateKey, HdPublicKey}
+import com.bloxbean.cardano.client.util.HexUtil
+import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters
+import org.scalacheck.Prop.forAll
+import org.scalacheck.{Arbitrary, Gen, Properties}
+import scalus.crypto.ed25519.{SigningKey as ScalusSigningKey, VerificationKey as ScalusVerificationKey}
+
+object WalletModuleTest extends Properties("WalletModule") {
+
+    // 32-byte entropy → BIP-39 24-word mnemonic space; HdKeyGenerator derives the same HdKeyPair
+    // shape TestPeers uses in production tests.
+    private val genEntropy: Gen[Array[Byte]] =
+        Gen.containerOfN[Array, Byte](32, Arbitrary.arbitrary[Byte])
+
+    // Non-empty so bloxbean's payload check is exercised.
+    private val genPayload: Gen[Array[Byte]] =
+        Gen.nonEmptyContainerOf[Array, Byte](Arbitrary.arbitrary[Byte])
+
+    private def bloxbeanKeys(entropy: Array[Byte]): (HdPublicKey, HdPrivateKey) =
+        val kp = new HdKeyGenerator().getRootKeyPairFromEntropy(entropy)
+        (kp.getPublicKey, kp.getPrivateKey)
+
+    private def scalusKeys(entropy: Array[Byte]): (ScalusVerificationKey, ScalusSigningKey) =
+        // Scalus uses standard 32-byte Ed25519 keys, not BIP-32 extended. Take the first 32 bytes
+        // of entropy as the Ed25519 seed and derive the matching public key via BouncyCastle.
+        val seed = entropy.take(32)
+        val privParams = new Ed25519PrivateKeyParameters(seed, 0)
+        val pubBytes = privParams.generatePublicKey().getEncoded
+        (ScalusVerificationKey.unsafeFromArray(pubBytes), ScalusSigningKey.unsafeFromArray(seed))
+
+    private def asDataSignature(signed: Cip30SignedData): DataSignature =
+        new DataSignature(signed.coseSignatureCborHex, signed.coseKeyCborHex)
+
+    // Property: bloxbean's own verify accepts what we produce — round-trip through the CIP-30
+    // signData/verify contract that HydrozoaRoutes relies on.
+    val _ = property("BloxBean.signCoseCip30 output validates via CIP30DataSigner.verify") =
+        forAll(genEntropy, genPayload) { (entropy, payload) =>
+            val (vk, sk) = bloxbeanKeys(entropy)
+            val signed = WalletModule.BloxBean.signCoseCip30(payload, vk, sk)
+            CIP30DataSigner.INSTANCE.verify(asDataSignature(signed))
+        }
+
+    val _ = property("Scalus.signCoseCip30 output validates via CIP30DataSigner.verify") =
+        forAll(genEntropy, genPayload) { (entropy, payload) =>
+            val (vk, sk) = scalusKeys(entropy)
+            val signed = WalletModule.Scalus.signCoseCip30(payload, vk, sk)
+            CIP30DataSigner.INSTANCE.verify(asDataSignature(signed))
+        }
+
+    // Property: coseKey's COSE key parameter -2 (OKP curve x-coordinate) is exactly the wallet's
+    // public key — the same field JsonCodecs.validateCoseSignature reads to recover userVk.
+    val _ = property(
+      "BloxBean.signCoseCip30 embeds the public key in the coseKey X header (param -2)"
+    ) = forAll(genEntropy, genPayload) { (entropy, payload) =>
+        val (vk, sk) = bloxbeanKeys(entropy)
+        val signed = WalletModule.BloxBean.signCoseCip30(payload, vk, sk)
+        val ds = asDataSignature(signed)
+        val extractedPubKey = ds.coseKey().otherHeaderAsBytes(-2L)
+        extractedPubKey.sameElements(vk.getKeyData)
+    }
+
+    // Leak check: the private-key hex must not appear as a substring in either the coseKey or
+    // the coseSignature CBOR hex. Collision on 64+ hex chars is astronomical; a positive substring
+    // hit would be a real leak.
+    val _ = property(
+      "BloxBean.signCoseCip30 does not leak the private key hex into coseKey/coseSignature"
+    ) = forAll(genEntropy, genPayload) { (entropy, payload) =>
+        val (vk, sk) = bloxbeanKeys(entropy)
+        val signed = WalletModule.BloxBean.signCoseCip30(payload, vk, sk)
+        val privHex = HexUtil.encodeHexString(sk.getKeyData).toLowerCase
+        val coseKeyHex = signed.coseKeyCborHex.toLowerCase
+        val coseSigHex = signed.coseSignatureCborHex.toLowerCase
+        !coseKeyHex.contains(privHex) && !coseSigHex.contains(privHex)
+    }
+
+    val _ = property(
+      "Scalus.signCoseCip30 does not leak the private key hex into coseKey/coseSignature"
+    ) = forAll(genEntropy, genPayload) { (entropy, payload) =>
+        val (vk, sk) = scalusKeys(entropy)
+        val signed = WalletModule.Scalus.signCoseCip30(payload, vk, sk)
+        val privHex = HexUtil.encodeHexString(sk.bytes).toLowerCase
+        val coseKeyHex = signed.coseKeyCborHex.toLowerCase
+        val coseSigHex = signed.coseSignatureCborHex.toLowerCase
+        !coseKeyHex.contains(privHex) && !coseSigHex.contains(privHex)
+    }
+}

--- a/src/test/scala/hydrozoa/multisig/ledger/eutxol2/L2OutputEvacuabilityTest.scala
+++ b/src/test/scala/hydrozoa/multisig/ledger/eutxol2/L2OutputEvacuabilityTest.scala
@@ -171,8 +171,7 @@ class L2OutputEvacuabilityTest extends AnyFunSuite {
               inputTreasuryUtxo = treasury,
               evacuateesToTryNext = m,
               allRemainingEvacuatees = m,
-              collateralUtxo = collateral,
-              feeUtxos = Map(fee.toTuple)
+              collateralUtxo = collateral
             )
             .result(using config) match {
             case Left(e) => Left(s"build: $e")

--- a/src/test/scala/hydrozoa/multisig/ledger/l1/txseq/InitializationTxSeqTest.scala
+++ b/src/test/scala/hydrozoa/multisig/ledger/l1/txseq/InitializationTxSeqTest.scala
@@ -327,9 +327,10 @@ object InitializationTxSeqTest extends Properties("InitializationTxSeq"):
 
             props.append(
               "rules-based treasury has no more than multisig treasury " +
-                  "+ extra from fallback tx fee" |:
+                  "+ extra from fallback tx fee + min-ada carried in for the treasury" |:
                   fbTx.treasuryProduced.treasuryOutput.toOutput(using config).value.coin.value <=
-                  fbTx.treasurySpent.value.coin.value + config.maxNonPlutusTxFee.value
+                  fbTx.treasurySpent.value.coin.value + config.maxNonPlutusTxFee.value +
+                  config.headParameters.fallbackContingency.collectiveContingency.minAdaForTreasury.value
             )
 
             props.append(
@@ -340,8 +341,7 @@ object InitializationTxSeqTest extends Properties("InitializationTxSeq"):
                     Babbage(
                       address = disputeResolutionAddress,
                       value = Value(
-                        config.headParameters.fallbackContingency.collectiveContingency.publicVoteDeposit
-                            + config.headParameters.fallbackContingency.collectiveContingency.minAdaForTreasury,
+                        config.headParameters.fallbackContingency.collectiveContingency.publicVoteDeposit,
                         MultiAsset(
                           SortedMap(
                             expectedHeadNativeScript.policyId -> SortedMap(

--- a/src/test/scala/hydrozoa/rulebased/ledger/l1/script/plutus/EvacuationAttackTest.scala
+++ b/src/test/scala/hydrozoa/rulebased/ledger/l1/script/plutus/EvacuationAttackTest.scala
@@ -139,8 +139,7 @@ class EvacuationAttackTest extends AnyFunSuite {
               inputTreasuryUtxo = treasuryUtxo,
               evacuateesToTryNext = subset,
               allRemainingEvacuatees = allRemaining,
-              collateralUtxo = collateral,
-              feeUtxos = Map(feeUtxo.toTuple)
+              collateralUtxo = collateral
             )
             .result(using config)
     }

--- a/src/test/scala/hydrozoa/rulebased/ledger/l1/script/plutus/EvacuationAttackTest.scala
+++ b/src/test/scala/hydrozoa/rulebased/ledger/l1/script/plutus/EvacuationAttackTest.scala
@@ -124,14 +124,13 @@ class EvacuationAttackTest extends AnyFunSuite {
           ++ config.scriptReferenceUtxos.toList.map(_.toTuple)
     )
 
-    /** Build an EvacuationTx draining the single obligation `key` from `treasuryUtxo` (paying fee
-      * from `feeUtxo`), as the `allRemaining` map sees it.
+    /** Build an EvacuationTx draining the single obligation `key` from `treasuryUtxo`, as the
+      * `allRemaining` map sees it. Fees come from the collateral utxo.
       */
     private def buildEvacuation(
         treasuryUtxo: RuleBasedTreasuryUtxo,
         key: EvacuationKey,
-        allRemaining: EvacuationMap,
-        feeUtxo: Utxo
+        allRemaining: EvacuationMap
     ): Either[EvacuationTx.Build.Error, EvacuationTx] = {
         val subset = allRemaining.removedAll(allRemaining.keys.filter(_ != key))
         EvacuationTx
@@ -146,7 +145,7 @@ class EvacuationAttackTest extends AnyFunSuite {
 
     /** An otherwise-valid EvacuationTx draining the first obligation of `M` (unsigned). */
     private val legitTx: Transaction =
-        buildEvacuation(treasury, evacMap.keys.head, evacMap, feeUtxos.head)
+        buildEvacuation(treasury, evacMap.keys.head, evacMap)
             .fold(e => throw new AssertionError(s"legit evacuation build failed: $e"), _.tx)
 
     /** The current treasury input in the emulator (the single utxo at the treasury address). */
@@ -345,7 +344,7 @@ class EvacuationAttackTest extends AnyFunSuite {
     test("treasury value-conservation prevents double-draining the same obligation") {
         val key = evacMap.keys.head
         // tx1: legitimately drain `key`.
-        val evac1 = buildEvacuation(treasury, key, evacMap, feeUtxos(0))
+        val evac1 = buildEvacuation(treasury, key, evacMap)
             .fold(e => fail(s"tx1 build failed: $e"), identity)
         val emu2 = mkEmulator().submit(ownWallet.signTx(evac1.tx)) match {
             case Right((_, e)) => e
@@ -357,7 +356,7 @@ class EvacuationAttackTest extends AnyFunSuite {
         // the value invariant (treasuryInput = treasuryOutput + Σ evacuated) makes the obligation
         // un-payable — the builder refuses; were a tx hand-crafted, the script's membership check
         // (against the advanced accumulator) would reject it.
-        buildEvacuation(residual, key, evacMap, feeUtxos(1)) match {
+        buildEvacuation(residual, key, evacMap) match {
             case Left(_) => () // expected: cannot re-pay a drained obligation from the residual
             case Right(evac2) =>
                 emu2.submit(ownWallet.signTx(evac2.tx)) match {

--- a/src/test/scala/hydrozoa/rulebased/ledger/l1/script/plutus/EvacuationDrainTest.scala
+++ b/src/test/scala/hydrozoa/rulebased/ledger/l1/script/plutus/EvacuationDrainTest.scala
@@ -6,6 +6,7 @@ import hydrozoa.config.HydrozoaBlueprint
 import hydrozoa.config.node.{MultiNodeConfig, NodeConfig}
 import hydrozoa.lib.cardano.scalus.QuantizedTime.QuantizedInstant.realTimeQuantizedInstant
 import hydrozoa.lib.cardano.scalus.VerificationKeyExtra.{addrKeyHash, shelleyAddress}
+import hydrozoa.lib.cardano.scalus.ledger.CollateralUtxo
 import hydrozoa.multisig.consensus.peer.PeerWallet
 import hydrozoa.multisig.ledger.commitment.TrustedSetup
 import hydrozoa.multisig.ledger.joint.EvacuationMap
@@ -123,6 +124,7 @@ class EvacuationDrainTest extends AnyFunSuite {
     private def evacuateAll(
         remaining: EvacuationMap,
         treasury: RuleBasedTreasuryUtxo,
+        collateral: CollateralUtxo,
         emulator: ImmutableEmulator,
         depth: Int,
         evacuated: List[TransactionOutput]
@@ -151,9 +153,13 @@ class EvacuationDrainTest extends AnyFunSuite {
             // real treasury input from the emulator before chaining.
             val newTreasury =
                 evac.treasuryUtxoProduced.copy(utxoId = currentTreasuryInput(nextEmulator))
+            // The collateral is spent and re-sent (minus the fee it absorbs) at output index 0, so
+            // thread the fresh collateral forward rather than reusing the now-spent input.
+            val newCollateral = currentCollateral(nextEmulator, evac.tx.id)
             evacuateAll(
               remaining.removed(key),
               newTreasury,
+              newCollateral,
               nextEmulator,
               depth + 1,
               evacuated ++ evac.evacuatedOutputs
@@ -165,7 +171,8 @@ class EvacuationDrainTest extends AnyFunSuite {
 
     test("evacuation drains the full evacuation map to exactly M") {
         val emulator0 = mkEmulator(initialUtxos, now.toSlot)
-        val (finalTreasury, evacuated) = evacuateAll(evacMap, treasury, emulator0, 0, Nil)
+        val (finalTreasury, evacuated) =
+            evacuateAll(evacMap, treasury, collateral, emulator0, 0, Nil)
 
         val _ = assert(
           bag(evacuated) == bag(evacMap.outputsCooked.toList),
@@ -196,4 +203,19 @@ class EvacuationDrainTest extends AnyFunSuite {
     /** The current treasury input in the emulator (the single utxo at the treasury address). */
     private def currentTreasuryInput(emu: ImmutableEmulator): TransactionInput =
         emu.utxos.collectFirst { case (i, o) if o.address == treasuryAddr => i }.get
+
+    /** The re-sent collateral produced by an evacuation tx. EvacuationTx returns collateral at
+      * output index 0 (its diff handler absorbs the fee there), so read `(txId, 0)` and re-parse
+      * it.
+      */
+    private def currentCollateral(emu: ImmutableEmulator, txId: TransactionHash): CollateralUtxo = {
+        val input = TransactionInput(txId, 0)
+        val output = emu.utxos
+            .collectFirst { case (i, o) if i == input => o }
+            .getOrElse(fail(s"collateral output not found at $input"))
+        CollateralUtxo.parse(Utxo(input, output)) match {
+            case Right(c)  => c
+            case Left(err) => fail(s"collateral parse failed: $err")
+        }
+    }
 }

--- a/src/test/scala/hydrozoa/rulebased/ledger/l1/script/plutus/EvacuationDrainTest.scala
+++ b/src/test/scala/hydrozoa/rulebased/ledger/l1/script/plutus/EvacuationDrainTest.scala
@@ -5,7 +5,8 @@ import hydrozoa.*
 import hydrozoa.config.HydrozoaBlueprint
 import hydrozoa.config.node.{MultiNodeConfig, NodeConfig}
 import hydrozoa.lib.cardano.scalus.QuantizedTime.QuantizedInstant.realTimeQuantizedInstant
-import hydrozoa.lib.cardano.scalus.VerificationKeyExtra.{addrKeyHash, shelleyAddress}
+import hydrozoa.lib.cardano.scalus.VerificationKeyExtra.addrKeyHash
+import hydrozoa.lib.cardano.scalus.ledger.CollateralUtxo
 import hydrozoa.multisig.consensus.peer.PeerWallet
 import hydrozoa.multisig.ledger.commitment.TrustedSetup
 import hydrozoa.multisig.ledger.joint.EvacuationMap
@@ -23,7 +24,7 @@ import scalus.cardano.ledger.EvaluatorMode.EvaluateAndComputeCost
 import scalus.cardano.ledger.rules.{CardanoMutator, State, UtxoEnv}
 import scalus.testing.ImmutableEmulator
 import scalus.uplc.builtin.bls12_381.G2Element
-import test.Generators.Hydrozoa.{genEvacuationMap, genPubKeyUtxo}
+import test.Generators.Hydrozoa.genEvacuationMap
 
 /** Evacuation-map drain test for the rule-based regime (test "B").
   *
@@ -42,9 +43,9 @@ import test.Generators.Hydrozoa.{genEvacuationMap, genPubKeyUtxo}
   * choices here, hence no `Scenario`. (A peer redirecting the residual treasury to its own address
   * or breaking evacuation liveness is a separate, genuinely adversarial scenario test.)
   *
-  * Each `EvacuationTx` **spends its fee utxo** (and re-sends collateral rather than spending it),
-  * so every step gets its own fee utxo; one collateral is reused. Evacuation has no time-validity
-  * bound, so no deadline/sleep is involved.
+  * Each `EvacuationTx` pays its fee from the collateral utxo (returned fee-subtracted at output
+  * index 0), and the drain loop threads that returned collateral into the next step. Evacuation
+  * has no time-validity bound, so no deadline/sleep is involved.
   */
 class EvacuationDrainTest extends AnyFunSuite {
 
@@ -59,7 +60,6 @@ class EvacuationDrainTest extends AnyFunSuite {
     private val config: NodeConfig = env.nodeConfigs.head._2
     private val ownWallet: PeerWallet = env.nodePrivateConfigs.head._2.ownWallet
     private val ownKeyHash = ownWallet.exportVerificationKey.addrKeyHash
-    private val ownAddr = ownWallet.exportVerificationKey.shelleyAddress()(using env.headConfig)
     private val treasuryAddr = HydrozoaBlueprint.mkTreasuryAddress(env.headConfig.network)
 
     // Small on purpose: each step is an on-chain KZG membership check. Larger maps belong to the
@@ -93,17 +93,8 @@ class EvacuationDrainTest extends AnyFunSuite {
           RuleBasedTreasuryOutput(resolvedDatum, treasuryBaseValue + evacMap.totalValue)
     )
 
-    // One fee utxo per evacuation step (each EvacuationTx spends its fee utxo); one shared
-    // collateral (evacuation re-sends collateral rather than spending it).
-    private val feeUtxos: List[Utxo] =
-        (0 until numEvacuees).toList.map(i =>
-            fixed(
-              genPubKeyUtxo(address = ownAddr, genValue = Gen.const(Value.ada(100)))(using
-                env.headConfig
-              ),
-              20L + i
-            )
-        )
+    // One collateral utxo, threaded through the drain loop: each EvacuationTx spends it as its
+    // fee-paying input and returns it (fee-subtracted) at index 0 for the next step to consume.
     private val collateral = fixed(genCollateralUtxo(ownKeyHash)(using env.headConfig), 4)
 
     private val initialUtxos: Utxos = (
@@ -111,7 +102,6 @@ class EvacuationDrainTest extends AnyFunSuite {
         (treasury.utxoId, treasury.treasuryOutput.toOutput(using config)),
         (collateral.input, collateral.collateralOutput.toOutput(using env))
       )
-          ++ feeUtxos.map(_.toTuple)
           ++ config.scriptReferenceUtxos.toList.map(_.toTuple)
     )
 
@@ -123,6 +113,7 @@ class EvacuationDrainTest extends AnyFunSuite {
     private def evacuateAll(
         remaining: EvacuationMap,
         treasury: RuleBasedTreasuryUtxo,
+        collateral: CollateralUtxo,
         emulator: ImmutableEmulator,
         depth: Int,
         evacuated: List[TransactionOutput]
@@ -151,9 +142,19 @@ class EvacuationDrainTest extends AnyFunSuite {
             // real treasury input from the emulator before chaining.
             val newTreasury =
                 evac.treasuryUtxoProduced.copy(utxoId = currentTreasuryInput(nextEmulator))
+            // The returned collateral (fee-subtracted) sits at output index 0 of the just-submitted
+            // evacuation tx; parse it back into a CollateralUtxo for the next step.
+            val newCollateralInput = TransactionInput(evac.tx.id, 0)
+            val newCollateral = CollateralUtxo
+                .parse(Utxo(newCollateralInput, nextEmulator.utxos(newCollateralInput)))
+                .fold(
+                  err => fail(s"parsing returned collateral at step $depth failed: $err"),
+                  identity
+                )
             evacuateAll(
               remaining.removed(key),
               newTreasury,
+              newCollateral,
               nextEmulator,
               depth + 1,
               evacuated ++ evac.evacuatedOutputs
@@ -165,7 +166,8 @@ class EvacuationDrainTest extends AnyFunSuite {
 
     test("evacuation drains the full evacuation map to exactly M") {
         val emulator0 = mkEmulator(initialUtxos, now.toSlot)
-        val (finalTreasury, evacuated) = evacuateAll(evacMap, treasury, emulator0, 0, Nil)
+        val (finalTreasury, evacuated) =
+            evacuateAll(evacMap, treasury, collateral, emulator0, 0, Nil)
 
         val _ = assert(
           bag(evacuated) == bag(evacMap.outputsCooked.toList),

--- a/src/test/scala/hydrozoa/rulebased/ledger/l1/script/plutus/EvacuationDrainTest.scala
+++ b/src/test/scala/hydrozoa/rulebased/ledger/l1/script/plutus/EvacuationDrainTest.scala
@@ -136,8 +136,7 @@ class EvacuationDrainTest extends AnyFunSuite {
                   inputTreasuryUtxo = treasury,
                   evacuateesToTryNext = subset,
                   allRemainingEvacuatees = remaining,
-                  collateralUtxo = collateral,
-                  feeUtxos = Map(feeUtxos(depth).toTuple)
+                  collateralUtxo = collateral
                 )
                 .result(using config) match {
                 case Right(e)  => e

--- a/src/test/scala/hydrozoa/rulebased/ledger/l1/script/plutus/EvacuationDrainTest.scala
+++ b/src/test/scala/hydrozoa/rulebased/ledger/l1/script/plutus/EvacuationDrainTest.scala
@@ -44,8 +44,8 @@ import test.Generators.Hydrozoa.genEvacuationMap
   * or breaking evacuation liveness is a separate, genuinely adversarial scenario test.)
   *
   * Each `EvacuationTx` pays its fee from the collateral utxo (returned fee-subtracted at output
-  * index 0), and the drain loop threads that returned collateral into the next step. Evacuation
-  * has no time-validity bound, so no deadline/sleep is involved.
+  * index 0), and the drain loop threads that returned collateral into the next step. Evacuation has
+  * no time-validity bound, so no deadline/sleep is involved.
   */
 class EvacuationDrainTest extends AnyFunSuite {
 

--- a/src/test/scala/hydrozoa/rulebased/ledger/l1/tx/EvacuationTxTest.scala
+++ b/src/test/scala/hydrozoa/rulebased/ledger/l1/tx/EvacuationTxTest.scala
@@ -27,8 +27,6 @@ import scalus.cardano.onchain.plutus.prelude
 import scalus.cardano.onchain.plutus.v3.TokenName
 import scalus.uplc.builtin.bls12_381.{G1Element, G2Element}
 import supranational.blst.Scalar
-import test.*
-import test.Generators.Hydrozoa.genPubKeyUtxo
 
 /** Generator for resolved treasury UTXO with resolved datum */
 def genResolvedTreasuryUtxo(
@@ -123,12 +121,6 @@ def genEvacuationTxBuild(using config: MultiNodeConfig): Gen[EvacuationTx.Build]
 
         addr = config.nodeConfigs.head._2.ownWallet.exportVerificationKey
             .shelleyAddress()(using config.headConfig)
-
-        feeUtxo <-
-            genPubKeyUtxo(
-              address = addr,
-              genValue = Gen.const(Value.ada(100))
-            )
 
         collateralUtxo <- genCollateralUtxo(addr.payment.asInstanceOf[Key].hash)(using config)
 

--- a/src/test/scala/hydrozoa/rulebased/ledger/l1/tx/EvacuationTxTest.scala
+++ b/src/test/scala/hydrozoa/rulebased/ledger/l1/tx/EvacuationTxTest.scala
@@ -136,7 +136,6 @@ def genEvacuationTxBuild(using config: MultiNodeConfig): Gen[EvacuationTx.Build]
       inputTreasuryUtxo = adjustedTreasuryUtxo,
       evacuateesToTryNext = evacuatees,
       allRemainingEvacuatees = evacMap,
-      feeUtxos = Map(feeUtxo.toTuple),
       collateralUtxo = collateralUtxo
     )
 


### PR DESCRIPTION
- Timing tuning for dispute resolution tests
- Less unsafe IO usage
- Adds an in-memory HTTP submission client instead of using the request sequencer actor handle directly, exercising the signed JSON request API
- Adds back in actual evacuation (not just resolution) in EvacuationPropertyTest.scala and updates classifier
- Adds CIP30 signing to the wallet module for the HTTP endpoint + associated tests
- Adds setupG2 as non-empty to the production path for the fallback treasusry (previously the evac test was doing this synthetically)
  - adds the minAda to the unresolved treasury output instead of the public ballot box (!). If the L2 value was low, the inclusion of the G2 datum to unresolved treasury could bump the treasury above the minAda threshold.
  - Why did we put the minAda for the treasury in the public ballot box?
  - This goes away in the next ticket I'll be working on, probably
- Spends the collateral to pay the fee for evacuation txs rather than requiring another fee utxo. Simplifies things.
- Improves tracing and pattern matching in the RBA
- Gates tally on voting deadline for better tracing
- Adds "evacuation" sentinel datums to init parameters gen for UTXO classifier purposes