### PR TITLE
revert(gen): drop unneeded ensureMinAda top-up in top-down L2 output generator

### DIFF
--- a/src/test/scala/hydrozoa/config/head/initialization/InitializationParametersGen.scala
+++ b/src/test/scala/hydrozoa/config/head/initialization/InitializationParametersGen.scala
@@ -270,25 +270,16 @@ object InitializationParametersGenTopDown {
                         for {
                             next <- generateCappedValue(cardanoNetwork)(capValue = rest)
                             address <- Gen.oneOf(peerAddresses)
-                            // The datum bumps the output's min-ADA above what generateCappedValue
-                            // budgeted for `next`; top up here and advance the loop using the
-                            // actually-consumed value.
-                            output = Babbage(
+                            acc_ = acc :+ Babbage(
                               address = address,
                               value = next,
                               datumOption =
                                   Some(Inline(toData(ByteString.fromString("evacuation")))),
-                            ).ensureMinAda(cardanoNetwork)
+                            )
                         } yield
-                            if (rest - output.value).coin.value < 0L
-                            then Right(acc)
-                            else {
-                                val acc_ = acc :+ output
-                                val newRest = rest - output.value
-                                if next == rest || newRest.coin.value == 0L
-                                then Right(acc_)
-                                else Left(acc_ -> newRest)
-                            }
+                            if next == rest
+                            then Right(acc_)
+                            else Left(acc_ -> (rest - next))
                     )
                 else Gen.const(List.empty)
 


### PR DESCRIPTION
Reverts the `ensureMinAda` top-up added to `InitializationParametersGenTopDown` in #519. It was added while chasing the "Insufficient funds" failures, but the real cause was the FallbackTx treasury min-ada (fixed separately in #519); the generator change was never needed.

Full root suite with the revert: 313 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)