### PR TITLE
Head API: path restructure (/head/*, /l2/cardano-eutxo/*)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,7 @@ Working design and reference docs live in `docs/`:
 
 **API**
 - [`l2-query-endpoints.md`](docs/l2-query-endpoints.md) — the user-facing server's read-only L2
-  queries: `GET /api/l2/utxos/{address}` and `GET /api/l2/transactions` (EUTXO-only).
+  queries: `GET /l2/cardano-eutxo/utxos/{address}` and `GET /l2/cardano-eutxo/transactions` (EUTXO-only).
 - [`observability-endpoints.md`](docs/observability-endpoints.md) — the user-facing server's
   `/health` (liveness) and `/ready` (readiness) endpoints and the `NodeStatus` behind them.
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -69,8 +69,8 @@ process talking to Cardano L1 (a public testnet) via Blockfrost:
   (`peer-<label>/rocksdb`) and the EUTXO ledger store
   (`peer-<label>/l2-rocksdb`). Default data dir `.hydrozoa-data` relative to
   cwd; give each node its own.
-- **L2 query API** (head peers only, EUTXO only): `GET /api/l2/utxos/{address}` and
-  `GET /api/l2/transactions` are served only when the node runs the EUTXO ledger; a remote-ledger
+- **L2 query API** (head peers only, EUTXO only): `GET /l2/cardano-eutxo/utxos/{address}` and
+  `GET /l2/cardano-eutxo/transactions` are served only when the node runs the EUTXO ledger; a remote-ledger
   node serves neither.
 
 ### Network matrix
@@ -367,11 +367,11 @@ code changes.
 just submit-l2-tx        # or: just submit-l2-tx config/demo http://localhost:8081
 ```
 
-Pick a peer (its key signs), pick one of its L2 utxos (fetched from `GET /api/l2/utxos/{address}`
+Pick a peer (its key signs), pick one of its L2 utxos (fetched from `GET /l2/cardano-eutxo/utxos/{address}`
 — the opening `l2-cardano-eutxo.json` outputs sit at the head peers' addresses), enter a
 destination (bech32, or a peer name like `head-1`) and a value. The tool builds the zero-fee
 native tx (with the CIP-67 output designations and the headId pin in the metadata), signs it with
-the peer wallet, and posts it to `POST /api/l2/submit`. An example session — send 2 of head-0's
+the peer wallet, and posts it to `POST /head/tx`. An example session — send 2 of head-0's
 opening 5 ADA to head-1:
 
 ```
@@ -390,10 +390,10 @@ Enter 1..1: 1
 Destination (bech32 address, or a peer name like head-1): head-1
 Value to send (whole ADA, available 5.000000 ADA): 2
 Built + signed L2 tx 8de4...
-Accepted: requestId=... . Watch GET http://localhost:8080/api/l2/utxos/... for the result.
+Accepted: requestId=... . Watch GET http://localhost:8080/l2/cardano-eutxo/utxos/... for the result.
 ```
 
-Verify with `curl http://localhost:8080/api/l2/utxos/<address>` for both peers — head-1 gains a
+Verify with `curl http://localhost:8080/l2/cardano-eutxo/utxos/<address>` for both peers — head-1 gains a
 2-ADA utxo, head-0 keeps 3 ADA change.
 
 ### Deposit into the head
@@ -405,7 +405,7 @@ just deposit
 Pick a peer, pick one of its **L1** utxos (via the peer's Blockfrost backend — for the demo that
 is head peer 0, the funded one), and enter the L2 outputs the deposit should spawn. The tool
 serializes the L2 payload (its hash rides in the deposit tx metadata), registers the deposit with
-`POST /api/deposit/register`, then signs the deposit tx and submits it to L1 via Blockfrost,
+`POST /head/deposit`, then signs the deposit tx and submits it to L1 via Blockfrost,
 polling until the utxo lands. An example session — deposit 3 ADA from head-0's L1 funds to
 coil-0's L2 address:
 
@@ -426,11 +426,11 @@ Add another output? [y/N]: n
 Built deposit TransactionInput(...#0) (3.000000 ADA to L2, accept-by ...)
 Registered with the head: requestId=...
 Submitted deposit tx ... to L1; waiting for the utxo…
-Deposit is on L1. The head absorbs it after maturity — watch GET .../api/l2/utxos/{destination}
+Deposit is on L1. The head absorbs it after maturity — watch GET .../l2/cardano-eutxo/utxos/{destination}
 ```
 
 The head absorbs the deposit after maturity (a few minutes with the demo timing) — then
-`curl http://localhost:8080/api/l2/utxos/<coil-0 address>` shows the spawned 3-ADA output.
+`curl http://localhost:8080/l2/cardano-eutxo/utxos/<coil-0 address>` shows the spawned 3-ADA output.
 
 ### Querying the head
 
@@ -438,12 +438,12 @@ Any head peer answers (`:8080` for head-0, `:8081` for head-1):
 
 ```bash
 curl http://localhost:8080/ready                               # 200 once the head is up and active
-curl "http://localhost:8080/api/l2/transactions?count=10"      # recent applied L2 activity, newest first
-curl "http://localhost:8080/api/l2/utxos/<bech32-address>"     # current L2 utxos at an address
+curl "http://localhost:8080/l2/cardano-eutxo/transactions?count=10"      # recent applied L2 activity, newest first
+curl "http://localhost:8080/l2/cardano-eutxo/utxos/<bech32-address>"     # current L2 utxos at an address
 ```
 
-`/api/l2/transactions` covers plain L2 transactions plus deposit registrations, absorptions, and
-refunds (the `kind` field tells them apart); `/api/l2/utxos` returns the utxos as CIP-0116 JSON.
+`/l2/cardano-eutxo/transactions` covers plain L2 transactions plus deposit registrations, absorptions, and
+refunds (the `kind` field tells them apart); `/l2/cardano-eutxo/utxos` returns the utxos as CIP-0116 JSON.
 Both are the quickest way to watch a submitted tx or deposit land.
 
 ### Teardown / recovery of funds

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ protocol spec). For project-wide conventions, start with the style guide.
 | [fast-consensus.md](fast-consensus.md) | The fast cycle: per-peer soft-confirmation of block headers, eager signature collection, BlockWeaver / JointLedger / FastConsensusActor roles. |
 | [integration-stages.md](integration-stages.md) | The two integration test stages under `integration/`: which stage tests what, where to add a test, what each property checks. |
 | [l2-isomorphism.md](l2-isomorphism.md) | L2 isomorphism: driving the EUTXO ledger with native Cardano txs — the headId pin, mandatory tx metadata, screening vs submission, how deposits pin their L2 payload, and the `cardano-eutxo` / `any-remote` backend selection. |
-| [l2-query-endpoints.md](l2-query-endpoints.md) | The user-facing server's read-only L2 queries: `GET /api/l2/utxos/{address}` (CIP-0116 utxos) and `GET /api/l2/transactions` (recent activity); EUTXO-only, empty on a remote-ledger node. |
+| [l2-query-endpoints.md](l2-query-endpoints.md) | The user-facing server's read-only L2 queries: `GET /l2/cardano-eutxo/utxos/{address}` (CIP-0116 utxos) and `GET /l2/cardano-eutxo/transactions` (recent activity); EUTXO-only, empty on a remote-ledger node. |
 | [logging-tracing.md](logging-tracing.md) | Contextual logging and tracing: Tracer, IOLocal-carried context, routing keys, migration off SLF4J MDC. |
 | [observability-endpoints.md](observability-endpoints.md) | The user-facing server's `/health` (liveness) and `/ready` (readiness) endpoints: semantics, status mapping, how `NodeStatus` is maintained. |
 | [rate-limiter.md](rate-limiter.md) | A generic throttling actor that slows the fast/slow cycles (longer block/stack durations) without touching consensus logic. |

--- a/docs/l2-isomorphism.md
+++ b/docs/l2-isomorphism.md
@@ -69,7 +69,7 @@ the application already bakes a headId-like domain separator into its own txs. L
 `examples/src/main/scala/hydrozoa/examples/demo/SubmitL2Transaction.scala` builds exactly this
 shape end-to-end and is the reference client.
 
-What a client needs from the head: `GET /api/head-info` serves the `headId` (for the pin) and the
+What a client needs from the head: `GET /head/info` serves the `headId` (for the pin) and the
 deposit timing offsets (`submissionDurationSeconds`, `absorptionStartOffsetSeconds`,
 `refundStartOffsetSeconds`); slot↔time interpretation uses the network's standard slot config.
 
@@ -82,7 +82,7 @@ no clock, so at apply it receives the block-creation time. What Hydrozoa keeps i
 *sequencing*: a request is screened first, admitted second.
 
 ```
-user ──POST /api/l2/submit──► RequestSequencer
+user ──POST /head/tx──► RequestSequencer
                                    │  sendScreenTx(l2Payload)            (stateless)
                                    ▼
                               L2Ledger screening ── fail ──► rejected, no RequestId
@@ -105,7 +105,7 @@ tx id). Screening cannot resolve inputs, check balance, or test the validity win
 state. It returns pass/fail with an error reason; Hydrozoa itself never inspects or compares head
 identities — the pin check lives entirely inside the ledger. Passing is what assigns the
 `RequestId`, so an unparseable or unauthenticated payload is dropped before it consumes a durable
-id or any peer traffic. On the wire, `POST /api/l2/submit` returns the assigned `RequestId` on
+id or any peer traffic. On the wire, `POST /head/tx` returns the assigned `RequestId` on
 acceptance and the rejection reason otherwise (`docs/openapi.yaml`).
 
 **Submission** is the stateful apply path at block production: the validity interval against the
@@ -113,7 +113,7 @@ block-creation time, input resolution against the active utxo set, value conserv
 fee, and that the witnesses cover the resolved inputs' payment credentials. A request that screens
 clean but fails here (say, its inputs were spent by an earlier tx in the block) is marked
 `Invalid` by `JointLedger`; the block completes regardless. An `Invalid` request is terminal — the
-head does not retry it, and it never appears in `GET /api/l2/transactions` — so the client
+head does not retry it, and it never appears in `GET /l2/cardano-eutxo/transactions` — so the client
 resubmits a corrected tx.
 
 ## Deposits: pinned to their L2 payload
@@ -131,7 +131,7 @@ and void the signatures.
 The deposit path, in order (client steps marked):
 
 1. **Client:** build the deposit tx (`DepositTx.Build` puts `blake2b_256(l2Payload)` in its
-   metadata) and register both payloads with `POST /api/deposit/register`.
+   metadata) and register both payloads with `POST /head/deposit`.
 2. **Deposit L1 screening** — Hydrozoa's stage, before the ledger sees the deposit
    (`multisig/ledger/l1/tx/DepositL1Screening.scala`, called by `RequestSequencer`).
    `screen(l1Payload, l2Payload, now)`:
@@ -187,8 +187,8 @@ peer's replica the same ordered commands, so a non-deterministic backend diverge
 consensus. The EUTXO ledger gets determinism from native tx validation; a remote ledger must
 provide it by design.
 
-The read side follows the backend: the L2 query endpoints (`GET /api/l2/utxos/{address}`,
-`GET /api/l2/transactions`) are mounted only when the node runs the EUTXO ledger — see
+The read side follows the backend: the L2 query endpoints (`GET /l2/cardano-eutxo/utxos/{address}`,
+`GET /l2/cardano-eutxo/transactions`) are mounted only when the node runs the EUTXO ledger — see
 [l2-query-endpoints.md](l2-query-endpoints.md).
 
 ### Opening state

--- a/docs/l2-query-endpoints.md
+++ b/docs/l2-query-endpoints.md
@@ -1,10 +1,10 @@
-# L2 query endpoints: /api/l2/utxos and /api/l2/transactions
+# L2 query endpoints: /l2/cardano-eutxo/utxos and /l2/cardano-eutxo/transactions
 
 The user-facing HTTP server (`multisig/server/HydrozoaServer.scala`) exposes two read-only `GET`
 endpoints for inspecting the L2 ledger's current state and recent activity. They are the
-read counterpart to the existing write path (`POST /api/l2/submit`, `POST /api/deposit/register`).
+read counterpart to the existing write path (`POST /head/tx`, `POST /head/deposit`).
 
-| | `GET /api/l2/utxos/{address}` | `GET /api/l2/transactions` |
+| | `GET /l2/cardano-eutxo/utxos/{address}` | `GET /l2/cardano-eutxo/transactions` |
 |---|---|---|
 | Answers | what does this address control on L2 now? | what happened on L2 recently? |
 | Shape | array of CIP-0116 utxos | array of transaction summaries, newest first |
@@ -20,13 +20,13 @@ box and exposes no query channel, so it has no such reader: the server is handed
 only this narrow reader lets the HTTP layer read L2 state without being able to issue ledger
 commands.
 
-## GET /api/l2/utxos/{address}
+## GET /l2/cardano-eutxo/utxos/{address}
 
 The current L2 utxos controlled by a bech32 `address`, serialized with the repo's CIP-0116
 codecs. A malformed address is a `400`; an unknown-but-well-formed address is `200 []`.
 
 ```bash
-curl http://localhost:8080/api/l2/utxos/addr_test1vryvgass5dsrf2kxl3vgfz76uhp83kv5lagzcp29tcana6q4a064h
+curl http://localhost:8080/l2/cardano-eutxo/utxos/addr_test1vryvgass5dsrf2kxl3vgfz76uhp83kv5lagzcp29tcana6q4a064h
 ```
 ```json
 [
@@ -47,13 +47,13 @@ curl http://localhost:8080/api/l2/utxos/addr_test1vryvgass5dsrf2kxl3vgfz76uhp83k
 `datum` is `null` when the output has none; otherwise it is an object with `inline` (the datum's
 CBOR hex) or `hash` (a datum-hash reference), whichever applies — the two kinds are kept distinct.
 
-## GET /api/l2/transactions
+## GET /l2/cardano-eutxo/transactions
 
 The most recent applied L2 transactions, newest first, as lightweight summaries. `?count=N`
 bounds the number of **summaries** returned (default 50); a non-integer `count` is a `400`.
 
 ```bash
-curl "http://localhost:8080/api/l2/transactions?count=10"
+curl "http://localhost:8080/l2/cardano-eutxo/transactions?count=10"
 ```
 ```json
 [

--- a/docs/openapi-eutxo-l2.yaml
+++ b/docs/openapi-eutxo-l2.yaml
@@ -3,10 +3,10 @@ info:
   title: Hydrozoa EUTXO L2 ledger API
   version: 0.1.0
 paths:
-  /api/l2/utxos/{address}:
+  /l2/cardano-eutxo/utxos/{address}:
     get:
       description: Current L2 utxos controlled by a bech32 address (EUTXO ledger only).
-      operationId: getApiL2UtxosAddress
+      operationId: getL2CardanoEutxoUtxos
       parameters:
       - name: address
         in: path
@@ -28,10 +28,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-  /api/l2/transactions:
+  /l2/cardano-eutxo/transactions:
     get:
       description: Recent applied L2 transactions, newest first (EUTXO ledger only).
-      operationId: getApiL2Transactions
+      operationId: getL2CardanoEutxoTransactions
       parameters:
       - name: count
         in: query

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -3,11 +3,11 @@ info:
   title: Hydrozoa node API
   version: 0.1.0
 paths:
-  /api/l2/submit:
+  /head/tx:
     post:
       description: Submit an L2 transaction (a JSON UserRequest whose L2 payload is
         a native, self-authenticating Cardano transaction).
-      operationId: postApiL2Submit
+      operationId: postHeadTx
       requestBody:
         content:
           application/json:
@@ -27,11 +27,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-  /api/deposit/register:
+  /head/deposit:
     post:
-      description: Register an L1 deposit (a JSON UserRequest whose L2 payload is
-        a native, self-authenticating Cardano transaction).
-      operationId: postApiDepositRegister
+      description: Register an L1 deposit (a JSON UserRequest carrying the unsigned
+        deposit tx CBOR and the serialized L2 outputs the deposit spawns on absorption).
+      operationId: postHeadDeposit
       requestBody:
         content:
           application/json:
@@ -51,10 +51,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-  /api/head-info:
+  /head/info:
     get:
       description: Head parameters plus the current node time.
-      operationId: getApiHead-info
+      operationId: getHeadInfo
       responses:
         '200':
           description: ''
@@ -94,7 +94,7 @@ paths:
   /api/admin/finalize:
     post:
       description: Trigger head finalization (admin only).
-      operationId: postApiAdminFinalize
+      operationId: postAdminFinalize
       responses:
         '200':
           description: ''

--- a/examples/src/main/scala/hydrozoa/examples/demo/SubmitDeposit.scala
+++ b/examples/src/main/scala/hydrozoa/examples/demo/SubmitDeposit.scala
@@ -32,8 +32,8 @@ import scalus.uplc.builtin.ByteString
   * own Blockfrost backend), enter the L2 outputs the deposit should spawn on absorption (same
   * destination/value flow as [[SubmitL2Transaction]]), and the tool builds the L2 payload (its hash
   * pins the payload in the deposit tx metadata, docs/l2-isomorphism.md), registers the deposit with
-  * the head (`POST /api/deposit/register`), then signs the deposit tx and submits it to L1 via
-  * Blockfrost, polling until the deposit utxo lands. The head absorbs it after maturity.
+  * the head (`POST /head/deposit`), then signs the deposit tx and submits it to L1 via Blockfrost,
+  * polling until the deposit utxo lands. The head absorbs it after maturity.
   *
   * Usage:
   * {{{
@@ -161,7 +161,7 @@ object SubmitDeposit
                 _ <- awaitUtxo(backend, depositTx.depositProduced.utxoId)
                 _ <- IO.println(
                   "Deposit is on L1. The head absorbs it after maturity — watch " +
-                      s"GET $headUri/api/l2/utxos/{destination} for the spawned outputs."
+                      s"GET $headUri/l2/cardano-eutxo/utxos/{destination} for the spawned outputs."
                 )
             } yield ExitCode.Success
         }

--- a/examples/src/main/scala/hydrozoa/examples/demo/SubmitL2Transaction.scala
+++ b/examples/src/main/scala/hydrozoa/examples/demo/SubmitL2Transaction.scala
@@ -30,10 +30,10 @@ import scalus.uplc.builtin.ByteString
 /** Interactive demo target: submit a native L2 transaction to a running head.
   *
   * Select a peer (its key signs), pick one of the peer's L2 utxos (fetched from the head's
-  * `GET /api/l2/utxos/{address}`), enter a destination + value, and the tool builds the zero-fee
-  * native tx (destination output + change back to the sender, the CIP-67 all-L2 output designation
-  * and the headId pin in the metadata), signs it with the peer wallet, and posts it to
-  * `POST /api/l2/submit`.
+  * `GET /l2/cardano-eutxo/utxos/{address}`), enter a destination + value, and the tool builds the
+  * zero-fee native tx (destination output + change back to the sender, the CIP-67 all-L2 output
+  * designation and the headId pin in the metadata), signs it with the peer wallet, and posts it to
+  * `POST /head/tx`.
   *
   * Usage:
   * {{{
@@ -104,7 +104,7 @@ object SubmitL2Transaction
                       )
                     )
                 _ <- IO.println(
-                  s"Accepted: requestId=$requestId. Watch GET $headUri/api/l2/utxos/$ownBech32 " +
+                  s"Accepted: requestId=$requestId. Watch GET $headUri/l2/cardano-eutxo/utxos/$ownBech32 " +
                       "for the result."
                 )
             } yield ExitCode.Success
@@ -177,9 +177,9 @@ object SubmitL2Transaction
             .map(_.toString)
     }
 
-    /** Parse one `GET /api/l2/utxos/{address}` entry back into scalus types. Datum-bearing utxos
-      * are accepted for display but their datum is not reconstructed — the input reference is what
-      * the tx spends.
+    /** Parse one `GET /l2/cardano-eutxo/utxos/{address}` entry back into scalus types.
+      * Datum-bearing utxos are accepted for display but their datum is not reconstructed — the
+      * input reference is what the tx spends.
       */
     private def parseUtxoView(view: L2UtxoView): Either[String, (TransactionInput, Babbage)] =
         for {

--- a/src/main/scala/hydrozoa/app/Main.scala
+++ b/src/main/scala/hydrozoa/app/Main.scala
@@ -179,10 +179,10 @@ object Main
     }
 
     /** Instantiate the head-agreed L2 ledger and, when it is the built-in EUTXO ledger, the
-      * read-only view the user-facing server exposes over the `GET /api/l2/...` endpoints. A node
-      * wired to a remote ledger has no such reader, so the server is handed `None` and mounts no
-      * L2-query endpoints. The EUTXO ledger owns its own RocksDB persistence, separate from the
-      * consensus store.
+      * read-only view the user-facing server exposes over the `GET /l2/cardano-eutxo/...`
+      * endpoints. A node wired to a remote ledger has no such reader, so the server is handed
+      * `None` and mounts no L2-query endpoints. The EUTXO ledger owns its own RocksDB persistence,
+      * separate from the consensus store.
       */
     private def mkL2Ledger(
         nodeConfig: NodeConfig,
@@ -414,7 +414,7 @@ object Main
                           ),
                           connections.blockWeaver,
                           mrm.nodeStatus.get,
-                          // Some(reader) for a cardano-eutxo node (mounts GET /api/l2/...); None for
+                          // Some(reader) for a cardano-eutxo node (mounts GET /l2/cardano-eutxo/...); None for
                           // a remote-ledger node, which serves no L2-query endpoints.
                           l2QueryReader,
                           nodeConfig.headConfig,

--- a/src/main/scala/hydrozoa/multisig/ledger/l2/EutxoL2LedgerReader.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/l2/EutxoL2LedgerReader.scala
@@ -4,7 +4,7 @@ import scalus.cardano.address.Address
 import scalus.cardano.ledger.Utxos
 
 /** The read-only L2-ledger queries the user-facing HTTP server exposes for the **EUTXO reference
-  * ledger** (`GET /api/l2/utxos`, `GET /api/l2/transactions`).
+  * ledger** (`GET /l2/cardano-eutxo/utxos`, `GET /l2/cardano-eutxo/transactions`).
   *
   * Implemented only by [[hydrozoa.multisig.ledger.eutxol2.EutxoL2Ledger]], which holds its state
   * locally. A node wired to a remote ledger has no such reader, so the server is handed `None` and

--- a/src/main/scala/hydrozoa/multisig/server/ApiResponse.scala
+++ b/src/main/scala/hydrozoa/multisig/server/ApiResponse.scala
@@ -1,9 +1,6 @@
 package hydrozoa.multisig.server
 
-import hydrozoa.config.head.initialization.InitializationParameters.HeadId
 import hydrozoa.multisig.ledger.event.RequestId
-import scalus.cardano.address.ShelleyAddress
-import scalus.cardano.ledger.{AssetName, Coin, PolicyId, TransactionInput}
 
 /** Response types for the HTTP API */
 object ApiResponse {
@@ -11,55 +8,5 @@ object ApiResponse {
     /** Response when a request is successfully accepted. */
     final case class RequestAccepted(
         requestId: RequestId
-    )
-
-    /** Error response */
-    final case class Error(
-        error: String
-    )
-
-    /** @param headId
-      *   to use in the request AND in the deposit tx's metadata
-      * @param headAddress
-      *   to send the deposit utxo to
-      * @param multisigRegimeUtxo
-      *   id (should be referenced in the deposit tx)
-      * @param submissionDurationSeconds
-      *   to calculate ttl of the deposit tx: deposit_tx.ttl = request.validity_end +
-      *   submission_duration (ttl is mandatory)
-      *
-      * @param absorptionStartOffsetSeconds
-      *   offset from request.validity_end to when the head will begin attempting to absorb the
-      *   deposit: absorption_start = request.validity_end + absorption_start_offset
-      *
-      * @param refundStartOffsetSeconds
-      *   to calculate the validity start of the post-dated refund (it's needed in the deposit utxo
-      *   datum): deposit_utxo.datum.refund_instructions.refund_start = request.validity_end +
-      *   refund_start_offset
-      *
-      * @param currentTimePosixSeconds
-      *   the current time, in seconds, since January 1st 1970 UTC. NOTE: Contrary to this field,
-      *   many places in cardano interpret `PosixTime` as MILLISECONDS.
-      *
-      * @param maxNonPlutusTxFee
-      *   to check whether deposit utxo value is big enough to cover minAda in the refunded utxo and
-      *   the refund tx fee
-      */
-    final case class HeadInfo(
-        headId: HeadId,
-        headAddress: ShelleyAddress,
-        multisigRegimeUtxo: TransactionInput,
-        treasuryBeaconToken: CardanoNativeToken,
-        submissionDurationSeconds: Long,
-        absorptionStartOffsetSeconds: Long,
-        refundStartOffsetSeconds: Long,
-        currentTimePosixSeconds: Long,
-        maxNonPlutusTxFee: Coin
-    )
-
-    // Serialized as string: {policyIdHex}.{assetNameHex}
-    final case class CardanoNativeToken(
-        policyId: PolicyId,
-        tokenName: AssetName
     )
 }

--- a/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
+++ b/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
@@ -69,7 +69,8 @@ class HydrozoaRoutes(
 
     private val submitEndpoint: ServerEndpoint[Any, IO] =
         endpoint.post
-            .in("api" / "l2" / "submit")
+            .in("head" / "tx")
+            .name("postHeadTx")
             .in(stringJsonBody)
             .out(jsonBody[RequestAcceptedResponse])
             .errorOut(errorOut)
@@ -77,23 +78,25 @@ class HydrozoaRoutes(
               "Submit an L2 transaction (a JSON UserRequest whose L2 payload is a native, " +
                   "self-authenticating Cardano transaction)."
             )
-            .serverLogic(body => acceptUserRequest("POST /api/l2/submit", body))
+            .serverLogic(body => acceptUserRequest("POST /head/tx", body))
 
     private val registerDepositEndpoint: ServerEndpoint[Any, IO] =
         endpoint.post
-            .in("api" / "deposit" / "register")
+            .in("head" / "deposit")
+            .name("postHeadDeposit")
             .in(stringJsonBody)
             .out(jsonBody[RequestAcceptedResponse])
             .errorOut(errorOut)
             .description(
-              "Register an L1 deposit (a JSON UserRequest whose L2 payload is a native, " +
-                  "self-authenticating Cardano transaction)."
+              "Register an L1 deposit (a JSON UserRequest carrying the unsigned deposit tx " +
+                  "CBOR and the serialized L2 outputs the deposit spawns on absorption)."
             )
-            .serverLogic(body => acceptUserRequest("POST /api/deposit/register", body))
+            .serverLogic(body => acceptUserRequest("POST /head/deposit", body))
 
     private val headInfoEndpoint: ServerEndpoint[Any, IO] =
         endpoint.get
-            .in("api" / "head-info")
+            .in("head" / "info")
+            .name("getHeadInfo")
             .out(jsonBody[HeadInfoResponse])
             .errorOut(errorOut)
             .description("Head parameters plus the current node time.")
@@ -111,7 +114,8 @@ class HydrozoaRoutes(
     private val l2UtxosDef
         : PublicEndpoint[String, (StatusCode, ErrorResponse), List[L2UtxoView], Any] =
         endpoint.get
-            .in("api" / "l2" / "utxos" / path[String]("address"))
+            .in("l2" / "cardano-eutxo" / "utxos" / path[String]("address"))
+            .name("getL2CardanoEutxoUtxos")
             .out(jsonBody[List[L2UtxoView]])
             .errorOut(errorOut)
             .description("Current L2 utxos controlled by a bech32 address (EUTXO ledger only).")
@@ -119,7 +123,8 @@ class HydrozoaRoutes(
     private val l2TransactionsDef
         : PublicEndpoint[Option[Int], (StatusCode, ErrorResponse), List[L2TxSummaryView], Any] =
         endpoint.get
-            .in("api" / "l2" / "transactions")
+            .in("l2" / "cardano-eutxo" / "transactions")
+            .name("getL2CardanoEutxoTransactions")
             .in(query[Option[Int]]("count"))
             .out(jsonBody[List[L2TxSummaryView]])
             .errorOut(errorOut)
@@ -157,6 +162,7 @@ class HydrozoaRoutes(
     private val healthEndpoint: ServerEndpoint[Any, IO] =
         endpoint.get
             .in("health")
+            .name("getHealth")
             .out(jsonBody[HealthResponse])
             .description("Liveness — always 200 while the process is serving HTTP.")
             .serverLogicSuccess(_ => IO.pure(HealthResponse("ok")))
@@ -168,6 +174,7 @@ class HydrozoaRoutes(
     private val readyEndpoint: ServerEndpoint[Any, IO] =
         endpoint.get
             .in("ready")
+            .name("getReady")
             .out(statusCode.and(jsonBody[ReadinessResponse]))
             .description(
               "Readiness — 200 only while the head is Active (open on L1); 503 with the lifecycle " +
@@ -188,6 +195,7 @@ class HydrozoaRoutes(
             // absent, rather than tapir short-circuiting the missing-header case.
             .securityIn(auth.basic[Option[UsernamePassword]](adminChallenge))
             .in("api" / "admin" / "finalize")
+            .name("postAdminFinalize")
             .out(jsonBody[FinalizeResponse])
             .errorOut(finalizeErrorOut)
             .description("Trigger head finalization (admin only).")

--- a/src/main/scala/hydrozoa/multisig/server/HydrozoaServer.scala
+++ b/src/main/scala/hydrozoa/multisig/server/HydrozoaServer.scala
@@ -36,8 +36,9 @@ object HydrozoaServer {
       *   Node lifecycle status behind `GET /ready`, maintained by `MultisigRegimeManagerBase` and
       *   `CardanoLiaison`
       * @param l2QueryReader
-      *   The EUTXO L2-ledger read model behind `GET /api/l2/utxos` and `/api/l2/transactions`, or
-      *   `None` on a node that runs a remote ledger (those endpoints are then not mounted)
+      *   The EUTXO L2-ledger read model behind `GET /l2/cardano-eutxo/utxos` and
+      *   `/l2/cardano-eutxo/transactions`, or `None` on a node that runs a remote ledger (those
+      *   endpoints are then not mounted)
       * @param headConfig
       *   Head configuration
       * @param config

--- a/src/main/scala/hydrozoa/multisig/server/JsonCodecs.scala
+++ b/src/main/scala/hydrozoa/multisig/server/JsonCodecs.scala
@@ -1,16 +1,13 @@
 package hydrozoa.multisig.server
 
-import hydrozoa.config.head.initialization.InitializationParameters
-import hydrozoa.config.head.initialization.InitializationParameters.HeadId
 import hydrozoa.lib.cardano.cip116
 import hydrozoa.multisig.consensus.UserRequestBody.{DepositRequestBody, TransactionRequestBody}
 import hydrozoa.multisig.consensus.peer.HeadPeerNumber
 import hydrozoa.multisig.consensus.{UserRequest, UserRequestBody}
 import hydrozoa.multisig.ledger.event.{RequestId, RequestNumber}
 import hydrozoa.multisig.ledger.l2.{L2TxKind, L2TxSummary}
-import hydrozoa.multisig.server.ApiResponse.{Error, HeadInfo, RequestAccepted}
+import hydrozoa.multisig.server.ApiResponse.RequestAccepted
 import io.bullet.borer.Cbor
-import io.circe.generic.semiauto.*
 import io.circe.syntax.*
 import io.circe.{Decoder, Encoder, Json}
 import scalus.cardano.address.ShelleyAddress
@@ -21,7 +18,6 @@ import scalus.uplc.builtin.ByteString
 object JsonCodecs {
 
     import cip116.JsonCodecs.CIP0116.Conway.given
-    import hydrozoa.config.head.initialization.InitializationParameters.HeadId.{given Decoder[HeadId], given Encoder[HeadId]}
 
     //// Make TransactionInput codecs available as given instances
     // given Encoder[TransactionInput] = transactionInputEncoder
@@ -129,45 +125,7 @@ object JsonCodecs {
         c.downField("requestId").as[RequestId].map(RequestAccepted.apply)
     }
 
-    given errorEncoder: Encoder[Error] = deriveEncoder[Error]
-
-    given errorDecoder: Decoder[Error] = deriveDecoder[Error]
-
-    // CardanoNativeToken codec - serialized as "{policyIdHex}.{assetNameHex}"
-    given cardanoNativeTokenEncoder: Encoder[ApiResponse.CardanoNativeToken] =
-        (token: ApiResponse.CardanoNativeToken) => {
-            val policyIdHex = token.policyId.toHex
-            val assetNameHex = token.tokenName.bytes.toHex
-            Json.fromString(s"$policyIdHex.$assetNameHex")
-        }
-
-    given cardanoNativeTokenDecoder: Decoder[ApiResponse.CardanoNativeToken] =
-        Decoder.decodeString.emap { str =>
-            str.split('.') match {
-                case Array(policyIdHex, assetNameHex) =>
-                    scala.util
-                        .Try {
-                            val policyIdBytes = ByteString.fromHex(policyIdHex)
-                            val assetNameBytes = ByteString.fromHex(assetNameHex)
-                            val policyId = ScriptHash.fromByteString(policyIdBytes)
-                            val assetName = AssetName(assetNameBytes)
-                            ApiResponse.CardanoNativeToken(policyId, assetName)
-                        }
-                        .toEither
-                        .left
-                        .map(e => s"Failed to decode CardanoNativeToken: ${e.getMessage}")
-                case _ =>
-                    Left(
-                      s"Invalid CardanoNativeToken format, expected '{policyIdHex}.{assetNameHex}', got: $str"
-                    )
-            }
-        }
-
-    given headInfoEncoder: Encoder[HeadInfo] = deriveEncoder[HeadInfo]
-
-    given headInfoDecoder: Decoder[HeadInfo] = deriveDecoder[HeadInfo]
-
-    // ---- L2 query endpoints (GET /api/l2/utxos, /api/l2/transactions) ----
+    // ---- L2 query endpoints (GET /l2/cardano-eutxo/utxos, /l2/cardano-eutxo/transactions) ----
     // CIP-0116-structured utxo encoding. `transactionInputEncoder` and `valueEncoder` come from the
     // CIP-0116 givens imported above; only the output object is assembled here, since CIP-0116
     // defines no `TransactionOutput` encoder.

--- a/src/main/scala/hydrozoa/multisig/server/SubmissionClient.scala
+++ b/src/main/scala/hydrozoa/multisig/server/SubmissionClient.scala
@@ -53,8 +53,8 @@ object SubmissionClient:
 
     private def pathFor(request: UserRequest): Uri.Path =
         request match
-            case _: UserRequest.DepositRequest => Uri.Path.unsafeFromString("/api/deposit/register")
-            case _: UserRequest.TransactionRequest => Uri.Path.unsafeFromString("/api/l2/submit")
+            case _: UserRequest.DepositRequest     => Uri.Path.unsafeFromString("/head/deposit")
+            case _: UserRequest.TransactionRequest => Uri.Path.unsafeFromString("/head/tx")
 
     private def requestJson(request: UserRequest): Json =
         request.body match

--- a/src/test/scala/hydrozoa/multisig/server/L2QueryEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/L2QueryEndpointsTest.scala
@@ -24,11 +24,11 @@ import org.scalacheck.rng.Seed
 import org.scalatest.funsuite.AnyFunSuite
 import scalus.cardano.address.ShelleyAddress
 
-/** End-to-end demo + test for the L2 query endpoints (`GET /api/l2/utxos/{address}`,
-  * `GET /api/l2/transactions`). Boots an in-memory [[EutxoL2Ledger]], seeds it (genesis utxos plus
-  * a few applied commands), builds the real [[HydrozoaRoutes]] against it with stub consensus
-  * actors, and drives both endpoints through the HTTP layer — asserting the responses and printing
-  * the JSON so the flow can be shown in a screen recording.
+/** End-to-end demo + test for the L2 query endpoints (`GET /l2/cardano-eutxo/utxos/{address}`,
+  * `GET /l2/cardano-eutxo/transactions`). Boots an in-memory [[EutxoL2Ledger]], seeds it (genesis
+  * utxos plus a few applied commands), builds the real [[HydrozoaRoutes]] against it with stub
+  * consensus actors, and drives both endpoints through the HTTP layer — asserting the responses and
+  * printing the JSON so the flow can be shown in a screen recording.
   */
 class L2QueryEndpointsTest extends AnyFunSuite:
 
@@ -43,8 +43,9 @@ class L2QueryEndpointsTest extends AnyFunSuite:
     private val nodeConfig = multiNodeConfig.nodeConfigs(HeadPeerNumber.zero)
 
     /** A refunded-deposit decision at `blockNum` — a real command that logs (so it shows up in
-      * `/api/l2/transactions`) without needing a constructed deposit/tx payload: `refundedDeposits`
-      * are only removed from the pending set, which tolerates ids that were never registered.
+      * `/l2/cardano-eutxo/transactions`) without needing a constructed deposit/tx payload:
+      * `refundedDeposits` are only removed from the pending set, which tolerates ids that were
+      * never registered.
       */
     private def refundDecision(
         blockNum: Int,
@@ -149,16 +150,18 @@ class L2QueryEndpointsTest extends AnyFunSuite:
             .collect { case s: ShelleyAddress => s }
             .toList
 
-    test("GET /api/l2/utxos/{address} returns the address's current L2 utxos, CIP-0116-style") {
+    test(
+      "GET /l2/cardano-eutxo/utxos/{address} returns the address's current L2 utxos, CIP-0116-style"
+    ) {
         val shelley = genesisShelleyAddresses.headOption
             .getOrElse(fail("genesis produced no Shelley L2 utxos to query"))
         val bech32 = shelley.toBech32.getOrElse(shelley.toHex)
         withSeededRoutes { (app, ledger) =>
             for {
                 expected <- ledger.utxosByAddress(shelley)
-                result <- get(app, s"/api/l2/utxos/$bech32")
+                result <- get(app, s"/l2/cardano-eutxo/utxos/$bech32")
                 (status, body) = result
-                _ <- IO.println(s"[demo] GET /api/l2/utxos/$bech32")
+                _ <- IO.println(s"[demo] GET /l2/cardano-eutxo/utxos/$bech32")
                 _ <- IO.println(printer.print(body))
                 _ <- IO(assert(status == Status.Ok))
                 _ <- IO(assert(expected.nonEmpty, "the chosen genesis address controls no utxos"))
@@ -186,14 +189,14 @@ class L2QueryEndpointsTest extends AnyFunSuite:
         }
     }
 
-    test("GET /api/l2/utxos/{valid address with no utxos} returns an empty array") {
+    test("GET /l2/cardano-eutxo/utxos/{valid address with no utxos} returns an empty array") {
         // A well-formed bech32 address the ledger holds nothing for: the head's own L1 multisig
         // address, which is never an L2 output address.
         val unfunded = multiNodeConfig.headConfig.headMultisigAddress.toBech32
             .getOrElse(fail("head multisig address is not bech32-encodable"))
         withSeededRoutes { (app, _) =>
             for {
-                result <- get(app, s"/api/l2/utxos/$unfunded")
+                result <- get(app, s"/l2/cardano-eutxo/utxos/$unfunded")
                 (status, body) = result
                 _ <- IO(assert(status == Status.Ok))
                 _ <- IO(assert(body.asArray.exists(_.isEmpty), s"expected [], got $body"))
@@ -201,22 +204,24 @@ class L2QueryEndpointsTest extends AnyFunSuite:
         }
     }
 
-    test("GET /api/l2/utxos/{malformed} is a 400, not a 500") {
+    test("GET /l2/cardano-eutxo/utxos/{malformed} is a 400, not a 500") {
         withSeededRoutes { (app, _) =>
             for {
-                result <- get(app, "/api/l2/utxos/not-a-real-address")
+                result <- get(app, "/l2/cardano-eutxo/utxos/not-a-real-address")
                 (status, _) = result
                 _ <- IO(assert(status == Status.BadRequest))
             } yield ()
         }
     }
 
-    test("GET /api/l2/transactions returns recent applied L2 transactions, newest first") {
+    test(
+      "GET /l2/cardano-eutxo/transactions returns recent applied L2 transactions, newest first"
+    ) {
         withSeededRoutes { (app, _) =>
             for {
-                result <- get(app, "/api/l2/transactions?count=10")
+                result <- get(app, "/l2/cardano-eutxo/transactions?count=10")
                 (status, body) = result
-                _ <- IO.println("[demo] GET /api/l2/transactions?count=10")
+                _ <- IO.println("[demo] GET /l2/cardano-eutxo/transactions?count=10")
                 _ <- IO.println(printer.print(body))
                 _ <- IO(assert(status == Status.Ok))
                 entries = body.asArray.getOrElse(Vector.empty)
@@ -240,10 +245,10 @@ class L2QueryEndpointsTest extends AnyFunSuite:
         }
     }
 
-    test("GET /api/l2/transactions?count=1 honors the limit") {
+    test("GET /l2/cardano-eutxo/transactions?count=1 honors the limit") {
         withSeededRoutes { (app, _) =>
             for {
-                result <- get(app, "/api/l2/transactions?count=1")
+                result <- get(app, "/l2/cardano-eutxo/transactions?count=1")
                 (status, body) = result
                 _ <- IO(assert(status == Status.Ok))
                 _ <- IO(assert(body.asArray.exists(_.size == 1)))
@@ -251,10 +256,12 @@ class L2QueryEndpointsTest extends AnyFunSuite:
         }
     }
 
-    test("GET /api/l2/transactions with no ?count returns all seeded entries (default limit)") {
+    test(
+      "GET /l2/cardano-eutxo/transactions with no ?count returns all seeded entries (default limit)"
+    ) {
         withSeededRoutes { (app, _) =>
             for {
-                result <- get(app, "/api/l2/transactions")
+                result <- get(app, "/l2/cardano-eutxo/transactions")
                 (status, body) = result
                 _ <- IO(assert(status == Status.Ok))
                 _ <- IO(assert(body.asArray.exists(_.size == 3)))
@@ -262,10 +269,10 @@ class L2QueryEndpointsTest extends AnyFunSuite:
         }
     }
 
-    test("GET /api/l2/transactions?count=0 returns an empty array") {
+    test("GET /l2/cardano-eutxo/transactions?count=0 returns an empty array") {
         withSeededRoutes { (app, _) =>
             for {
-                result <- get(app, "/api/l2/transactions?count=0")
+                result <- get(app, "/l2/cardano-eutxo/transactions?count=0")
                 (status, body) = result
                 _ <- IO(assert(status == Status.Ok))
                 _ <- IO(assert(body.asArray.exists(_.isEmpty)))
@@ -288,13 +295,16 @@ class L2QueryEndpointsTest extends AnyFunSuite:
         }
     }
 
-    test("GET /api/l2/transactions?count=abc is a 400, not a 404") {
+    test("GET /l2/cardano-eutxo/transactions?count=abc is a 400, not a 404") {
         withSeededRoutes { (app, _) =>
             // tapir rejects an un-decodable query param with a 400 and a plain-text body, so check
             // the status directly rather than through the JSON helper.
             for {
                 resp <- app.run(
-                  Request[IO](Method.GET, Uri.unsafeFromString("/api/l2/transactions?count=abc"))
+                  Request[IO](
+                    Method.GET,
+                    Uri.unsafeFromString("/l2/cardano-eutxo/transactions?count=abc")
+                  )
                 )
                 _ <- IO(
                   assert(resp.status == Status.BadRequest, s"expected 400, got ${resp.status}")
@@ -314,21 +324,24 @@ class L2QueryEndpointsTest extends AnyFunSuite:
         withNoReaderRoutes { app =>
             for {
                 utxos <- app.run(
-                  Request[IO](Method.GET, Uri.unsafeFromString(s"/api/l2/utxos/$validAddr"))
+                  Request[IO](
+                    Method.GET,
+                    Uri.unsafeFromString(s"/l2/cardano-eutxo/utxos/$validAddr")
+                  )
                 )
                 _ <- IO(
                   assert(
                     utxos.status == Status.NotFound,
-                    s"expected 404 for /api/l2/utxos with no reader, got ${utxos.status}"
+                    s"expected 404 for /l2/cardano-eutxo/utxos with no reader, got ${utxos.status}"
                   )
                 )
                 txs <- app.run(
-                  Request[IO](Method.GET, Uri.unsafeFromString("/api/l2/transactions"))
+                  Request[IO](Method.GET, Uri.unsafeFromString("/l2/cardano-eutxo/transactions"))
                 )
                 _ <- IO(
                   assert(
                     txs.status == Status.NotFound,
-                    s"expected 404 for /api/l2/transactions with no reader, got ${txs.status}"
+                    s"expected 404 for /l2/cardano-eutxo/transactions with no reader, got ${txs.status}"
                   )
                 )
                 admin <- app.run(


### PR DESCRIPTION
The path restructure for the head API — the first of **two** PRs (the read model, block/request endpoints, and timestamp capture all live in the follow-up **#545**, which bases on this branch). The earlier per-slice PRs #541–#544 were collapsed into #545.

## Moves

| Old | New |
|---|---|
| `POST /api/l2/submit` | `POST /head/tx` |
| `POST /api/deposit/register` | `POST /head/deposit` |
| `GET /api/head-info` | `GET /head/info` |
| `GET /api/l2/utxos/{address}` | `GET /l2/cardano-eutxo/utxos/{address}` |
| `GET /api/l2/transactions` | `GET /l2/cardano-eutxo/transactions` |

`POST /api/admin/finalize`, `/health`, `/ready` unchanged. No backward-compat aliases — no active heads exist.

## Also here

- **Pinned tapir `operationId`s** on every endpoint so the OpenAPI goldens stop churning on path changes (the old derived `getApiHead-info` was even malformed). Both goldens regenerated.
- **Fixed the deposit endpoint description** — it was a copy-paste of the tx one calling the payload "a native, self-authenticating Cardano transaction"; a deposit's l2Payload is the serialized L2 outputs, hash-pinned to the deposit tx.
- **Deleted the dead DTO layer** `ApiResponse.{HeadInfo, Error, CardanoNativeToken}` + codecs; `ApiResponse` keeps only `RequestAccepted`.
- `SubmissionClient.pathFor`, examples, test literals, and the docs sweep.

## Verified

Compile clean incl. `integration/Test` and `examples`; `OpenApiSchemaTest`, `L2QueryEndpointsTest`, `ReadyEndpointTest`, `MainSmokeTest` green; repo-wide grep for old paths clean.

## Follow-up

**#545** (based on this branch): consensus-store read model, `GET /head/blocks*` and `GET /head/requests*`, the reverse-index + timestamp capture (arrival stamps + a `Cf.Meta` zero-time anchor — no wall clock persisted), and the opaque request id + filters. The block-effects subsystem follows after that.