### PR TITLE
feat(rbr): full evacuation property test; EvacuationTx pays fee from collateral

### DIFF
--- a/integration/src/test/scala/hydrozoa/integration/rbr/property/EvacuationPropertyTest.scala
+++ b/integration/src/test/scala/hydrozoa/integration/rbr/property/EvacuationPropertyTest.scala
@@ -13,6 +13,7 @@ import hydrozoa.integration.harness.MultiPeerHeadHarness
 import hydrozoa.integration.harness.MultiPeerHeadHarness.Transport.Mode as TransportMode
 import hydrozoa.lib.cardano.scalus.QuantizedTime.QuantizedInstant
 import hydrozoa.lib.logging.{ContraTracer, Slf4jTracer}
+import scala.annotation.unused
 import hydrozoa.multisig.backend.cardano.{CardanoBackend as L1Backend, FirewalledCardanoBackend, FirewalledCardanoBackendEvent, yaciTestSauceGenesis}
 import hydrozoa.multisig.consensus.peer.{HeadPeerNumber, PeerId}
 import hydrozoa.multisig.consensus.{CardanoLiaisonEvent, RequestSequencer, UserRequest, UserRequestBody, UserRequestHeader}
@@ -410,6 +411,7 @@ object EvacuationPropertyTest extends Properties("RBR Evacuation Property"):
       * cardinality shifts. Toggle by uncommenting the `logAmbientUtxos(...)` call site in
       * [[runClassifier]]. Not on the happy path so callers pay nothing when commented out.
       */
+    @unused
     private def logAmbientUtxos(classifier: RBRClassifier, utxos: List[Utxo]): IO[Unit] =
         val ambient = utxos.filter(u => classifier.classify(u).contains(AmbientPlaceId))
         val lines = ambient.zipWithIndex.map { case (u, idx) =>

--- a/integration/src/test/scala/hydrozoa/integration/rbr/property/EvacuationPropertyTest.scala
+++ b/integration/src/test/scala/hydrozoa/integration/rbr/property/EvacuationPropertyTest.scala
@@ -41,12 +41,9 @@ import test.{SeedPhrase, TestPeers}
   *   4. RBA's persistence-backed `loadAction` walks backward, finds the SEC matching the
   *      on-chain treasury's `versionMajor = 1`, and submits a Vote that Plutus accepts.
   *   5. Voting deadline elapses → TallyTx → ResolutionTx.
-  *   6. Test asserts a ResolutionTx submitted successfully (i.e. the dispute resolved).
-  *
-  * Full evacuation (`RuleBasedActorEvent.Evacuation.NoMore`) is not asserted: the EvacuationTx
-  * builder trips the treasury validator's `Trusted setup in the treasury is not big enough`
-  * check because [[FallbackTx.scala]] sets `setupG2 = SList.empty` (TODO there). Wiring the
-  * KZG G2 trusted setup through fallback construction is separate follow-up work.
+  *   6. Every peer's RBA builds and submits an [[EvacuationTx]] until its `Evacuation.NoMore`
+  *      terminal event fires.
+  *   7. Test asserts the shared-L1 UTxO histogram matches the expected terminal cardinalities.
   */
 object EvacuationPropertyTest extends Properties("RBR Evacuation Property"):
 
@@ -55,10 +52,10 @@ object EvacuationPropertyTest extends Properties("RBR Evacuation Property"):
     ): org.scalacheck.Test.Parameters = p.withMinSuccessfulTests(1)
 
     private val nHeadPeers: Int              = 2
-    private val scenarioTimeout: FiniteDuration = 3.minutes
+    private val scenarioTimeout: FiniteDuration = 5.minutes
     private val cardanoNetwork: CardanoNetwork = CardanoNetwork.Preprod
 
-    val _ = property("ws: fallback→RRM→vote→tally→resolve dispute completes") =
+    val _ = property("ws: fallback→RRM→vote→tally→resolve→evacuate happy path") =
         testProperty(TransportMode.WebSocket)
 
     private def testProperty(transportMode: TransportMode): Prop =
@@ -106,7 +103,8 @@ object EvacuationPropertyTest extends Properties("RBR Evacuation Property"):
             _ <- step1b_startPeriodicRequestLoop
             _ <- step2_awaitFallbackToRuleBasedHandoff
             _ <- step3_awaitResolutionSubmitted
-            _ <- step4_assertTerminalHistogram
+            _ <- step4_awaitEvacuationDone
+            _ <- step5_assertTerminalHistogram
         yield true
 
     /** State + handles threaded between steps. */
@@ -116,6 +114,15 @@ object EvacuationPropertyTest extends Properties("RBR Evacuation Property"):
         harness: MultiPeerHeadHarness.Harness[Option[RequestSequencer.Handle]],
         fallbackDispatched: Deferred[IO, Unit],
         resolutionSubmitted: Deferred[IO, Unit],
+        // Set of peers whose RBA has fired `Evacuation.NoMore`. `evacuationDone` is only
+        // completed once every head peer has fired — waiting for the first NoMore is racy: the
+        // winning-drain peer fires while others may still be mid-submission.
+        peersEvacuationDone: Ref[IO, Set[HeadPeerNumber]],
+        evacuationDone: Deferred[IO, Unit],
+        // First `PayoutsLeft(n)` observed on any peer — the KZG-committed evacuation count at
+        // the RBA's read of the resolved treasury. Subsequent PayoutsLeft values are strictly
+        // smaller as drain progresses; taking the first captures the pre-drain total.
+        firstPayoutsLeft: Ref[IO, Option[Int]],
         periodicRequestFiber: Ref[IO, Option[FiberIO[Nothing]]],
     )
 
@@ -149,18 +156,31 @@ object EvacuationPropertyTest extends Properties("RBR Evacuation Property"):
             _   <- lift(ctx.resolutionSubmitted.get.timeout(scenarioTimeout))
         yield ()
 
-    /** After resolution lands, cancel the periodic-request loop, wait a beat for any in-flight
-      * tx to settle, snapshot the shared mock L1, and check the UTxO distribution matches the
-      * expected terminal buckets.
+    private def step4_awaitEvacuationDone: test.TestM[Ctx, Unit] =
+        for
+            ctx <- ask
+            _   <- lift(ctx.evacuationDone.get.timeout(scenarioTimeout))
+        yield ()
+
+    /** After evacuation completes, cancel the periodic-request loop, wait a beat for any
+      * in-flight tx to settle, snapshot the shared mock L1, and check the UTxO distribution
+      * matches the expected terminal buckets.
       */
-    private def step4_assertTerminalHistogram: test.TestM[Ctx, Unit] =
+    private def step5_assertTerminalHistogram: test.TestM[Ctx, Unit] =
         for
             ctx    <- ask
             _      <- lift(ctx.periodicRequestFiber.get.flatMap(_.traverse_(_.cancel)))
             _      <- lift(IO.sleep(quiescenceDelay))
             utxos  <- lift(ctx.harness.l1Snapshot)
             actual <- lift(runClassifier(utxos)(using ctx.multiNodeConfig))
-            expected = expectedCardinalities
+            expectedEvacCount <- lift(ctx.firstPayoutsLeft.get.flatMap(
+              IO.fromOption(_)(
+                new IllegalStateException(
+                  "no `Evacuation.PayoutsLeft` observed; RBA never entered the drain loop"
+                )
+              )
+            ))
+            expected = expectedCardinalities(expectedEvacCount)
             _ <- assertWith(
               actual == expected,
               s"Cardinality mismatch:\n  expected: $expected\n  actual:   $actual",
@@ -184,6 +204,9 @@ object EvacuationPropertyTest extends Properties("RBR Evacuation Property"):
         for
             fallbackDispatched   <- Resource.eval(Deferred[IO, Unit])
             resolutionSubmitted  <- Resource.eval(Deferred[IO, Unit])
+            peersEvacuationDone  <- Resource.eval(Ref[IO].of(Set.empty[HeadPeerNumber]))
+            evacuationDone       <- Resource.eval(Deferred[IO, Unit])
+            firstPayoutsLeft     <- Resource.eval(Ref[IO].of(Option.empty[Int]))
             periodicRequestFiber <- Resource.eval(Ref[IO].of(Option.empty[FiberIO[Nothing]]))
 
             preinitPeerUtxosL1 = yaciTestSauceGenesis(cardanoNetwork.network)(testPeers)
@@ -196,6 +219,9 @@ object EvacuationPropertyTest extends Properties("RBR Evacuation Property"):
               tracer = humanFormatTracer |+| observerTracer(
                 fallbackDispatched,
                 resolutionSubmitted,
+                peersEvacuationDone,
+                evacuationDone,
+                firstPayoutsLeft,
               ),
               handle = {
                   case (PeerId.Head(peerNum), conns) =>
@@ -235,6 +261,9 @@ object EvacuationPropertyTest extends Properties("RBR Evacuation Property"):
           harness = harness,
           fallbackDispatched = fallbackDispatched,
           resolutionSubmitted = resolutionSubmitted,
+          peersEvacuationDone = peersEvacuationDone,
+          evacuationDone = evacuationDone,
+          firstPayoutsLeft = firstPayoutsLeft,
           periodicRequestFiber = periodicRequestFiber,
         )
 
@@ -315,9 +344,12 @@ object EvacuationPropertyTest extends Properties("RBR Evacuation Property"):
     private def observerTracer(
         fallbackDispatched: Deferred[IO, Unit],
         resolutionSubmitted: Deferred[IO, Unit],
+        peersEvacuationDone: Ref[IO, Set[HeadPeerNumber]],
+        evacuationDone: Deferred[IO, Unit],
+        firstPayoutsLeft: Ref[IO, Option[Int]],
     ): ContraTracer[IO, MultiPeerHeadHarness.Event] =
         ContraTracer[IO, MultiPeerHeadHarness.Event] {
-            case MultiPeerHeadHarness.Event.Head(_, evt) =>
+            case MultiPeerHeadHarness.Event.Head(peerNum, evt) =>
                 evt match {
                     case CommonChildEvent.CardanoLiaison(
                           _: CardanoLiaisonEvent.FallbackToRuleBasedDispatched
@@ -328,6 +360,22 @@ object EvacuationPropertyTest extends Properties("RBR Evacuation Property"):
                           RuleBasedActorEvent.Tx.SubmitSuccess(tx)
                         ) if tx.transactionFamily == "Resolution" =>
                         resolutionSubmitted.complete(()).void
+
+                    case RuleBasedOnlyChildEvent.RuleBasedActor(
+                          RuleBasedActorEvent.Evacuation.PayoutsLeft(n)
+                        ) =>
+                        firstPayoutsLeft.update(_.orElse(Some(n)))
+
+                    case RuleBasedOnlyChildEvent.RuleBasedActor(
+                          RuleBasedActorEvent.Evacuation.NoMore
+                        ) =>
+                        peersEvacuationDone
+                            .updateAndGet(_ + peerNum)
+                            .flatMap { seen =>
+                                IO.whenA(seen.size == nHeadPeers)(
+                                  evacuationDone.complete(()).void
+                                )
+                            }
 
                     case _ => IO.unit
                 }
@@ -347,16 +395,42 @@ object EvacuationPropertyTest extends Properties("RBR Evacuation Property"):
         utxos: Utxos
     )(using MultiNodeConfig): IO[Map[RBRPlaceId, Int]] =
         val classifier = new RBRClassifier
-        Histogram.empty(classifier).addAll(utxos.toList.map { case (i, o) => Utxo(i, o) }).toEither match
+        val allUtxos   = utxos.toList.map { case (i, o) => Utxo(i, o) }
+        Histogram.empty(classifier).addAll(allUtxos).toEither match
             case Left(errs) =>
                 IO.raiseError(
                   new RuntimeException(s"Ambiguous UTxO classification: ${errs.toList}")
                 )
             case Right(hist) =>
+                // logAmbientUtxos(classifier, allUtxos) *>
                 IO.pure(RBRPlaceId.values.toList.map(k => k -> hist(k)).toMap)
 
-    /** Expected terminal cardinalities: init → settle-v1 → fallback → vote → tally → resolve on
-      * the happy path (no evacuation — blocked by the KZG G2 TODO in [[FallbackTx]]).
+    /** Diagnostic helper: emit each ambient-bucket UTxO (input / address / value / datum) via
+      * Slf4j so the composition of [[AmbientPlaceId]] can be identified when the terminal
+      * cardinality shifts. Toggle by uncommenting the `logAmbientUtxos(...)` call site in
+      * [[runClassifier]]. Not on the happy path so callers pay nothing when commented out.
+      */
+    private def logAmbientUtxos(classifier: RBRClassifier, utxos: List[Utxo]): IO[Unit] =
+        val ambient = utxos.filter(u => classifier.classify(u).contains(AmbientPlaceId))
+        val lines = ambient.zipWithIndex.map { case (u, idx) =>
+            s"  [$idx] input=${u.input} addr=${u.output.address} value=${u.output.value} datum=${u.output.datumOption}"
+        }.mkString("\n")
+        Slf4jTracer.sink.traceWith(
+          hydrozoa.lib.logging.LogEvent
+              .From(Map.empty, "AmbientDiagnostic")
+              .info(s"AmbientPlaceId utxos (${ambient.size}):\n$lines")
+        )
+
+    /** Expected terminal cardinalities: init → settle-v1 → fallback → vote → tally → resolve →
+      * evacuate on the happy path. `evacuationCount` is the first `PayoutsLeft(n)` observed
+      * from any peer's RBA — exactly the size of the resolved treasury's evacuation map before
+      * drain begins (see `RuleBasedActor.Evacuation.handle`).
+      *   - `EvacuationOutputPlaceId -> evacuationCount`: every L2 output was drained to L1 via
+      *     the RBA's `EvacuationTx` loop; each output carries the `"evacuation"` inline-datum
+      *     sentinel stamped by [[InitializationParametersGen.generatePeerContribution]], which
+      *     survives the KZG membership hash and so appears on the L1 evacuation outputs.
+      *   - `PayoutObligationsPlaceId -> 0`: no in-flight payout obligations remain on the
+      *     resolved treasury.
       *   - `CollateralPlaceId -> 0`: the [[RBRClassifier]] identifies collateral by the
       *     `"collateral"` datum sentinel, which only exists in the synthetic
       *     [[InitialDisputeUtxos]] fixture — the real tx builders draw collateral from plain
@@ -365,10 +439,14 @@ object EvacuationPropertyTest extends Properties("RBR Evacuation Property"):
       *     scenario is to walk the tx graph and mark any output that is later consumed as a
       *     `collateral_input` of some downstream tx — i.e. classify by role in tx history
       *     rather than by content sentinel.
-      *   - `AmbientPlaceId -> 4`: `nHeadPeers = 2` (2 collateral + 2 change/genesis leftovers);
-      *     fixed for this scenario, observed via instrumentation run.
+      *   - `AmbientPlaceId -> nHeadPeers * 2`: each peer maintains two parallel wallet-ADA
+      *     streams at their shelley address — an [[InitializationTx]] change output and a
+      *     [[FallbackTx]] equity payout. Every RBR-side script tx that pays its fee from
+      *     collateral (Vote/Resolution/Evacuation) picks one of these as its collateral
+      *     input and returns it (fee-subtracted) at the same address, so no utxo is
+      *     destroyed — the two streams persist for the full flow.
       */
-    private val expectedCardinalities: Map[RBRPlaceId, Int] =
+    private def expectedCardinalities(evacuationCount: Int): Map[RBRPlaceId, Int] =
         Map(
           TreasuryRefPlaceId        -> 1,
           DisputeRefPlaceId         -> 1,
@@ -377,7 +455,7 @@ object EvacuationPropertyTest extends Properties("RBR Evacuation Property"):
           VotedPlaceId              -> 0,
           UnvotedPlaceId            -> 0,
           CollateralPlaceId         -> 0,
-          EvacuationOutputPlaceId   -> 0,
+          EvacuationOutputPlaceId   -> evacuationCount,
           PayoutObligationsPlaceId  -> 0,
-          AmbientPlaceId            -> 4,
+          AmbientPlaceId            -> nHeadPeers * 2,
         )

--- a/src/main/scala/hydrozoa/multisig/ledger/l1/tx/FallbackTx.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/l1/tx/FallbackTx.scala
@@ -7,12 +7,14 @@ import hydrozoa.config.head.multisig.timing.TxTiming.BlockTimes.FallbackTxStartT
 import hydrozoa.lib.cardano.scalus.contextualscalus.Change
 import hydrozoa.lib.cardano.scalus.contextualscalus.TransactionBuilder.{addExpectedSigners, build, finalizeContext}
 import hydrozoa.multisig.consensus.peer.HeadPeerNumber
+import hydrozoa.multisig.ledger.commitment.TrustedSetup
 import hydrozoa.multisig.ledger.l1.script.multisig.HeadMultisigScript
 import hydrozoa.multisig.ledger.l1.tx.Metadata.Fallback
 import hydrozoa.multisig.ledger.l1.utxo.{MultisigRegimeOutput, MultisigRegimeUtxo, MultisigTreasuryUtxo}
 import hydrozoa.rulebased.ledger.l1.state.TreasuryState.RuleBasedTreasuryDatum.Unresolved
 import hydrozoa.rulebased.ledger.l1.state.VoteDatum as VD
 import hydrozoa.rulebased.ledger.l1.state.VoteState.VoteDatum
+import hydrozoa.rulebased.ledger.l1.tx.EvacuationTx
 import hydrozoa.rulebased.ledger.l1.utxo.{RuleBasedTreasuryOutput, RuleBasedTreasuryUtxo}
 import io.circe.*
 import monocle.{Focus, Lens}
@@ -20,13 +22,13 @@ import scalus.cardano.address.ShelleyAddress
 import scalus.cardano.ledger.DatumOption.Inline
 import scalus.cardano.ledger.TransactionOutput.Babbage
 import scalus.cardano.ledger.{Mint as _, TransactionOutput, *}
-import scalus.cardano.onchain.plutus.prelude.List as SList
 import scalus.cardano.onchain.plutus.v1.PubKeyHash
 import scalus.cardano.txbuilder.*
 import scalus.cardano.txbuilder.TransactionBuilder.ResolvedUtxos
 import scalus.cardano.txbuilder.TransactionBuilderStep.*
 import scalus.uplc.builtin.Builtins.blake2b_224
 import scalus.uplc.builtin.Data.toData
+import scalus.uplc.builtin.bls12_381.G2Element
 import scalus.uplc.builtin.{ByteString, Data}
 import scalus.|>
 
@@ -143,8 +145,12 @@ private object FallbackTxOps {
                               config.slotConfig.slotToTime(validityStartTime.toSlot.slot) +
                                   config.votingDuration.finiteDuration.toMillis,
                           versionMajor = Steps.Spends.Treasury.datum.versionMajor.toInt,
-                          // TODO: pull the onchain G2 prefix from the head's TrustedSetup
-                          setupG2 = SList.empty
+                          // Size the G2 prefix to cover the largest EvacuationTx the treasury will
+                          // ever validate (evacuatedUtxos.length + 1 elements per tx, capped at
+                          // maxEvacuationsPerTx).
+                          setupG2 = TrustedSetup
+                              .takeSrsG2(EvacuationTx.Assumptions.maxEvacuationsPerTx + 1)
+                              .map(p2 => G2Element(p2).toCompressedByteString)
                         )
                     }
 

--- a/src/main/scala/hydrozoa/rulebased/RuleBasedActor.scala
+++ b/src/main/scala/hydrozoa/rulebased/RuleBasedActor.scala
@@ -708,13 +708,12 @@ final case class RuleBasedActor(
                         )
                     else traceRight(RuleBasedActorEvent.Evacuation.PayoutsLeft(toEvacuate.size))
 
-                feeAndCollateral <- getFeeAndCollateral
+                collateralUtxo <- getEvacuationCollateral
                 evacBuilder = EvacuationTx.Build(
                   inputTreasuryUtxo = treasuryUtxo,
                   evacuateesToTryNext = toEvacuate,
                   allRemainingEvacuatees = toEvacuate,
-                  feeUtxos = feeAndCollateral._1,
-                  collateralUtxo = feeAndCollateral._2
+                  collateralUtxo = collateralUtxo
                 )
                 // NoEvacuatees is recoverable (poll-then-retry), not a fatal build failure — peel
                 // it off before delegating to the generic buildAndSubmit which raises on Left.
@@ -821,7 +820,7 @@ final case class RuleBasedActor(
             }
 
         /** Query the evacuation wallet's utxos and derive collateral from the first one. */
-        def getFeeAndCollateral: EitherT[IO, Error.RecoverableErrors, (Utxos, CollateralUtxo)] = {
+        def getEvacuationCollateral: EitherT[IO, Error.RecoverableErrors, CollateralUtxo] = {
             val walletAddress = config.ruleBasedWallet.exportVerificationKey.shelleyAddress()
             for {
                 feeUtxos <- Backend.utxosAtFee(walletAddress)
@@ -841,7 +840,7 @@ final case class RuleBasedActor(
                                 )
                         }
                 }
-            } yield (feeUtxos, collateralUtxo)
+            } yield collateralUtxo
         }
     }
 

--- a/src/main/scala/hydrozoa/rulebased/ledger/l1/tx/EvacuationTx.scala
+++ b/src/main/scala/hydrozoa/rulebased/ledger/l1/tx/EvacuationTx.scala
@@ -86,8 +86,8 @@ private object EvacuationTxOps {
       *   The map of all evacuations that still need to be processed
       * @param collateralUtxo
       *   Wallet UTxO used both as Plutus collateral and as the fee-paying regular input; the
-      *   returned collateral output absorbs the fee via the diff handler, matching the
-      *   pattern used by [[VoteTx]], [[ResolutionTx]], [[DeinitTx]] et al.
+      *   returned collateral output absorbs the fee via the diff handler, matching the pattern used
+      *   by [[VoteTx]], [[ResolutionTx]], [[DeinitTx]] et al.
       */
     final case class Build(
         inputTreasuryUtxo: RuleBasedTreasuryUtxo,

--- a/src/main/scala/hydrozoa/rulebased/ledger/l1/tx/EvacuationTx.scala
+++ b/src/main/scala/hydrozoa/rulebased/ledger/l1/tx/EvacuationTx.scala
@@ -22,7 +22,7 @@ import scalus.cardano.ledger.TransactionException.{ExUnitsExceedMaxException, In
 import scalus.cardano.onchain.plutus.prelude.List as SList
 import scalus.cardano.txbuilder.*
 import scalus.cardano.txbuilder.TransactionBuilder.ResolvedUtxos
-import scalus.cardano.txbuilder.TransactionBuilderStep.{Send, Spend}
+import scalus.cardano.txbuilder.TransactionBuilderStep.Send
 
 final case class EvacuationTx(
     treasuryUtxoSpent: RuleBasedTreasuryUtxo,
@@ -84,15 +84,16 @@ private object EvacuationTxOps {
       *   The sub-map of evacuations to try in this transaction
       * @param allRemainingEvacuatees
       *   The map of all evacuations that still need to be processed
-      * @param feeUtxos
-      *   Utxos to use to pay the fees
+      * @param collateralUtxo
+      *   Wallet UTxO used both as Plutus collateral and as the fee-paying regular input; the
+      *   returned collateral output absorbs the fee via the diff handler, matching the
+      *   pattern used by [[VoteTx]], [[ResolutionTx]], [[DeinitTx]] et al.
       */
     final case class Build(
         inputTreasuryUtxo: RuleBasedTreasuryUtxo,
         evacuateesToTryNext: EvacuationMap,
         allRemainingEvacuatees: EvacuationMap,
         collateralUtxo: CollateralUtxo,
-        feeUtxos: Utxos,
     ) {
 
         private def halveEvacuation(evacuatees: EvacuationMap): EvacuationMap = {
@@ -190,17 +191,16 @@ private object EvacuationTxOps {
                   List(
                     config.referenceTreasury,
                     inputTreasuryUtxo.spendAttached(evacuationRedeemer),
+                    // Spend the collateral utxo as a regular input; the returned
+                    // collateral output absorbs the tx fee via the index-0 diff handler.
                     collateralUtxo.add,
-                    collateralUtxo.send,
+                    collateralUtxo.spend,
+                    collateralUtxo.collateralOutput.send,
                     residualTreasury.send
                   )
                       ++
                           // Outputs for withdrawals
                           evacuationOutputs.map(Send(_))
-                          // Spend the fee utxos
-                          ++ feeUtxos.toList.map((ti, to) =>
-                              Spend(scalus.cardano.ledger.Utxo(ti, to), PubKeyWitness)
-                          )
                 )
                     .explainConst("Building evacuation tx failed")
                     .left

--- a/src/test/scala/hydrozoa/config/head/initialization/InitializationParametersGen.scala
+++ b/src/test/scala/hydrozoa/config/head/initialization/InitializationParametersGen.scala
@@ -26,7 +26,10 @@ import scala.collection.immutable.{SortedMap, TreeMap}
 import scala.concurrent.duration.DurationInt
 import scalus.cardano.address.Address
 import scalus.cardano.ledger.*
+import scalus.cardano.ledger.DatumOption.Inline
 import scalus.cardano.ledger.TransactionOutput.Babbage
+import scalus.uplc.builtin.ByteString
+import scalus.uplc.builtin.Data.toData
 import scalus.|>
 import spire.math.{Rational, SafeLong}
 import test.Generators.Hydrozoa.*
@@ -258,12 +261,21 @@ object InitializationParametersGenTopDown {
             l2TransactionOutputs <-
                 if rest == ensureMinAdaLenient(cardanoNetwork)(rest)
                 then
-                    // Generate L2 utxos from the rest (if present)
+                    // Generate L2 utxos from the rest (if present). Each output carries an
+                    // "evacuation" inline-datum sentinel so `RBRClassifier` can bucket the
+                    // eventual L1 evacuation outputs by content — the sentinel is committed
+                    // to the KZG at obligation-creation time, so `RuleBasedTreasuryScript`'s
+                    // membership check reproduces the same hash and accepts the L1 output.
                     Gen.tailRecM(List.empty[Babbage] -> rest)((acc, rest) =>
                         for {
                             next <- generateCappedValue(cardanoNetwork)(capValue = rest)
                             address <- Gen.oneOf(peerAddresses)
-                            acc_ = acc :+ Babbage(address, next)
+                            acc_ = acc :+ Babbage(
+                              address = address,
+                              value = next,
+                              datumOption =
+                                  Some(Inline(toData(ByteString.fromString("evacuation")))),
+                            )
                         } yield
                             if next == rest
                             then Right(acc_)

--- a/src/test/scala/hydrozoa/multisig/ledger/eutxol2/L2OutputEvacuabilityTest.scala
+++ b/src/test/scala/hydrozoa/multisig/ledger/eutxol2/L2OutputEvacuabilityTest.scala
@@ -171,8 +171,7 @@ class L2OutputEvacuabilityTest extends AnyFunSuite {
               inputTreasuryUtxo = treasury,
               evacuateesToTryNext = m,
               allRemainingEvacuatees = m,
-              collateralUtxo = collateral,
-              feeUtxos = Map(fee.toTuple)
+              collateralUtxo = collateral
             )
             .result(using config) match {
             case Left(e) => Left(s"build: $e")

--- a/src/test/scala/hydrozoa/rulebased/ledger/l1/script/plutus/EvacuationAttackTest.scala
+++ b/src/test/scala/hydrozoa/rulebased/ledger/l1/script/plutus/EvacuationAttackTest.scala
@@ -139,8 +139,7 @@ class EvacuationAttackTest extends AnyFunSuite {
               inputTreasuryUtxo = treasuryUtxo,
               evacuateesToTryNext = subset,
               allRemainingEvacuatees = allRemaining,
-              collateralUtxo = collateral,
-              feeUtxos = Map(feeUtxo.toTuple)
+              collateralUtxo = collateral
             )
             .result(using config)
     }

--- a/src/test/scala/hydrozoa/rulebased/ledger/l1/script/plutus/EvacuationAttackTest.scala
+++ b/src/test/scala/hydrozoa/rulebased/ledger/l1/script/plutus/EvacuationAttackTest.scala
@@ -124,14 +124,13 @@ class EvacuationAttackTest extends AnyFunSuite {
           ++ config.scriptReferenceUtxos.toList.map(_.toTuple)
     )
 
-    /** Build an EvacuationTx draining the single obligation `key` from `treasuryUtxo` (paying fee
-      * from `feeUtxo`), as the `allRemaining` map sees it.
+    /** Build an EvacuationTx draining the single obligation `key` from `treasuryUtxo`, as the
+      * `allRemaining` map sees it. Fees come from the collateral utxo.
       */
     private def buildEvacuation(
         treasuryUtxo: RuleBasedTreasuryUtxo,
         key: EvacuationKey,
-        allRemaining: EvacuationMap,
-        feeUtxo: Utxo
+        allRemaining: EvacuationMap
     ): Either[EvacuationTx.Build.Error, EvacuationTx] = {
         val subset = allRemaining.removedAll(allRemaining.keys.filter(_ != key))
         EvacuationTx
@@ -146,7 +145,7 @@ class EvacuationAttackTest extends AnyFunSuite {
 
     /** An otherwise-valid EvacuationTx draining the first obligation of `M` (unsigned). */
     private val legitTx: Transaction =
-        buildEvacuation(treasury, evacMap.keys.head, evacMap, feeUtxos.head)
+        buildEvacuation(treasury, evacMap.keys.head, evacMap)
             .fold(e => throw new AssertionError(s"legit evacuation build failed: $e"), _.tx)
 
     /** The current treasury input in the emulator (the single utxo at the treasury address). */
@@ -345,7 +344,7 @@ class EvacuationAttackTest extends AnyFunSuite {
     test("treasury value-conservation prevents double-draining the same obligation") {
         val key = evacMap.keys.head
         // tx1: legitimately drain `key`.
-        val evac1 = buildEvacuation(treasury, key, evacMap, feeUtxos(0))
+        val evac1 = buildEvacuation(treasury, key, evacMap)
             .fold(e => fail(s"tx1 build failed: $e"), identity)
         val emu2 = mkEmulator().submit(ownWallet.signTx(evac1.tx)) match {
             case Right((_, e)) => e
@@ -357,7 +356,7 @@ class EvacuationAttackTest extends AnyFunSuite {
         // the value invariant (treasuryInput = treasuryOutput + Σ evacuated) makes the obligation
         // un-payable — the builder refuses; were a tx hand-crafted, the script's membership check
         // (against the advanced accumulator) would reject it.
-        buildEvacuation(residual, key, evacMap, feeUtxos(1)) match {
+        buildEvacuation(residual, key, evacMap) match {
             case Left(_) => () // expected: cannot re-pay a drained obligation from the residual
             case Right(evac2) =>
                 emu2.submit(ownWallet.signTx(evac2.tx)) match {

--- a/src/test/scala/hydrozoa/rulebased/ledger/l1/script/plutus/EvacuationDrainTest.scala
+++ b/src/test/scala/hydrozoa/rulebased/ledger/l1/script/plutus/EvacuationDrainTest.scala
@@ -5,7 +5,8 @@ import hydrozoa.*
 import hydrozoa.config.HydrozoaBlueprint
 import hydrozoa.config.node.{MultiNodeConfig, NodeConfig}
 import hydrozoa.lib.cardano.scalus.QuantizedTime.QuantizedInstant.realTimeQuantizedInstant
-import hydrozoa.lib.cardano.scalus.VerificationKeyExtra.{addrKeyHash, shelleyAddress}
+import hydrozoa.lib.cardano.scalus.VerificationKeyExtra.addrKeyHash
+import hydrozoa.lib.cardano.scalus.ledger.CollateralUtxo
 import hydrozoa.multisig.consensus.peer.PeerWallet
 import hydrozoa.multisig.ledger.commitment.TrustedSetup
 import hydrozoa.multisig.ledger.joint.EvacuationMap
@@ -23,7 +24,7 @@ import scalus.cardano.ledger.EvaluatorMode.EvaluateAndComputeCost
 import scalus.cardano.ledger.rules.{CardanoMutator, State, UtxoEnv}
 import scalus.testing.ImmutableEmulator
 import scalus.uplc.builtin.bls12_381.G2Element
-import test.Generators.Hydrozoa.{genEvacuationMap, genPubKeyUtxo}
+import test.Generators.Hydrozoa.genEvacuationMap
 
 /** Evacuation-map drain test for the rule-based regime (test "B").
   *
@@ -42,9 +43,9 @@ import test.Generators.Hydrozoa.{genEvacuationMap, genPubKeyUtxo}
   * choices here, hence no `Scenario`. (A peer redirecting the residual treasury to its own address
   * or breaking evacuation liveness is a separate, genuinely adversarial scenario test.)
   *
-  * Each `EvacuationTx` **spends its fee utxo** (and re-sends collateral rather than spending it),
-  * so every step gets its own fee utxo; one collateral is reused. Evacuation has no time-validity
-  * bound, so no deadline/sleep is involved.
+  * Each `EvacuationTx` pays its fee from the collateral utxo (returned fee-subtracted at output
+  * index 0), and the drain loop threads that returned collateral into the next step. Evacuation
+  * has no time-validity bound, so no deadline/sleep is involved.
   */
 class EvacuationDrainTest extends AnyFunSuite {
 
@@ -59,7 +60,6 @@ class EvacuationDrainTest extends AnyFunSuite {
     private val config: NodeConfig = env.nodeConfigs.head._2
     private val ownWallet: PeerWallet = env.nodePrivateConfigs.head._2.ownWallet
     private val ownKeyHash = ownWallet.exportVerificationKey.addrKeyHash
-    private val ownAddr = ownWallet.exportVerificationKey.shelleyAddress()(using env.headConfig)
     private val treasuryAddr = HydrozoaBlueprint.mkTreasuryAddress(env.headConfig.network)
 
     // Small on purpose: each step is an on-chain KZG membership check. Larger maps belong to the
@@ -93,17 +93,8 @@ class EvacuationDrainTest extends AnyFunSuite {
           RuleBasedTreasuryOutput(resolvedDatum, treasuryBaseValue + evacMap.totalValue)
     )
 
-    // One fee utxo per evacuation step (each EvacuationTx spends its fee utxo); one shared
-    // collateral (evacuation re-sends collateral rather than spending it).
-    private val feeUtxos: List[Utxo] =
-        (0 until numEvacuees).toList.map(i =>
-            fixed(
-              genPubKeyUtxo(address = ownAddr, genValue = Gen.const(Value.ada(100)))(using
-                env.headConfig
-              ),
-              20L + i
-            )
-        )
+    // One collateral utxo, threaded through the drain loop: each EvacuationTx spends it as its
+    // fee-paying input and returns it (fee-subtracted) at index 0 for the next step to consume.
     private val collateral = fixed(genCollateralUtxo(ownKeyHash)(using env.headConfig), 4)
 
     private val initialUtxos: Utxos = (
@@ -111,7 +102,6 @@ class EvacuationDrainTest extends AnyFunSuite {
         (treasury.utxoId, treasury.treasuryOutput.toOutput(using config)),
         (collateral.input, collateral.collateralOutput.toOutput(using env))
       )
-          ++ feeUtxos.map(_.toTuple)
           ++ config.scriptReferenceUtxos.toList.map(_.toTuple)
     )
 
@@ -123,6 +113,7 @@ class EvacuationDrainTest extends AnyFunSuite {
     private def evacuateAll(
         remaining: EvacuationMap,
         treasury: RuleBasedTreasuryUtxo,
+        collateral: CollateralUtxo,
         emulator: ImmutableEmulator,
         depth: Int,
         evacuated: List[TransactionOutput]
@@ -151,9 +142,19 @@ class EvacuationDrainTest extends AnyFunSuite {
             // real treasury input from the emulator before chaining.
             val newTreasury =
                 evac.treasuryUtxoProduced.copy(utxoId = currentTreasuryInput(nextEmulator))
+            // The returned collateral (fee-subtracted) sits at output index 0 of the just-submitted
+            // evacuation tx; parse it back into a CollateralUtxo for the next step.
+            val newCollateralInput = TransactionInput(evac.tx.id, 0)
+            val newCollateral = CollateralUtxo
+                .parse(Utxo(newCollateralInput, nextEmulator.utxos(newCollateralInput)))
+                .fold(
+                  err => fail(s"parsing returned collateral at step $depth failed: $err"),
+                  identity
+                )
             evacuateAll(
               remaining.removed(key),
               newTreasury,
+              newCollateral,
               nextEmulator,
               depth + 1,
               evacuated ++ evac.evacuatedOutputs
@@ -165,7 +166,8 @@ class EvacuationDrainTest extends AnyFunSuite {
 
     test("evacuation drains the full evacuation map to exactly M") {
         val emulator0 = mkEmulator(initialUtxos, now.toSlot)
-        val (finalTreasury, evacuated) = evacuateAll(evacMap, treasury, emulator0, 0, Nil)
+        val (finalTreasury, evacuated) =
+            evacuateAll(evacMap, treasury, collateral, emulator0, 0, Nil)
 
         val _ = assert(
           bag(evacuated) == bag(evacMap.outputsCooked.toList),

--- a/src/test/scala/hydrozoa/rulebased/ledger/l1/script/plutus/EvacuationDrainTest.scala
+++ b/src/test/scala/hydrozoa/rulebased/ledger/l1/script/plutus/EvacuationDrainTest.scala
@@ -136,8 +136,7 @@ class EvacuationDrainTest extends AnyFunSuite {
                   inputTreasuryUtxo = treasury,
                   evacuateesToTryNext = subset,
                   allRemainingEvacuatees = remaining,
-                  collateralUtxo = collateral,
-                  feeUtxos = Map(feeUtxos(depth).toTuple)
+                  collateralUtxo = collateral
                 )
                 .result(using config) match {
                 case Right(e)  => e

--- a/src/test/scala/hydrozoa/rulebased/ledger/l1/script/plutus/EvacuationDrainTest.scala
+++ b/src/test/scala/hydrozoa/rulebased/ledger/l1/script/plutus/EvacuationDrainTest.scala
@@ -44,8 +44,8 @@ import test.Generators.Hydrozoa.genEvacuationMap
   * or breaking evacuation liveness is a separate, genuinely adversarial scenario test.)
   *
   * Each `EvacuationTx` pays its fee from the collateral utxo (returned fee-subtracted at output
-  * index 0), and the drain loop threads that returned collateral into the next step. Evacuation
-  * has no time-validity bound, so no deadline/sleep is involved.
+  * index 0), and the drain loop threads that returned collateral into the next step. Evacuation has
+  * no time-validity bound, so no deadline/sleep is involved.
   */
 class EvacuationDrainTest extends AnyFunSuite {
 

--- a/src/test/scala/hydrozoa/rulebased/ledger/l1/tx/EvacuationTxTest.scala
+++ b/src/test/scala/hydrozoa/rulebased/ledger/l1/tx/EvacuationTxTest.scala
@@ -27,8 +27,6 @@ import scalus.cardano.onchain.plutus.prelude
 import scalus.cardano.onchain.plutus.v3.TokenName
 import scalus.uplc.builtin.bls12_381.{G1Element, G2Element}
 import supranational.blst.Scalar
-import test.*
-import test.Generators.Hydrozoa.genPubKeyUtxo
 
 /** Generator for resolved treasury UTXO with resolved datum */
 def genResolvedTreasuryUtxo(
@@ -123,12 +121,6 @@ def genEvacuationTxBuild(using config: MultiNodeConfig): Gen[EvacuationTx.Build]
 
         addr = config.nodeConfigs.head._2.ownWallet.exportVerificationKey
             .shelleyAddress()(using config.headConfig)
-
-        feeUtxo <-
-            genPubKeyUtxo(
-              address = addr,
-              genValue = Gen.const(Value.ada(100))
-            )
 
         collateralUtxo <- genCollateralUtxo(addr.payment.asInstanceOf[Key].hash)(using config)
 

--- a/src/test/scala/hydrozoa/rulebased/ledger/l1/tx/EvacuationTxTest.scala
+++ b/src/test/scala/hydrozoa/rulebased/ledger/l1/tx/EvacuationTxTest.scala
@@ -136,7 +136,6 @@ def genEvacuationTxBuild(using config: MultiNodeConfig): Gen[EvacuationTx.Build]
       inputTreasuryUtxo = adjustedTreasuryUtxo,
       evacuateesToTryNext = evacuatees,
       allRemainingEvacuatees = evacMap,
-      feeUtxos = Map(feeUtxo.toTuple),
       collateralUtxo = collateralUtxo
     )
 


### PR DESCRIPTION
## Summary

- `FallbackTx.setupG2`: use `TrustedSetup.takeSrsG2` instead of `SList.empty` so the RBR evacuation flow can actually run end-to-end.
- `InitializationParametersGen`: stamp L2 outputs with an `"evacuation"` inline-datum sentinel so `RBRClassifier` can bucket the resulting L1 evacuation outputs by content (the sentinel is committed to the KZG at obligation-creation time, so the on-chain membership check reproduces the same hash and accepts the L1 output).
- `EvacuationTx`: pay the fee from the collateral utxo (`add + spend + collateralOutput.send`, diff at index 0), matching the pattern used by `VoteTx` / `ResolutionTx` / `DeinitTx` et al. Drops the separate `feeUtxos` parameter and the wallet-input Spend loop.
- `RuleBasedActor`: `getFeeAndCollateral` → `getEvacuationCollateral`, returns just `CollateralUtxo`.
- `EvacuationPropertyTest`: asserts the full-drain terminal state.
  - `EvacuationOutputPlaceId` is the first `PayoutsLeft(n)` observed on any peer's RBA (the KZG-committed evacuation count at read-of-treasury time).
  - `AmbientPlaceId = nHeadPeers * 2` — each peer maintains two parallel wallet-ADA streams (init-change + fallback-equity); every RBR-side script tx that pays fee from collateral picks one of these, returns it fee-subtracted at the same address, so no utxo is destroyed.
- Test-file cleanups for the `feeUtxos` removal (`EvacuationTxTest`, `EvacuationAttackTest`, `EvacuationDrainTest`, `L2OutputEvacuabilityTest`).

## Test plan

- [x] `just fmt-check`
- [x] `just lint-check`
- [x] `just build-werror`
- [x] `sbtn "integration/testOnly *EvacuationPropertyTest*"` — passes with `EvacuationOutputPlaceId == PayoutsLeft(n)` and `AmbientPlaceId == 4` for the 2-peer scenario.
- [ ] Existing evacuation unit tests (`EvacuationTxTest`, `EvacuationAttackTest`, `EvacuationDrainTest`, `L2OutputEvacuabilityTest`) still pass after the `feeUtxos` parameter removal.