### PR TITLE
Route Stage4 harness submissions through in-memory HTTP JSON endpoints

### DIFF
--- a/integration/src/test/scala/hydrozoa/integration/harness/MultiPeerHeadHarness.scala
+++ b/integration/src/test/scala/hydrozoa/integration/harness/MultiPeerHeadHarness.scala
@@ -27,11 +27,14 @@ import hydrozoa.multisig.consensus.transport.*
 import hydrozoa.multisig.ledger.eutxol2.EutxoL2Ledger
 import hydrozoa.multisig.persistence.rocksdb.RocksDbBackendStore
 import hydrozoa.multisig.persistence.{BackendStore, Cf, InMemoryBackendStore, Persistence, PersistenceEvent, PersistenceEventFormat}
+import hydrozoa.multisig.server.{HydrozoaHttpEvent, HydrozoaHttpEventFormat, HydrozoaRoutes, HydrozoaServer, SubmissionClient}
 import hydrozoa.multisig.{CoilMultisigRegimeManager, CoilMultisigRegimeManagerEventFormat, CoilRegimeManagerEvent, HeadMultisigRegimeManager, HeadMultisigRegimeManagerEventFormat, HeadRegimeManagerEvent}
 import java.nio.file.{Files, Path}
 import java.time.Instant
 import java.util.concurrent.TimeUnit
+import org.http4s.client.Client as Http4sClient
 import org.http4s.client.websocket.WSClient
+import org.http4s.implicits.*
 import org.http4s.jdkhttpclient.JdkWSClient
 import org.http4s.server.websocket.WebSocketBuilder2
 import org.http4s.{HttpRoutes, Uri}
@@ -227,12 +230,14 @@ object MultiPeerHeadHarness:
         wrapBackend: (PeerId, L1Backend[IO]) => L1Backend[IO] = (_, b) => b,
     )
 
-    /** Per-node artifacts exposed to callers: resolved connections, persistence backend, and the
-      * caller-derived handle. Used for both head peers and coil peers.
+    /** Per-head-peer artifacts exposed to callers: resolved connections, persistence backend, the
+      * in-process [[SubmissionClient]] (bound to this peer's [[HydrozoaRoutes]] via
+      * `Client.fromHttpApp`), and the caller-derived handle.
       */
     case class Peer[H](
         connections: HeadMultisigRegimeManager.Connections,
         backendStore: BackendStore[IO],
+        submissionClient: SubmissionClient,
         handle: H,
     )
 
@@ -354,13 +359,19 @@ object MultiPeerHeadHarness:
                  )
             peerEntries <- Resource.eval(
                                peerConnections.toList.traverse { case (peerNum, conns) =>
-                                   hooks.handle(PeerId.Head(peerNum), conns).map { h =>
-                                       peerNum -> Peer(
-                                         connections = conns,
-                                         backendStore = peerMrms(peerNum).backendStore,
-                                         handle = h,
-                                       )
-                                   }
+                                   for
+                                       submissionClient <- Http.mkPeerSubmissionClient(
+                                                               peerNum,
+                                                               conns,
+                                                               multiNodeConfig,
+                                                           )
+                                       h <- hooks.handle(PeerId.Head(peerNum), conns)
+                                   yield peerNum -> Peer(
+                                     connections = conns,
+                                     backendStore = peerMrms(peerNum).backendStore,
+                                     submissionClient = submissionClient,
+                                     handle = h,
+                                   )
                                }
                            )
             coilEntries <- Resource.eval(
@@ -906,6 +917,49 @@ object MultiPeerHeadHarness:
                            )
                     _ <- Resource.eval(system.actorOf(mrm, s"cmrm-${coilNum.convert}"))
                 yield Coil(mrm, backendStore, coilConfig)
+            }
+
+    // ===================================
+    // Http — per-peer in-memory HydrozoaRoutes + SubmissionClient
+    // ===================================
+
+    object Http:
+        /** Placeholder authority for the in-process HTTP client. `Client.fromHttpApp` dispatches
+          * by path against the wrapped `HttpApp`, so the authority never hits a socket.
+          */
+        private val InProcBaseUri: Uri = uri"http://harness"
+
+        /** Build a peer's [[HydrozoaRoutes]] and wrap it in an in-memory http4s
+          * [[org.http4s.client.Client]] via `Client.fromHttpApp`, then return a
+          * [[SubmissionClient]] that signs each request with the peer's own wallet.
+          */
+        def mkPeerSubmissionClient(
+            peerNum: HeadPeerNumber,
+            conns: HeadMultisigRegimeManager.Connections,
+            multiNodeConfig: MultiNodeConfig,
+        ): IO[SubmissionClient] =
+            val nodeConfig = multiNodeConfig.nodeConfigs(peerNum)
+            val requestSequencer = conns.requestSequencer.getOrElse(
+              throw new IllegalStateException(
+                s"head peer $peerNum missing RequestSequencer; cannot build SubmissionClient"
+              )
+            )
+            val serverConfig = HydrozoaServer.Config(
+              adminUsername = "harness-admin",
+              adminPassword = "harness-admin",
+            )
+            val httpTracer: ContraTracer[IO, HydrozoaHttpEvent] =
+                Slf4jTracer.sink.contramap(HydrozoaHttpEventFormat.humanFormat)
+            HydrozoaRoutes(
+              requestSequencer,
+              conns.blockWeaver,
+              nodeConfig.headConfig,
+              serverConfig,
+              httpTracer,
+            ).map { hydrozoaRoutes =>
+                val client: Http4sClient[IO] =
+                    Http4sClient.fromHttpApp(hydrozoaRoutes.routes.orNotFound)
+                SubmissionClient.http(client, InProcBaseUri, nodeConfig.ownWallet)
             }
 
     // ===================================

--- a/integration/src/test/scala/hydrozoa/integration/stage4/Suite.scala
+++ b/integration/src/test/scala/hydrozoa/integration/stage4/Suite.scala
@@ -28,6 +28,7 @@ import hydrozoa.multisig.ledger.event.RequestId.ValidityFlag
 import hydrozoa.multisig.ledger.event.{RequestId, RequestNumber}
 import hydrozoa.multisig.ledger.stack.{PartitionEffects, Stack, StackEffects}
 import hydrozoa.multisig.persistence.{BackendStore, Cf}
+import hydrozoa.multisig.server.SubmissionClient
 import org.scalacheck.commands.{AnyCommand, ModelBasedSuite, ScenarioGen}
 import org.scalacheck.{Gen, Prop, PropertyM}
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
@@ -147,8 +148,10 @@ case class Stage4Suite(
                               IO.pure(
                                 Some(
                                   Stage4PeerHandle(
-                                    conns.requestSequencer.getOrElse(
-                                      sys.error(s"head peer $peerNum missing RequestSequencer")
+                                    SubmissionClient.direct(
+                                      conns.requestSequencer.getOrElse(
+                                        sys.error(s"head peer $peerNum missing RequestSequencer")
+                                      )
                                     )
                                   )
                                 )

--- a/integration/src/test/scala/hydrozoa/integration/stage4/Suite.scala
+++ b/integration/src/test/scala/hydrozoa/integration/stage4/Suite.scala
@@ -28,7 +28,6 @@ import hydrozoa.multisig.ledger.event.RequestId.ValidityFlag
 import hydrozoa.multisig.ledger.event.{RequestId, RequestNumber}
 import hydrozoa.multisig.ledger.stack.{PartitionEffects, Stack, StackEffects}
 import hydrozoa.multisig.persistence.{BackendStore, Cf}
-import hydrozoa.multisig.server.SubmissionClient
 import org.scalacheck.commands.{AnyCommand, ModelBasedSuite, ScenarioGen}
 import org.scalacheck.{Gen, Prop, PropertyM}
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
@@ -133,7 +132,9 @@ case class Stage4Suite(
             // SUT-command-fed Ref (not a plugin — written by commands, not tracer arms)
             submittedRequestIds <- Resource.eval(Ref[IO].of(Vector.empty[RequestId]))
 
-            hooks = MultiPeerHeadHarness.Hooks[Option[Stage4PeerHandle]](
+            // Hooks.handle is unused now — each head peer's SubmissionClient is built by the
+            // harness against its in-process HydrozoaRoutes and exposed on Peer[H].submissionClient.
+            hooks = MultiPeerHeadHarness.Hooks[Unit](
                       tracer = Plugin.tracerOf(
                         perPeer,
                         perCoil,
@@ -143,21 +144,7 @@ case class Stage4Suite(
                         effectsLandedSignal,
                         fallbackEnteredSignal,
                       ),
-                      handle = {
-                          case (PeerId.Head(peerNum), conns) =>
-                              IO.pure(
-                                Some(
-                                  Stage4PeerHandle(
-                                    SubmissionClient.direct(
-                                      conns.requestSequencer.getOrElse(
-                                        sys.error(s"head peer $peerNum missing RequestSequencer")
-                                      )
-                                    )
-                                  )
-                                )
-                              )
-                          case (_: PeerId.Coil, _) => IO.pure(None)
-                      },
+                      handle = (_, _) => IO.unit,
                     )
             harness <- MultiPeerHeadHarness.resource(
                            MultiPeerHeadHarness.Inputs(
@@ -175,13 +162,7 @@ case class Stage4Suite(
           static = Stage4SutStatic(
             system = harness.system,
             cardanoBackend = harness.cardanoBackend,
-            // Head peers always yield `Some` (see the `Hooks.handle` above); crash loudly if the
-            // invariant is violated so downstream doesn't silently drop peers.
-            peers = harness.peers.map { case (n, p) =>
-                n -> p.handle.getOrElse(
-                  sys.error(s"head peer $n missing Stage4PeerHandle after harness bring-up")
-                )
-            },
+            peers = harness.peers.map { case (n, p) => n -> p.submissionClient },
             backendStores = harness.peers.map { case (n, p) => n -> p.backendStore },
             log = Slf4jTracer.sink.contramap(Slf4jMsgFormat.humanFormat("Stage4.Sut")),
           ),

--- a/integration/src/test/scala/hydrozoa/integration/stage4/Sut.scala
+++ b/integration/src/test/scala/hydrozoa/integration/stage4/Sut.scala
@@ -24,20 +24,17 @@ import scalus.cardano.ledger.TransactionHash
 // Stage 4 SUT
 // ===================================
 
-/** Per-peer submission handle exposed to SUT commands. Routes a [[UserRequest]] through the
-  * transport the harness chose (direct actor send today; in-memory http4s round-trip once wired).
-  */
-case class Stage4PeerHandle(
-    submissionClient: SubmissionClient,
-)
-
 /** Immutable, set-once resources of a running stage4 SUT. Allocated during `sutResource`,
   * referenced from anywhere thereafter — no field on this case class ever changes.
+  *
+  * `peers` holds each head peer's [[SubmissionClient]] — built by the harness against that peer's
+  * in-process [[hydrozoa.multisig.server.HydrozoaRoutes]] via `Client.fromHttpApp`, so submissions
+  * exercise the real HTTP/JSON codec surface without binding a socket.
   */
 case class Stage4SutStatic(
     system: ActorSystem[IO],
     cardanoBackend: CardanoBackend[IO],
-    peers: Map[HeadPeerNumber, Stage4PeerHandle],
+    peers: Map[HeadPeerNumber, SubmissionClient],
     /** Per-peer persistence backend store — used by `analyzePersistence` to assert SC + SCA
       * writes (Treasury + EvacuationMap + HardConfirmation) landed during the scenario.
       */
@@ -150,25 +147,26 @@ object Stage4SutCommands:
         override def run(cmd: DelayCommand, sut: Stage4Sut): IO[Unit] = IO.unit
     }
 
-    // L2 tx: submit via the peer's SubmissionClient (direct actor send today; HTTP round-trip
-    // once wired). Result is always Valid (trivial); oracle check in shutdownSut compares model
-    // predictions against actual block-brief outcomes.
+    // L2 tx: submit via the peer's SubmissionClient (in-memory http4s round-trip through the
+    // harness's HydrozoaRoutes). Result is always Valid (trivial); oracle check in shutdownSut
+    // compares model predictions against actual block-brief outcomes.
     given SutCommand[L2TxCommand, ValidityFlag, Stage4Sut] with {
         override def run(cmd: L2TxCommand, sut: Stage4Sut): IO[ValidityFlag] = {
             for {
-                reqId <- sut.static.peers(cmd.peerNum).submissionClient.submit(cmd.request.asUserRequest)
+                reqId <- sut.static.peers(cmd.peerNum).submit(cmd.request.asUserRequest)
                 _ <- sut.static.log.trace(s"reqId=$reqId, cmd.request.requestId=${cmd.request.requestId}")
                 _ <- sut.mutable.submittedRequestIds.update(_ :+ cmd.request.requestId)
             } yield ValidityFlag.Valid
         }
     }
 
-    // Deposit: register with the peer's SubmissionClient AND submit the signed deposit tx to the
-    // shared mock L1 backend so CardanoLiaison can observe it on-chain at the correct time.
+    // Deposit: submit via the peer's SubmissionClient (in-memory http4s round-trip) AND submit
+    // the signed deposit tx to the shared mock L1 backend so CardanoLiaison can observe it
+    // on-chain at the correct time.
     given SutCommand[RegisterAndSubmitDepositCommand, ValidityFlag, Stage4Sut] with {
         override def run(cmd: RegisterAndSubmitDepositCommand, sut: Stage4Sut): IO[ValidityFlag] = {
             for {
-                reqId <- sut.static.peers(cmd.peerNum).submissionClient.submit(cmd.request.asUserRequest)
+                reqId <- sut.static.peers(cmd.peerNum).submit(cmd.request.asUserRequest)
                 _ <- sut.static.log.trace(s"reqId=$reqId, cmd.request.requestId=${cmd.request.requestId}")
                 _ <- sut.mutable.submittedRequestIds.update(_ :+ cmd.request.requestId)
                 _ <- sut.static.cardanoBackend.submitTx(RawTx(cmd.depositTxBytesSigned))

--- a/integration/src/test/scala/hydrozoa/integration/stage4/Sut.scala
+++ b/integration/src/test/scala/hydrozoa/integration/stage4/Sut.scala
@@ -9,13 +9,14 @@ import hydrozoa.integration.stage4.EffectsLanded.BlockExpectation
 import hydrozoa.lib.logging.{ContraTracer, Slf4jMsg, trace}
 import hydrozoa.multisig.backend.cardano.CardanoBackend
 import hydrozoa.multisig.consensus.peer.{CoilPeerNumber, HeadPeerNumber}
-import hydrozoa.multisig.consensus.{RequestSequencer, UserRequest, UserRequestWithId}
+import hydrozoa.multisig.consensus.{UserRequest, UserRequestWithId}
 import hydrozoa.multisig.ledger.block.BlockBrief
 import hydrozoa.multisig.ledger.event.RequestId
 import hydrozoa.multisig.ledger.event.RequestId.ValidityFlag
 import hydrozoa.multisig.ledger.l1.tx.RawTx
 import hydrozoa.multisig.ledger.stack.Stack
 import hydrozoa.multisig.persistence.BackendStore
+import hydrozoa.multisig.server.SubmissionClient
 import org.scalacheck.commands.SutCommand
 import scalus.cardano.ledger.TransactionHash
 
@@ -23,9 +24,11 @@ import scalus.cardano.ledger.TransactionHash
 // Stage 4 SUT
 // ===================================
 
-/** Per-peer actor handles exposed to SUT commands. */
+/** Per-peer submission handle exposed to SUT commands. Routes a [[UserRequest]] through the
+  * transport the harness chose (direct actor send today; in-memory http4s round-trip once wired).
+  */
 case class Stage4PeerHandle(
-    requestSequencer: RequestSequencer.Handle,
+    submissionClient: SubmissionClient,
 )
 
 /** Immutable, set-once resources of a running stage4 SUT. Allocated during `sutResource`,
@@ -147,25 +150,25 @@ object Stage4SutCommands:
         override def run(cmd: DelayCommand, sut: Stage4Sut): IO[Unit] = IO.unit
     }
 
-    // L2 tx: submit directly to the peer's RequestSequencer.
-    // Result is always Valid (trivial); oracle check in shutdownSut compares model
+    // L2 tx: submit via the peer's SubmissionClient (direct actor send today; HTTP round-trip
+    // once wired). Result is always Valid (trivial); oracle check in shutdownSut compares model
     // predictions against actual block-brief outcomes.
     given SutCommand[L2TxCommand, ValidityFlag, Stage4Sut] with {
         override def run(cmd: L2TxCommand, sut: Stage4Sut): IO[ValidityFlag] = {
             for {
-                reqId <- sut.static.peers(cmd.peerNum).requestSequencer ?: cmd.request.asUserRequest
+                reqId <- sut.static.peers(cmd.peerNum).submissionClient.submit(cmd.request.asUserRequest)
                 _ <- sut.static.log.trace(s"reqId=$reqId, cmd.request.requestId=${cmd.request.requestId}")
                 _ <- sut.mutable.submittedRequestIds.update(_ :+ cmd.request.requestId)
             } yield ValidityFlag.Valid
         }
     }
 
-    // Deposit: register with RequestSequencer AND submit the signed deposit tx to the shared
-    // mock L1 backend so CardanoLiaison can observe it on-chain at the correct time.
+    // Deposit: register with the peer's SubmissionClient AND submit the signed deposit tx to the
+    // shared mock L1 backend so CardanoLiaison can observe it on-chain at the correct time.
     given SutCommand[RegisterAndSubmitDepositCommand, ValidityFlag, Stage4Sut] with {
         override def run(cmd: RegisterAndSubmitDepositCommand, sut: Stage4Sut): IO[ValidityFlag] = {
             for {
-                reqId <- sut.static.peers(cmd.peerNum).requestSequencer ?: cmd.request.asUserRequest
+                reqId <- sut.static.peers(cmd.peerNum).submissionClient.submit(cmd.request.asUserRequest)
                 _ <- sut.static.log.trace(s"reqId=$reqId, cmd.request.requestId=${cmd.request.requestId}")
                 _ <- sut.mutable.submittedRequestIds.update(_ :+ cmd.request.requestId)
                 _ <- sut.static.cardanoBackend.submitTx(RawTx(cmd.depositTxBytesSigned))

--- a/src/main/scala/hydrozoa/lib/cardano/wallet/Cip30SignedData.scala
+++ b/src/main/scala/hydrozoa/lib/cardano/wallet/Cip30SignedData.scala
@@ -1,0 +1,9 @@
+package hydrozoa.lib.cardano.wallet
+
+/** CIP-30 `signData()` output: COSE_Key + COSE_Sign1 as CBOR hex. Constructor is `private[wallet]`
+  * — only [[WalletModule]] impls produce values.
+  */
+final case class Cip30SignedData private[wallet] (
+    coseKeyCborHex: String,
+    coseSignatureCborHex: String,
+)

--- a/src/main/scala/hydrozoa/lib/cardano/wallet/WalletModule.scala
+++ b/src/main/scala/hydrozoa/lib/cardano/wallet/WalletModule.scala
@@ -1,6 +1,8 @@
 package hydrozoa.lib.cardano.wallet
 
+import com.bloxbean.cardano.client.address.{AddressProvider, Credential}
 import com.bloxbean.cardano.client.cip.cip30.CIP30DataSigner
+import com.bloxbean.cardano.client.common.model.Networks
 import com.bloxbean.cardano.client.crypto.Blake2bUtil
 import com.bloxbean.cardano.client.crypto.api.SigningProvider
 import com.bloxbean.cardano.client.crypto.bip32.key.{HdPrivateKey, HdPublicKey}
@@ -69,12 +71,12 @@ trait WalletModule:
 
     /** Sign `payload` as a CIP-30 `signData()` COSE_Sign1, returning the (coseKey, coseSignature)
       * pair as CBOR-encoded hex strings — the shape [[hydrozoa.multisig.server.JsonCodecs]] expects
-      * on the request wire. The `addressBytes` argument goes into the COSE protected headers and is
-      * not otherwise validated by the server-side verifier.
+      * on the request wire. The COSE "address" header is derived internally as an enterprise
+      * address of `verificationKey`'s payment credential; bloxbean's `CIP30DataSigner.verify` walks
+      * back to that credential when validating the signature.
       */
     def signCoseCip30(
         payload: Array[Byte],
-        addressBytes: Array[Byte],
         verificationKey: VerificationKey,
         signingKey: SigningKey
     ): (String, String)
@@ -122,10 +124,13 @@ object WalletModule {
 
         override def signCoseCip30(
             payload: Array[Byte],
-            addressBytes: Array[Byte],
             verificationKey: VerificationKey,
             signingKey: SigningKey
         ): (String, String) =
+            val keyHash = Blake2bUtil.blake2bHash224(verificationKey.getKeyData)
+            val addressBytes = AddressProvider
+                .getEntAddress(Credential.fromKey(keyHash), Networks.testnet())
+                .getBytes
             val ds = CIP30DataSigner.INSTANCE.signData(
               addressBytes,
               payload,
@@ -157,10 +162,13 @@ object WalletModule {
 
         override def signCoseCip30(
             payload: Array[Byte],
-            addressBytes: Array[Byte],
             verificationKey: VerificationKey,
             signingKey: SigningKey
         ): (String, String) =
+            val keyHash = Blake2bUtil.blake2bHash224(verificationKey.bytes)
+            val addressBytes = AddressProvider
+                .getEntAddress(Credential.fromKey(keyHash), Networks.testnet())
+                .getBytes
             val ds = CIP30DataSigner.INSTANCE.signData(
               addressBytes,
               payload,

--- a/src/main/scala/hydrozoa/lib/cardano/wallet/WalletModule.scala
+++ b/src/main/scala/hydrozoa/lib/cardano/wallet/WalletModule.scala
@@ -1,5 +1,6 @@
 package hydrozoa.lib.cardano.wallet
 
+import com.bloxbean.cardano.client.cip.cip30.CIP30DataSigner
 import com.bloxbean.cardano.client.crypto.Blake2bUtil
 import com.bloxbean.cardano.client.crypto.api.SigningProvider
 import com.bloxbean.cardano.client.crypto.bip32.key.{HdPrivateKey, HdPublicKey}
@@ -66,6 +67,18 @@ trait WalletModule:
         signingKey: SigningKey
     ): IArray[Byte]
 
+    /** Sign `payload` as a CIP-30 `signData()` COSE_Sign1, returning the (coseKey, coseSignature)
+      * pair as CBOR-encoded hex strings — the shape [[hydrozoa.multisig.server.JsonCodecs]] expects
+      * on the request wire. The `addressBytes` argument goes into the COSE protected headers and is
+      * not otherwise validated by the server-side verifier.
+      */
+    def signCoseCip30(
+        payload: Array[Byte],
+        addressBytes: Array[Byte],
+        verificationKey: VerificationKey,
+        signingKey: SigningKey
+    ): (String, String)
+
 object WalletModule {
     // TODO: this may be moved to test
     object BloxBean extends WalletModule:
@@ -107,6 +120,20 @@ object WalletModule {
             )
             IArray.from(signature)
 
+        override def signCoseCip30(
+            payload: Array[Byte],
+            addressBytes: Array[Byte],
+            verificationKey: VerificationKey,
+            signingKey: SigningKey
+        ): (String, String) =
+            val ds = CIP30DataSigner.INSTANCE.signData(
+              addressBytes,
+              payload,
+              signingKey.getKeyData,
+              verificationKey.getKeyData
+            )
+            (ds.key(), ds.signature())
+
     object Scalus extends WalletModule:
         override type VerificationKey = ScalusVerificationKey
         override type SigningKey = ScalusSigningKey
@@ -127,4 +154,18 @@ object WalletModule {
             val msgBs = ByteString.fromArray(IArray.genericWrapArray(msg).toArray)
             IArray.from(signEd25519(signingKey, msgBs).bytes)
         }
+
+        override def signCoseCip30(
+            payload: Array[Byte],
+            addressBytes: Array[Byte],
+            verificationKey: VerificationKey,
+            signingKey: SigningKey
+        ): (String, String) =
+            val ds = CIP30DataSigner.INSTANCE.signData(
+              addressBytes,
+              payload,
+              signingKey.bytes,
+              verificationKey.bytes
+            )
+            (ds.key(), ds.signature())
 }

--- a/src/main/scala/hydrozoa/lib/cardano/wallet/WalletModule.scala
+++ b/src/main/scala/hydrozoa/lib/cardano/wallet/WalletModule.scala
@@ -69,17 +69,18 @@ trait WalletModule:
         signingKey: SigningKey
     ): IArray[Byte]
 
-    /** Sign `payload` as a CIP-30 `signData()` COSE_Sign1, returning the (coseKey, coseSignature)
-      * pair as CBOR-encoded hex strings — the shape [[hydrozoa.multisig.server.JsonCodecs]] expects
-      * on the request wire. The COSE "address" header is derived internally as an enterprise
-      * address of `verificationKey`'s payment credential; bloxbean's `CIP30DataSigner.verify` walks
-      * back to that credential when validating the signature.
+    /** Sign `payload` as a CIP-30 `signData()` COSE_Sign1, returning a [[Cip30SignedData]] wrapping
+      * the (coseKey, coseSignature) CBOR-hex pair — the shape
+      * [[hydrozoa.multisig.server.JsonCodecs]] expects on the request wire. The COSE "address"
+      * header is derived internally as an enterprise address of `verificationKey`'s payment
+      * credential; bloxbean's `CIP30DataSigner.verify` walks back to that credential when
+      * validating the signature.
       */
     def signCoseCip30(
         payload: Array[Byte],
         verificationKey: VerificationKey,
         signingKey: SigningKey
-    ): (String, String)
+    ): Cip30SignedData
 
 object WalletModule {
     // TODO: this may be moved to test
@@ -126,7 +127,7 @@ object WalletModule {
             payload: Array[Byte],
             verificationKey: VerificationKey,
             signingKey: SigningKey
-        ): (String, String) =
+        ): Cip30SignedData =
             val keyHash = Blake2bUtil.blake2bHash224(verificationKey.getKeyData)
             val addressBytes = AddressProvider
                 .getEntAddress(Credential.fromKey(keyHash), Networks.testnet())
@@ -137,7 +138,7 @@ object WalletModule {
               signingKey.getKeyData,
               verificationKey.getKeyData
             )
-            (ds.key(), ds.signature())
+            Cip30SignedData(coseKeyCborHex = ds.key(), coseSignatureCborHex = ds.signature())
 
     object Scalus extends WalletModule:
         override type VerificationKey = ScalusVerificationKey
@@ -164,7 +165,7 @@ object WalletModule {
             payload: Array[Byte],
             verificationKey: VerificationKey,
             signingKey: SigningKey
-        ): (String, String) =
+        ): Cip30SignedData =
             val keyHash = Blake2bUtil.blake2bHash224(verificationKey.bytes)
             val addressBytes = AddressProvider
                 .getEntAddress(Credential.fromKey(keyHash), Networks.testnet())
@@ -175,5 +176,5 @@ object WalletModule {
               signingKey.bytes,
               verificationKey.bytes
             )
-            (ds.key(), ds.signature())
+            Cip30SignedData(coseKeyCborHex = ds.key(), coseSignatureCborHex = ds.signature())
 }

--- a/src/main/scala/hydrozoa/multisig/consensus/peer/PeerWallet.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/peer/PeerWallet.scala
@@ -76,7 +76,7 @@ final class PeerWallet(
       * coseSignatureCborHex)` — the shape the request-side JSON codec unpacks in
       * [[hydrozoa.multisig.server.JsonCodecs.UserRequestDecoder.validateCoseSignature]].
       */
-    def signCoseCip30(payload: Array[Byte]): (String, String) =
+    def signCoseCip30(payload: Array[Byte]): Cip30SignedData =
         walletModule.signCoseCip30(payload, verificationKey, signingKey)
 }
 

--- a/src/main/scala/hydrozoa/multisig/consensus/peer/PeerWallet.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/peer/PeerWallet.scala
@@ -71,6 +71,15 @@ final class PeerWallet(
         headerSerialized: IArray[Byte]
     ): BlockHeader.HeaderSignature =
         BlockHeader.Minor.HeaderSignature(walletModule.signMsg(headerSerialized, signingKey))
+
+    /** Sign `payload` as a CIP-30 `signData()` COSE_Sign1. Returns `(coseKeyCborHex,
+      * coseSignatureCborHex)` — the shape the request-side JSON codec unpacks in
+      * [[hydrozoa.multisig.server.JsonCodecs.UserRequestDecoder.validateCoseSignature]]. The
+      * "address" bytes required by CIP-30 are stubbed with the exported 32-byte public key, which
+      * the server-side verifier doesn't check against a Cardano address anyway.
+      */
+    def signCoseCip30(payload: Array[Byte]): (String, String) =
+        walletModule.signCoseCip30(payload, exportVerificationKey.bytes, verificationKey, signingKey)
 }
 
 object PeerWallet:

--- a/src/main/scala/hydrozoa/multisig/consensus/peer/PeerWallet.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/peer/PeerWallet.scala
@@ -74,12 +74,10 @@ final class PeerWallet(
 
     /** Sign `payload` as a CIP-30 `signData()` COSE_Sign1. Returns `(coseKeyCborHex,
       * coseSignatureCborHex)` — the shape the request-side JSON codec unpacks in
-      * [[hydrozoa.multisig.server.JsonCodecs.UserRequestDecoder.validateCoseSignature]]. The
-      * "address" bytes required by CIP-30 are stubbed with the exported 32-byte public key, which
-      * the server-side verifier doesn't check against a Cardano address anyway.
+      * [[hydrozoa.multisig.server.JsonCodecs.UserRequestDecoder.validateCoseSignature]].
       */
     def signCoseCip30(payload: Array[Byte]): (String, String) =
-        walletModule.signCoseCip30(payload, exportVerificationKey.bytes, verificationKey, signingKey)
+        walletModule.signCoseCip30(payload, verificationKey, signingKey)
 }
 
 object PeerWallet:

--- a/src/main/scala/hydrozoa/multisig/server/JsonCodecs.scala
+++ b/src/main/scala/hydrozoa/multisig/server/JsonCodecs.scala
@@ -248,7 +248,10 @@ object JsonCodecs {
             Json.obj("requestId" -> ra.requestId.asJson)
         }
 
-//    given requestAcceptedDecoder: Decoder[RequestAccepted] = deriveDecoder[RequestAccepted]
+    given requestAcceptedDecoder: Decoder[RequestAccepted] = c => {
+        import RequestId.i64.given
+        c.downField("requestId").as[RequestId].map(RequestAccepted.apply)
+    }
 
     given errorEncoder: Encoder[Error] = deriveEncoder[Error]
 

--- a/src/main/scala/hydrozoa/multisig/server/SubmissionClient.scala
+++ b/src/main/scala/hydrozoa/multisig/server/SubmissionClient.scala
@@ -1,8 +1,17 @@
 package hydrozoa.multisig.server
 
 import cats.effect.IO
-import hydrozoa.multisig.consensus.{RequestSequencer, UserRequest}
+import hydrozoa.multisig.consensus.peer.PeerWallet
+import hydrozoa.multisig.consensus.{RequestSequencer, UserRequest, UserRequestBody}
 import hydrozoa.multisig.ledger.event.RequestId
+import hydrozoa.multisig.server.ApiResponse.RequestAccepted
+import hydrozoa.multisig.server.JsonCodecs.given
+import io.circe.Json
+import io.circe.syntax.*
+import org.http4s.circe.CirceEntityDecoder.*
+import org.http4s.circe.CirceEntityEncoder.*
+import org.http4s.client.Client
+import org.http4s.{Method, Request as Http4sRequest, Uri}
 
 /** A client-side handle for submitting [[UserRequest]]s to a Hydrozoa peer and awaiting its
   * assigned [[RequestId]]. Abstracts over the transport: an in-process actor send, an in-memory
@@ -20,3 +29,42 @@ object SubmissionClient:
         new SubmissionClient:
             def submit(userRequest: UserRequest): IO[RequestId] =
                 handle ?: userRequest
+
+    /** http4s-based impl: signs the [[UserRequestHeader]] with `wallet` as a CIP-30 COSE_Sign1,
+      * routes the request to the deposit-register or l2-submit endpoint by variant, and expects a
+      * [[RequestAccepted]] JSON response. `client` can be a real http4s `Client[IO]` or an
+      * in-memory `Client.fromHttpApp` — the harness uses the latter so no socket is bound.
+      */
+    def http(
+        client: Client[IO],
+        baseUri: Uri,
+        wallet: PeerWallet,
+    ): SubmissionClient =
+        new SubmissionClient:
+            def submit(userRequest: UserRequest): IO[RequestId] =
+                val (coseKey, coseSignature) = wallet.signCoseCip30(userRequest.header.bytes)
+                val bodyJson                 = signedRequestJson(userRequest, coseKey, coseSignature)
+                val path                     = pathFor(userRequest)
+                val req = Http4sRequest[IO](Method.POST, baseUri.withPath(path))
+                    .withEntity(bodyJson)
+                client.expect[RequestAccepted](req).map(_.requestId)
+
+    private def pathFor(request: UserRequest): Uri.Path =
+        request match
+            case _: UserRequest.DepositRequest     => Uri.Path.unsafeFromString("/api/deposit/register")
+            case _: UserRequest.TransactionRequest => Uri.Path.unsafeFromString("/api/l2/submit")
+
+    private def signedRequestJson(
+        request: UserRequest,
+        coseKey: String,
+        coseSignature: String,
+    ): Json =
+        val bodyField: (String, Json) = request.body match
+            case b: UserRequestBody.DepositRequestBody     => "deposit"     -> b.asJson
+            case b: UserRequestBody.TransactionRequestBody => "transaction" -> b.asJson
+        Json.obj(
+          "header"        -> request.header.asJson,
+          bodyField,
+          "coseKey"       -> Json.fromString(coseKey),
+          "coseSignature" -> Json.fromString(coseSignature),
+        )

--- a/src/main/scala/hydrozoa/multisig/server/SubmissionClient.scala
+++ b/src/main/scala/hydrozoa/multisig/server/SubmissionClient.scala
@@ -1,0 +1,22 @@
+package hydrozoa.multisig.server
+
+import cats.effect.IO
+import hydrozoa.multisig.consensus.{RequestSequencer, UserRequest}
+import hydrozoa.multisig.ledger.event.RequestId
+
+/** A client-side handle for submitting [[UserRequest]]s to a Hydrozoa peer and awaiting its
+  * assigned [[RequestId]]. Abstracts over the transport: an in-process actor send, an in-memory
+  * http4s round-trip against [[HydrozoaRoutes]], or a real over-the-wire HTTP call.
+  */
+trait SubmissionClient:
+    def submit(userRequest: UserRequest): IO[RequestId]
+
+object SubmissionClient:
+
+    /** In-process impl that forwards to a peer's [[RequestSequencer]] actor via `?:`. Matches the
+      * pre-HTTP integration path used by the multipeer harness.
+      */
+    def direct(handle: RequestSequencer.Handle): SubmissionClient =
+        new SubmissionClient:
+            def submit(userRequest: UserRequest): IO[RequestId] =
+                handle ?: userRequest

--- a/src/main/scala/hydrozoa/multisig/server/SubmissionClient.scala
+++ b/src/main/scala/hydrozoa/multisig/server/SubmissionClient.scala
@@ -1,6 +1,7 @@
 package hydrozoa.multisig.server
 
 import cats.effect.IO
+import hydrozoa.lib.cardano.wallet.Cip30SignedData
 import hydrozoa.multisig.consensus.peer.PeerWallet
 import hydrozoa.multisig.consensus.{RequestSequencer, UserRequest, UserRequestBody}
 import hydrozoa.multisig.ledger.event.RequestId
@@ -42,8 +43,8 @@ object SubmissionClient:
     ): SubmissionClient =
         new SubmissionClient:
             def submit(userRequest: UserRequest): IO[RequestId] =
-                val (coseKey, coseSignature) = wallet.signCoseCip30(userRequest.header.bytes)
-                val bodyJson = signedRequestJson(userRequest, coseKey, coseSignature)
+                val signed = wallet.signCoseCip30(userRequest.header.bytes)
+                val bodyJson = signedRequestJson(userRequest, signed)
                 val path = pathFor(userRequest)
                 val req = Http4sRequest[IO](Method.POST, baseUri.withPath(path))
                     .withEntity(bodyJson)
@@ -56,8 +57,7 @@ object SubmissionClient:
 
     private def signedRequestJson(
         request: UserRequest,
-        coseKey: String,
-        coseSignature: String,
+        signed: Cip30SignedData,
     ): Json =
         val bodyField: (String, Json) = request.body match
             case b: UserRequestBody.DepositRequestBody     => "deposit" -> b.asJson
@@ -65,6 +65,6 @@ object SubmissionClient:
         Json.obj(
           "header" -> request.header.asJson,
           bodyField,
-          "coseKey" -> Json.fromString(coseKey),
-          "coseSignature" -> Json.fromString(coseSignature),
+          "coseKey" -> Json.fromString(signed.coseKeyCborHex),
+          "coseSignature" -> Json.fromString(signed.coseSignatureCborHex),
         )

--- a/src/main/scala/hydrozoa/multisig/server/SubmissionClient.scala
+++ b/src/main/scala/hydrozoa/multisig/server/SubmissionClient.scala
@@ -43,15 +43,15 @@ object SubmissionClient:
         new SubmissionClient:
             def submit(userRequest: UserRequest): IO[RequestId] =
                 val (coseKey, coseSignature) = wallet.signCoseCip30(userRequest.header.bytes)
-                val bodyJson                 = signedRequestJson(userRequest, coseKey, coseSignature)
-                val path                     = pathFor(userRequest)
+                val bodyJson = signedRequestJson(userRequest, coseKey, coseSignature)
+                val path = pathFor(userRequest)
                 val req = Http4sRequest[IO](Method.POST, baseUri.withPath(path))
                     .withEntity(bodyJson)
                 client.expect[RequestAccepted](req).map(_.requestId)
 
     private def pathFor(request: UserRequest): Uri.Path =
         request match
-            case _: UserRequest.DepositRequest     => Uri.Path.unsafeFromString("/api/deposit/register")
+            case _: UserRequest.DepositRequest => Uri.Path.unsafeFromString("/api/deposit/register")
             case _: UserRequest.TransactionRequest => Uri.Path.unsafeFromString("/api/l2/submit")
 
     private def signedRequestJson(
@@ -60,11 +60,11 @@ object SubmissionClient:
         coseSignature: String,
     ): Json =
         val bodyField: (String, Json) = request.body match
-            case b: UserRequestBody.DepositRequestBody     => "deposit"     -> b.asJson
+            case b: UserRequestBody.DepositRequestBody     => "deposit" -> b.asJson
             case b: UserRequestBody.TransactionRequestBody => "transaction" -> b.asJson
         Json.obj(
-          "header"        -> request.header.asJson,
+          "header" -> request.header.asJson,
           bodyField,
-          "coseKey"       -> Json.fromString(coseKey),
+          "coseKey" -> Json.fromString(coseKey),
           "coseSignature" -> Json.fromString(coseSignature),
         )

--- a/src/test/scala/hydrozoa/lib/cardano/wallet/WalletModuleTest.scala
+++ b/src/test/scala/hydrozoa/lib/cardano/wallet/WalletModuleTest.scala
@@ -1,0 +1,90 @@
+package hydrozoa.lib.cardano.wallet
+
+import com.bloxbean.cardano.client.cip.cip30.{CIP30DataSigner, DataSignature}
+import com.bloxbean.cardano.client.crypto.bip32.HdKeyGenerator
+import com.bloxbean.cardano.client.crypto.bip32.key.{HdPrivateKey, HdPublicKey}
+import com.bloxbean.cardano.client.util.HexUtil
+import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters
+import org.scalacheck.Prop.forAll
+import org.scalacheck.{Arbitrary, Gen, Properties}
+import scalus.crypto.ed25519.{SigningKey as ScalusSigningKey, VerificationKey as ScalusVerificationKey}
+
+object WalletModuleTest extends Properties("WalletModule") {
+
+    // 32-byte entropy → BIP-39 24-word mnemonic space; HdKeyGenerator derives the same HdKeyPair
+    // shape TestPeers uses in production tests.
+    private val genEntropy: Gen[Array[Byte]] =
+        Gen.containerOfN[Array, Byte](32, Arbitrary.arbitrary[Byte])
+
+    // Non-empty so bloxbean's payload check is exercised.
+    private val genPayload: Gen[Array[Byte]] =
+        Gen.nonEmptyContainerOf[Array, Byte](Arbitrary.arbitrary[Byte])
+
+    private def bloxbeanKeys(entropy: Array[Byte]): (HdPublicKey, HdPrivateKey) =
+        val kp = new HdKeyGenerator().getRootKeyPairFromEntropy(entropy)
+        (kp.getPublicKey, kp.getPrivateKey)
+
+    private def scalusKeys(entropy: Array[Byte]): (ScalusVerificationKey, ScalusSigningKey) =
+        // Scalus uses standard 32-byte Ed25519 keys, not BIP-32 extended. Take the first 32 bytes
+        // of entropy as the Ed25519 seed and derive the matching public key via BouncyCastle.
+        val seed = entropy.take(32)
+        val privParams = new Ed25519PrivateKeyParameters(seed, 0)
+        val pubBytes = privParams.generatePublicKey().getEncoded
+        (ScalusVerificationKey.unsafeFromArray(pubBytes), ScalusSigningKey.unsafeFromArray(seed))
+
+    private def asDataSignature(signed: Cip30SignedData): DataSignature =
+        new DataSignature(signed.coseSignatureCborHex, signed.coseKeyCborHex)
+
+    // Property: bloxbean's own verify accepts what we produce — round-trip through the CIP-30
+    // signData/verify contract that HydrozoaRoutes relies on.
+    val _ = property("BloxBean.signCoseCip30 output validates via CIP30DataSigner.verify") =
+        forAll(genEntropy, genPayload) { (entropy, payload) =>
+            val (vk, sk) = bloxbeanKeys(entropy)
+            val signed = WalletModule.BloxBean.signCoseCip30(payload, vk, sk)
+            CIP30DataSigner.INSTANCE.verify(asDataSignature(signed))
+        }
+
+    val _ = property("Scalus.signCoseCip30 output validates via CIP30DataSigner.verify") =
+        forAll(genEntropy, genPayload) { (entropy, payload) =>
+            val (vk, sk) = scalusKeys(entropy)
+            val signed = WalletModule.Scalus.signCoseCip30(payload, vk, sk)
+            CIP30DataSigner.INSTANCE.verify(asDataSignature(signed))
+        }
+
+    // Property: coseKey's COSE key parameter -2 (OKP curve x-coordinate) is exactly the wallet's
+    // public key — the same field JsonCodecs.validateCoseSignature reads to recover userVk.
+    val _ = property(
+      "BloxBean.signCoseCip30 embeds the public key in the coseKey X header (param -2)"
+    ) = forAll(genEntropy, genPayload) { (entropy, payload) =>
+        val (vk, sk) = bloxbeanKeys(entropy)
+        val signed = WalletModule.BloxBean.signCoseCip30(payload, vk, sk)
+        val ds = asDataSignature(signed)
+        val extractedPubKey = ds.coseKey().otherHeaderAsBytes(-2L)
+        extractedPubKey.sameElements(vk.getKeyData)
+    }
+
+    // Leak check: the private-key hex must not appear as a substring in either the coseKey or
+    // the coseSignature CBOR hex. Collision on 64+ hex chars is astronomical; a positive substring
+    // hit would be a real leak.
+    val _ = property(
+      "BloxBean.signCoseCip30 does not leak the private key hex into coseKey/coseSignature"
+    ) = forAll(genEntropy, genPayload) { (entropy, payload) =>
+        val (vk, sk) = bloxbeanKeys(entropy)
+        val signed = WalletModule.BloxBean.signCoseCip30(payload, vk, sk)
+        val privHex = HexUtil.encodeHexString(sk.getKeyData).toLowerCase
+        val coseKeyHex = signed.coseKeyCborHex.toLowerCase
+        val coseSigHex = signed.coseSignatureCborHex.toLowerCase
+        !coseKeyHex.contains(privHex) && !coseSigHex.contains(privHex)
+    }
+
+    val _ = property(
+      "Scalus.signCoseCip30 does not leak the private key hex into coseKey/coseSignature"
+    ) = forAll(genEntropy, genPayload) { (entropy, payload) =>
+        val (vk, sk) = scalusKeys(entropy)
+        val signed = WalletModule.Scalus.signCoseCip30(payload, vk, sk)
+        val privHex = HexUtil.encodeHexString(sk.bytes).toLowerCase
+        val coseKeyHex = signed.coseKeyCborHex.toLowerCase
+        val coseSigHex = signed.coseSignatureCborHex.toLowerCase
+        !coseKeyHex.contains(privHex) && !coseSigHex.contains(privHex)
+    }
+}


### PR DESCRIPTION
## Summary

Integrates the production HTTP JSON endpoints into the multipeer harness so
Stage4 submissions exercise the real request path — JSON encode + CIP-30 COSE
sign + http4s round-trip + COSE verify + `RequestSequencer` — instead of
sending a `UserRequest` message directly to the peer's actor. No sockets:
each peer's `HydrozoaRoutes` is wrapped in `http4s.Client.fromHttpApp`, so it
composes with TestControl-mode direct runs unchanged.

Changes in order:

- `JsonCodecs`: add the previously-commented `Decoder[RequestAccepted]`,
  mirroring the encoder's `i64` shape.
- Introduce `SubmissionClient` trait (`submit(UserRequest): IO[RequestId]`)
  with two impls: `.direct(handle)` (actor `?:`) and `.http(client, uri,
  wallet)` (signs the header CIP-30, routes deposits vs L2 tx to the
  matching endpoint, decodes `RequestAccepted`).
- `WalletModule`: add abstract `signCoseCip30`; each impl (BloxBean, Scalus)
  keeps its private key encapsulated and internally derives the enterprise
  address of `blake2b_224(pubKey)` for bloxbean's `CIP30DataSigner.verify`
  to walk back to on the server side.
- `MultiPeerHeadHarness.Peer[H]` gains a `submissionClient` field; a new
  `Http.mkPeerSubmissionClient` builds per-peer `HydrozoaRoutes`, wraps
  them via `Client.fromHttpApp`, and hands back a `SubmissionClient.http`
  bound to the peer's own wallet.
- Stage4 `Suite` / `Sut`: drop the now-empty `Stage4PeerHandle` wrapper;
  `Stage4SutStatic.peers: Map[HeadPeerNumber, SubmissionClient]` reads
  each client from `harness.peers(n).submissionClient`.

## Test plan

- [x] `sbtn compile` clean on both core and `integration / Test / compile`
- [x] `integration/testOnly Stage4Properties -z "Two-peers"` — the extended
      variant (500 commands) passes 100 tests over the http round-trip;
      earlier failure `AddressRuntimeException: Unknown network type` was
      the trigger for the enterprise-address derivation fix
- [x] Full `Stage4Properties` suite (non-extended, extended, WS variants)
- [x] `EvacuationPropertyTest` + `VoteVersionMismatchTest` still compile
      (they carry their own `H` type, so the added `Peer[H].submissionClient`
      field is transparent)