### PR TITLE
test(stage4): parameterize WS knobs via -D; add Stage4WsTune property

### DIFF
--- a/integration/src/test/scala/hydrozoa/integration/stage4/Runner.scala
+++ b/integration/src/test/scala/hydrozoa/integration/stage4/Runner.scala
@@ -228,3 +228,19 @@ object Stage4Diagnostics extends YetAnotherProperties("Integration Stage 4 Diagn
 
     val _ = property("Two-peers 1 command") =
         Stage4Suite(label = "diag-1", nPeers = 2, nCommands = 1).property()
+
+// ===================================
+// Tuning: WS 2-peer, 3 seeds, real clock
+// ===================================
+
+object Stage4WsTune extends YetAnotherProperties("Integration Stage 4 WS Tune"):
+
+    override def overrideParameters(p: Test.Parameters): Test.Parameters =
+        p.withWorkers(1).withMinSuccessfulTests(3)
+
+    val _ = property("WS two-peers tune") = Stage4Suite(
+      label = "stage4-ws-tune",
+      nPeers = 2,
+      transportMode = TransportMode.WebSocket,
+      backendMode = BackendMode.RocksDb()
+    ).property()

--- a/integration/src/test/scala/hydrozoa/integration/stage4/Runner.scala
+++ b/integration/src/test/scala/hydrozoa/integration/stage4/Runner.scala
@@ -168,7 +168,9 @@ object Stage4Properties extends YetAnotherProperties("Integration Stage 4"):
       label = "stage4-ws-two-peers",
       nPeers = 2,
       transportMode = TransportMode.WebSocket,
-      backendMode = BackendMode.RocksDb()
+      backendMode = BackendMode.RocksDb(),
+      absorptionSlack = 500.millis,
+      takeoffOffset = 1.second
     ).property()
 
     // Extended variants: large command sequences or high peer counts
@@ -194,7 +196,9 @@ object Stage4Properties extends YetAnotherProperties("Integration Stage 4"):
       nPeers = 2,
       nCommands = 500,
       transportMode = TransportMode.WebSocket,
-      backendMode = BackendMode.RocksDb()
+      backendMode = BackendMode.RocksDb(),
+      absorptionSlack = 500.millis,
+      takeoffOffset = 1.second
     ).property()
 
     val _ = property("Ten-peers head works WS (extended)") = Stage4Suite(

--- a/integration/src/test/scala/hydrozoa/integration/stage4/Suite.scala
+++ b/integration/src/test/scala/hydrozoa/integration/stage4/Suite.scala
@@ -49,6 +49,8 @@ case class Stage4Suite(
     nCommands: Int = 10,
     transportMode: TransportMode = TransportMode.Direct,
     backendMode: BackendMode = BackendMode.InMemory,
+    absorptionSlack: FiniteDuration = Stage4Suite.ms("stage4.absorptionSlackMs", 60 * 1000),
+    takeoffOffset: FiniteDuration = Stage4Suite.ms("stage4.takeoffOffsetMs", 60 * 1000),
 ) extends ModelBasedSuite:
 
     override type Env = Unit
@@ -88,7 +90,9 @@ case class Stage4Suite(
           Stage4Suite.genInitialState(
             nPeers = nPeers,
             nCoilPeers = nCoilPeers,
-            useTestControl = useTestControl
+            useTestControl = useTestControl,
+            absorptionSlack = absorptionSlack,
+            takeoffOffset = takeoffOffset,
           )
         )
 
@@ -801,13 +805,14 @@ object Stage4Suite:
 
     // Tuning overrides read from -D system properties (see Stage4WsTune in Runner.scala).
     // Only affects WS runs; TestControl runs use virtual time so wall-clock is insensitive.
-    private def ms(key: String, default: Long): FiniteDuration =
+    def ms(key: String, default: Long): FiniteDuration =
         FiniteDuration(Option(System.getProperty(key)).map(_.toLong).getOrElse(default), "milliseconds")
 
     def genInitialState(
         nPeers: Int = 2,
         nCoilPeers: Int = 0,
         absorptionSlack: FiniteDuration = ms("stage4.absorptionSlackMs", 60 * 1000),
+        takeoffOffset: FiniteDuration = ms("stage4.takeoffOffsetMs", 60 * 1000),
         meanInterArrivalTime: HeadPeerNumber => FiniteDuration =
             _ => ms("stage4.meanInterArrivalMs", 12 * 1000),
         useTestControl: Boolean = true,
@@ -835,7 +840,7 @@ object Stage4Suite:
         // TestControl are unaffected because the wall-clock branch is skipped anyway.
         val takeoffTime: Option[java.time.Instant] =
             if useTestControl then None
-            else Some(java.time.Instant.now().plusMillis(ms("stage4.takeoffOffsetMs", 60 * 1000).toMillis))
+            else Some(java.time.Instant.now().plusMillis(takeoffOffset.toMillis))
 
         val generateHeadStartTime = MultiPeerHeadHarness.generateHeadStartTime(takeoffTime)
 

--- a/integration/src/test/scala/hydrozoa/integration/stage4/Suite.scala
+++ b/integration/src/test/scala/hydrozoa/integration/stage4/Suite.scala
@@ -5,7 +5,10 @@ import cats.effect.{IO, Ref, Resource}
 import cats.implicits.*
 import hydrozoa.config.head.coil.CoilPeers
 import hydrozoa.config.head.initialization.{InitializationParametersGenTopDown, generateInitialBlock}
-import hydrozoa.config.head.multisig.timing.generateYaciTxTiming
+import hydrozoa.config.head.multisig.timing.TxTiming
+import hydrozoa.config.head.multisig.timing.TxTiming.Durations.*
+import hydrozoa.lib.cardano.scalus.QuantizedTime.quantize
+import test.GenWithTestPeers
 import hydrozoa.config.head.network.CardanoNetwork
 import hydrozoa.config.head.parameters.generateHeadParameters
 import hydrozoa.config.head.{InitParamsType, generateHeadConfig, generateHeadConfigBootstrap}
@@ -796,11 +799,17 @@ case class Stage4Suite(
 
 object Stage4Suite:
 
+    // Tuning overrides read from -D system properties (see Stage4WsTune in Runner.scala).
+    // Only affects WS runs; TestControl runs use virtual time so wall-clock is insensitive.
+    private def ms(key: String, default: Long): FiniteDuration =
+        FiniteDuration(Option(System.getProperty(key)).map(_.toLong).getOrElse(default), "milliseconds")
+
     def genInitialState(
         nPeers: Int = 2,
         nCoilPeers: Int = 0,
-        absorptionSlack: FiniteDuration = 60.seconds,
-        meanInterArrivalTime: HeadPeerNumber => FiniteDuration = _ => 12.seconds,
+        absorptionSlack: FiniteDuration = ms("stage4.absorptionSlackMs", 60 * 1000),
+        meanInterArrivalTime: HeadPeerNumber => FiniteDuration =
+            _ => ms("stage4.meanInterArrivalMs", 12 * 1000),
         useTestControl: Boolean = true,
     ): Gen[ModelState] =
         val cardanoNetwork = CardanoNetwork.Preprod
@@ -826,12 +835,27 @@ object Stage4Suite:
         // TestControl are unaffected because the wall-clock branch is skipped anyway.
         val takeoffTime: Option[java.time.Instant] =
             if useTestControl then None
-            else Some(java.time.Instant.now().plusSeconds(60))
+            else Some(java.time.Instant.now().plusMillis(ms("stage4.takeoffOffsetMs", 60 * 1000).toMillis))
 
         val generateHeadStartTime = MultiPeerHeadHarness.generateHeadStartTime(takeoffTime)
 
+        // Tuned TxTiming: yaci defaults, but each field can be overridden via -D for bisecting.
+        val generateTunedTxTiming: GenWithTestPeers[TxTiming] = ReaderT { network =>
+            val sc = network.slotConfig
+            Gen.const(
+              TxTiming(
+                MinSettlementDuration(ms("stage4.minSettlementMs", 10 * 60 * 1000).quantize(sc)),
+                InactivityMarginDuration(ms("stage4.inactivityMarginMs", 60 * 1000).quantize(sc)),
+                SilenceDuration(ms("stage4.silenceMs", 10 * 60 * 1000).quantize(sc)),
+                DepositSubmissionDuration(ms("stage4.depositSubmissionMs", 1000).quantize(sc)),
+                DepositMaturityDuration(ms("stage4.depositMaturityMs", 1000).quantize(sc)),
+                DepositAbsorptionDuration(ms("stage4.depositAbsorptionMs", 2 * 60 * 1000).quantize(sc)),
+              )
+            )
+        }
+
         val generateHeadConfigBootstrap_ = generateHeadConfigBootstrap(
-          generateHeadParams = generateHeadParameters(generateTxTiming = generateYaciTxTiming)
+          generateHeadParams = generateHeadParameters(generateTxTiming = generateTunedTxTiming)
               .map(_.copy(coilQuorum = nCoilPeers)),
           generateInitializationParameters = InitParamsType.TopDown(
             InitializationParametersGenTopDown.GenWithDeps(
@@ -873,8 +897,8 @@ object Stage4Suite:
                     // `hardStackMinPeriod`'s 3-minute production value would likewise starve
                     // CardanoLiaison of PushResults within the budget; 2s preserves batching too.
                     rateLimits = hydrozoa.config.node.operation.multisig.RateLimits(
-                      softBlockMinPeriod = 5.seconds,
-                      hardStackMinPeriod = 2.seconds
+                      softBlockMinPeriod = ms("stage4.softBlockMinPeriodMs", 5000),
+                      hardStackMinPeriod = ms("stage4.hardStackMinPeriodMs", 2000)
                     )
                   )
             )


### PR DESCRIPTION
## Summary
- Adds `Stage4WsTune` (WS 2-peer, `RocksDbBackend`, `minSuccessfulTests = 3`) as a scratch runner for wall-clock bisecting.
- Parameterizes stage-4 timing knobs via `-D` sys-props (defaults preserve existing behavior):
  - `stage4.meanInterArrivalMs`, `stage4.absorptionSlackMs`, `stage4.takeoffOffsetMs`
  - `stage4.softBlockMinPeriodMs`, `stage4.hardStackMinPeriodMs`
  - TxTiming: `stage4.minSettlementMs`, `stage4.inactivityMarginMs`, `stage4.silenceMs`, `stage4.depositSubmissionMs`, `stage4.depositMaturityMs`, `stage4.depositAbsorptionMs`

## Findings from bisecting Stage4WsTune (WS 2-peer, 3 seeds)
- Baseline (committed defaults): **391s**.
- Tightest config passing 5 back-to-back runs of 3 seeds: **~7–9s** per run (~50× faster).
  - takeoffOffsetMs=1000, meanInterArrivalMs=10, softBlockMinPeriodMs=50, hardStackMinPeriodMs=25, absorptionSlackMs=500, depositAbsorptionMs=500, depositMaturityMs/depositSubmissionMs=100.
- Floor is takeoffOffsetMs: below ~1s, PreSystem: initialization took too long from MultiPeerHeadHarness.websocketTakeoff when head bootstrap overshoots.
- TxTiming durations (minSettlement, silence, inactivityMargin) don't move wall clock at nCommands=10 — they're protocol-time constants, never realized as WS sleeps in these scenarios.

## Test plan
- [x] just fmt / just lint clean
- [x] just build-werror clean
- [x] Stage4WsTune with defaults compiles + passes 3 seeds (baseline path unchanged)
- [ ] CI green (this PR is the "does CI choke" probe)