### PR TITLE
feat(rbr): split loaded SEC sigs into head + coil for DisputeAction.Vote

### DIFF
--- a/integration/src/test/scala/hydrozoa/integration/fallbackhandoff/VoteVersionMismatchTest.scala
+++ b/integration/src/test/scala/hydrozoa/integration/fallbackhandoff/VoteVersionMismatchTest.scala
@@ -11,7 +11,7 @@ import hydrozoa.integration.harness.MultiPeerHeadHarness.Transport.Mode as Trans
 import hydrozoa.lib.cardano.scalus.QuantizedTime.QuantizedInstant
 import hydrozoa.lib.logging.{ContraTracer, Slf4jTracer}
 import hydrozoa.multisig.backend.cardano.{CardanoBackend as L1Backend, FirewalledCardanoBackend, FirewalledCardanoBackendEvent, yaciTestSauceGenesis}
-import hydrozoa.multisig.consensus.peer.HeadPeerNumber
+import hydrozoa.multisig.consensus.peer.{HeadPeerNumber, PeerId}
 import hydrozoa.multisig.consensus.{CardanoLiaisonEvent, RequestSequencer, SlowConsensusActorEvent, UserRequest, UserRequestBody, UserRequestHeader}
 import hydrozoa.multisig.ledger.block.BlockVersion.Major.given_Conversion_Major_Int
 import hydrozoa.multisig.ledger.l1.tx.SettlementTx
@@ -48,7 +48,7 @@ object VoteVersionMismatchTest extends Properties("Vote Version Mismatch"):
     ): org.scalacheck.Test.Parameters = p.withMinSuccessfulTests(1)
 
     private val nHeadPeers: Int = 2
-    private val nCoilPeers: Int = 0
+    private val nCoilPeers: Int = 1
     private val scenarioTimeout: FiniteDuration = 90.seconds
     private val cardanoNetwork: CardanoNetwork = CardanoNetwork.Preprod
 
@@ -69,7 +69,7 @@ object VoteVersionMismatchTest extends Properties("Vote Version Mismatch"):
           transportMode = transportMode,
           testPeers = testPeers,
           testPeerToUtxos = testPeerToUtxos,
-          takeoffOffset = 2.seconds,
+          takeoffOffset = 10.seconds,
           coilPeers = coilPeersConfig,
         ) { (takeoffTime, mnc) =>
             buildCtxResource(transportMode, mnc, testPeers, coilWallets, takeoffTime)
@@ -103,13 +103,10 @@ object VoteVersionMismatchTest extends Properties("Vote Version Mismatch"):
             // `Action.FallbackToRuleBased`; HMRM auto-spawns RRM/RBA.
             _ <- lift(ctx.fallbackDispatched.get.timeout(scenarioTimeout))
 
-            // 4. RBA's `loadAction` walks backward through hard-confirmed stacks and picks the
-            // SEC matching the on-chain treasury's `versionMajor` (major-1 here). Assert that:
-            // - the actor attempted a Vote (proves handoff + persistence load)
-            // - the Vote submitted OK (proves the version match worked)
-            // - `sutErrors` does not contain `"versionMajor field must match"` 
-            _    <- lift(ctx.voteBuildAttempted.get.timeout(scenarioTimeout))
-            _    <- lift(ctx.voteSubmittedOk.get.timeout(scenarioTimeout))
+            // 4. Every head peer's RBA finds the SEC matching the on-chain treasury's
+            // versionMajor and submits a Vote that passes Plutus.
+            _    <- lift(ctx.allHeadsBuildingVote.get.timeout(scenarioTimeout))
+            _    <- lift(ctx.allHeadsVoteSubmittedOk.get.timeout(scenarioTimeout))
             errs <- lift(ctx.harness.sutErrors.get)
             _ <- assertWith(
               !errs.exists(_.contains("versionMajor field must match")),
@@ -117,13 +114,11 @@ object VoteVersionMismatchTest extends Properties("Vote Version Mismatch"):
                   "loadAction is voting with an SEC ahead of the on-chain treasury version",
             )
 
-            // 5. Coil peer runs the same RBA as head peers (spawned by
-            // `CoilMultisigRegimeManager.onHandoffToRuleBased`) but its `Dispute.handle` routes
-            // into `handleCoil`: it picks an Open-phase ballot box and submits a
-            // `RatchetVoteTx`. Skipped when `nCoilPeers == 0`.
+            // 5. Every coil peer runs `handleCoil` (proves the CL handoff routed each coil into
+            // the rule-based regime). Skipped when `nCoilPeers == 0`.
             _ <-
                 if nCoilPeers > 0
-                then lift(ctx.coilRatchetSubmitted.get.timeout(scenarioTimeout))
+                then lift(ctx.allCoilsHandledDispute.get.timeout(scenarioTimeout))
                 else pure(())
         yield true
 
@@ -136,22 +131,22 @@ object VoteVersionMismatchTest extends Properties("Vote Version Mismatch"):
         transportMode: TransportMode,
         multiNodeConfig: MultiNodeConfig,
         firewall: FirewallState,
-        harness: MultiPeerHeadHarness.Harness[RequestSequencer.Handle, Unit],
+        harness: MultiPeerHeadHarness.Harness[Option[RequestSequencer.Handle]],
         fallbackDispatched: Deferred[IO, Unit],
         bothPeersConfirmedMajor2: Deferred[IO, Unit],
-        voteBuildAttempted: Deferred[IO, Unit],
-        voteSubmittedOk: Deferred[IO, Unit],
-        coilRatchetSubmitted: Deferred[IO, Unit],
+        allHeadsBuildingVote: Deferred[IO, Unit],
+        allHeadsVoteSubmittedOk: Deferred[IO, Unit],
+        allCoilsHandledDispute: Deferred[IO, Unit],
     )
 
     private final case class FirewallState(
         dropped: Ref[
           IO,
-          Map[HeadPeerNumber, List[FirewalledCardanoBackendEvent.DroppedOutboundTx]],
+          Map[PeerId, List[FirewalledCardanoBackendEvent.DroppedOutboundTx]],
         ],
         submitted: Ref[
           IO,
-          Map[HeadPeerNumber, List[FirewalledCardanoBackendEvent.SubmittedTx]],
+          Map[PeerId, List[FirewalledCardanoBackendEvent.SubmittedTx]],
         ],
     )
 
@@ -173,9 +168,9 @@ object VoteVersionMismatchTest extends Properties("Vote Version Mismatch"):
             firewall <- Resource.eval(newFirewallState)
             fallbackDispatched <- Resource.eval(Deferred[IO, Unit])
             bothPeersConfirmedMajor2 <- Resource.eval(Deferred[IO, Unit])
-            voteBuildAttempted <- Resource.eval(Deferred[IO, Unit])
-            voteSubmittedOk    <- Resource.eval(Deferred[IO, Unit])
-            coilRatchetSubmitted <- Resource.eval(Deferred[IO, Unit])
+            allHeadsBuildingVote <- Resource.eval(Deferred[IO, Unit])
+            allHeadsVoteSubmittedOk    <- Resource.eval(Deferred[IO, Unit])
+            allCoilsHandledDispute <- Resource.eval(Deferred[IO, Unit])
 
             preinitPeerUtxosL1 = yaciTestSauceGenesis(cardanoNetwork.network)(testPeers)
                 .map { case (name, utxos) => name.headPeerNumber -> utxos }
@@ -188,27 +183,31 @@ object VoteVersionMismatchTest extends Properties("Vote Version Mismatch"):
 
             coilNodeConfigs = multiNodeConfig.mkCoilNodeConfigs(coilWallets)
 
-            hooks = MultiPeerHeadHarness.Hooks[RequestSequencer.Handle, Unit](
+            hooks = MultiPeerHeadHarness.Hooks[Option[RequestSequencer.Handle]](
               tracer = humanFormatTracer |+| observerTracer(
                 bothPeersConfirmedMajor2,
                 fallbackDispatched,
-                voteBuildAttempted,
-                voteSubmittedOk,
-                coilRatchetSubmitted,
+                allHeadsBuildingVote,
+                allHeadsVoteSubmittedOk,
+                allCoilsHandledDispute,
               ),
-              peerHandle = (peerNum, conns) =>
-                  IO.fromOption(conns.requestSequencer)(
-                    new NoSuchElementException(
-                      s"peer $peerNum has no RequestSequencer.Handle in its Connections"
-                    )
-                  ),
-              coilHandle = (_, _) => IO.unit,
-              wrapPeerBackend = wrapPeerBackend(firewall),
+              handle = {
+                  case (PeerId.Head(peerNum), conns) =>
+                      IO.fromOption(conns.requestSequencer)(
+                        new NoSuchElementException(
+                          s"peer $peerNum has no RequestSequencer.Handle in its Connections"
+                        )
+                      ).map(Some(_))
+                  case (_: PeerId.Coil, _) => IO.pure(None)
+              },
+              // Firewall every node — coil CL would otherwise submit the head-dropped v2
+              // settlement out-of-band, suppressing the fallback path.
+              wrapBackend = (peerId, backend) => wrapNodeBackend(firewall)(peerId, backend),
             )
 
             label = s"VoteVersionMismatch-${transportMode.toString.toLowerCase}"
 
-            harness <- MultiPeerHeadHarness.resource[RequestSequencer.Handle, Unit](
+            harness <- MultiPeerHeadHarness.resource[Option[RequestSequencer.Handle]](
               MultiPeerHeadHarness.Inputs(
                 config = MultiPeerHeadHarness.Config(
                   label = label,
@@ -230,9 +229,9 @@ object VoteVersionMismatchTest extends Properties("Vote Version Mismatch"):
           harness = harness,
           fallbackDispatched = fallbackDispatched,
           bothPeersConfirmedMajor2 = bothPeersConfirmedMajor2,
-          voteBuildAttempted = voteBuildAttempted,
-          voteSubmittedOk = voteSubmittedOk,
-          coilRatchetSubmitted = coilRatchetSubmitted,
+          allHeadsBuildingVote = allHeadsBuildingVote,
+          allHeadsVoteSubmittedOk = allHeadsVoteSubmittedOk,
+          allCoilsHandledDispute = allCoilsHandledDispute,
         )
 
     // ------------------------------------------------------------------
@@ -267,7 +266,7 @@ object VoteVersionMismatchTest extends Properties("Vote Version Mismatch"):
               bodyHash = body.hash,
             )
             userRequest = UserRequest.TransactionRequest(header, body, userVk)
-            sequencer <- IO.fromOption(ctx.harness.peers.get(peerNum).map(_.handle))(
+            sequencer <- IO.fromOption(ctx.harness.peers.get(peerNum).flatMap(_.handle))(
               new NoSuchElementException(s"peer $peerNum missing in harness")
             )
             _ <- sequencer ?: userRequest
@@ -276,10 +275,10 @@ object VoteVersionMismatchTest extends Properties("Vote Version Mismatch"):
     private def newFirewallState: IO[FirewallState] =
         for
             dropped <- Ref[IO].of(
-              Map.empty[HeadPeerNumber, List[FirewalledCardanoBackendEvent.DroppedOutboundTx]]
+              Map.empty[PeerId, List[FirewalledCardanoBackendEvent.DroppedOutboundTx]]
             )
             submitted <- Ref[IO].of(
-              Map.empty[HeadPeerNumber, List[FirewalledCardanoBackendEvent.SubmittedTx]]
+              Map.empty[PeerId, List[FirewalledCardanoBackendEvent.SubmittedTx]]
             )
         yield FirewallState(dropped, submitted)
 
@@ -299,28 +298,28 @@ object VoteVersionMismatchTest extends Properties("Vote Version Mismatch"):
                 )
         }
 
-    /** Static drop predicate + per-peer event capture. */
-    private def wrapPeerBackend(state: FirewallState)(
-        peerNum: HeadPeerNumber,
+    /** Static drop predicate + per-node event capture. */
+    private def wrapNodeBackend(state: FirewallState)(
+        peerId: PeerId,
         underlying: L1Backend[IO],
     ): L1Backend[IO] =
         val slf4jSink: ContraTracer[IO, FirewalledCardanoBackendEvent] =
             Slf4jTracer.sink.contramap {
                 case FirewalledCardanoBackendEvent.DroppedOutboundTx(hash) =>
                     hydrozoa.lib.logging.LogEvent
-                        .From(Map("peer" -> peerNum.toString), "FirewalledCardanoBackend")
+                        .From(Map("peer" -> peerId.toString), "FirewalledCardanoBackend")
                         .warn(s"firewall DROPPED tx $hash")
                 case FirewalledCardanoBackendEvent.SubmittedTx(hash, result) =>
                     hydrozoa.lib.logging.LogEvent
-                        .From(Map("peer" -> peerNum.toString), "FirewalledCardanoBackend")
+                        .From(Map("peer" -> peerId.toString), "FirewalledCardanoBackend")
                         .info(s"firewall passed tx $hash result=$result")
             }
-        val perPeerTracer: ContraTracer[IO, FirewalledCardanoBackendEvent] =
+        val perNodeTracer: ContraTracer[IO, FirewalledCardanoBackendEvent] =
             slf4jSink |+| ContraTracer[IO, FirewalledCardanoBackendEvent] {
                 case e: FirewalledCardanoBackendEvent.DroppedOutboundTx =>
-                    state.dropped.update(m => m.updated(peerNum, m.getOrElse(peerNum, Nil) :+ e))
+                    state.dropped.update(m => m.updated(peerId, m.getOrElse(peerId, Nil) :+ e))
                 case e: FirewalledCardanoBackendEvent.SubmittedTx =>
-                    state.submitted.update(m => m.updated(peerNum, m.getOrElse(peerNum, Nil) :+ e))
+                    state.submitted.update(m => m.updated(peerId, m.getOrElse(peerId, Nil) :+ e))
             }
         FirewalledCardanoBackend(
           underlying = underlying,
@@ -329,18 +328,23 @@ object VoteVersionMismatchTest extends Properties("Vote Version Mismatch"):
                   case s: SettlementTx => s.majorVersionProduced.convert == 2
                   case _               => false
               }),
-          firewallTracer = perPeerTracer,
+          firewallTracer = perNodeTracer,
         )
 
-    /** Observer tracer wiring — see class-level Ctx doc for what each signal represents. */
+    /** Observer tracer wiring — vote/build signals fire when **every** head peer hits the
+      * milestone (not just the first), so a regression in the CL handoff would surface.
+      */
     private def observerTracer(
         bothPeersConfirmedMajor2: Deferred[IO, Unit],
         fallbackDispatched: Deferred[IO, Unit],
-        voteBuildAttempted: Deferred[IO, Unit],
-        voteSubmittedOk: Deferred[IO, Unit],
-        coilRatchetSubmitted: Deferred[IO, Unit],
+        allHeadsBuildingVote: Deferred[IO, Unit],
+        allHeadsVoteSubmittedOk: Deferred[IO, Unit],
+        allCoilsHandledDispute: Deferred[IO, Unit],
     ): ContraTracer[IO, MultiPeerHeadHarness.Event] =
         val peersAtMajor2: Ref[IO, Set[HeadPeerNumber]] = Ref.unsafe(Set.empty)
+        val headsBuildingVote: Ref[IO, Set[HeadPeerNumber]] = Ref.unsafe(Set.empty)
+        val headsVoteSubmittedOk: Ref[IO, Set[HeadPeerNumber]] = Ref.unsafe(Set.empty)
+        val coilsHandledDispute: Ref[IO, Set[Int]] = Ref.unsafe(Set.empty)
 
         def lastMajorVersion(effects: StackEffects.HardConfirmed): Option[Int] =
             effects match {
@@ -376,22 +380,37 @@ object VoteVersionMismatchTest extends Properties("Vote Version Mismatch"):
                     case RuleBasedOnlyChildEvent.RuleBasedActor(
                           RuleBasedActorEvent.Tx.Building("VoteTx")
                         ) =>
-                        voteBuildAttempted.complete(()).void
+                        headsBuildingVote.updateAndGet(_ + peerNum).flatMap { s =>
+                            if s.size >= nHeadPeers
+                            then allHeadsBuildingVote.complete(()).void
+                            else IO.unit
+                        }
 
                     case RuleBasedOnlyChildEvent.RuleBasedActor(
                           RuleBasedActorEvent.Tx.SubmitSuccess(tx)
                         ) if tx.transactionFamily == "VoteTx" =>
-                        voteSubmittedOk.complete(()).void
+                        headsVoteSubmittedOk.updateAndGet(_ + peerNum).flatMap { s =>
+                            if s.size >= nHeadPeers
+                            then allHeadsVoteSubmittedOk.complete(()).void
+                            else IO.unit
+                        }
 
                     case _ => IO.unit
                 }
 
-            case MultiPeerHeadHarness.Event.Coil(_, evt) =>
+            case MultiPeerHeadHarness.Event.Coil(coilNum, evt) =>
                 evt match {
+                    // Any of the three coil-side terminal events proves `handleCoil` ran.
                     case RuleBasedOnlyChildEvent.RuleBasedActor(
-                          RuleBasedActorEvent.Tx.SubmitSuccess(tx)
-                        ) if tx.transactionFamily == "RatchetVoteTx" =>
-                        coilRatchetSubmitted.complete(()).void
+                          _: RuleBasedActorEvent.Dispute.Coil.ParsingRatchet.type |
+                          _: RuleBasedActorEvent.Dispute.Coil.AlreadyAtTarget.type |
+                          _: RuleBasedActorEvent.Dispute.Coil.NoRatchetTarget.type
+                        ) =>
+                        coilsHandledDispute.updateAndGet(_ + coilNum.convert).flatMap { s =>
+                            if s.size >= nCoilPeers
+                            then allCoilsHandledDispute.complete(()).void
+                            else IO.unit
+                        }
                     case _ => IO.unit
                 }
         }

--- a/integration/src/test/scala/hydrozoa/integration/harness/MultiPeerHeadHarness.scala
+++ b/integration/src/test/scala/hydrozoa/integration/harness/MultiPeerHeadHarness.scala
@@ -215,16 +215,20 @@ object MultiPeerHeadHarness:
      * and gets contramapped with the regime managers' tracers. `peerHandle` / `coilHandle` run once each MRM's
       * `connectionsDeferred` resolves.
       */
-    case class Hooks[H, C](
+    /** Test-side wiring — one `PeerId`-keyed hook per concern. Callers that only need a head-side
+      * handle can use `H = Option[HeadHandle]` and return `None` from the coil branch; likewise
+      * `wrapBackend` can pattern-match on `PeerId.Head` / `PeerId.Coil` when the wrap differs
+      * (e.g. only head peers get firewalled).
+      */
+    case class Hooks[H](
         tracer: ContraTracer[IO, Event],
-        peerHandle: (HeadPeerNumber, HeadMultisigRegimeManager.Connections) => IO[H],
-        coilHandle: (CoilPeerNumber, HeadMultisigRegimeManager.Connections) => IO[C],
+        handle: (PeerId, HeadMultisigRegimeManager.Connections) => IO[H],
         // Wrap the shared mock backend per peer (e.g. FirewalledCardanoBackend). Identity default.
-        wrapPeerBackend: (HeadPeerNumber, L1Backend[IO]) => L1Backend[IO] = (_, b) => b,
+        wrapBackend: (PeerId, L1Backend[IO]) => L1Backend[IO] = (_, b) => b,
     )
 
-    /** Per-peer artifacts exposed to callers: resolved connections, persistence backend, and the
-      * caller-derived handle.
+    /** Per-node artifacts exposed to callers: resolved connections, persistence backend, and the
+      * caller-derived handle. Used for both head peers and coil peers.
       */
     case class Peer[H](
         connections: HeadMultisigRegimeManager.Connections,
@@ -232,30 +236,30 @@ object MultiPeerHeadHarness:
         handle: H,
     )
 
-    case class Coil[C](
+    case class Coil[H](
         connections: HeadMultisigRegimeManager.Connections,
         backendStore: BackendStore[IO],
-        handle: C,
+        handle: H,
     )
 
     /** Everything the harness yields. `sutErrors` is appended to by the error drainer (one entry
       * per uncaught actor exception); callers read it post-run.
       */
-    case class Harness[H, C](
+    case class Harness[H](
         system: ActorSystem[IO],
         cardanoBackend: L1Backend[IO],
         peers: Map[HeadPeerNumber, Peer[H]],
-        coils: Map[CoilPeerNumber, Coil[C]],
+        coils: Map[CoilPeerNumber, Coil[H]],
         sutErrors: Ref[IO, List[String]],
     )
 
     /** Build a fully-wired multi-peer head + coil followers. The returned resource owns
       * everything; release cancels the CL tick fibers and the error drainer.
       */
-    def resource[H, C](
+    def resource[H](
         inputs: Inputs,
-        hooks: Hooks[H, C],
-    ): Resource[IO, Harness[H, C]] =
+        hooks: Hooks[H],
+    ): Resource[IO, Harness[H]] =
         import inputs.*
         import inputs.config.*
         val peers = multiNodeConfig.nodeConfigs.keys.toSeq.sortBy(p => p: Int)
@@ -287,7 +291,7 @@ object MultiPeerHeadHarness:
                                     .buildPeer(
                                       peerNum,
                                       system,
-                                      hooks.wrapPeerBackend(peerNum, cardanoBackend),
+                                      hooks.wrapBackend(PeerId.Head(peerNum), cardanoBackend),
                                       multiNodeConfig,
                                       backendMode,
                                       transports.headNetworks(peerNum),
@@ -304,7 +308,7 @@ object MultiPeerHeadHarness:
                                       coilConfig,
                                       coilNum,
                                       system,
-                                      cardanoBackend,
+                                      hooks.wrapBackend(PeerId.Coil(coilNum), cardanoBackend),
                                       multiNodeConfig,
                                       transports.coilUplinks(coilNum),
                                       hooks.tracer.contramap(Event.Coil(coilNum, _)),
@@ -350,7 +354,7 @@ object MultiPeerHeadHarness:
                  )
             peerEntries <- Resource.eval(
                                peerConnections.toList.traverse { case (peerNum, conns) =>
-                                   hooks.peerHandle(peerNum, conns).map { h =>
+                                   hooks.handle(PeerId.Head(peerNum), conns).map { h =>
                                        peerNum -> Peer(
                                          connections = conns,
                                          backendStore = peerMrms(peerNum).backendStore,
@@ -361,7 +365,7 @@ object MultiPeerHeadHarness:
                            )
             coilEntries <- Resource.eval(
                                coilConnections.toList.traverse { case (coilNum, conns) =>
-                                   hooks.coilHandle(coilNum, conns).map { h =>
+                                   hooks.handle(PeerId.Coil(coilNum), conns).map { h =>
                                        coilNum -> Coil(
                                          connections = conns,
                                          backendStore = coilMrms(coilNum).backendStore,

--- a/integration/src/test/scala/hydrozoa/integration/rbr/property/EvacuationPropertyTest.scala
+++ b/integration/src/test/scala/hydrozoa/integration/rbr/property/EvacuationPropertyTest.scala
@@ -14,7 +14,7 @@ import hydrozoa.integration.harness.MultiPeerHeadHarness.Transport.Mode as Trans
 import hydrozoa.lib.cardano.scalus.QuantizedTime.QuantizedInstant
 import hydrozoa.lib.logging.{ContraTracer, Slf4jTracer}
 import hydrozoa.multisig.backend.cardano.{CardanoBackend as L1Backend, FirewalledCardanoBackend, FirewalledCardanoBackendEvent, yaciTestSauceGenesis}
-import hydrozoa.multisig.consensus.peer.HeadPeerNumber
+import hydrozoa.multisig.consensus.peer.{HeadPeerNumber, PeerId}
 import hydrozoa.multisig.consensus.{CardanoLiaisonEvent, RequestSequencer, UserRequest, UserRequestBody, UserRequestHeader}
 import hydrozoa.multisig.ledger.l1.tx.SettlementTx
 import hydrozoa.multisig.ledger.block.BlockVersion.Major.given_Conversion_Major_Int
@@ -108,7 +108,7 @@ object EvacuationPropertyTest extends Properties("RBR Evacuation Property"):
     private final case class Ctx(
         transportMode: TransportMode,
         multiNodeConfig: MultiNodeConfig,
-        harness: MultiPeerHeadHarness.Harness[RequestSequencer.Handle, Unit],
+        harness: MultiPeerHeadHarness.Harness[Option[RequestSequencer.Handle]],
         fallbackDispatched: Deferred[IO, Unit],
         resolutionSubmitted: Deferred[IO, Unit],
     )
@@ -164,24 +164,29 @@ object EvacuationPropertyTest extends Properties("RBR Evacuation Property"):
             startEpochMs = multiNodeConfig.headConfig.initialBlock.blockBrief.endTime
                 .convert.instant.toEpochMilli
 
-            hooks = MultiPeerHeadHarness.Hooks[RequestSequencer.Handle, Unit](
+            hooks = MultiPeerHeadHarness.Hooks[Option[RequestSequencer.Handle]](
               tracer = humanFormatTracer |+| observerTracer(
                 fallbackDispatched,
                 resolutionSubmitted,
               ),
-              peerHandle = (peerNum, conns) =>
-                  IO.fromOption(conns.requestSequencer)(
-                    new NoSuchElementException(
-                      s"peer $peerNum has no RequestSequencer.Handle in its Connections"
-                    )
-                  ),
-              coilHandle = (_, _) => IO.unit,
-              wrapPeerBackend = wrapPeerBackend,
+              handle = {
+                  case (PeerId.Head(peerNum), conns) =>
+                      IO.fromOption(conns.requestSequencer)(
+                        new NoSuchElementException(
+                          s"peer $peerNum has no RequestSequencer.Handle in its Connections"
+                        )
+                      ).map(Some(_))
+                  case (_: PeerId.Coil, _) => IO.pure(None)
+              },
+              wrapBackend = {
+                  case (PeerId.Head(peerNum), backend) => wrapPeerBackend(peerNum, backend)
+                  case (_: PeerId.Coil, backend)       => backend
+              },
             )
 
             label = s"RBREvacuation-${transportMode.toString.toLowerCase}"
 
-            harness <- MultiPeerHeadHarness.resource[RequestSequencer.Handle, Unit](
+            harness <- MultiPeerHeadHarness.resource[Option[RequestSequencer.Handle]](
               MultiPeerHeadHarness.Inputs(
                 config = MultiPeerHeadHarness.Config(
                   label = label,
@@ -230,7 +235,7 @@ object EvacuationPropertyTest extends Properties("RBR Evacuation Property"):
               bodyHash = body.hash,
             )
             userRequest = UserRequest.TransactionRequest(header, body, userVk)
-            sequencer <- IO.fromOption(ctx.harness.peers.get(peerNum).map(_.handle))(
+            sequencer <- IO.fromOption(ctx.harness.peers.get(peerNum).flatMap(_.handle))(
               new NoSuchElementException(s"peer $peerNum missing in harness")
             )
             _ <- sequencer ?: userRequest

--- a/integration/src/test/scala/hydrozoa/integration/stage4/Suite.scala
+++ b/integration/src/test/scala/hydrozoa/integration/stage4/Suite.scala
@@ -132,7 +132,7 @@ case class Stage4Suite(
             // SUT-command-fed Ref (not a plugin — written by commands, not tracer arms)
             submittedRequestIds <- Resource.eval(Ref[IO].of(Vector.empty[RequestId]))
 
-            hooks = MultiPeerHeadHarness.Hooks[Stage4PeerHandle, Unit](
+            hooks = MultiPeerHeadHarness.Hooks[Option[Stage4PeerHandle]](
                       tracer = Plugin.tracerOf(
                         perPeer,
                         perCoil,
@@ -142,15 +142,19 @@ case class Stage4Suite(
                         effectsLandedSignal,
                         fallbackEnteredSignal,
                       ),
-                      peerHandle = (peerNum, conns) =>
-                          IO.pure(
-                            Stage4PeerHandle(
-                              conns.requestSequencer.getOrElse(
-                                sys.error(s"head peer $peerNum missing RequestSequencer")
+                      handle = {
+                          case (PeerId.Head(peerNum), conns) =>
+                              IO.pure(
+                                Some(
+                                  Stage4PeerHandle(
+                                    conns.requestSequencer.getOrElse(
+                                      sys.error(s"head peer $peerNum missing RequestSequencer")
+                                    )
+                                  )
+                                )
                               )
-                            )
-                          ),
-                      coilHandle = (_, _) => IO.unit,
+                          case (_: PeerId.Coil, _) => IO.pure(None)
+                      },
                     )
             harness <- MultiPeerHeadHarness.resource(
                            MultiPeerHeadHarness.Inputs(
@@ -168,7 +172,13 @@ case class Stage4Suite(
           static = Stage4SutStatic(
             system = harness.system,
             cardanoBackend = harness.cardanoBackend,
-            peers = harness.peers.map { case (n, p) => n -> p.handle },
+            // Head peers always yield `Some` (see the `Hooks.handle` above); crash loudly if the
+            // invariant is violated so downstream doesn't silently drop peers.
+            peers = harness.peers.map { case (n, p) =>
+                n -> p.handle.getOrElse(
+                  sys.error(s"head peer $n missing Stage4PeerHandle after harness bring-up")
+                )
+            },
             backendStores = harness.peers.map { case (n, p) => n -> p.backendStore },
             log = Slf4jTracer.sink.contramap(Slf4jMsgFormat.humanFormat("Stage4.Sut")),
           ),

--- a/src/main/scala/hydrozoa/multisig/CoilMultisigRegimeManager.scala
+++ b/src/main/scala/hydrozoa/multisig/CoilMultisigRegimeManager.scala
@@ -158,18 +158,22 @@ trait CoilMultisigRegimeManager(
       * [[RuleBasedRegimeManager]], whose actor will run the coil ratchet path (see
       * `RuleBasedActor.Dispute.handleCoil`).
       */
+    // Idempotent — mirrors HMRM.onHandoffToRuleBased.
     override protected def onHandoffToRuleBased(fallback: FallbackTx): IO[Unit] =
-        for {
-            refs <- nonClChildren.getAndSet(Nil)
-            _ <- refs.traverse_(context.stop)
-            _ <- context.actorOf(
-              RuleBasedRegimeManager(
-                cardanoBackend = cardanoBackend,
-                persistence = persistence,
-                tracer = tracers.ruleBasedActor,
-              )(using config)
-            )
-        } yield ()
+        nonClChildren.getAndSet(Nil).flatMap {
+            case Nil => IO.unit
+            case refs =>
+                refs.traverse_(context.stop) >>
+                    context
+                        .actorOf(
+                          RuleBasedRegimeManager(
+                            cardanoBackend = cardanoBackend,
+                            persistence = persistence,
+                            tracer = tracers.ruleBasedActor,
+                          )(using config)
+                        )
+                        .void
+        }
 }
 
 object CoilMultisigRegimeManager {

--- a/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManager.scala
+++ b/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManager.scala
@@ -264,18 +264,22 @@ trait HeadMultisigRegimeManager(
             )
         } yield ()
 
+    // Idempotent: `Nil` from `getAndSet` means we've already handed off.
     override protected def onHandoffToRuleBased(fallback: FallbackTx): IO[Unit] =
-        for {
-            refs <- nonClChildren.getAndSet(Nil)
-            _ <- refs.traverse_(context.stop)
-            _ <- context.actorOf(
-              RuleBasedRegimeManager(
-                cardanoBackend = cardanoBackend,
-                persistence = persistence,
-                tracer = tracers.ruleBasedActor,
-              )(using config)
-            )
-        } yield ()
+        nonClChildren.getAndSet(Nil).flatMap {
+            case Nil => IO.unit
+            case refs =>
+                refs.traverse_(context.stop) >>
+                    context
+                        .actorOf(
+                          RuleBasedRegimeManager(
+                            cardanoBackend = cardanoBackend,
+                            persistence = persistence,
+                            tracer = tracers.ruleBasedActor,
+                          )(using config)
+                        )
+                        .void
+        }
 }
 
 /** Multisig regime manager starts-up and monitors all the actors of the multisig regime.

--- a/src/main/scala/hydrozoa/multisig/consensus/CardanoLiaison.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/CardanoLiaison.scala
@@ -735,10 +735,6 @@ trait CardanoLiaison(
                         )
                     }
 
-                    fallbackAction = actionsToSubmit.collectFirst {
-                        case a: Action.FallbackToRuleBased => a
-                    }
-
                     submitRet <-
                         if actionsToSubmit.nonEmpty then
                             IO.traverse(actionsToSubmit.flatMap(actionTxs).toList)(etx =>
@@ -757,25 +753,24 @@ trait CardanoLiaison(
                       tracer.traceWith(CardanoLiaisonEvent.SubmissionErrors(submissionErrors.size))
                     )
 
-                    // Post-submission: fire FallbackToRuleBasedDispatched and signal the regime
-                    // manager only after the fallback tx was accepted by the backend. "Dispatched"
-                    // denotes confirmed submission, not intent — pre-effect intent is logged
-                    // earlier as ActionsDispatched.
-                    _ <- fallbackAction match {
-                        case None => IO.unit
-                        case Some(action) =>
-                            val id = action.tx.tx.id
-                            val submittedOk = submitRet.exists { case (etx, ret) =>
-                                etx.tx.id == id && ret.isRight
+                    // Every peer that sees a known fallback tx on L1 hands off — not just the
+                    // submitter. MRM handler is idempotent so re-fires are safe.
+                    _ <- state.fallbackEffects.values.toList
+                        .traverse { ft =>
+                            cardanoBackend.isTxKnown(ft.tx.id).map {
+                                case Right(true) => Some(ft)
+                                case _           => None
                             }
-                            IO.whenA(submittedOk)(
-                              tracer.traceWith(
-                                CardanoLiaisonEvent.FallbackToRuleBasedDispatched(id)
-                              ) >> (mrmSelf ! HeadMultisigRegimeManager.HandoffToRuleBased(
-                                action.tx
-                              ))
-                            )
-                    }
+                        }
+                        .map(_.flatten.headOption)
+                        .flatMap {
+                            case None => IO.unit
+                            case Some(ft) =>
+                                tracer.traceWith(
+                                  CardanoLiaisonEvent.FallbackToRuleBasedDispatched(ft.tx.id)
+                                ) >>
+                                    (mrmSelf ! HeadMultisigRegimeManager.HandoffToRuleBased(ft))
+                        }
 
                 } yield ()
         }

--- a/src/main/scala/hydrozoa/rulebased/RuleBasedActor.scala
+++ b/src/main/scala/hydrozoa/rulebased/RuleBasedActor.scala
@@ -245,12 +245,19 @@ final case class RuleBasedActor(
                         RuleBasedActor
                             .lastSecMatchingVersion(r.partitions, treasuryVersionMajor) match {
                             case Some(multiSec) =>
+                                // `HardAckAggregator.collectSecSignatures` stores sigs in
+                                // `secSigners` order = `allHeadPeers.sorted ++
+                                // coilPeers.sorted.take(coilQuorum)`. Head sigs occupy the
+                                // first `nHeadPeers` positions; the tail is the coil quorum,
+                                // dense (only signers appear — no `None` slots).
+                                val (head, coil) = multiSec.headerMultiSigned
+                                    .splitAt(config.nHeadPeers.convert)
                                 IO.pure(
                                   Right(
                                     DisputeAction.Vote(
                                       sec = RuleBasedActor.toOnchain(multiSec.commitment),
-                                      signatures = multiSec.headerMultiSigned,
-                                      coilSignatures = Nil // coil-side recovery deferred
+                                      signatures = head,
+                                      coilSignatures = coil.map(Some(_))
                                     )
                                   )
                                 )

--- a/src/test/scala/hydrozoa/multisig/backend/cardano/YaciTestSauce.scala
+++ b/src/test/scala/hydrozoa/multisig/backend/cardano/YaciTestSauce.scala
@@ -13,7 +13,12 @@ def mkGenesis(setup: List[(String, TestPeerName)])(@unused network: Network)(
     testPeers: TestPeers
 ): Map[TestPeerName, Utxos] = {
 
-    val peerNames = testPeers.headPeerIds.map(id => TestPeerName.fromOrdinal(id._1)).toList
+    // Include coil peer names too — coil-side RBAs need ADA-only wallet UTxOs for collateral.
+    val headNames = testPeers.headPeerIds.map(id => TestPeerName.fromOrdinal(id._1)).toList
+    val coilNames = (0 until testPeers.coilPeersNumber)
+        .map(i => TestPeerName.fromOrdinal(testPeers.peersNumber + i))
+        .toList
+    val peerNames = headNames ++ coilNames
 
     setup
         // filtering out unneeded elements from the setup

--- a/src/test/scala/test/TestPeers.scala
+++ b/src/test/scala/test/TestPeers.scala
@@ -52,10 +52,12 @@ case class TestPeers private (
 
     private val peerNumbers: List[Int] = List.range(0, peersNumber)
 
+    // Head peers occupy ordinals `[0, peersNumber)`; coil peers occupy
+    // `[peersNumber, peersNumber + coilPeersNumber)`.
     private def _require(peer: TestPeerName): Unit =
         require(
-          peer.ordinal < peersNumber,
-          s"Can't access peer $peer there is only $peersNumber is the head"
+          peer.ordinal < peersNumber + coilPeersNumber,
+          s"Can't access peer $peer; head=$peersNumber, coil=$coilPeersNumber"
         )
 
     require(


### PR DESCRIPTION
## Summary
`RuleBasedActor.loadAction` now splits the SEC's `headerMultiSigned` list into head and coil components before packing it into `DisputeAction.Vote`. Previously it passed the whole list as `signatures` and hardcoded `coilSignatures = Nil`, which produced a bad on-chain redeemer once `coilQuorum > 0`.

## What was wrong
`HardAckAggregator.collectSecSignatures` stores SEC signatures in `secSigners` order — `allHeadPeers.sorted ++ coilPeers.sorted.take(coilQuorum)`. So `MultiSigned.headerMultiSigned` today already includes coil sigs, mixed at the tail with head sigs and untagged.

The dispute-resolution Plutus script expects them split:
- `headMultisig: List[Signature]` — one per head peer, verified against head VKs
- `coilMultisig: List[Option[Signature]]` — position-aligned to `coilPeers`, verified against coil VKs, quorum-terminated

Passing the flat mixed list as `signatures` fails Plutus verification when `coilQuorum > 0` because the tail sigs get checked against head VKs.

## The fix
In `loadAction`, split `multiSec.headerMultiSigned` at `config.nHeadPeers`. Front = head sigs; tail = coil sigs, wrapped in `Some(_)` (dense; only signers appear upstream, no `None` slots to reconstruct). Plutus tolerates a shorter list — it terminates the coil walk when either `coilPeers` or `coilMultisig` runs out.

## Coverage
Existing tests all use `coilQuorum = 0`, so the split is a no-op (`(headSigs, Nil)`) — behaviorally identical to the previous `coilSignatures = Nil` placeholder. The new coil path becomes active when someone raises `nCoilPeers > 0` in the dispute-flow tests (VVMT already has TODO wiring for this).

## Test plan
- [ ] `sbtn "testOnly hydrozoa.rulebased.ledger.l1.*"` (46 pass locally)
- [ ] `sbtn "integration/testOnly *VoteVersionMismatch* *EvacuationProperty*"` (2 pass locally)
- [ ] `just build-werror` (green locally)
- [ ] CI full test run