### PR TITLE
Head API: reshape /head/requests (opaque id, filters, drop per-peer)

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -70,10 +70,22 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
   /head/requests:
     get:
-      description: Every request the head has assigned an id, across all head peers
-        — request id (author peer number + request number) and type (transaction or
-        deposit).
+      description: Requests the head has assigned an id — opaque request id, author
+        peer number, and type (transaction or deposit). Filter with ?type=transaction|deposit
+        and ?peer_number=<n>.
       operationId: getHeadRequests
+      parameters:
+      - name: type
+        in: query
+        required: false
+        schema:
+          type: string
+      - name: peer_number
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int32
       responses:
         '200':
           description: ''
@@ -89,47 +101,15 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-  /head/requests/{head-peer-number}:
+  /head/requests/{request-id}:
     get:
-      description: Every request authored by one head peer, in request-number order
-        — request number and type.
-      operationId: getHeadPeerRequests
-      parameters:
-      - name: head-peer-number
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int32
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/PeerRequestSummaryView'
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-  /head/requests/{head-peer-number}/{request-number}:
-    get:
-      description: 'One request''s type, receive time, and lifecycle status: UNPROCESSED,
-        LOCALLY_PROCESSED (block + validity), SOFT_CONFIRMED (+ this node''s soft-confirmation
-        time), or HARD_CONFIRMED (+ its hard-confirmation time).'
+      description: 'One request''s peer, type, receive time, and lifecycle status:
+        UNPROCESSED, LOCALLY_PROCESSED (block + validity), SOFT_CONFIRMED (+ this
+        node''s soft-confirmation time), or HARD_CONFIRMED (+ its hard-confirmation
+        time).'
       operationId: getHeadRequest
       parameters:
-      - name: head-peer-number
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int32
-      - name: request-number
+      - name: request-id
         in: path
         required: true
         schema:
@@ -376,18 +356,6 @@ components:
       properties:
         status:
           type: string
-    PeerRequestSummaryView:
-      title: PeerRequestSummaryView
-      type: object
-      required:
-      - requestNumber
-      - requestType
-      properties:
-        requestNumber:
-          type: integer
-          format: int64
-        requestType:
-          type: string
     ReadinessResponse:
       title: ReadinessResponse
       type: object
@@ -410,31 +378,23 @@ components:
       type: object
       required:
       - requestId
+      - peerNumber
       - requestType
       - receivedAt
       - status
       properties:
         requestId:
-          $ref: '#/components/schemas/RequestIdView'
+          type: integer
+          format: int64
+        peerNumber:
+          type: integer
+          format: int32
         requestType:
           type: string
         receivedAt:
           type: string
         status:
           $ref: '#/components/schemas/RequestStatusView'
-    RequestIdView:
-      title: RequestIdView
-      type: object
-      required:
-      - headPeerNumber
-      - requestNumber
-      properties:
-        headPeerNumber:
-          type: integer
-          format: int32
-        requestNumber:
-          type: integer
-          format: int64
     RequestStatusView:
       title: RequestStatusView
       type: object
@@ -462,10 +422,15 @@ components:
       type: object
       required:
       - requestId
+      - peerNumber
       - requestType
       properties:
         requestId:
-          $ref: '#/components/schemas/RequestIdView'
+          type: integer
+          format: int64
+        peerNumber:
+          type: integer
+          format: int32
         requestType:
           type: string
     TxInputView:

--- a/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
+++ b/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
@@ -151,15 +151,11 @@ object ApiDto {
         case _: BlockBrief.Major => "major"
         case _: BlockBrief.Final => "final"
 
-    /** One row of the head-wide request listing: the full request id and the request type. */
-    final case class RequestSummaryView(requestId: RequestIdView, requestType: String)
-    given Codec[RequestSummaryView] = deriveCodec
-
-    /** One row of a single peer's request listing: the request number (the peer is the path) and
-      * the request type.
+    /** One row of the request listing: the opaque request id (the packed i64, the same value the
+      * submit response returns), the author peer number, and the request type.
       */
-    final case class PeerRequestSummaryView(requestNumber: Long, requestType: String)
-    given Codec[PeerRequestSummaryView] = deriveCodec
+    final case class RequestSummaryView(requestId: Long, peerNumber: Int, requestType: String)
+    given Codec[RequestSummaryView] = deriveCodec
 
     /** A request's lifecycle status from this node's viewpoint: `UNPROCESSED`, `LOCALLY_PROCESSED`,
       * `SOFT_CONFIRMED`, or `HARD_CONFIRMED`, with the fields each stage adds. `relatedEffects` is
@@ -175,9 +171,12 @@ object ApiDto {
     )
     given Codec[RequestStatusView] = deriveCodec
 
-    /** The request-details body: id, type, receive time, and the lifecycle status. */
+    /** The request-details body: opaque id (echoed from the path), author peer, type, receive time,
+      * and the lifecycle status.
+      */
     final case class RequestDetailsView(
-        requestId: RequestIdView,
+        requestId: Long,
+        peerNumber: Int,
         requestType: String,
         receivedAt: String,
         status: RequestStatusView
@@ -189,13 +188,13 @@ object ApiDto {
         case _: UserRequestWithId.DepositRequest     => "deposit"
         case _: UserRequestWithId.TransactionRequest => "transaction"
 
-    /** Map a request to its head-wide listing row. */
+    /** Map a request to its listing row. */
     def mkRequestSummaryView(request: UserRequestWithId): RequestSummaryView =
-        RequestSummaryView(mkRequestIdView(request.requestId), requestTypeName(request))
-
-    /** Map a request to its per-peer listing row. */
-    def mkPeerRequestSummaryView(request: UserRequestWithId): PeerRequestSummaryView =
-        PeerRequestSummaryView(request.requestId.requestNum.convert, requestTypeName(request))
+        RequestSummaryView(
+          requestId = request.requestId.asI64,
+          peerNumber = request.requestId.peerNum.convert,
+          requestType = requestTypeName(request)
+        )
 
     private def validityName(validity: ValidityFlag): String = validity match
         case ValidityFlag.Valid   => "valid"
@@ -230,7 +229,8 @@ object ApiDto {
         status: RequestStatusView
     ): RequestDetailsView =
         RequestDetailsView(
-          requestId = mkRequestIdView(request.requestId),
+          requestId = request.requestId.asI64,
+          peerNumber = request.requestId.peerNum.convert,
           requestType = requestTypeName(request),
           receivedAt = request.receivedAt.toString,
           status = status

--- a/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
+++ b/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
@@ -9,7 +9,7 @@ import hydrozoa.multisig.NodeStatus
 import hydrozoa.multisig.consensus.peer.HeadPeerNumber
 import hydrozoa.multisig.consensus.{BlockWeaver, RequestSequencer}
 import hydrozoa.multisig.ledger.block.{BlockBrief, BlockNumber}
-import hydrozoa.multisig.ledger.event.RequestNumber
+import hydrozoa.multisig.ledger.event.{RequestId, RequestNumber}
 import hydrozoa.multisig.ledger.l2.EutxoL2LedgerReader
 import hydrozoa.multisig.persistence.ConsensusStoreReader
 import hydrozoa.multisig.server.ApiDto.*
@@ -132,31 +132,19 @@ class HydrozoaRoutes(
                 )
         )(_.convert)
 
-    /** `{head-peer-number}` path segments decode to a validated [[HeadPeerNumber]] (0..255); an
-      * out-of-range number is a 400 at decode, not a throw in the type's `apply`.
+    /** `{request-id}` path segments decode to a validated [[RequestId]] from its opaque i64 form
+      * (`asI64`, bits 40-47 = author peer, bits 0-39 = request number). Out of `[0, 2^48)` — where
+      * `fromI64` would throw an out-of-range peer/number — is a 400 at decode, not a 500.
       */
-    private given Codec[String, HeadPeerNumber, CodecFormat.TextPlain] =
-        Codec.int.mapDecode(i =>
-            if i >= 0 && i < (1 << 8) then DecodeResult.Value(HeadPeerNumber(i))
-            else
-                DecodeResult.Error(
-                  i.toString,
-                  new IllegalArgumentException("head peer number out of range [0, 256)")
-                )
-        )(_.convert)
-
-    /** `{request-number}` path segments decode to a validated [[RequestNumber]] (a 40-bit
-      * non-negative), a 400 at decode rather than a throw.
-      */
-    private given Codec[String, RequestNumber, CodecFormat.TextPlain] =
+    private given Codec[String, RequestId, CodecFormat.TextPlain] =
         Codec.long.mapDecode(n =>
-            if n >= 0 && n < (1L << 40) then DecodeResult.Value(RequestNumber(n))
+            if n >= 0 && n < (1L << 48) then DecodeResult.Value(RequestId.fromI64(n))
             else
                 DecodeResult.Error(
                   n.toString,
-                  new IllegalArgumentException("request number out of range [0, 2^40)")
+                  new IllegalArgumentException("request id out of range [0, 2^48)")
                 )
-        )(_.convert)
+        )(_.asI64)
 
     private val blocksEndpoint: ServerEndpoint[Any, IO] =
         endpoint.get
@@ -212,53 +200,34 @@ class HydrozoaRoutes(
     private val requestsEndpoint: ServerEndpoint[Any, IO] =
         endpoint.get
             .in("head" / "requests")
+            .in(query[Option[String]]("type"))
+            .in(query[Option[Int]]("peer_number"))
             .name("getHeadRequests")
             .out(jsonBody[List[RequestSummaryView]])
             .errorOut(errorOut)
             .description(
-              "Every request the head has assigned an id, across all head peers — request id " +
-                  "(author peer number + request number) and type (transaction or deposit)."
+              "Requests the head has assigned an id — opaque request id, author peer number, and " +
+                  "type (transaction or deposit). Filter with ?type=transaction|deposit and " +
+                  "?peer_number=<n>."
             )
-            .serverLogic(_ =>
-                headConfig.headPeerNums.toList
-                    .traverse(consensusReader.requestsOf)
-                    .map(perPeer => Right(perPeer.flatten.map(ApiDto.mkRequestSummaryView)))
-                    .handleError(err => Left(fail(StatusCode.InternalServerError, err.getMessage)))
-            )
-
-    private val peerRequestsEndpoint: ServerEndpoint[Any, IO] =
-        endpoint.get
-            .in("head" / "requests" / path[HeadPeerNumber]("head-peer-number"))
-            .name("getHeadPeerRequests")
-            .out(jsonBody[List[PeerRequestSummaryView]])
-            .errorOut(errorOut)
-            .description(
-              "Every request authored by one head peer, in request-number order — request " +
-                  "number and type."
-            )
-            .serverLogic(peer =>
-                consensusReader
-                    .requestsOf(peer)
-                    .map(requests => Right(requests.map(ApiDto.mkPeerRequestSummaryView)))
+            .serverLogic((typeFilter, peerFilter) =>
+                listRequests(typeFilter, peerFilter)
                     .handleError(err => Left(fail(StatusCode.InternalServerError, err.getMessage)))
             )
 
     private val requestDetailsEndpoint: ServerEndpoint[Any, IO] =
         endpoint.get
-            .in(
-              "head" / "requests" / path[HeadPeerNumber]("head-peer-number") /
-                  path[RequestNumber]("request-number")
-            )
+            .in("head" / "requests" / path[RequestId]("request-id"))
             .name("getHeadRequest")
             .out(jsonBody[RequestDetailsView])
             .errorOut(errorOut)
             .description(
-              "One request's type, receive time, and lifecycle status: UNPROCESSED, " +
+              "One request's peer, type, receive time, and lifecycle status: UNPROCESSED, " +
                   "LOCALLY_PROCESSED (block + validity), SOFT_CONFIRMED (+ this node's " +
                   "soft-confirmation time), or HARD_CONFIRMED (+ its hard-confirmation time)."
             )
-            .serverLogic((peer, num) =>
-                requestDetails(peer, num)
+            .serverLogic(id =>
+                requestDetails(id.peerNum, id.requestNum)
                     .handleError(err => Left(fail(StatusCode.InternalServerError, err.getMessage)))
             )
 
@@ -397,7 +366,6 @@ class HydrozoaRoutes(
           registerDepositEndpoint,
           headInfoEndpoint,
           requestsEndpoint,
-          peerRequestsEndpoint,
           requestDetailsEndpoint,
           blocksEndpoint,
           blockDetailsEndpoint,
@@ -555,6 +523,24 @@ class HydrozoaRoutes(
       * The lifecycle status resolves through the request → block index and the block's confirmation
       * records.
       */
+    /** The request listing, optionally narrowed to one author peer (`peer_number`) and one type
+      * (`transaction`/`deposit`). An unknown `type` value matches nothing (empty list); an
+      * out-of-range `peer_number` likewise yields an empty list, since no such author exists.
+      */
+    private def listRequests(
+        typeFilter: Option[String],
+        peerFilter: Option[Int]
+    ): IO[Either[(StatusCode, ErrorResponse), List[RequestSummaryView]]] =
+        val peers = peerFilter match
+            case None    => headConfig.headPeerNums.toList
+            case Some(p) => headConfig.headPeerNums.toList.filter(_.convert == p)
+        peers
+            .traverse(consensusReader.requestsOf)
+            .map { perPeer =>
+                val rows = perPeer.flatten.map(ApiDto.mkRequestSummaryView)
+                Right(typeFilter.fold(rows)(t => rows.filter(_.requestType == t)))
+            }
+
     private def requestDetails(
         peer: HeadPeerNumber,
         num: RequestNumber
@@ -583,7 +569,7 @@ class HydrozoaRoutes(
     ): (StatusCode, ErrorResponse) =
         fail(
           StatusCode.NotFound,
-          s"Request ${peer.convert}/${num.convert} not found"
+          s"Request ${RequestId(peer, num).asI64} not found"
         )
 
     private def blockNotFound(num: BlockNumber): (StatusCode, ErrorResponse) =

--- a/src/test/scala/hydrozoa/multisig/server/HeadRequestsEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/HeadRequestsEndpointsTest.scala
@@ -127,7 +127,7 @@ class HeadRequestsEndpointsTest extends AnyFunSuite:
             body <- resp.as[Json]
         } yield (resp.status, body)
 
-    test("GET /head/requests lists every peer's requests with full ids and types") {
+    test("GET /head/requests lists rows with the opaque i64 id, peer number, and type") {
         val reader = stubReader(
           Map(peer0 -> List(txRequest(peer0, 0), depositRequest(peer0, 1)))
         )
@@ -137,34 +137,48 @@ class HeadRequestsEndpointsTest extends AnyFunSuite:
                 val rows = body.asArray.get
                 val _ = assert(rows.size == 2)
                 val r0 = rows(0).hcursor
-                val _ = assert(r0.downField("requestId").get[Int]("headPeerNumber") == Right(0))
-                val _ = assert(r0.downField("requestId").get[Long]("requestNumber") == Right(0L))
+                // peer 0, request 0 packs to i64 0.
+                val _ = assert(r0.get[Long]("requestId") == Right(0L))
+                val _ = assert(r0.get[Int]("peerNumber") == Right(0))
                 val _ = assert(r0.get[String]("requestType") == Right("transaction"))
-                val _ = assert(rows(1).hcursor.get[String]("requestType") == Right("deposit"))
+                val r1 = rows(1).hcursor
+                val _ = assert(r1.get[Long]("requestId") == Right(1L))
+                val _ = assert(r1.get[String]("requestType") == Right("deposit"))
                 ()
             }
         }
     }
 
-    test("GET /head/requests/0 lists that peer's requests by number and type") {
-        val reader = stubReader(Map(peer0 -> List(txRequest(peer0, 0), depositRequest(peer0, 1))))
+    test("GET /head/requests?type= and ?peer_number= narrow the listing") {
+        val reader = stubReader(
+          Map(peer0 -> List(txRequest(peer0, 0), depositRequest(peer0, 1)))
+        )
         withRoutes(reader) { app =>
-            get(app, "/head/requests/0").map { (status, body) =>
-                val _ = assert(status == Status.Ok)
-                val rows = body.asArray.get
-                val _ = assert(rows.size == 2)
-                val _ = assert(rows(0).hcursor.get[Long]("requestNumber") == Right(0L))
-                val _ = assert(rows(1).hcursor.get[String]("requestType") == Right("deposit"))
+            for {
+                deposits <- get(app, "/head/requests?type=deposit")
+                thisPeer <- get(app, "/head/requests?peer_number=0")
+                otherPeer <- get(app, "/head/requests?peer_number=99")
+                unknownType <- get(app, "/head/requests?type=nonsense")
+            } yield {
+                val _ = assert(deposits._1 == Status.Ok)
+                val depRows = deposits._2.asArray.get
+                val _ = assert(depRows.size == 1)
+                val _ = assert(depRows(0).hcursor.get[String]("requestType") == Right("deposit"))
+                val _ = assert(thisPeer._2.asArray.get.size == 2)
+                // No such author peer -> empty, not an error.
+                val _ = assert(otherPeer._1 == Status.Ok && otherPeer._2.asArray.get.isEmpty)
+                val _ = assert(unknownType._2.asArray.get.isEmpty)
                 ()
             }
         }
     }
 
-    test("GET /head/requests/0/0 walks the lifecycle: UNPROCESSED to HARD_CONFIRMED") {
+    test("GET /head/requests/{id} walks the lifecycle: UNPROCESSED to HARD_CONFIRMED") {
         def statusOf(reader: ConsensusStoreReader[IO]): (String, Option[Int], Option[String]) =
             var out: (String, Option[Int], Option[String]) = ("", None, None)
             withRoutes(reader) { app =>
-                get(app, "/head/requests/0/0").map { (status, body) =>
+                // peer 0, request 0 -> opaque id 0.
+                get(app, "/head/requests/0").map { (status, body) =>
                     val _ = assert(status == Status.Ok)
                     val s = body.hcursor.downField("status")
                     out = (
@@ -201,14 +215,16 @@ class HeadRequestsEndpointsTest extends AnyFunSuite:
         )
     }
 
-    test("GET /head/requests/0/0 carries the receive time and the invalid verdict") {
+    test("GET /head/requests/{id} carries the opaque id, peer, receive time, and verdict") {
         val reader = stubReader(
           Map(peer0 -> List(txRequest(peer0, 0))),
           processed = Some(RequestBlockEntry(BlockNumber(2), ValidityFlag.Invalid))
         )
         withRoutes(reader) { app =>
-            get(app, "/head/requests/0/0").map { (status, body) =>
+            get(app, "/head/requests/0").map { (status, body) =>
                 val _ = assert(status == Status.Ok)
+                val _ = assert(body.hcursor.get[Long]("requestId") == Right(0L))
+                val _ = assert(body.hcursor.get[Int]("peerNumber") == Right(0))
                 val _ = assert(body.hcursor.get[String]("receivedAt") == Right(receivedAt.toString))
                 val _ = assert(
                   body.hcursor.downField("status").get[String]("validity") == Right("invalid")
@@ -218,21 +234,22 @@ class HeadRequestsEndpointsTest extends AnyFunSuite:
         }
     }
 
-    test("GET /head/requests/{unknown} is a 404; a malformed segment is a 4xx, not a 500") {
+    test("GET /head/requests/{unknown} is a 404; a malformed id is a 4xx, not a 500") {
         val reader = stubReader(Map(peer0 -> List(txRequest(peer0, 0))))
         withRoutes(reader) { app =>
             for {
-                missing <- get(app, "/head/requests/0/99")
-                badPeer <- app.run(
+                missing <- get(app, "/head/requests/99")
+                malformed <- app.run(
                   Request[IO](Method.GET, Uri.unsafeFromString("/head/requests/oops"))
                 )
-                badNum <- app.run(
-                  Request[IO](Method.GET, Uri.unsafeFromString("/head/requests/0/oops"))
+                // 2^48 is out of the packable range -> a clean decode error, never a 500.
+                outOfRange <- app.run(
+                  Request[IO](Method.GET, Uri.unsafeFromString("/head/requests/281474976710656"))
                 )
             } yield {
                 val _ = assert(missing._1 == Status.NotFound)
-                val _ = assert(badPeer.status.code >= 400 && badPeer.status.code < 500)
-                val _ = assert(badNum.status.code >= 400 && badNum.status.code < 500)
+                val _ = assert(malformed.status.code >= 400 && malformed.status.code < 500)
+                val _ = assert(outOfRange.status.code >= 400 && outOfRange.status.code < 500)
                 ()
             }
         }


### PR DESCRIPTION
Applies the revised requests design (agreed in discussion) on top of the built requests slice (#543). Stacked on `feature/head-api-requests`; retarget down the stack as parents merge. The new block-effects subsystem is a separate follow-up PR (next).

## What changed vs #543

- **Listing rows** are now `{ requestId (opaque i64), peerNumber, requestType }` instead of the object-form id. The i64 is the packed `asI64` — the same value `POST /head/tx` returns in `RequestAcceptedResponse`, so `GET /head/requests/<that>` round-trips with the accept response.
- **Query filters** `?type=transaction|deposit` and `?peer_number=<n>` on the listing. An unknown `type` or out-of-range `peer_number` yields an empty list, not an error.
- **The per-peer path endpoint** `GET /head/requests/{head-peer-number}` is **removed** — `?peer_number=` replaces it.
- **Details** key by a single opaque segment: `GET /head/requests/{request-id}` (was `/{peer}/{number}`). The path codec bounds the i64 to `[0, 2^48)` so an out-of-range token is a clean **400** (`RequestId.fromI64` would otherwise throw an out-of-range peer/number and 500). The details body carries the opaque id, author peer, type, receive time, and lifecycle status.
- `relatedEffects` stays absent — request→effects remains a separate task.

Removes the now-dead `PeerRequestSummaryView` (+ mapper) and the `HeadPeerNumber`/`RequestNumber` path codecs (no path uses them anymore). OpenAPI golden regenerated.

## Decisions applied (from discussion)

Opaque id = **decimal i64 string**; requests reshape shipped **before** block-effects; `relatedEffects` deferred.

## Verified

`just build-werror` green; `HeadRequestsEndpointsTest` reshaped to the new surface (5/5: i64 rows, both filters incl. empty-result cases, the opaque-id lifecycle ladder, id/peer/receive-time/verdict in details, 404 for unknown id + 400 for malformed/out-of-range); all 25 server suites; golden regenerated; `integration/Test` compiles.

## Next

The block-effects read subsystem: `GET /head/blocks/{n}/effects` (per-block-type listing, decomposing per-stack partitions back onto blocks), the per-kind sub-resources incl. the SEC (head+coil signatures via a positional split at nHeadPeers, synthetic `blake2b_256(sec.header)` id), and `GET /head/effects/{l1TxId}` backed by a new reverse-index CF.