### PR TITLE
Head API restructure, slices 4-5: /head/requests endpoints

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -68,6 +68,86 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /head/requests:
+    get:
+      description: Every request the head has assigned an id, across all head peers
+        — request id (author peer number + request number) and type (transaction or
+        deposit).
+      operationId: getHeadRequests
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/RequestSummaryView'
+        default:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /head/requests/{head-peer-number}:
+    get:
+      description: Every request authored by one head peer, in request-number order
+        — request number and type.
+      operationId: getHeadPeerRequests
+      parameters:
+      - name: head-peer-number
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int32
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PeerRequestSummaryView'
+        default:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /head/requests/{head-peer-number}/{request-number}:
+    get:
+      description: 'One request''s type, receive time, and lifecycle status: UNPROCESSED,
+        LOCALLY_PROCESSED (block + validity), SOFT_CONFIRMED (+ this node''s soft-confirmation
+        time), or HARD_CONFIRMED (+ its hard-confirmation time).'
+      operationId: getHeadRequest
+      parameters:
+      - name: head-peer-number
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int32
+      - name: request-number
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RequestDetailsView'
+        default:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /head/blocks:
     get:
       description: Every block of the head in block order — number, fast-cycle leader,
@@ -296,6 +376,18 @@ components:
       properties:
         status:
           type: string
+    PeerRequestSummaryView:
+      title: PeerRequestSummaryView
+      type: object
+      required:
+      - requestNumber
+      - requestType
+      properties:
+        requestNumber:
+          type: integer
+          format: int64
+        requestType:
+          type: string
     ReadinessResponse:
       title: ReadinessResponse
       type: object
@@ -313,6 +405,69 @@ components:
         requestId:
           type: integer
           format: int64
+    RequestDetailsView:
+      title: RequestDetailsView
+      type: object
+      required:
+      - requestId
+      - requestType
+      - receivedAt
+      - status
+      properties:
+        requestId:
+          $ref: '#/components/schemas/RequestIdView'
+        requestType:
+          type: string
+        receivedAt:
+          type: string
+        status:
+          $ref: '#/components/schemas/RequestStatusView'
+    RequestIdView:
+      title: RequestIdView
+      type: object
+      required:
+      - headPeerNumber
+      - requestNumber
+      properties:
+        headPeerNumber:
+          type: integer
+          format: int32
+        requestNumber:
+          type: integer
+          format: int64
+    RequestStatusView:
+      title: RequestStatusView
+      type: object
+      required:
+      - status
+      properties:
+        status:
+          type: string
+        blockNumber:
+          type: integer
+          format: int32
+        validity:
+          type: string
+        softConfirmedAt:
+          type: string
+        hardConfirmedAt:
+          type: string
+        relatedEffects:
+          type: array
+          items:
+            type: integer
+            format: int32
+    RequestSummaryView:
+      title: RequestSummaryView
+      type: object
+      required:
+      - requestId
+      - requestType
+      properties:
+        requestId:
+          $ref: '#/components/schemas/RequestIdView'
+        requestType:
+          type: string
     TxInputView:
       title: TxInputView
       type: object

--- a/src/main/scala/hydrozoa/multisig/persistence/ConsensusStoreReader.scala
+++ b/src/main/scala/hydrozoa/multisig/persistence/ConsensusStoreReader.scala
@@ -2,7 +2,10 @@ package hydrozoa.multisig.persistence
 
 import cats.effect.IO
 import hydrozoa.config.head.network.CardanoNetwork
+import hydrozoa.multisig.consensus.UserRequestWithId
+import hydrozoa.multisig.consensus.peer.HeadPeerNumber
 import hydrozoa.multisig.ledger.block.{Block, BlockBrief, BlockNumber}
+import hydrozoa.multisig.ledger.event.RequestNumber
 import hydrozoa.multisig.ledger.stack.{StackEffects, StackNumber}
 import hydrozoa.multisig.persistence.recovery.CursorScan
 import java.nio.ByteBuffer
@@ -33,6 +36,18 @@ trait ConsensusStoreReader[F[_]]:
       * confirmation moment.
       */
     def hardConfirmation(num: StackNumber): F[Option[Timestamped[StackEffects.HardConfirmed]]]
+
+    /** One head peer's assigned requests, in request-number order (that author's Request journal).
+      */
+    def requestsOf(peer: HeadPeerNumber): F[List[UserRequestWithId]]
+
+    /** One assigned request, if persisted. */
+    def request(peer: HeadPeerNumber, num: RequestNumber): F[Option[UserRequestWithId]]
+
+    /** The block that locally processed a request, plus its validity verdict — absent while the
+      * request is still unprocessed.
+      */
+    def requestBlock(peer: HeadPeerNumber, num: RequestNumber): F[Option[RequestBlockEntry]]
 
 object ConsensusStoreReader:
 
@@ -65,6 +80,24 @@ object ConsensusStoreReader:
             ): IO[Option[Timestamped[StackEffects.HardConfirmed]]] =
                 persistence.get(StoreKey.HardConfirmation(num))
 
+            def requestsOf(peer: HeadPeerNumber): IO[List[UserRequestWithId]] =
+                CursorScan.cursorWalk(
+                  persistence.backend,
+                  Cf.Request(peer),
+                  JournalKey.Request(peer, RequestNumber.zero).encode,
+                  keyBytes =>
+                      JournalKey.Request(peer, RequestNumber(ByteBuffer.wrap(keyBytes).getLong))
+                )((key, valueBytes) => key.decodeValue(valueBytes).payload)
+
+            def request(peer: HeadPeerNumber, num: RequestNumber): IO[Option[UserRequestWithId]] =
+                persistence.get(JournalKey.Request(peer, num)).map(_.map(_.payload))
+
+            def requestBlock(
+                peer: HeadPeerNumber,
+                num: RequestNumber
+            ): IO[Option[RequestBlockEntry]] =
+                persistence.get(StoreKey.RequestBlockIndex(peer, num))
+
     /** A reader over no data — every lookup is empty. For wiring the routes on a node whose store
       * is absent or irrelevant (test and harness setups).
       */
@@ -79,3 +112,12 @@ object ConsensusStoreReader:
             def hardConfirmation(
                 num: StackNumber
             ): IO[Option[Timestamped[StackEffects.HardConfirmed]]] = IO.pure(None)
+            def requestsOf(peer: HeadPeerNumber): IO[List[UserRequestWithId]] = IO.pure(Nil)
+            def request(
+                peer: HeadPeerNumber,
+                num: RequestNumber
+            ): IO[Option[UserRequestWithId]] = IO.pure(None)
+            def requestBlock(
+                peer: HeadPeerNumber,
+                num: RequestNumber
+            ): IO[Option[RequestBlockEntry]] = IO.pure(None)

--- a/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
+++ b/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
@@ -2,8 +2,10 @@ package hydrozoa.multisig.server
 
 import hydrozoa.config.head.HeadConfig
 import hydrozoa.multisig.NodeStatus
+import hydrozoa.multisig.consensus.UserRequestWithId
 import hydrozoa.multisig.ledger.block.BlockBrief
 import hydrozoa.multisig.ledger.event.RequestId
+import hydrozoa.multisig.ledger.event.RequestId.ValidityFlag
 import hydrozoa.multisig.ledger.l2.{L2TxKind, L2TxSummary}
 import io.bullet.borer.Cbor
 import io.circe.Codec
@@ -148,6 +150,91 @@ object ApiDto {
         case _: BlockBrief.Minor => "minor"
         case _: BlockBrief.Major => "major"
         case _: BlockBrief.Final => "final"
+
+    /** One row of the head-wide request listing: the full request id and the request type. */
+    final case class RequestSummaryView(requestId: RequestIdView, requestType: String)
+    given Codec[RequestSummaryView] = deriveCodec
+
+    /** One row of a single peer's request listing: the request number (the peer is the path) and
+      * the request type.
+      */
+    final case class PeerRequestSummaryView(requestNumber: Long, requestType: String)
+    given Codec[PeerRequestSummaryView] = deriveCodec
+
+    /** A request's lifecycle status from this node's viewpoint: `UNPROCESSED`, `LOCALLY_PROCESSED`,
+      * `SOFT_CONFIRMED`, or `HARD_CONFIRMED`, with the fields each stage adds. `relatedEffects` is
+      * always absent for now (per-request effect tracking is a separate change).
+      */
+    final case class RequestStatusView(
+        status: String,
+        blockNumber: Option[Int],
+        validity: Option[String],
+        softConfirmedAt: Option[String],
+        hardConfirmedAt: Option[String],
+        relatedEffects: Option[List[Int]]
+    )
+    given Codec[RequestStatusView] = deriveCodec
+
+    /** The request-details body: id, type, receive time, and the lifecycle status. */
+    final case class RequestDetailsView(
+        requestId: RequestIdView,
+        requestType: String,
+        receivedAt: String,
+        status: RequestStatusView
+    )
+    given Codec[RequestDetailsView] = deriveCodec
+
+    /** The request type discriminator, matching the submit-body field names. */
+    def requestTypeName(request: UserRequestWithId): String = request match
+        case _: UserRequestWithId.DepositRequest     => "deposit"
+        case _: UserRequestWithId.TransactionRequest => "transaction"
+
+    /** Map a request to its head-wide listing row. */
+    def mkRequestSummaryView(request: UserRequestWithId): RequestSummaryView =
+        RequestSummaryView(mkRequestIdView(request.requestId), requestTypeName(request))
+
+    /** Map a request to its per-peer listing row. */
+    def mkPeerRequestSummaryView(request: UserRequestWithId): PeerRequestSummaryView =
+        PeerRequestSummaryView(request.requestId.requestNum.convert, requestTypeName(request))
+
+    private def validityName(validity: ValidityFlag): String = validity match
+        case ValidityFlag.Valid   => "valid"
+        case ValidityFlag.Invalid => "invalid"
+
+    /** Assemble the request-status view from its resolved lifecycle stages: the processing block
+      * and verdict (absent while unprocessed) and the node-local confirmation moments.
+      */
+    def mkRequestStatusView(
+        block: Option[(Int, ValidityFlag)],
+        softConfirmedAt: Option[Instant],
+        hardConfirmedAt: Option[Instant]
+    ): RequestStatusView =
+        val status = block match
+            case None => "UNPROCESSED"
+            case Some(_) =>
+                if hardConfirmedAt.isDefined then "HARD_CONFIRMED"
+                else if softConfirmedAt.isDefined then "SOFT_CONFIRMED"
+                else "LOCALLY_PROCESSED"
+        RequestStatusView(
+          status = status,
+          blockNumber = block.map(_._1),
+          validity = block.map((_, v) => validityName(v)),
+          softConfirmedAt = softConfirmedAt.map(_.toString),
+          hardConfirmedAt = hardConfirmedAt.map(_.toString),
+          relatedEffects = None
+        )
+
+    /** Map a request plus its resolved status to the details body. */
+    def mkRequestDetailsView(
+        request: UserRequestWithId,
+        status: RequestStatusView
+    ): RequestDetailsView =
+        RequestDetailsView(
+          requestId = mkRequestIdView(request.requestId),
+          requestType = requestTypeName(request),
+          receivedAt = request.receivedAt.toString,
+          status = status
+        )
 
     /** A utxo reference, `{ transaction_id, index }` (CIP-0116). */
     final case class TxInputView(transaction_id: String, index: Int)

--- a/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
+++ b/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
@@ -1,12 +1,15 @@
 package hydrozoa.multisig.server
 
 import cats.effect.IO
+import cats.syntax.traverse.*
 import hydrozoa.config.head.HeadConfig
 import hydrozoa.config.head.network.CardanoNetwork
 import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.NodeStatus
+import hydrozoa.multisig.consensus.peer.HeadPeerNumber
 import hydrozoa.multisig.consensus.{BlockWeaver, RequestSequencer}
 import hydrozoa.multisig.ledger.block.{BlockBrief, BlockNumber}
+import hydrozoa.multisig.ledger.event.RequestNumber
 import hydrozoa.multisig.ledger.l2.EutxoL2LedgerReader
 import hydrozoa.multisig.persistence.ConsensusStoreReader
 import hydrozoa.multisig.server.ApiDto.*
@@ -15,6 +18,7 @@ import hydrozoa.multisig.server.JsonCodecs.UserRequestDecoder
 import hydrozoa.multisig.server.TapirJson.*
 import io.circe.Json
 import io.circe.syntax.*
+import java.time.Instant
 import org.http4s.HttpRoutes
 import scala.util.Try
 import scalus.cardano.address.Address
@@ -128,6 +132,32 @@ class HydrozoaRoutes(
                 )
         )(_.convert)
 
+    /** `{head-peer-number}` path segments decode to a validated [[HeadPeerNumber]] (0..255); an
+      * out-of-range number is a 400 at decode, not a throw in the type's `apply`.
+      */
+    private given Codec[String, HeadPeerNumber, CodecFormat.TextPlain] =
+        Codec.int.mapDecode(i =>
+            if i >= 0 && i < (1 << 8) then DecodeResult.Value(HeadPeerNumber(i))
+            else
+                DecodeResult.Error(
+                  i.toString,
+                  new IllegalArgumentException("head peer number out of range [0, 256)")
+                )
+        )(_.convert)
+
+    /** `{request-number}` path segments decode to a validated [[RequestNumber]] (a 40-bit
+      * non-negative), a 400 at decode rather than a throw.
+      */
+    private given Codec[String, RequestNumber, CodecFormat.TextPlain] =
+        Codec.long.mapDecode(n =>
+            if n >= 0 && n < (1L << 40) then DecodeResult.Value(RequestNumber(n))
+            else
+                DecodeResult.Error(
+                  n.toString,
+                  new IllegalArgumentException("request number out of range [0, 2^40)")
+                )
+        )(_.convert)
+
     private val blocksEndpoint: ServerEndpoint[Any, IO] =
         endpoint.get
             .in("head" / "blocks")
@@ -176,6 +206,59 @@ class HydrozoaRoutes(
             )
             .serverLogic(num =>
                 blockHeader(num)
+                    .handleError(err => Left(fail(StatusCode.InternalServerError, err.getMessage)))
+            )
+
+    private val requestsEndpoint: ServerEndpoint[Any, IO] =
+        endpoint.get
+            .in("head" / "requests")
+            .name("getHeadRequests")
+            .out(jsonBody[List[RequestSummaryView]])
+            .errorOut(errorOut)
+            .description(
+              "Every request the head has assigned an id, across all head peers — request id " +
+                  "(author peer number + request number) and type (transaction or deposit)."
+            )
+            .serverLogic(_ =>
+                headConfig.headPeerNums.toList
+                    .traverse(consensusReader.requestsOf)
+                    .map(perPeer => Right(perPeer.flatten.map(ApiDto.mkRequestSummaryView)))
+                    .handleError(err => Left(fail(StatusCode.InternalServerError, err.getMessage)))
+            )
+
+    private val peerRequestsEndpoint: ServerEndpoint[Any, IO] =
+        endpoint.get
+            .in("head" / "requests" / path[HeadPeerNumber]("head-peer-number"))
+            .name("getHeadPeerRequests")
+            .out(jsonBody[List[PeerRequestSummaryView]])
+            .errorOut(errorOut)
+            .description(
+              "Every request authored by one head peer, in request-number order — request " +
+                  "number and type."
+            )
+            .serverLogic(peer =>
+                consensusReader
+                    .requestsOf(peer)
+                    .map(requests => Right(requests.map(ApiDto.mkPeerRequestSummaryView)))
+                    .handleError(err => Left(fail(StatusCode.InternalServerError, err.getMessage)))
+            )
+
+    private val requestDetailsEndpoint: ServerEndpoint[Any, IO] =
+        endpoint.get
+            .in(
+              "head" / "requests" / path[HeadPeerNumber]("head-peer-number") /
+                  path[RequestNumber]("request-number")
+            )
+            .name("getHeadRequest")
+            .out(jsonBody[RequestDetailsView])
+            .errorOut(errorOut)
+            .description(
+              "One request's type, receive time, and lifecycle status: UNPROCESSED, " +
+                  "LOCALLY_PROCESSED (block + validity), SOFT_CONFIRMED (+ this node's " +
+                  "soft-confirmation time), or HARD_CONFIRMED (+ its hard-confirmation time)."
+            )
+            .serverLogic((peer, num) =>
+                requestDetails(peer, num)
                     .handleError(err => Left(fail(StatusCode.InternalServerError, err.getMessage)))
             )
 
@@ -313,6 +396,9 @@ class HydrozoaRoutes(
           submitEndpoint,
           registerDepositEndpoint,
           headInfoEndpoint,
+          requestsEndpoint,
+          peerRequestsEndpoint,
+          requestDetailsEndpoint,
           blocksEndpoint,
           blockDetailsEndpoint,
           blockHeaderEndpoint,
@@ -450,6 +536,12 @@ class HydrozoaRoutes(
       * moment, and — through the block → stack index — the hard-confirmation moment.
       */
     private def blockConfirmation(num: BlockNumber): IO[BlockConfirmationView] =
+        confirmationTimes(num).map((soft, hard) => ApiDto.mkBlockConfirmationView(soft, hard))
+
+    /** This node's `(soft, hard)` confirmation moments for a block: the soft-confirmation record's
+      * stamp, and — through the block → stack index — the hard-confirmation record's stamp.
+      */
+    private def confirmationTimes(num: BlockNumber): IO[(Option[Instant], Option[Instant])] =
         for {
             soft <- consensusReader.softConfirmation(num)
             stack <- consensusReader.stackOf(num)
@@ -457,7 +549,42 @@ class HydrozoaRoutes(
                 case None    => IO.pure(None)
                 case Some(s) => consensusReader.hardConfirmation(s)
             }
-        } yield ApiDto.mkBlockConfirmationView(soft.map(_.at), hard.map(_.at))
+        } yield (soft.map(_.at), hard.map(_.at))
+
+    /** The request-details body for `(peer, num)`, or a 404 when the head has assigned no such id.
+      * The lifecycle status resolves through the request → block index and the block's confirmation
+      * records.
+      */
+    private def requestDetails(
+        peer: HeadPeerNumber,
+        num: RequestNumber
+    ): IO[Either[(StatusCode, ErrorResponse), RequestDetailsView]] =
+        consensusReader.request(peer, num).flatMap {
+            case None => IO.pure(Left(requestNotFound(peer, num)))
+            case Some(request) =>
+                for {
+                    processed <- consensusReader.requestBlock(peer, num)
+                    confirmation <- processed match {
+                        case None        => IO.pure((Option.empty[Instant], Option.empty[Instant]))
+                        case Some(entry) => confirmationTimes(entry.blockNum)
+                    }
+                    (softAt, hardAt) = confirmation
+                    status = ApiDto.mkRequestStatusView(
+                      block = processed.map(e => (e.blockNum.convert, e.validity)),
+                      softConfirmedAt = softAt,
+                      hardConfirmedAt = hardAt
+                    )
+                } yield Right(ApiDto.mkRequestDetailsView(request, status))
+        }
+
+    private def requestNotFound(
+        peer: HeadPeerNumber,
+        num: RequestNumber
+    ): (StatusCode, ErrorResponse) =
+        fail(
+          StatusCode.NotFound,
+          s"Request ${peer.convert}/${num.convert} not found"
+        )
 
     private def blockNotFound(num: BlockNumber): (StatusCode, ErrorResponse) =
         fail(StatusCode.NotFound, s"Block ${num.convert} not found")

--- a/src/test/scala/hydrozoa/multisig/server/HeadBlocksEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/HeadBlocksEndpointsTest.scala
@@ -9,11 +9,13 @@ import hydrozoa.config.node.MultiNodeConfig
 import hydrozoa.lib.cardano.scalus.QuantizedTime.QuantizedInstant.realTimeQuantizedInstant
 import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.NodeStatus
-import hydrozoa.multisig.consensus.{BlockWeaver, RequestSequencer}
+import hydrozoa.multisig.consensus.peer.HeadPeerNumber
+import hydrozoa.multisig.consensus.{BlockWeaver, RequestSequencer, UserRequestWithId}
 import hydrozoa.multisig.ledger.block.{Block, BlockBody, BlockBrief, BlockHeader, BlockNumber, BlockVersion}
+import hydrozoa.multisig.ledger.event.RequestNumber
 import hydrozoa.multisig.ledger.joint.EvacuationMap
 import hydrozoa.multisig.ledger.stack.{PartitionEffects, StackEffects, StackNumber, StandaloneEvacuationCommitment}
-import hydrozoa.multisig.persistence.{ConsensusStoreReader, Timestamped}
+import hydrozoa.multisig.persistence.{ConsensusStoreReader, RequestBlockEntry, Timestamped}
 import hydrozoa.rulebased.ledger.l1.state.StandaloneEvacuationCommitmentOnchain
 import io.circe.Json
 import java.time.Instant
@@ -122,6 +124,15 @@ class HeadBlocksEndpointsTest extends AnyFunSuite:
                 num: StackNumber
             ): IO[Option[Timestamped[StackEffects.HardConfirmed]]] =
                 IO.pure(Option.when(hard && num == StackNumber(1))(Timestamped(hardAt, hardRecord)))
+            def requestsOf(peer: HeadPeerNumber): IO[List[UserRequestWithId]] = IO.pure(Nil)
+            def request(
+                peer: HeadPeerNumber,
+                num: RequestNumber
+            ): IO[Option[UserRequestWithId]] = IO.pure(None)
+            def requestBlock(
+                peer: HeadPeerNumber,
+                num: RequestNumber
+            ): IO[Option[RequestBlockEntry]] = IO.pure(None)
 
     private def withRoutes(reader: ConsensusStoreReader[IO])(check: HttpApp[IO] => IO[Unit]): Unit =
         ActorSystem[IO]("HeadBlocksEndpointsTest")

--- a/src/test/scala/hydrozoa/multisig/server/HeadRequestsEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/HeadRequestsEndpointsTest.scala
@@ -1,0 +1,239 @@
+package hydrozoa.multisig.server
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import com.suprnation.actor.Actor.{Actor, Receive}
+import com.suprnation.actor.ActorSystem
+import hydrozoa.config.node.MultiNodeConfig
+import hydrozoa.lib.logging.ContraTracer
+import hydrozoa.multisig.NodeStatus
+import hydrozoa.multisig.consensus.UserRequest.{DepositRequest, TransactionRequest}
+import hydrozoa.multisig.consensus.UserRequestBody.{DepositRequestBody, TransactionRequestBody}
+import hydrozoa.multisig.consensus.peer.HeadPeerNumber
+import hydrozoa.multisig.consensus.{BlockWeaver, RequestSequencer, UserRequestWithId}
+import hydrozoa.multisig.ledger.block.{Block, BlockBrief, BlockNumber}
+import hydrozoa.multisig.ledger.event.RequestId.ValidityFlag
+import hydrozoa.multisig.ledger.event.{RequestId, RequestNumber}
+import hydrozoa.multisig.ledger.stack.{StackEffects, StackNumber}
+import hydrozoa.multisig.persistence.{ConsensusStoreReader, RequestBlockEntry, Timestamped}
+import io.circe.Json
+import java.time.Instant
+import org.http4s.circe.*
+import org.http4s.implicits.*
+import org.http4s.{HttpApp, Method, Request, Status, Uri}
+import org.scalacheck.Gen
+import org.scalacheck.rng.Seed
+import org.scalatest.funsuite.AnyFunSuite
+import scalus.uplc.builtin.ByteString
+
+/** The `/head/requests` queries through the HTTP layer against a stubbed [[ConsensusStoreReader]]:
+  * the head-wide and per-peer listings, and the request-details lifecycle ladder (UNPROCESSED →
+  * LOCALLY_PROCESSED → SOFT_CONFIRMED → HARD_CONFIRMED), plus the 404 / 400 edges.
+  */
+class HeadRequestsEndpointsTest extends AnyFunSuite:
+
+    private val multiNodeConfig: MultiNodeConfig =
+        MultiNodeConfig.generateDefault.pureApply(Gen.Parameters.default, Seed(0L))
+    private val headConfig = multiNodeConfig.headConfig
+    private val peer0 = HeadPeerNumber(0)
+
+    private val receivedAt = Instant.parse("2026-01-01T00:00:00Z")
+    private val softAt = Instant.parse("2026-01-01T00:01:00Z")
+    private val hardAt = Instant.parse("2026-01-01T00:05:00Z")
+
+    private def txRequest(peer: HeadPeerNumber, num: Long): UserRequestWithId =
+        UserRequestWithId(
+          TransactionRequest(TransactionRequestBody(ByteString.empty)),
+          RequestId(peer, RequestNumber(num)),
+          receivedAt
+        )
+
+    private def depositRequest(peer: HeadPeerNumber, num: Long): UserRequestWithId =
+        UserRequestWithId(
+          DepositRequest(DepositRequestBody(ByteString.empty, ByteString.empty)),
+          RequestId(peer, RequestNumber(num)),
+          receivedAt
+        )
+
+    /** A reader over a fixed per-peer request map, plus an optional lifecycle for request
+      * `(peer0, 0)`: its processing block/verdict and that block's confirmation moments.
+      */
+    private def stubReader(
+        requests: Map[HeadPeerNumber, List[UserRequestWithId]],
+        processed: Option[RequestBlockEntry] = None,
+        softBlock: Option[(BlockNumber, Instant)] = None,
+        hardStack: Option[(BlockNumber, StackNumber, Instant)] = None
+    ): ConsensusStoreReader[IO] =
+        new ConsensusStoreReader[IO]:
+            def blockBriefs: IO[List[BlockBrief.Next]] = IO.pure(Nil)
+            def blockBrief(num: BlockNumber): IO[Option[BlockBrief.Next]] = IO.pure(None)
+            def softConfirmation(
+                num: BlockNumber
+            ): IO[Option[Timestamped[Block.SoftConfirmed.Next]]] =
+                IO.pure(softBlock.collect { case (b, at) if b == num => Timestamped(at, null) })
+            def stackOf(num: BlockNumber): IO[Option[StackNumber]] =
+                IO.pure(hardStack.collect { case (b, s, _) if b == num => s })
+            def hardConfirmation(
+                num: StackNumber
+            ): IO[Option[Timestamped[StackEffects.HardConfirmed]]] =
+                IO.pure(hardStack.collect { case (_, s, at) if s == num => Timestamped(at, null) })
+            def requestsOf(peer: HeadPeerNumber): IO[List[UserRequestWithId]] =
+                IO.pure(requests.getOrElse(peer, Nil))
+            def request(peer: HeadPeerNumber, num: RequestNumber): IO[Option[UserRequestWithId]] =
+                IO.pure(
+                  requests.getOrElse(peer, Nil).find(_.requestId.requestNum == num)
+                )
+            def requestBlock(
+                peer: HeadPeerNumber,
+                num: RequestNumber
+            ): IO[Option[RequestBlockEntry]] =
+                IO.pure(
+                  processed.filter(_ => peer == peer0 && num == RequestNumber(0))
+                )
+
+    private def withRoutes(reader: ConsensusStoreReader[IO])(check: HttpApp[IO] => IO[Unit]): Unit =
+        ActorSystem[IO]("HeadRequestsEndpointsTest")
+            .use { system =>
+                for {
+                    requestSequencerStub <- system.actorOf(
+                      new Actor[IO, RequestSequencer.Request] {
+                          override def receive: Receive[IO, RequestSequencer.Request] =
+                              _ => IO.pure(())
+                      }
+                    )
+                    blockWeaverStub <- system.actorOf(
+                      new Actor[IO, BlockWeaver.Request] {
+                          override def receive: Receive[IO, BlockWeaver.Request] = _ => IO.pure(())
+                      }
+                    )
+                    routes <- HydrozoaRoutes(
+                      requestSequencerStub,
+                      blockWeaverStub,
+                      IO.pure(NodeStatus.Active),
+                      reader,
+                      None,
+                      headConfig,
+                      HydrozoaServer.Config(adminUsername = "admin", adminPassword = "admin"),
+                      ContraTracer[IO, HydrozoaHttpEvent](_ => IO.unit)
+                    )
+                    _ <- check(routes.routes.orNotFound)
+                } yield ()
+            }
+            .unsafeRunSync()
+
+    private def get(app: HttpApp[IO], path: String): IO[(Status, Json)] =
+        for {
+            resp <- app.run(Request[IO](Method.GET, Uri.unsafeFromString(path)))
+            body <- resp.as[Json]
+        } yield (resp.status, body)
+
+    test("GET /head/requests lists every peer's requests with full ids and types") {
+        val reader = stubReader(
+          Map(peer0 -> List(txRequest(peer0, 0), depositRequest(peer0, 1)))
+        )
+        withRoutes(reader) { app =>
+            get(app, "/head/requests").map { (status, body) =>
+                val _ = assert(status == Status.Ok)
+                val rows = body.asArray.get
+                val _ = assert(rows.size == 2)
+                val r0 = rows(0).hcursor
+                val _ = assert(r0.downField("requestId").get[Int]("headPeerNumber") == Right(0))
+                val _ = assert(r0.downField("requestId").get[Long]("requestNumber") == Right(0L))
+                val _ = assert(r0.get[String]("requestType") == Right("transaction"))
+                val _ = assert(rows(1).hcursor.get[String]("requestType") == Right("deposit"))
+                ()
+            }
+        }
+    }
+
+    test("GET /head/requests/0 lists that peer's requests by number and type") {
+        val reader = stubReader(Map(peer0 -> List(txRequest(peer0, 0), depositRequest(peer0, 1))))
+        withRoutes(reader) { app =>
+            get(app, "/head/requests/0").map { (status, body) =>
+                val _ = assert(status == Status.Ok)
+                val rows = body.asArray.get
+                val _ = assert(rows.size == 2)
+                val _ = assert(rows(0).hcursor.get[Long]("requestNumber") == Right(0L))
+                val _ = assert(rows(1).hcursor.get[String]("requestType") == Right("deposit"))
+                ()
+            }
+        }
+    }
+
+    test("GET /head/requests/0/0 walks the lifecycle: UNPROCESSED to HARD_CONFIRMED") {
+        def statusOf(reader: ConsensusStoreReader[IO]): (String, Option[Int], Option[String]) =
+            var out: (String, Option[Int], Option[String]) = ("", None, None)
+            withRoutes(reader) { app =>
+                get(app, "/head/requests/0/0").map { (status, body) =>
+                    val _ = assert(status == Status.Ok)
+                    val s = body.hcursor.downField("status")
+                    out = (
+                      s.get[String]("status").toOption.get,
+                      s.get[Int]("blockNumber").toOption,
+                      s.get[String]("hardConfirmedAt").toOption
+                    )
+                }
+            }
+            out
+
+        val base = Map(peer0 -> List(txRequest(peer0, 0)))
+        val entry = RequestBlockEntry(BlockNumber(3), ValidityFlag.Valid)
+
+        val _ = assert(statusOf(stubReader(base)) == ("UNPROCESSED", None, None))
+        val _ = assert(
+          statusOf(stubReader(base, processed = Some(entry))) ==
+              ("LOCALLY_PROCESSED", Some(3), None)
+        )
+        val _ = assert(
+          statusOf(
+            stubReader(base, processed = Some(entry), softBlock = Some((BlockNumber(3), softAt)))
+          ) == ("SOFT_CONFIRMED", Some(3), None)
+        )
+        assert(
+          statusOf(
+            stubReader(
+              base,
+              processed = Some(entry),
+              softBlock = Some((BlockNumber(3), softAt)),
+              hardStack = Some((BlockNumber(3), StackNumber(1), hardAt))
+            )
+          ) == ("HARD_CONFIRMED", Some(3), Some(hardAt.toString))
+        )
+    }
+
+    test("GET /head/requests/0/0 carries the receive time and the invalid verdict") {
+        val reader = stubReader(
+          Map(peer0 -> List(txRequest(peer0, 0))),
+          processed = Some(RequestBlockEntry(BlockNumber(2), ValidityFlag.Invalid))
+        )
+        withRoutes(reader) { app =>
+            get(app, "/head/requests/0/0").map { (status, body) =>
+                val _ = assert(status == Status.Ok)
+                val _ = assert(body.hcursor.get[String]("receivedAt") == Right(receivedAt.toString))
+                val _ = assert(
+                  body.hcursor.downField("status").get[String]("validity") == Right("invalid")
+                )
+                ()
+            }
+        }
+    }
+
+    test("GET /head/requests/{unknown} is a 404; a malformed segment is a 4xx, not a 500") {
+        val reader = stubReader(Map(peer0 -> List(txRequest(peer0, 0))))
+        withRoutes(reader) { app =>
+            for {
+                missing <- get(app, "/head/requests/0/99")
+                badPeer <- app.run(
+                  Request[IO](Method.GET, Uri.unsafeFromString("/head/requests/oops"))
+                )
+                badNum <- app.run(
+                  Request[IO](Method.GET, Uri.unsafeFromString("/head/requests/0/oops"))
+                )
+            } yield {
+                val _ = assert(missing._1 == Status.NotFound)
+                val _ = assert(badPeer.status.code >= 400 && badPeer.status.code < 500)
+                val _ = assert(badNum.status.code >= 400 && badNum.status.code < 500)
+                ()
+            }
+        }
+    }


### PR DESCRIPTION
Slices 4-5 of the head-API effort, **stacked on #542** (base = `feature/head-api-read`; retarget down the stack as #541 → #542 merge). Adds the request queries over the `Request` journals and the reverse indices from slice 2.

## What

- **`ConsensusStoreReader`** gains request reads: `requestsOf` (per-author `Request`-journal scan), `request` (point read), `requestBlock` (`RequestBlockIndex` point read).
- **`GET /head/requests`** — every request the head has assigned an id, across all head peers: object-form request id (`{headPeerNumber, requestNumber}`) + type (`transaction` / `deposit`).
- **`GET /head/requests/{head-peer-number}`** — one peer's requests, by number and type.
- **`GET /head/requests/{head-peer-number}/{request-number}`** — type, receive time (`receivedAt` from slice 2), and the lifecycle status: `UNPROCESSED | LOCALLY_PROCESSED (block + validity) | SOFT_CONFIRMED | HARD_CONFIRMED`, resolved through the `request → block` index and the block's confirmation records (reusing the blocks slice's confirmation-time helper). `relatedEffects` is always absent — per-request effect tracking (reverse-index #3) is its own ticket.
- **Validated tapir path codecs** for `HeadPeerNumber` (0..255) and `RequestNumber` (40-bit) — out-of-range input is a 400 at decode, never a throw in the types' `apply`.

Request ids are object-form everywhere in these responses, per the API decision; the packed i64 stays remote-ledger-only (the write-path `RequestAcceptedResponse` is unchanged in this slice).

## Verified

`just build-werror` green (caught the same `-Werror` value-discard class in the new test — fixed); new `HeadRequestsEndpointsTest` 5/5 through the HTTP layer (head-wide + per-peer listings, the full UNPROCESSED→HARD_CONFIRMED ladder with times and the invalid verdict, 404/400 edges); all server suites 25/25; core OpenAPI golden regenerated; `integration/Test` compiles.

## Remaining in the effort

The per-block effects endpoints (`/head/blocks/{n}/effects/*`) — per-block attribution over the per-stack `HardConfirmation` records — and eventually reverse-index #3 (request → effects) to fill `relatedEffects`.