### PR TITLE
Head API restructure, slice 3: consensus read model + /head/blocks endpoints

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -68,6 +68,76 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /head/blocks:
+    get:
+      description: Every block of the head in block order — number, fast-cycle leader,
+        and type. Block 0 is the head's initial block (config, no leader).
+      operationId: getHeadBlocks
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/BlockSummaryView'
+        default:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /head/blocks/{block-number}:
+    get:
+      description: 'One block''s type, leader, and confirmation status: PROPOSED,
+        SOFT (with this node''s soft-confirmation time), or HARD (plus its hard-confirmation
+        time).'
+      operationId: getHeadBlock
+      parameters:
+      - name: block-number
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int32
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BlockDetailsView'
+        default:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /head/blocks/{block-number}/header:
+    get:
+      description: The block's header content. The shape varies by block type (initial,
+        minor, major, final).
+      operationId: getHeadBlockHeader
+      parameters:
+      - name: block-number
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int32
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        default:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /health:
     get:
       description: Liveness — always 200 while the process is serving HTTP.
@@ -118,6 +188,51 @@ paths:
       - httpAuth: []
 components:
   schemas:
+    BlockConfirmationView:
+      title: BlockConfirmationView
+      type: object
+      required:
+      - status
+      properties:
+        status:
+          type: string
+        softConfirmedAt:
+          type: string
+        hardConfirmedAt:
+          type: string
+    BlockDetailsView:
+      title: BlockDetailsView
+      type: object
+      required:
+      - number
+      - blockType
+      - confirmation
+      properties:
+        number:
+          type: integer
+          format: int32
+        leader:
+          type: integer
+          format: int32
+        blockType:
+          type: string
+        confirmation:
+          $ref: '#/components/schemas/BlockConfirmationView'
+    BlockSummaryView:
+      title: BlockSummaryView
+      type: object
+      required:
+      - number
+      - blockType
+      properties:
+        number:
+          type: integer
+          format: int32
+        leader:
+          type: integer
+          format: int32
+        blockType:
+          type: string
     ErrorResponse:
       title: ErrorResponse
       type: object

--- a/integration/src/test/scala/hydrozoa/integration/harness/MultiPeerHeadHarness.scala
+++ b/integration/src/test/scala/hydrozoa/integration/harness/MultiPeerHeadHarness.scala
@@ -28,7 +28,7 @@ import hydrozoa.multisig.ledger.block.BlockVersion.Major.given_Conversion_Major_
 import hydrozoa.multisig.ledger.eutxol2.EutxoL2Ledger
 import hydrozoa.multisig.ledger.l1.tx.{EnrichedTx, SettlementTx}
 import hydrozoa.multisig.persistence.rocksdb.RocksDbBackendStore
-import hydrozoa.multisig.persistence.{BackendStore, Cf, InMemoryBackendStore, Persistence, PersistenceEvent, PersistenceEventFormat}
+import hydrozoa.multisig.persistence.{BackendStore, Cf, ConsensusStoreReader, InMemoryBackendStore, Persistence, PersistenceEvent, PersistenceEventFormat}
 import hydrozoa.multisig.server.{HydrozoaHttpEvent, HydrozoaHttpEventFormat, HydrozoaRoutes, HydrozoaServer, SubmissionClient}
 import hydrozoa.multisig.{CoilMultisigRegimeManager, CoilMultisigRegimeManagerEventFormat, CoilRegimeManagerEvent, HeadMultisigRegimeManager, HeadMultisigRegimeManagerEventFormat, HeadRegimeManagerEvent, NodeStatus}
 import java.nio.file.{Files, Path}
@@ -1120,6 +1120,8 @@ object MultiPeerHeadHarness:
               conns.blockWeaver,
               // The harness runs no head lifecycle, so readiness is a constant Active.
               IO.pure(NodeStatus.Active),
+              // No consensus-store reader in the harness — the block queries are unit-tested.
+              ConsensusStoreReader.empty,
               // No EUTXO L2-query reader in the harness — the SubmissionClient uses the write path.
               None,
               nodeConfig.headConfig,

--- a/src/main/scala/hydrozoa/app/Main.scala
+++ b/src/main/scala/hydrozoa/app/Main.scala
@@ -22,7 +22,7 @@ import hydrozoa.multisig.ledger.eutxol2.store.RocksDbL2Store
 import hydrozoa.multisig.ledger.l2.{EutxoL2LedgerReader, L2Ledger}
 import hydrozoa.multisig.ledger.remote.{RemoteL2Ledger, RemoteL2LedgerEventFormat}
 import hydrozoa.multisig.persistence.rocksdb.RocksDbBackendStore
-import hydrozoa.multisig.persistence.{Cf, Persistence, PersistenceEventFormat}
+import hydrozoa.multisig.persistence.{Cf, ConsensusStoreReader, Persistence, PersistenceEventFormat}
 import hydrozoa.multisig.server.{HydrozoaHttpEvent, HydrozoaHttpEventFormat, HydrozoaServer}
 import hydrozoa.multisig.{CoilMultisigRegimeManager, CoilMultisigRegimeManagerEventFormat, CoilRegimeManagerEvent, HeadMultisigRegimeManager, HeadMultisigRegimeManagerEventFormat, HeadRegimeManagerEvent, MrmTracers}
 import java.nio.file.Path
@@ -166,12 +166,23 @@ object Main
                       ownCoilNum,
                     )
             }
-        } yield (nodeConfig, system, nodeRun)
+            // Read-only consensus-store view behind the /head/blocks queries.
+            consensusReader = ConsensusStoreReader.fromPersistence(persistence)(using
+              nodeConfig.headConfig
+            )
+        } yield (nodeConfig, system, nodeRun, consensusReader)
 
-        resource.use { case (nodeConfig, system, nodeRun) =>
+        resource.use { case (nodeConfig, system, nodeRun, consensusReader) =>
             nodeRun match {
                 case NodeRun.HeadNode(mrm, l2QueryReader) =>
-                    runHeadNode(nodeConfig, system, mrm, l2QueryReader, httpExtraTracer)
+                    runHeadNode(
+                      nodeConfig,
+                      system,
+                      mrm,
+                      consensusReader,
+                      l2QueryReader,
+                      httpExtraTracer
+                    )
                 case NodeRun.CoilNode(mrm) =>
                     runCoilNode(system, mrm)
             }
@@ -375,6 +386,7 @@ object Main
         nodeConfig: NodeConfig,
         system: ActorSystem[IO],
         mrm: HeadMultisigRegimeManager,
+        consensusReader: ConsensusStoreReader[IO],
         l2QueryReader: Option[EutxoL2LedgerReader[IO]],
         httpExtraTracer: ContraTracer[IO, HydrozoaHttpEvent],
     ): IO[ExitCode] =
@@ -414,6 +426,7 @@ object Main
                           ),
                           connections.blockWeaver,
                           mrm.nodeStatus.get,
+                          consensusReader,
                           // Some(reader) for a cardano-eutxo node (mounts GET /api/l2/...); None for
                           // a remote-ledger node, which serves no L2-query endpoints.
                           l2QueryReader,

--- a/src/main/scala/hydrozoa/multisig/persistence/ConsensusStoreReader.scala
+++ b/src/main/scala/hydrozoa/multisig/persistence/ConsensusStoreReader.scala
@@ -1,0 +1,81 @@
+package hydrozoa.multisig.persistence
+
+import cats.effect.IO
+import hydrozoa.config.head.network.CardanoNetwork
+import hydrozoa.multisig.ledger.block.{Block, BlockBrief, BlockNumber}
+import hydrozoa.multisig.ledger.stack.{StackEffects, StackNumber}
+import hydrozoa.multisig.persistence.recovery.CursorScan
+import java.nio.ByteBuffer
+
+/** Read-only view over the consensus store for the user-facing HTTP API (the
+  * [[hydrozoa.multisig.ledger.l2.EutxoL2LedgerReader]] pattern): block briefs from the block spine,
+  * plus the confirmation records and reverse indices the block and request queries resolve through.
+  * Never writes.
+  */
+trait ConsensusStoreReader[F[_]]:
+    /** Every persisted block brief, in block order (the block spine; block 0 is config, not a spine
+      * entry).
+      */
+    def blockBriefs: F[List[BlockBrief.Next]]
+
+    /** One block's brief, if persisted. */
+    def blockBrief(num: BlockNumber): F[Option[BlockBrief.Next]]
+
+    /** This node's soft-confirmation record for a block: the aggregate plus the local confirmation
+      * moment.
+      */
+    def softConfirmation(num: BlockNumber): F[Option[Timestamped[Block.SoftConfirmed.Next]]]
+
+    /** The stack that hard-confirmed a block, if any. */
+    def stackOf(num: BlockNumber): F[Option[StackNumber]]
+
+    /** This node's hard-confirmation record for a stack: the multisigned effects plus the local
+      * confirmation moment.
+      */
+    def hardConfirmation(num: StackNumber): F[Option[Timestamped[StackEffects.HardConfirmed]]]
+
+object ConsensusStoreReader:
+
+    /** The reader over a live [[Persistence]] instance. */
+    def fromPersistence(
+        persistence: Persistence[IO]
+    )(using CardanoNetwork.Section): ConsensusStoreReader[IO] =
+        new ConsensusStoreReader[IO]:
+            def blockBriefs: IO[List[BlockBrief.Next]] =
+                CursorScan.cursorWalk(
+                  persistence.backend,
+                  Cf.Block,
+                  JournalKey.Block(BlockNumber(0)).encode,
+                  keyBytes => JournalKey.Block(BlockNumber(ByteBuffer.wrap(keyBytes).getInt))
+                )((key, valueBytes) => key.decodeValue(valueBytes).payload)
+
+            def blockBrief(num: BlockNumber): IO[Option[BlockBrief.Next]] =
+                persistence.get(JournalKey.Block(num)).map(_.map(_.payload))
+
+            def softConfirmation(
+                num: BlockNumber
+            ): IO[Option[Timestamped[Block.SoftConfirmed.Next]]] =
+                persistence.get(StoreKey.SoftConfirmation(num))
+
+            def stackOf(num: BlockNumber): IO[Option[StackNumber]] =
+                persistence.get(StoreKey.BlockStackIndex(num))
+
+            def hardConfirmation(
+                num: StackNumber
+            ): IO[Option[Timestamped[StackEffects.HardConfirmed]]] =
+                persistence.get(StoreKey.HardConfirmation(num))
+
+    /** A reader over no data — every lookup is empty. For wiring the routes on a node whose store
+      * is absent or irrelevant (test and harness setups).
+      */
+    def empty: ConsensusStoreReader[IO] =
+        new ConsensusStoreReader[IO]:
+            def blockBriefs: IO[List[BlockBrief.Next]] = IO.pure(Nil)
+            def blockBrief(num: BlockNumber): IO[Option[BlockBrief.Next]] = IO.pure(None)
+            def softConfirmation(
+                num: BlockNumber
+            ): IO[Option[Timestamped[Block.SoftConfirmed.Next]]] = IO.pure(None)
+            def stackOf(num: BlockNumber): IO[Option[StackNumber]] = IO.pure(None)
+            def hardConfirmation(
+                num: StackNumber
+            ): IO[Option[Timestamped[StackEffects.HardConfirmed]]] = IO.pure(None)

--- a/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
+++ b/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
@@ -2,11 +2,13 @@ package hydrozoa.multisig.server
 
 import hydrozoa.config.head.HeadConfig
 import hydrozoa.multisig.NodeStatus
+import hydrozoa.multisig.ledger.block.BlockBrief
 import hydrozoa.multisig.ledger.event.RequestId
 import hydrozoa.multisig.ledger.l2.{L2TxKind, L2TxSummary}
 import io.bullet.borer.Cbor
 import io.circe.Codec
 import io.circe.generic.semiauto.deriveCodec
+import java.time.Instant
 import scalus.cardano.address.{Address, ShelleyAddress}
 import scalus.cardano.ledger.{DatumOption, TransactionInput, TransactionOutput, Value}
 import scalus.uplc.builtin.ByteString
@@ -88,6 +90,64 @@ object ApiDto {
         case L2TxKind.DepositRegistered => "depositRegistered"
         case L2TxKind.DepositAbsorbed   => "depositAbsorbed"
         case L2TxKind.DepositRefunded   => "depositRefunded"
+
+    /** One row of the block listing: number, fast-cycle leader (absent for the initial block, which
+      * is config, not woven), and block type.
+      */
+    final case class BlockSummaryView(number: Int, leader: Option[Int], blockType: String)
+    given Codec[BlockSummaryView] = deriveCodec
+
+    /** A block's confirmation from this node's viewpoint: `PROPOSED`, `SOFT`, or `HARD`, with the
+      * node-local confirmation moments (ISO-8601) where reached.
+      */
+    final case class BlockConfirmationView(
+        status: String,
+        softConfirmedAt: Option[String],
+        hardConfirmedAt: Option[String]
+    )
+    given Codec[BlockConfirmationView] = deriveCodec
+
+    /** The block-details body: the listing row plus the confirmation status. */
+    final case class BlockDetailsView(
+        number: Int,
+        leader: Option[Int],
+        blockType: String,
+        confirmation: BlockConfirmationView
+    )
+    given Codec[BlockDetailsView] = deriveCodec
+
+    /** Map a brief to its listing row; `nHeadPeers` fixes the round-robin leader. */
+    def mkBlockSummaryView(brief: BlockBrief.Next, nHeadPeers: Int): BlockSummaryView =
+        BlockSummaryView(
+          number = brief.blockNum.convert,
+          leader = Some(brief.blockNum.convert % nHeadPeers),
+          blockType = blockTypeName(brief)
+        )
+
+    /** The synthesized listing row for the initial block (block 0 is config, not a spine entry).
+      */
+    def mkInitialBlockSummaryView: BlockSummaryView =
+        BlockSummaryView(number = 0, leader = None, blockType = "initial")
+
+    /** Assemble the confirmation view from the optional node-local confirmation moments. */
+    def mkBlockConfirmationView(
+        softConfirmedAt: Option[Instant],
+        hardConfirmedAt: Option[Instant]
+    ): BlockConfirmationView =
+        val status =
+            if hardConfirmedAt.isDefined then "HARD"
+            else if softConfirmedAt.isDefined then "SOFT"
+            else "PROPOSED"
+        BlockConfirmationView(
+          status = status,
+          softConfirmedAt = softConfirmedAt.map(_.toString),
+          hardConfirmedAt = hardConfirmedAt.map(_.toString)
+        )
+
+    private def blockTypeName(brief: BlockBrief.Next): String = brief match
+        case _: BlockBrief.Minor => "minor"
+        case _: BlockBrief.Major => "major"
+        case _: BlockBrief.Final => "final"
 
     /** A utxo reference, `{ transaction_id, index }` (CIP-0116). */
     final case class TxInputView(transaction_id: String, index: Int)

--- a/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
+++ b/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
@@ -2,14 +2,19 @@ package hydrozoa.multisig.server
 
 import cats.effect.IO
 import hydrozoa.config.head.HeadConfig
+import hydrozoa.config.head.network.CardanoNetwork
 import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.NodeStatus
 import hydrozoa.multisig.consensus.{BlockWeaver, RequestSequencer}
+import hydrozoa.multisig.ledger.block.{BlockBrief, BlockNumber}
 import hydrozoa.multisig.ledger.l2.EutxoL2LedgerReader
+import hydrozoa.multisig.persistence.ConsensusStoreReader
 import hydrozoa.multisig.server.ApiDto.*
 import hydrozoa.multisig.server.HydrozoaHttpEvent.*
 import hydrozoa.multisig.server.JsonCodecs.UserRequestDecoder
 import hydrozoa.multisig.server.TapirJson.*
+import io.circe.Json
+import io.circe.syntax.*
 import org.http4s.HttpRoutes
 import scala.util.Try
 import scalus.cardano.address.Address
@@ -35,12 +40,18 @@ class HydrozoaRoutes(
     requestSequencer: RequestSequencer.Handle,
     blockWeaver: BlockWeaver.Handle,
     nodeStatus: IO[NodeStatus],
+    consensusReader: ConsensusStoreReader[IO],
     l2QueryReader: Option[EutxoL2LedgerReader[IO]],
     headConfig: HeadConfig,
     serverConfig: HydrozoaServer.Config,
     tracer: ContraTracer[IO, HydrozoaHttpEvent]
 ) {
     import HydrozoaRoutes.{apiTitle, apiVersion, l2ApiTitle}
+
+    /** The block-0 header encoder and the brief codecs are `CardanoNetwork.Section`-dependent;
+      * `headConfig` satisfies the section.
+      */
+    private given CardanoNetwork.Section = headConfig
 
     /** How many recent L2 transactions to return when `?count=` is omitted. */
     private val defaultRecentTxCount = 50
@@ -101,6 +112,70 @@ class HydrozoaRoutes(
                 IO.realTimeInstant
                     .map(_.getEpochSecond)
                     .map(now => Right(ApiDto.mkHeadInfoResponse(headConfig, now)))
+                    .handleError(err => Left(fail(StatusCode.InternalServerError, err.getMessage)))
+            )
+
+    /** `{block-number}` path segments decode to a validated [[BlockNumber]] — a malformed or
+      * negative number is a 400 at decode, never a throw in a handler.
+      */
+    private given Codec[String, BlockNumber, CodecFormat.TextPlain] =
+        Codec.int.mapDecode(i =>
+            if i >= 0 then DecodeResult.Value(BlockNumber(i))
+            else
+                DecodeResult.Error(
+                  i.toString,
+                  new IllegalArgumentException("negative block number")
+                )
+        )(_.convert)
+
+    private val blocksEndpoint: ServerEndpoint[Any, IO] =
+        endpoint.get
+            .in("head" / "blocks")
+            .name("getHeadBlocks")
+            .out(jsonBody[List[BlockSummaryView]])
+            .errorOut(errorOut)
+            .description(
+              "Every block of the head in block order — number, fast-cycle leader, and type. " +
+                  "Block 0 is the head's initial block (config, no leader)."
+            )
+            .serverLogic(_ =>
+                consensusReader.blockBriefs
+                    .map(briefs =>
+                        Right(
+                          ApiDto.mkInitialBlockSummaryView ::
+                              briefs.map(ApiDto.mkBlockSummaryView(_, headConfig.nHeadPeers))
+                        )
+                    )
+                    .handleError(err => Left(fail(StatusCode.InternalServerError, err.getMessage)))
+            )
+
+    private val blockDetailsEndpoint: ServerEndpoint[Any, IO] =
+        endpoint.get
+            .in("head" / "blocks" / path[BlockNumber]("block-number"))
+            .name("getHeadBlock")
+            .out(jsonBody[BlockDetailsView])
+            .errorOut(errorOut)
+            .description(
+              "One block's type, leader, and confirmation status: PROPOSED, SOFT (with this " +
+                  "node's soft-confirmation time), or HARD (plus its hard-confirmation time)."
+            )
+            .serverLogic(num =>
+                blockDetails(num)
+                    .handleError(err => Left(fail(StatusCode.InternalServerError, err.getMessage)))
+            )
+
+    private val blockHeaderEndpoint: ServerEndpoint[Any, IO] =
+        endpoint.get
+            .in("head" / "blocks" / path[BlockNumber]("block-number") / "header")
+            .name("getHeadBlockHeader")
+            .out(jsonBody[Json])
+            .errorOut(errorOut)
+            .description(
+              "The block's header content. The shape varies by block type (initial, minor, " +
+                  "major, final)."
+            )
+            .serverLogic(num =>
+                blockHeader(num)
                     .handleError(err => Left(fail(StatusCode.InternalServerError, err.getMessage)))
             )
 
@@ -238,6 +313,9 @@ class HydrozoaRoutes(
           submitEndpoint,
           registerDepositEndpoint,
           headInfoEndpoint,
+          blocksEndpoint,
+          blockDetailsEndpoint,
+          blockHeaderEndpoint,
           healthEndpoint,
           readyEndpoint,
           finalizeEndpoint
@@ -321,6 +399,69 @@ class HydrozoaRoutes(
                     .as(Left(fail(StatusCode.BadRequest, err.getMessage)))
             )
 
+    /** The block-details body for `num`: block 0 is synthesized from the head config; any other
+      * block resolves through its persisted brief, or a 404.
+      */
+    private def blockDetails(
+        num: BlockNumber
+    ): IO[Either[(StatusCode, ErrorResponse), BlockDetailsView]] =
+        if num == BlockNumber.zero then
+            blockConfirmation(num).map(confirmation =>
+                val summary = ApiDto.mkInitialBlockSummaryView
+                Right(
+                  BlockDetailsView(summary.number, summary.leader, summary.blockType, confirmation)
+                )
+            )
+        else
+            consensusReader.blockBrief(num).flatMap {
+                case None => IO.pure(Left(blockNotFound(num)))
+                case Some(brief) =>
+                    blockConfirmation(num).map(confirmation =>
+                        val summary = ApiDto.mkBlockSummaryView(brief, headConfig.nHeadPeers)
+                        Right(
+                          BlockDetailsView(
+                            summary.number,
+                            summary.leader,
+                            summary.blockType,
+                            confirmation
+                          )
+                        )
+                    )
+            }
+
+    /** The block's header as JSON: block 0's comes from the head config, the rest from their
+      * persisted briefs.
+      */
+    private def blockHeader(num: BlockNumber): IO[Either[(StatusCode, ErrorResponse), Json]] =
+        if num == BlockNumber.zero then
+            IO.pure(Right(headConfig.initialBlock.blockBrief.header.asJson))
+        else
+            consensusReader.blockBrief(num).map {
+                case None => Left(blockNotFound(num))
+                case Some(brief) =>
+                    Right(brief match {
+                        case b: BlockBrief.Minor => b.header.asJson
+                        case b: BlockBrief.Major => b.header.asJson
+                        case b: BlockBrief.Final => b.header.asJson
+                    })
+            }
+
+    /** Resolve a block's confirmation status from this node's records: the soft-confirmation
+      * moment, and — through the block → stack index — the hard-confirmation moment.
+      */
+    private def blockConfirmation(num: BlockNumber): IO[BlockConfirmationView] =
+        for {
+            soft <- consensusReader.softConfirmation(num)
+            stack <- consensusReader.stackOf(num)
+            hard <- stack match {
+                case None    => IO.pure(None)
+                case Some(s) => consensusReader.hardConfirmation(s)
+            }
+        } yield ApiDto.mkBlockConfirmationView(soft.map(_.at), hard.map(_.at))
+
+    private def blockNotFound(num: BlockNumber): (StatusCode, ErrorResponse) =
+        fail(StatusCode.NotFound, s"Block ${num.convert} not found")
+
     /** Parse a bech32 address, or a message describing why it is malformed. */
     private def parseAddress(bech32: String): Either[String, Address] =
         Try(Address.fromBech32(bech32)).toEither.left
@@ -336,6 +477,7 @@ object HydrozoaRoutes {
         requestSequencer: RequestSequencer.Handle,
         blockWeaver: BlockWeaver.Handle,
         nodeStatus: IO[NodeStatus],
+        consensusReader: ConsensusStoreReader[IO],
         l2QueryReader: Option[EutxoL2LedgerReader[IO]],
         headConfig: HeadConfig,
         serverConfig: HydrozoaServer.Config,
@@ -346,6 +488,7 @@ object HydrozoaRoutes {
             requestSequencer,
             blockWeaver,
             nodeStatus,
+            consensusReader,
             l2QueryReader,
             headConfig,
             serverConfig,

--- a/src/main/scala/hydrozoa/multisig/server/HydrozoaServer.scala
+++ b/src/main/scala/hydrozoa/multisig/server/HydrozoaServer.scala
@@ -7,6 +7,7 @@ import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.NodeStatus
 import hydrozoa.multisig.consensus.{BlockWeaver, RequestSequencer}
 import hydrozoa.multisig.ledger.l2.EutxoL2LedgerReader
+import hydrozoa.multisig.persistence.ConsensusStoreReader
 import hydrozoa.multisig.server.HydrozoaHttpEvent.ServerStarted
 import org.http4s.ember.server.EmberServerBuilder
 import org.http4s.server.Server
@@ -35,6 +36,8 @@ object HydrozoaServer {
       * @param nodeStatus
       *   Node lifecycle status behind `GET /ready`, maintained by `MultisigRegimeManagerBase` and
       *   `CardanoLiaison`
+      * @param consensusReader
+      *   The consensus-store read model behind the `/head/blocks` queries
       * @param l2QueryReader
       *   The EUTXO L2-ledger read model behind `GET /api/l2/utxos` and `/api/l2/transactions`, or
       *   `None` on a node that runs a remote ledger (those endpoints are then not mounted)
@@ -51,6 +54,7 @@ object HydrozoaServer {
         requestSequencer: RequestSequencer.Handle,
         blockWeaver: BlockWeaver.Handle,
         nodeStatus: IO[NodeStatus],
+        consensusReader: ConsensusStoreReader[IO],
         l2QueryReader: Option[EutxoL2LedgerReader[IO]],
         headConfig: HeadConfig,
         config: Config,
@@ -62,6 +66,7 @@ object HydrozoaServer {
                 requestSequencer,
                 blockWeaver,
                 nodeStatus,
+                consensusReader,
                 l2QueryReader,
                 headConfig,
                 config,
@@ -85,12 +90,22 @@ object HydrozoaServer {
         requestSequencer: RequestSequencer.Handle,
         blockWeaver: BlockWeaver.Handle,
         nodeStatus: IO[NodeStatus],
+        consensusReader: ConsensusStoreReader[IO],
         l2QueryReader: Option[EutxoL2LedgerReader[IO]],
         headConfig: HeadConfig,
         config: Config,
         tracer: ContraTracer[IO, HydrozoaHttpEvent]
     ): IO[Nothing] = {
-        create(requestSequencer, blockWeaver, nodeStatus, l2QueryReader, headConfig, config, tracer)
+        create(
+          requestSequencer,
+          blockWeaver,
+          nodeStatus,
+          consensusReader,
+          l2QueryReader,
+          headConfig,
+          config,
+          tracer
+        )
             .use(_ => IO.never)
     }
 }

--- a/src/test/scala/hydrozoa/multisig/server/HeadBlocksEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/HeadBlocksEndpointsTest.scala
@@ -1,0 +1,273 @@
+package hydrozoa.multisig.server
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import com.suprnation.actor.Actor.{Actor, Receive}
+import com.suprnation.actor.ActorSystem
+import hydrozoa.config.head.multisig.timing.TxTiming.BlockTimes.{BlockCreationEndTime, BlockCreationStartTime}
+import hydrozoa.config.node.MultiNodeConfig
+import hydrozoa.lib.cardano.scalus.QuantizedTime.QuantizedInstant.realTimeQuantizedInstant
+import hydrozoa.lib.logging.ContraTracer
+import hydrozoa.multisig.NodeStatus
+import hydrozoa.multisig.consensus.{BlockWeaver, RequestSequencer}
+import hydrozoa.multisig.ledger.block.{Block, BlockBody, BlockBrief, BlockHeader, BlockNumber, BlockVersion}
+import hydrozoa.multisig.ledger.joint.EvacuationMap
+import hydrozoa.multisig.ledger.stack.{PartitionEffects, StackEffects, StackNumber, StandaloneEvacuationCommitment}
+import hydrozoa.multisig.persistence.{ConsensusStoreReader, Timestamped}
+import hydrozoa.rulebased.ledger.l1.state.StandaloneEvacuationCommitmentOnchain
+import io.circe.Json
+import java.time.Instant
+import org.http4s.circe.*
+import org.http4s.implicits.*
+import org.http4s.{HttpApp, Method, Request, Status, Uri}
+import org.scalacheck.Gen
+import org.scalacheck.rng.Seed
+import org.scalatest.funsuite.AnyFunSuite
+import scala.concurrent.duration.DurationInt
+
+/** The `/head/blocks` queries through the HTTP layer, against a stubbed [[ConsensusStoreReader]]:
+  * the listing (block 0 synthesized from config + the spine briefs), the details' confirmation
+  * ladder (PROPOSED → SOFT → HARD with the node-local times), the header content, and the 404/400
+  * edges.
+  */
+class HeadBlocksEndpointsTest extends AnyFunSuite:
+
+    private val multiNodeConfig: MultiNodeConfig =
+        MultiNodeConfig.generateDefault.pureApply(Gen.Parameters.default, Seed(0L))
+    private val headConfig = multiNodeConfig.headConfig
+
+    private val softAt = Instant.parse("2026-01-01T00:00:00Z")
+    private val hardAt = Instant.parse("2026-01-01T00:05:00Z")
+
+    /** A minimal minor brief for block 1, timed off the head's slot config. */
+    private def mkMinorBrief1: IO[BlockBrief.Minor] =
+        for {
+            now <- realTimeQuantizedInstant(headConfig.slotConfig)
+        } yield {
+            val startTime = BlockCreationStartTime(now)
+            val endTime = BlockCreationEndTime(now + 1.second)
+            val fallbackTxStartTime = headConfig.txTiming.newFallbackStartTime(endTime)
+            BlockBrief.Minor(
+              BlockHeader.Minor(
+                blockNum = BlockNumber(1),
+                blockVersion = BlockVersion.Full(0, 0),
+                startTime = startTime,
+                endTime = endTime,
+                fallbackTxStartTime = fallbackTxStartTime,
+                forcedMajorBlockWakeupTime =
+                    headConfig.txTiming.forcedMajorBlockWakeupTime(fallbackTxStartTime),
+                mDepositDecisionWakeupTime = None
+              ),
+              BlockBody.Minor(events = List.empty, depositsRefunded = List.empty)
+            )
+        }
+
+    /** A hard-confirmation record with no signatures — the details handler reads only the
+      * timestamp, never the effects.
+      */
+    private val hardRecord: StackEffects.HardConfirmed =
+        StackEffects.HardConfirmed.Regular(
+          cats.data.NonEmptyList.of(
+            PartitionEffects.Minor(
+              sec = StandaloneEvacuationCommitment.MultiSigned(
+                commitment = StandaloneEvacuationCommitment(
+                  blockNum = BlockNumber(1),
+                  blockVersion = BlockVersion.Full(1, 0),
+                  kzgCommitment = EvacuationMap.empty.kzgCommitment,
+                  header = StandaloneEvacuationCommitmentOnchain(
+                    StandaloneEvacuationCommitmentOnchain(
+                      headId = headConfig.headTokenNames.treasuryTokenName.bytes,
+                      versionMajor = BigInt(1),
+                      versionMinor = BigInt(0),
+                      commitment = EvacuationMap.empty.kzgCommitment
+                    )
+                  )
+                ),
+                headerMultiSigned = List.empty
+              ),
+              refunds = List.empty
+            )
+          )
+        )
+
+    /** A stub reader over one block-1 brief plus optional confirmation records. */
+    private def stubReader(
+        brief: BlockBrief.Minor,
+        soft: Boolean,
+        hard: Boolean
+    ): ConsensusStoreReader[IO] =
+        new ConsensusStoreReader[IO]:
+            def blockBriefs: IO[List[BlockBrief.Next]] = IO.pure(List(brief))
+            def blockBrief(num: BlockNumber): IO[Option[BlockBrief.Next]] =
+                IO.pure(Option.when(num == BlockNumber(1))(brief))
+            def softConfirmation(
+                num: BlockNumber
+            ): IO[Option[Timestamped[Block.SoftConfirmed.Next]]] =
+                IO.pure(
+                  Option.when(soft && num == BlockNumber(1))(
+                    Timestamped(
+                      softAt,
+                      Block.SoftConfirmed
+                          .Minor(
+                            brief,
+                            headerMultiSigned = List.empty,
+                            finalizationRequested = false
+                          )
+                    )
+                  )
+                )
+            def stackOf(num: BlockNumber): IO[Option[StackNumber]] =
+                IO.pure(Option.when(hard && num == BlockNumber(1))(StackNumber(1)))
+            def hardConfirmation(
+                num: StackNumber
+            ): IO[Option[Timestamped[StackEffects.HardConfirmed]]] =
+                IO.pure(Option.when(hard && num == StackNumber(1))(Timestamped(hardAt, hardRecord)))
+
+    private def withRoutes(reader: ConsensusStoreReader[IO])(check: HttpApp[IO] => IO[Unit]): Unit =
+        ActorSystem[IO]("HeadBlocksEndpointsTest")
+            .use { system =>
+                for {
+                    requestSequencerStub <- system.actorOf(
+                      new Actor[IO, RequestSequencer.Request] {
+                          override def receive: Receive[IO, RequestSequencer.Request] =
+                              _ => IO.pure(())
+                      }
+                    )
+                    blockWeaverStub <- system.actorOf(
+                      new Actor[IO, BlockWeaver.Request] {
+                          override def receive: Receive[IO, BlockWeaver.Request] = _ => IO.pure(())
+                      }
+                    )
+                    routes <- HydrozoaRoutes(
+                      requestSequencerStub,
+                      blockWeaverStub,
+                      IO.pure(NodeStatus.Active),
+                      reader,
+                      None,
+                      headConfig,
+                      HydrozoaServer.Config(adminUsername = "admin", adminPassword = "admin"),
+                      ContraTracer[IO, HydrozoaHttpEvent](_ => IO.unit)
+                    )
+                    _ <- check(routes.routes.orNotFound)
+                } yield ()
+            }
+            .unsafeRunSync()
+
+    private def get(app: HttpApp[IO], path: String): IO[(Status, Json)] =
+        for {
+            resp <- app.run(Request[IO](Method.GET, Uri.unsafeFromString(path)))
+            body <- resp.as[Json]
+        } yield (resp.status, body)
+
+    test("GET /head/blocks lists block 0 plus the spine briefs, leaders round-robin") {
+        mkMinorBrief1
+            .flatMap(brief =>
+                IO(withRoutes(stubReader(brief, soft = false, hard = false)) { app =>
+                    get(app, "/head/blocks").map { (status, body) =>
+                        val _ = assert(status == Status.Ok)
+                        val rows = body.asArray.get
+                        val _ = assert(rows.size == 2)
+                        val row0 = rows(0).hcursor
+                        val _ = assert(row0.get[Int]("number") == Right(0))
+                        val _ = assert(row0.get[String]("blockType") == Right("initial"))
+                        val _ = assert(row0.downField("leader").focus.forall(_.isNull))
+                        val row1 = rows(1).hcursor
+                        val _ = assert(row1.get[Int]("number") == Right(1))
+                        val _ = assert(row1.get[String]("blockType") == Right("minor"))
+                        val _ = assert(
+                          row1.get[Int]("leader") == Right(1 % headConfig.nHeadPeers.convert)
+                        )
+                        ()
+                    }
+                })
+            )
+            .unsafeRunSync()
+    }
+
+    test("GET /head/blocks/1 walks the confirmation ladder: PROPOSED, SOFT, HARD") {
+        mkMinorBrief1
+            .flatMap { brief =>
+                def statusOf(
+                    soft: Boolean,
+                    hard: Boolean
+                ): (String, Option[String], Option[String]) =
+                    var out: (String, Option[String], Option[String]) = ("", None, None)
+                    withRoutes(stubReader(brief, soft, hard)) { app =>
+                        get(app, "/head/blocks/1").map { (status, body) =>
+                            val _ = assert(status == Status.Ok)
+                            val c = body.hcursor.downField("confirmation")
+                            out = (
+                              c.get[String]("status").toOption.get,
+                              c.get[String]("softConfirmedAt").toOption,
+                              c.get[String]("hardConfirmedAt").toOption
+                            )
+                        }
+                    }
+                    out
+                IO {
+                    val _ = assert(statusOf(soft = false, hard = false) == ("PROPOSED", None, None))
+                    val _ = assert(
+                      statusOf(soft = true, hard = false) == ("SOFT", Some(softAt.toString), None)
+                    )
+                    assert(
+                      statusOf(soft = true, hard = true) ==
+                          ("HARD", Some(softAt.toString), Some(hardAt.toString))
+                    )
+                }
+            }
+            .unsafeRunSync()
+    }
+
+    test("GET /head/blocks/0 and /head/blocks/0/header serve the config-derived initial block") {
+        mkMinorBrief1
+            .flatMap(brief =>
+                IO(withRoutes(stubReader(brief, soft = false, hard = false)) { app =>
+                    for {
+                        details <- get(app, "/head/blocks/0")
+                        header <- get(app, "/head/blocks/0/header")
+                    } yield {
+                        val _ = assert(details._1 == Status.Ok)
+                        val _ =
+                            assert(details._2.hcursor.get[String]("blockType") == Right("initial"))
+                        val _ = assert(header._1 == Status.Ok)
+                        ()
+                    }
+                })
+            )
+            .unsafeRunSync()
+    }
+
+    test("GET /head/blocks/1/header returns the brief's header content") {
+        mkMinorBrief1
+            .flatMap(brief =>
+                IO(withRoutes(stubReader(brief, soft = false, hard = false)) { app =>
+                    get(app, "/head/blocks/1/header").map { (status, body) =>
+                        val _ = assert(status == Status.Ok)
+                        val _ = assert(body.hcursor.downField("blockNum").succeeded)
+                        ()
+                    }
+                })
+            )
+            .unsafeRunSync()
+    }
+
+    test("GET /head/blocks/{unknown} is a 404; a malformed number is a 400, not a 500") {
+        mkMinorBrief1
+            .flatMap(brief =>
+                IO(withRoutes(stubReader(brief, soft = false, hard = false)) { app =>
+                    for {
+                        missing <- get(app, "/head/blocks/99")
+                        missingHeader <- get(app, "/head/blocks/99/header")
+                        malformed <- app.run(
+                          Request[IO](Method.GET, Uri.unsafeFromString("/head/blocks/oops"))
+                        )
+                    } yield {
+                        val _ = assert(missing._1 == Status.NotFound)
+                        val _ = assert(missingHeader._1 == Status.NotFound)
+                        val _ = assert(malformed.status.code < 500)
+                        ()
+                    }
+                })
+            )
+            .unsafeRunSync()
+    }

--- a/src/test/scala/hydrozoa/multisig/server/L2QueryEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/L2QueryEndpointsTest.scala
@@ -15,6 +15,7 @@ import hydrozoa.multisig.ledger.eutxol2.EutxoL2Ledger
 import hydrozoa.multisig.ledger.eutxol2.store.InMemoryL2Store
 import hydrozoa.multisig.ledger.event.RequestId
 import hydrozoa.multisig.ledger.l2.L2LedgerCommand
+import hydrozoa.multisig.persistence.ConsensusStoreReader
 import io.circe.{Json, Printer}
 import org.http4s.circe.*
 import org.http4s.implicits.*
@@ -90,6 +91,7 @@ class L2QueryEndpointsTest extends AnyFunSuite:
                       requestSequencerStub,
                       blockWeaverStub,
                       IO.pure(NodeStatus.Active),
+                      ConsensusStoreReader.empty,
                       Some(ledger),
                       multiNodeConfig.headConfig,
                       HydrozoaServer.Config(adminUsername = "admin", adminPassword = "admin"),
@@ -122,6 +124,7 @@ class L2QueryEndpointsTest extends AnyFunSuite:
                       requestSequencerStub,
                       blockWeaverStub,
                       IO.pure(NodeStatus.Active),
+                      ConsensusStoreReader.empty,
                       None,
                       multiNodeConfig.headConfig,
                       HydrozoaServer.Config(adminUsername = "admin", adminPassword = "admin"),

--- a/src/test/scala/hydrozoa/multisig/server/OpenApiSchemaTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/OpenApiSchemaTest.scala
@@ -9,6 +9,7 @@ import hydrozoa.config.node.MultiNodeConfig
 import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.NodeStatus
 import hydrozoa.multisig.consensus.{BlockWeaver, RequestSequencer}
+import hydrozoa.multisig.persistence.ConsensusStoreReader
 import java.nio.file.{Files, Path}
 import org.scalacheck.Gen
 import org.scalacheck.rng.Seed
@@ -56,6 +57,7 @@ class OpenApiSchemaTest extends AnyFunSuite:
                       requestSequencerStub,
                       blockWeaverStub,
                       IO.pure(NodeStatus.Active),
+                      ConsensusStoreReader.empty,
                       None,
                       multiNodeConfig.headConfig,
                       HydrozoaServer.Config(adminUsername = "admin", adminPassword = "admin"),

--- a/src/test/scala/hydrozoa/multisig/server/ReadyEndpointTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/ReadyEndpointTest.scala
@@ -9,6 +9,7 @@ import hydrozoa.config.node.MultiNodeConfig
 import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.NodeStatus
 import hydrozoa.multisig.consensus.{BlockWeaver, RequestSequencer}
+import hydrozoa.multisig.persistence.ConsensusStoreReader
 import io.circe.Json
 import org.http4s.circe.*
 import org.http4s.implicits.*
@@ -50,6 +51,7 @@ class ReadyEndpointTest extends AnyFunSuite:
                       requestSequencerStub,
                       blockWeaverStub,
                       IO.pure(status),
+                      ConsensusStoreReader.empty,
                       None,
                       multiNodeConfig.headConfig,
                       HydrozoaServer.Config(adminUsername = "admin", adminPassword = "admin"),


### PR DESCRIPTION
Slice 3 of the head-API effort, **stacked on #541** (base = `feature/head-api-capture`; retarget to `main` after #541 merges — this PR consumes its `Timestamped` values and `BlockStackIndex`).

## What

- **`ConsensusStoreReader`** — the read-only consensus-store view for the user-facing server, following the `EutxoL2LedgerReader` pattern: block-spine scan + point reads of briefs, soft/hard-confirmation records, and the block→stack index. Constructed from `Main`'s `Persistence` and threaded through `HydrozoaServer` into `HydrozoaRoutes`; `ConsensusStoreReader.empty` serves test/harness wiring.
- **`GET /head/blocks`** — number, round-robin leader (`blockNum % nHeadPeers`, pure config), type. Block 0 (the initial block) is synthesized from `HeadConfig` with no leader.
- **`GET /head/blocks/{block-number}`** — type, leader, and confirmation status `PROPOSED | SOFT | HARD` with this node's confirmation moments (ISO-8601), resolved via `SoftConfirmation` and `BlockStackIndex` → `HardConfirmation` from slice 2.
- **`GET /head/blocks/{block-number}/header`** — the header content (shape varies by block type); block 0 serves the config-derived `BlockHeader.Initial`.
- Validated tapir path codec for `BlockNumber` — malformed input is a 400 at decode, never a handler throw.

## Verified

`just build-werror` green (it caught value-discard warnings in the new test that the plain compile does not — fixed); new `HeadBlocksEndpointsTest` 5/5 through the HTTP layer (listing + leader math, the full PROPOSED→SOFT→HARD ladder with times, block-0 synthesis, header content, 404/400 edges); all server suites 20/20; core OpenAPI golden regenerated (second run green); `integration/Test` compiles.

Note: this branch does not include #540's path renames, so the regenerated `openapi.yaml` will conflict with #540's — whichever merges last regenerates the golden once (self-healing test).

## Next

Slices 4–5 remainder: `/head/requests` listing/per-peer/detail over the `Request` journals + `RequestBlockIndex` (needs the `HeadPeerNumber`/`RequestNumber` path codecs), then the per-block effects attribution.