### PR TITLE
feat(api): block-effects subsystem — per-block effect queries

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -202,6 +202,85 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /head/blocks/{block-number}/effects:
+    get:
+      description: A block's L1 effects as l1TxIds, grouped by kind (initialization,
+        settlement, fallback, sec, rollouts, refunds, finalization) per block type.
+        Empty until the block is hard-confirmed.
+      operationId: getHeadBlockEffects
+      parameters:
+      - name: block-number
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int32
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BlockEffectsView'
+        default:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /head/effects/{l1TxId}:
+    get:
+      description: Any effect by its l1TxId (real tx id, or an SEC's synthetic hash).
+      operationId: getHeadEffect
+      parameters:
+      - name: l1TxId
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EffectView'
+        default:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /head/blocks/{block-number}/effects/rollouts/{number}:
+    get:
+      description: One rollout of the block's rollout chain by index, or 404 if absent.
+      operationId: getHeadBlockRollout
+      parameters:
+      - name: block-number
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int32
+      - name: number
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int32
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EffectView'
+        default:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /health:
     get:
       description: Liveness — always 200 while the process is serving HTTP.
@@ -250,6 +329,126 @@ paths:
       security:
       - {}
       - httpAuth: []
+  /head/blocks/{block-number}/effects/initialization:
+    get:
+      description: The block's initialization effect in full, or 404 if it has none.
+      operationId: getHeadBlockEffect_initialization
+      parameters:
+      - name: block-number
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int32
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EffectView'
+        default:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /head/blocks/{block-number}/effects/settlement:
+    get:
+      description: The block's settlement effect in full, or 404 if it has none.
+      operationId: getHeadBlockEffect_settlement
+      parameters:
+      - name: block-number
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int32
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EffectView'
+        default:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /head/blocks/{block-number}/effects/fallback:
+    get:
+      description: The block's fallback effect in full, or 404 if it has none.
+      operationId: getHeadBlockEffect_fallback
+      parameters:
+      - name: block-number
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int32
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EffectView'
+        default:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /head/blocks/{block-number}/effects/sec:
+    get:
+      description: The block's sec effect in full, or 404 if it has none.
+      operationId: getHeadBlockEffect_sec
+      parameters:
+      - name: block-number
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int32
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EffectView'
+        default:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /head/blocks/{block-number}/effects/finalization:
+    get:
+      description: The block's finalization effect in full, or 404 if it has none.
+      operationId: getHeadBlockEffect_finalization
+      parameters:
+      - name: block-number
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int32
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EffectView'
+        default:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 components:
   schemas:
     BlockConfirmationView:
@@ -282,6 +481,32 @@ components:
           type: string
         confirmation:
           $ref: '#/components/schemas/BlockConfirmationView'
+    BlockEffectsView:
+      title: BlockEffectsView
+      type: object
+      required:
+      - blockType
+      properties:
+        blockType:
+          type: string
+        initialization:
+          type: string
+        settlement:
+          type: string
+        finalization:
+          type: string
+        fallback:
+          type: string
+        sec:
+          type: string
+        rollouts:
+          type: array
+          items:
+            type: string
+        refunds:
+          type: array
+          items:
+            type: string
     BlockSummaryView:
       title: BlockSummaryView
       type: object
@@ -297,6 +522,33 @@ components:
           format: int32
         blockType:
           type: string
+    EffectView:
+      title: EffectView
+      type: object
+      required:
+      - l1TxId
+      - kind
+      - blockNumber
+      properties:
+        l1TxId:
+          type: string
+        kind:
+          type: string
+        blockNumber:
+          type: integer
+          format: int32
+        txCbor:
+          type: string
+        secOnchainSerialized:
+          type: string
+        headSignatures:
+          type: array
+          items:
+            type: string
+        coilSignatures:
+          type: array
+          items:
+            type: string
     ErrorResponse:
       title: ErrorResponse
       type: object

--- a/src/main/scala/hydrozoa/multisig/consensus/SlowConsensusActor.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/SlowConsensusActor.scala
@@ -13,7 +13,7 @@ import hydrozoa.multisig.HeadMultisigRegimeManager
 import hydrozoa.multisig.consensus.ack.HardAck
 import hydrozoa.multisig.consensus.peer.PeerId
 import hydrozoa.multisig.ledger.block.BlockNumber
-import hydrozoa.multisig.ledger.stack.{PartitionEffects, Stack, StackBrief, StackEffects, StackNumber}
+import hydrozoa.multisig.ledger.stack.{EffectIds, PartitionEffects, Stack, StackBrief, StackEffects, StackNumber}
 import hydrozoa.multisig.persistence.{Persistence, StoreKey, Timestamped, WriteBatch}
 
 /** Slow-consensus actor.
@@ -388,9 +388,14 @@ final case class SlowConsensusActor(
     ): IO[Unit] = for {
         stamp <- persistence.arrivalStamp
         blockRange = ((brief.firstBlockNum: Int) to (brief.lastBlockNum: Int)).toList
-        batch = blockRange.foldLeft(
+        withBlockIndex = blockRange.foldLeft(
           WriteBatch.start.put(StoreKey.HardConfirmation(stackNum))(Timestamped(stamp, signed))
         )((b, n) => b.put(StoreKey.BlockStackIndex(BlockNumber(n)))(stackNum))
+        // One effect → stack reverse-index row per effect (each l1TxId, incl. the SEC synthetic
+        // ids), so GET /head/effects/<l1TxId> resolves to this stack in one lookup.
+        batch = EffectIds
+            .allL1TxIds(signed)
+            .foldLeft(withBlockIndex)((b, id) => b.put(StoreKey.EffectStackIndex(id))(stackNum))
         _ <- persistence.write(batch)
     } yield ()
 

--- a/src/main/scala/hydrozoa/multisig/ledger/stack/EffectIds.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/stack/EffectIds.scala
@@ -1,0 +1,42 @@
+package hydrozoa.multisig.ledger.stack
+
+import hydrozoa.multisig.ledger.stack.PartitionEffects.{Final, Major, Minor}
+import scalus.cardano.ledger.TransactionHash
+import scalus.uplc.builtin.{ByteString, platform}
+
+/** L1 identity of the effects a hard-confirmed stack carries. Every effect is addressed by a single
+  * `l1TxId`:
+  *   - a real L1 tx effect (initialization, settlement, fallback, rollout, finalization, post-dated
+  *     refund) is its `EnrichedTx`'s `tx.id`;
+  *   - a standalone evacuation commitment (SEC) is not an L1 tx, so it takes a **synthetic**
+  *     `l1TxId = blake2b_256(sec.header)` — the same 32-byte shape as a real tx id, over the SEC's
+  *     on-chain serialized bytes (never a real tx-body preimage, so it cannot collide in practice).
+  *
+  * These are the ids the effect queries resolve and the reverse index (`Cf.EffectStack`) keys.
+  */
+object EffectIds:
+
+    /** The synthetic l1TxId for a standalone evacuation commitment. */
+    def secL1TxId(sec: StandaloneEvacuationCommitment): TransactionHash =
+        val headerBytes: Array[Byte] = sec.header
+        TransactionHash.fromByteString(platform.blake2b_256(ByteString.fromArray(headerBytes)))
+
+    /** Every effect's l1TxId in a hard-confirmed stack, in a stable order (partition order, then
+      * within a partition the settlement/finalization opener, its rollouts, refunds, then the SEC).
+      * Used to write the reverse index at hard-confirmation time.
+      */
+    def allL1TxIds(hc: StackEffects.HardConfirmed): List[TransactionHash] = hc match
+        case i: StackEffects.HardConfirmed.Initial =>
+            List(i.initializationTx.tx.id, i.fallbackTx.tx.id)
+        case r: StackEffects.HardConfirmed.Regular =>
+            r.partitions.toList.flatMap {
+                case p: Major[StandaloneEvacuationCommitment.MultiSigned] =>
+                    List(p.settlement.tx.id, p.fallback.tx.id) ++
+                        p.rollouts.map(_.tx.id) ++
+                        p.refunds.map(_.tx.id) ++
+                        p.sec.map(ms => secL1TxId(ms.commitment)).toList
+                case p: Final =>
+                    p.finalization.tx.id :: p.rollouts.map(_.tx.id)
+                case p: Minor[StandaloneEvacuationCommitment.MultiSigned] =>
+                    secL1TxId(p.sec.commitment) :: p.refunds.map(_.tx.id)
+            }

--- a/src/main/scala/hydrozoa/multisig/persistence/Cf.scala
+++ b/src/main/scala/hydrozoa/multisig/persistence/Cf.scala
@@ -94,6 +94,13 @@ object Cf:
     case object BlockStackIndex extends Cf:
         def name = "BlockStackIndex"
 
+    /** Effect → stack reverse index: `l1TxId` → the stack whose `HardConfirmation` carries that
+      * effect. Written by SCA in the same atomic batch as the stack's `HardConfirmation`. Backs
+      * `GET /head/effects/<l1TxId>`.
+      */
+    case object EffectStackIndex extends Cf:
+        def name = "EffectStackIndex"
+
     /** Store-level metadata (schema version + arrival-stamp generation). */
     case object Meta extends Cf:
         def name = "Meta"
@@ -136,6 +143,7 @@ object Cf:
       EvacuationMap,
       RequestBlockIndex,
       BlockStackIndex,
+      EffectStackIndex,
       Meta
     )
 

--- a/src/main/scala/hydrozoa/multisig/persistence/ConsensusStoreReader.scala
+++ b/src/main/scala/hydrozoa/multisig/persistence/ConsensusStoreReader.scala
@@ -6,10 +6,11 @@ import hydrozoa.multisig.consensus.UserRequestWithId
 import hydrozoa.multisig.consensus.peer.HeadPeerNumber
 import hydrozoa.multisig.ledger.block.{Block, BlockBrief, BlockNumber}
 import hydrozoa.multisig.ledger.event.{RequestId, RequestNumber}
-import hydrozoa.multisig.ledger.stack.{StackEffects, StackNumber}
+import hydrozoa.multisig.ledger.stack.{StackBrief, StackEffects, StackNumber}
 import hydrozoa.multisig.persistence.recovery.CursorScan
 import java.nio.ByteBuffer
 import java.time.Instant
+import scalus.cardano.ledger.TransactionHash
 
 /** Read-only view over the consensus store for the user-facing HTTP API (the
   * [[hydrozoa.multisig.ledger.l2.EutxoL2LedgerReader]] pattern): block briefs from the block spine,
@@ -38,6 +39,14 @@ trait ConsensusStoreReader[F[_]]:
       * confirmation stamp.
       */
     def hardConfirmation(num: StackNumber): F[Option[Timestamped[StackEffects.HardConfirmed]]]
+
+    /** One stack's brief (its `[firstBlockNum, lastBlockNum]` range), if persisted. */
+    def stackBrief(num: StackNumber): F[Option[StackBrief]]
+
+    /** The stack whose hard-confirmation carries the effect with this l1TxId, if any (the effect →
+      * stack reverse index).
+      */
+    def effectStack(l1TxId: TransactionHash): F[Option[StackNumber]]
 
     /** One head peer's assigned requests, in request-number order (that author's Request journal),
       * each paired with the arrival stamp it was recorded at (its receive time).
@@ -88,6 +97,12 @@ object ConsensusStoreReader:
             ): IO[Option[Timestamped[StackEffects.HardConfirmed]]] =
                 persistence.get(StoreKey.HardConfirmation(num))
 
+            def stackBrief(num: StackNumber): IO[Option[StackBrief]] =
+                persistence.get(JournalKey.Stack(num)).map(_.map(_.payload))
+
+            def effectStack(l1TxId: TransactionHash): IO[Option[StackNumber]] =
+                persistence.get(StoreKey.EffectStackIndex(l1TxId))
+
             def requestsOf(peer: HeadPeerNumber): IO[List[Timestamped[UserRequestWithId]]] =
                 CursorScan.cursorWalk(
                   persistence.backend,
@@ -125,6 +140,8 @@ object ConsensusStoreReader:
             def hardConfirmation(
                 num: StackNumber
             ): IO[Option[Timestamped[StackEffects.HardConfirmed]]] = IO.pure(None)
+            def stackBrief(num: StackNumber): IO[Option[StackBrief]] = IO.pure(None)
+            def effectStack(l1TxId: TransactionHash): IO[Option[StackNumber]] = IO.pure(None)
             def requestsOf(peer: HeadPeerNumber): IO[List[Timestamped[UserRequestWithId]]] =
                 IO.pure(Nil)
             def request(id: RequestId): IO[Option[Timestamped[UserRequestWithId]]] = IO.pure(None)

--- a/src/main/scala/hydrozoa/multisig/persistence/JournalKey.scala
+++ b/src/main/scala/hydrozoa/multisig/persistence/JournalKey.scala
@@ -16,7 +16,7 @@ import java.nio.ByteBuffer
   * append-only replay sequence (scanned by [[recovery.JournalScan]], total-ordered across journals
   * by [[recovery.ArrivalOrderedMerge]]). It is a **subset** of the column families: `JournalKey
   * extends StoreKey`, so "journal" ≠ "column family" — every CF is a [[StoreKey]], but only the
-  * replayable ones are a `JournalKey`. The 13 non-journal CFs (snapshots, key-ordered / `max(key)`
+  * replayable ones are a `JournalKey`. The 14 non-journal CFs (snapshots, key-ordered / `max(key)`
   * reconstruction reads) stay plain [[StoreKey]]: unstamped, never merged.
   *
   * Encoded byte form (per §7.1, big-endian fixed-width so lexicographic byte order matches numeric
@@ -129,7 +129,7 @@ object JournalKey:
         case Cf.BlockResult | Cf.SoftConfirmation | Cf.HardConfirmation | Cf.DepositMap |
             Cf.Treasury | Cf.EvacuationMap | Cf.RequestHighWater | Cf.CoilStampMark |
             Cf.L2CommandNumber | Cf.UnsignedStack | Cf.RequestBlockIndex | Cf.BlockStackIndex |
-            Cf.Meta =>
+            Cf.EffectStackIndex | Cf.Meta =>
             throw new IllegalArgumentException(
               s"$cf is not a journal CF; JournalKey.decode is undefined for it"
             )

--- a/src/main/scala/hydrozoa/multisig/persistence/StoreDump.scala
+++ b/src/main/scala/hydrozoa/multisig/persistence/StoreDump.scala
@@ -130,6 +130,8 @@ object StoreDump:
             case Cf.RequestBlockIndex =>
                 if key.length == 8 then s"RequestBlockIndex(i64=${ByteBuffer.wrap(key).getLong})"
                 else hex(key)
+            case Cf.EffectStackIndex =>
+                s"EffectStackIndex(${hex(key)})"
             case Cf.DepositMap | Cf.Treasury | Cf.CoilStampMark =>
                 if key.isEmpty then "(singleton)" else hex(key)
             case Cf.Meta =>

--- a/src/main/scala/hydrozoa/multisig/persistence/StoreKey.scala
+++ b/src/main/scala/hydrozoa/multisig/persistence/StoreKey.scala
@@ -11,6 +11,7 @@ import hydrozoa.multisig.ledger.l1.utxo.MultisigTreasuryUtxo
 import hydrozoa.multisig.ledger.l2.L2CommandNumber as LedgerL2CommandNumber
 import hydrozoa.multisig.ledger.stack.{Stack, StackEffects, StackNumber}
 import hydrozoa.multisig.persistence.codec.{BlockResultCodec, CoilStampMarkCodec, DepositMapCodec, RequestHighWaterCodec, SoftConfirmationCodec, StackEffectsCodec, TreasuryCodec, UnsignedStackCodec}
+import scalus.cardano.ledger.TransactionHash
 
 /** The typed key surface for the high-level persistence API.
   *
@@ -20,7 +21,7 @@ import hydrozoa.multisig.persistence.codec.{BlockResultCodec, CoilStampMarkCodec
   * is keyed by one. A *journal* (the recovery concept: an arrival-stamped, index-ordered
   * append-only replay sequence, §3) is the **subset** of column families reached through
   * [[JournalKey]], which **extends** `StoreKey` (the 6 of those are documented there, not here).
-  * The 13 non-journal CFs — snapshots and key-ordered / `max(key)` reconstruction reads, unstamped
+  * The 14 non-journal CFs — snapshots and key-ordered / `max(key)` reconstruction reads, unstamped
   * and never arrival-merged — are the cases declared in the companion below:
   *
   *   - Spine-indexed metadata CFs (one entry per block / stack): [[StoreKey.BlockResult]] —
@@ -33,7 +34,8 @@ import hydrozoa.multisig.persistence.codec.{BlockResultCodec, CoilStampMarkCodec
   *     [[StoreKey.UnsignedStack]] — `Cf.UnsignedStack`, keyed by `stackNum`.
   *   - Reverse-index CFs: [[StoreKey.RequestBlockIndex]] — `Cf.RequestBlockIndex`, keyed by the
   *     request id (its packed i64). [[StoreKey.BlockStackIndex]] — `Cf.BlockStackIndex`, keyed by
-  *     `blockNum`.
+  *     `blockNum`. [[StoreKey.EffectStackIndex]] — `Cf.EffectStackIndex`, keyed by the effect's
+  *     `l1TxId`.
   *   - Singleton snapshot CFs (one entry total): [[StoreKey.DepositMap]], [[StoreKey.Treasury]],
   *     [[StoreKey.CoilStampMark]] (a hub's per-coil-peer stamped marks, one keyed blob).
   *   - Store-level metadata: [[StoreKey.Meta]] — `Cf.Meta`, name-keyed.
@@ -131,6 +133,16 @@ object StoreKey:
         given codec: StoreCodec[Value] = StoreCodec.fromCirce[Value]
         val cf: Cf = Cf.BlockStackIndex
         def encode: Array[Byte] = JournalKey.intBytes(num)
+
+    /** Key for [[Cf.EffectStackIndex]] — the effect → stack reverse index, keyed by the effect's
+      * `l1TxId` (its 32 raw bytes), holding the [[StackNumber]] whose `HardConfirmation` carries
+      * it. Written by SCA in the same atomic batch as that `HardConfirmation`.
+      */
+    final case class EffectStackIndex(l1TxId: TransactionHash) extends StoreKey:
+        type Value = StackNumber
+        given codec: StoreCodec[Value] = StoreCodec.fromCirce[Value]
+        val cf: Cf = Cf.EffectStackIndex
+        def encode: Array[Byte] = l1TxId.bytes.toArray
 
     /** Key for [[Cf.DepositMap]] — the single blob holding JL's deposits map at `softAcked`. */
     case object DepositMap extends StoreKey:

--- a/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
+++ b/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
@@ -242,6 +242,95 @@ object ApiDto {
           status = status
         )
 
+    /** A block's L1 effects as `l1TxId`s, grouped by kind — the fields present depend on the block
+      * type (INITIAL: initialization + fallback; MINOR: sec? + refunds; MAJOR: settlement +
+      * fallback + rollouts + refunds; FINAL: finalization + rollouts). Absent kinds are omitted.
+      */
+    final case class BlockEffectsView(
+        blockType: String,
+        initialization: Option[String],
+        settlement: Option[String],
+        finalization: Option[String],
+        fallback: Option[String],
+        sec: Option[String],
+        rollouts: List[String],
+        refunds: List[String]
+    )
+    given Codec[BlockEffectsView] = deriveCodec
+
+    /** One L1 effect in full. Every effect has an `l1TxId`, `kind`, and `blockNumber`. A real tx
+      * effect carries its `txCbor` (hex); a standalone evacuation commitment (kind `sec`) carries
+      * its serialized on-chain bytes (whose hash is the synthetic `l1TxId`) and the hard-ack
+      * signatures split into `headSignatures` then `coilSignatures`.
+      */
+    final case class EffectView(
+        l1TxId: String,
+        kind: String,
+        blockNumber: Int,
+        txCbor: Option[String],
+        secOnchainSerialized: Option[String],
+        headSignatures: Option[List[String]],
+        coilSignatures: Option[List[String]]
+    )
+    given Codec[EffectView] = deriveCodec
+
+    /** The effect-kind discriminator string (matches the sub-resource path segments). */
+    def effectKindName(kind: EffectKind): String = kind match
+        case EffectKind.Initialization => "initialization"
+        case EffectKind.Settlement     => "settlement"
+        case EffectKind.Fallback       => "fallback"
+        case EffectKind.Rollout        => "rollout"
+        case EffectKind.Finalization   => "finalization"
+        case EffectKind.Refund         => "refund"
+        case EffectKind.Sec            => "sec"
+
+    /** Group a block's resolved effects into the by-kind listing. */
+    def mkBlockEffectsView(blockType: String, effects: List[ResolvedEffect]): BlockEffectsView =
+        def firstIdOf(k: EffectKind): Option[String] =
+            effects.collectFirst { case e if e.kind == k => e.l1TxId.toHex }
+        def idsOf(k: EffectKind): List[String] =
+            effects.collect { case e if e.kind == k => e.l1TxId.toHex }
+        BlockEffectsView(
+          blockType = blockType,
+          initialization = firstIdOf(EffectKind.Initialization),
+          settlement = firstIdOf(EffectKind.Settlement),
+          finalization = firstIdOf(EffectKind.Finalization),
+          fallback = firstIdOf(EffectKind.Fallback),
+          sec = firstIdOf(EffectKind.Sec),
+          rollouts = idsOf(EffectKind.Rollout),
+          refunds = idsOf(EffectKind.Refund)
+        )
+
+    /** Map a resolved effect to its full view; `nHeadPeers` splits an SEC's hard-ack signatures
+      * into head (first `nHeadPeers`) then coil.
+      */
+    def mkEffectView(effect: ResolvedEffect, nHeadPeers: Int): EffectView = effect match
+        case tx: ResolvedEffect.Tx =>
+            EffectView(
+              l1TxId = tx.l1TxId.toHex,
+              kind = effectKindName(tx.kind),
+              blockNumber = tx.blockNumber.convert,
+              txCbor = Some(ByteString.fromArray(tx.tx.toCbor).toHex),
+              secOnchainSerialized = None,
+              headSignatures = None,
+              coilSignatures = None
+            )
+        case sec: ResolvedEffect.Sec =>
+            val sigsHex = sec.commitment.headerMultiSigned.map { sig =>
+                val bytes: Array[Byte] = sig
+                ByteString.fromArray(bytes).toHex
+            }
+            val headerBytes: Array[Byte] = sec.commitment.commitment.header
+            EffectView(
+              l1TxId = sec.l1TxId.toHex,
+              kind = "sec",
+              blockNumber = sec.blockNumber.convert,
+              txCbor = None,
+              secOnchainSerialized = Some(ByteString.fromArray(headerBytes).toHex),
+              headSignatures = Some(sigsHex.take(nHeadPeers)),
+              coilSignatures = Some(sigsHex.drop(nHeadPeers))
+            )
+
     /** A utxo reference, `{ transaction_id, index }` (CIP-0116). */
     final case class TxInputView(transaction_id: String, index: Int)
 

--- a/src/main/scala/hydrozoa/multisig/server/EffectsResolver.scala
+++ b/src/main/scala/hydrozoa/multisig/server/EffectsResolver.scala
@@ -1,0 +1,234 @@
+package hydrozoa.multisig.server
+
+import cats.data.NonEmptyList
+import cats.effect.IO
+import cats.syntax.all.*
+import hydrozoa.multisig.ledger.block.{BlockBrief, BlockNumber}
+import hydrozoa.multisig.ledger.l1.tx.RefundTx
+import hydrozoa.multisig.ledger.stack.PartitionEffects.{Final, Major, Minor}
+import hydrozoa.multisig.ledger.stack.{EffectIds, StackEffects, StackNumber, StandaloneEvacuationCommitment}
+import hydrozoa.multisig.persistence.ConsensusStoreReader
+import scalus.cardano.ledger.{Transaction, TransactionHash}
+
+/** The kind of L1 effect an entry represents. */
+enum EffectKind:
+    case Initialization, Settlement, Fallback, Rollout, Finalization, Refund, Sec
+
+/** One L1 effect a hard-confirmed stack carries, attributed to the single block it belongs to and
+  * addressed by its `l1TxId` (a real tx id, or the SEC's synthetic hash).
+  */
+sealed trait ResolvedEffect:
+    def l1TxId: TransactionHash
+    def blockNumber: BlockNumber
+    def kind: EffectKind
+
+object ResolvedEffect:
+    /** A real L1 tx effect — its `l1TxId` is the tx id. `rolloutIndex` positions a rollout within
+      * its block's rollout chain (`None` for non-rollout effects).
+      */
+    final case class Tx(
+        l1TxId: TransactionHash,
+        blockNumber: BlockNumber,
+        kind: EffectKind,
+        tx: Transaction,
+        rolloutIndex: Option[Int]
+    ) extends ResolvedEffect
+
+    /** A standalone evacuation commitment — not a real tx, so its `l1TxId` is synthetic. */
+    final case class Sec(
+        l1TxId: TransactionHash,
+        blockNumber: BlockNumber,
+        commitment: StandaloneEvacuationCommitment.MultiSigned
+    ) extends ResolvedEffect:
+        def kind: EffectKind = EffectKind.Sec
+
+/** Decomposes a hard-confirmed stack's **per-partition** effects onto the individual **blocks**
+  * they belong to — the bridge the block-effects queries cross, since effects are produced and
+  * persisted per stack/partition but the API addresses them per block.
+  *
+  * Attribution: an SEC self-identifies its block (`commitment.blockNum`); a settlement / fallback /
+  * finalization and its rollouts belong to their partition's opener block (the Major or Final
+  * block); a post-dated refund belongs to the block where its deposit was registered (via the
+  * request → block index). Stack 0 (`Initial`) is the initialization + initial-fallback pair on
+  * block 0.
+  */
+final class EffectsResolver(reader: ConsensusStoreReader[IO]):
+
+    /** The effects attributed to one block, or `None` when the block does not exist. A block that
+      * exists but is not yet hard-confirmed has an empty effect list.
+      */
+    def blockEffects(num: BlockNumber): IO[Option[List[ResolvedEffect]]] =
+        val existsAndEffects: IO[Option[List[ResolvedEffect]]] =
+            reader
+                .stackOf(num)
+                .flatMap {
+                    case Some(stackNum) =>
+                        resolveStack(stackNum).map(es => es.filter(_.blockNumber == num))
+                    case None => IO.pure(Nil)
+                }
+                .map(Some(_))
+        if num == BlockNumber.zero then existsAndEffects
+        else
+            reader.blockBrief(num).flatMap {
+                case None    => IO.pure(None)
+                case Some(_) => existsAndEffects
+            }
+
+    /** The single effect with this `l1TxId`, if the store has one (via the effect → stack index).
+      */
+    def effectById(l1TxId: TransactionHash): IO[Option[ResolvedEffect]] =
+        reader.effectStack(l1TxId).flatMap {
+            case None           => IO.pure(None)
+            case Some(stackNum) => resolveStack(stackNum).map(_.find(_.l1TxId == l1TxId))
+        }
+
+    /** Every effect a hard-confirmed stack carries, attributed per block. Empty when the stack is
+      * not hard-confirmed.
+      */
+    def resolveStack(stackNum: StackNumber): IO[List[ResolvedEffect]] =
+        reader.hardConfirmation(stackNum).flatMap {
+            case None => IO.pure(Nil)
+            case Some(timestamped) =>
+                timestamped.payload match
+                    case i: StackEffects.HardConfirmed.Initial =>
+                        IO.pure(
+                          List(
+                            ResolvedEffect
+                                .Tx(
+                                  i.initializationTx.tx.id,
+                                  BlockNumber.zero,
+                                  EffectKind.Initialization,
+                                  i.initializationTx.tx,
+                                  None
+                                ),
+                            ResolvedEffect.Tx(
+                              i.fallbackTx.tx.id,
+                              BlockNumber.zero,
+                              EffectKind.Fallback,
+                              i.fallbackTx.tx,
+                              None
+                            )
+                          )
+                        )
+                    case r: StackEffects.HardConfirmed.Regular =>
+                        resolveRegular(stackNum, r)
+        }
+
+    private def resolveRegular(
+        stackNum: StackNumber,
+        effects: StackEffects.HardConfirmed.Regular
+    ): IO[List[ResolvedEffect]] =
+        for {
+            briefs <- stackBriefs(stackNum)
+            groups = partitionGroups(briefs)
+            resolved <-
+                if groups.length != effects.partitions.length then
+                    IO.raiseError(
+                      new IllegalStateException(
+                        s"stack $stackNum: ${groups.length} block partitions but " +
+                            s"${effects.partitions.length} effect partitions"
+                      )
+                    )
+                else
+                    groups
+                        .zip(effects.partitions.toList)
+                        .flatTraverse((blockNums, pe) => resolvePartition(blockNums, pe))
+        } yield resolved
+
+    private def resolvePartition(
+        blockNums: NonEmptyList[BlockNumber],
+        pe: hydrozoa.multisig.ledger.stack.PartitionEffects[
+          StandaloneEvacuationCommitment.MultiSigned
+        ]
+    ): IO[List[ResolvedEffect]] =
+        val opener = blockNums.head
+        pe match
+            case p: Major[StandaloneEvacuationCommitment.MultiSigned] =>
+                val opening = ResolvedEffect
+                    .Tx(p.settlement.tx.id, opener, EffectKind.Settlement, p.settlement.tx, None) ::
+                    ResolvedEffect
+                        .Tx(p.fallback.tx.id, opener, EffectKind.Fallback, p.fallback.tx, None) ::
+                    rolloutEffects(opener, p.rollouts)
+                val sec = p.sec.toList.map(ms =>
+                    ResolvedEffect
+                        .Sec(EffectIds.secL1TxId(ms.commitment), ms.commitment.blockNum, ms)
+                )
+                p.refunds.traverse(attributeRefund(_, opener)).map(opening ++ sec ++ _)
+            case p: Final =>
+                IO.pure(
+                  ResolvedEffect
+                      .Tx(
+                        p.finalization.tx.id,
+                        opener,
+                        EffectKind.Finalization,
+                        p.finalization.tx,
+                        None
+                      )
+                      :: rolloutEffects(opener, p.rollouts)
+                )
+            case p: Minor[StandaloneEvacuationCommitment.MultiSigned] =>
+                val sec = ResolvedEffect
+                    .Sec(EffectIds.secL1TxId(p.sec.commitment), p.sec.commitment.blockNum, p.sec)
+                p.refunds.traverse(attributeRefund(_, opener)).map(sec :: _)
+
+    private def rolloutEffects(
+        block: BlockNumber,
+        rollouts: List[hydrozoa.multisig.ledger.l1.tx.RolloutTx]
+    ): List[ResolvedEffect] =
+        rollouts.zipWithIndex.map((rt, i) =>
+            ResolvedEffect.Tx(rt.tx.id, block, EffectKind.Rollout, rt.tx, Some(i))
+        )
+
+    /** A post-dated refund belongs to the block where its deposit was registered (the request →
+      * block index); `fallbackBlock` is used only if that index entry is somehow absent.
+      */
+    private def attributeRefund(refund: RefundTx, fallbackBlock: BlockNumber): IO[ResolvedEffect] =
+        val block: IO[BlockNumber] = refund match
+            case p: RefundTx.PostDated =>
+                reader
+                    .requestBlock(p.requestId)
+                    .map(_.map(_.blockNum).getOrElse(fallbackBlock))
+        block.map(b => ResolvedEffect.Tx(refund.tx.id, b, EffectKind.Refund, refund.tx, None))
+
+    /** The stack's block briefs in block order (its `[firstBlockNum, lastBlockNum]` range). */
+    private def stackBriefs(stackNum: StackNumber): IO[List[BlockBrief.Next]] =
+        reader.stackBrief(stackNum).flatMap {
+            case None => IO.pure(Nil)
+            case Some(brief) =>
+                ((brief.firstBlockNum: Int) to (brief.lastBlockNum: Int)).toList
+                    .traverse(n => reader.blockBrief(BlockNumber(n)))
+                    .map(_.flatten)
+        }
+
+    /** Group a stack's blocks into its partitions' block-number lists — mirrors
+      * [[hydrozoa.multisig.ledger.stack.StackPartition.partition]] exactly (leading minor run;
+      * Major + trailing same-nothing minors; Final alone), so the groups align 1:1 with the
+      * persisted [[StackEffects.HardConfirmed.Regular.partitions]].
+      */
+    private def partitionGroups(briefs: List[BlockBrief.Next]): List[NonEmptyList[BlockNumber]] =
+        def isMinor(b: BlockBrief.Next): Boolean = b match
+            case _: BlockBrief.Minor => true
+            case _                   => false
+
+        @annotation.tailrec
+        def loop(
+            remaining: List[BlockBrief.Next],
+            acc: List[NonEmptyList[BlockNumber]]
+        ): List[NonEmptyList[BlockNumber]] =
+            remaining match
+                case Nil => acc.reverse
+                case head :: rest =>
+                    head match
+                        case _: BlockBrief.Minor =>
+                            val (minors, rest2) = remaining.span(isMinor)
+                            loop(rest2, NonEmptyList.fromListUnsafe(minors.map(_.blockNum)) :: acc)
+                        case _: BlockBrief.Major =>
+                            val (trailing, rest2) = rest.span(isMinor)
+                            loop(
+                              rest2,
+                              NonEmptyList(head.blockNum, trailing.map(_.blockNum)) :: acc
+                            )
+                        case _ =>
+                            (NonEmptyList.one(head.blockNum) :: acc).reverse
+
+        loop(briefs, Nil)

--- a/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
+++ b/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
@@ -22,6 +22,8 @@ import java.time.Instant
 import org.http4s.HttpRoutes
 import scala.util.Try
 import scalus.cardano.address.Address
+import scalus.cardano.ledger.TransactionHash
+import scalus.uplc.builtin.ByteString
 import sttp.apispec.openapi.circe.yaml.*
 import sttp.model.StatusCode
 import sttp.model.headers.WWWAuthenticateChallenge
@@ -56,6 +58,9 @@ class HydrozoaRoutes(
       * `headConfig` satisfies the section.
       */
     private given CardanoNetwork.Section = headConfig
+
+    /** Decomposes hard-confirmed stacks' effects onto blocks for the effect queries. */
+    private val effectsResolver: EffectsResolver = EffectsResolver(consensusReader)
 
     /** How many recent L2 transactions to return when `?count=` is omitted. */
     private val defaultRecentTxCount = 50
@@ -149,6 +154,17 @@ class HydrozoaRoutes(
                 )
         )(_.asI64)
 
+    /** `{l1TxId}` path segments decode to a validated 32-byte [[TransactionHash]] from lower-case
+      * hex; a malformed or wrong-length token is a 400 at decode.
+      */
+    private given Codec[String, TransactionHash, CodecFormat.TextPlain] =
+        Codec.string.mapDecode(s =>
+            Try(TransactionHash.fromByteString(ByteString.fromHex(s))).toEither match
+                case Right(h) if h.bytes.size == 32 => DecodeResult.Value(h)
+                case _ =>
+                    DecodeResult.Error(s, new IllegalArgumentException("malformed 32-byte l1TxId"))
+        )(_.toHex)
+
     private val blocksEndpoint: ServerEndpoint[Any, IO] =
         endpoint.get
             .in("head" / "blocks")
@@ -202,6 +218,77 @@ class HydrozoaRoutes(
                 blockHeader(num)
                     .handleError(err => Left(fail(StatusCode.InternalServerError, err.getMessage)))
             )
+
+    private val blockEffectsEndpoint: ServerEndpoint[Any, IO] =
+        endpoint.get
+            .in("head" / "blocks" / path[BlockNumber]("block-number") / "effects")
+            .name("getHeadBlockEffects")
+            .out(jsonBody[BlockEffectsView])
+            .errorOut(errorOut)
+            .description(
+              "A block's L1 effects as l1TxIds, grouped by kind (initialization, settlement, " +
+                  "fallback, sec, rollouts, refunds, finalization) per block type. Empty until " +
+                  "the block is hard-confirmed."
+            )
+            .serverLogic(num =>
+                blockEffectsListing(num)
+                    .handleError(err => Left(fail(StatusCode.InternalServerError, err.getMessage)))
+            )
+
+    /** One `GET /head/blocks/<n>/effects/<kind>` endpoint per fixed kind — the effect in full, or a
+      * 404 when this block carries no effect of that kind.
+      */
+    private def blockEffectKindEndpoint(
+        segment: String,
+        kind: EffectKind
+    ): ServerEndpoint[Any, IO] =
+        endpoint.get
+            .in("head" / "blocks" / path[BlockNumber]("block-number") / "effects" / segment)
+            .name(s"getHeadBlockEffect_$segment")
+            .out(jsonBody[EffectView])
+            .errorOut(errorOut)
+            .description(s"The block's $segment effect in full, or 404 if it has none.")
+            .serverLogic(num =>
+                blockEffectOfKind(num, kind)
+                    .handleError(err => Left(fail(StatusCode.InternalServerError, err.getMessage)))
+            )
+
+    private val blockRolloutEndpoint: ServerEndpoint[Any, IO] =
+        endpoint.get
+            .in(
+              "head" / "blocks" / path[BlockNumber]("block-number") / "effects" / "rollouts" /
+                  path[Int]("number")
+            )
+            .name("getHeadBlockRollout")
+            .out(jsonBody[EffectView])
+            .errorOut(errorOut)
+            .description("One rollout of the block's rollout chain by index, or 404 if absent.")
+            .serverLogic((num, i) =>
+                blockRollout(num, i)
+                    .handleError(err => Left(fail(StatusCode.InternalServerError, err.getMessage)))
+            )
+
+    private val effectByIdEndpoint: ServerEndpoint[Any, IO] =
+        endpoint.get
+            .in("head" / "effects" / path[TransactionHash]("l1TxId"))
+            .name("getHeadEffect")
+            .out(jsonBody[EffectView])
+            .errorOut(errorOut)
+            .description("Any effect by its l1TxId (real tx id, or an SEC's synthetic hash).")
+            .serverLogic(id =>
+                effectById(id)
+                    .handleError(err => Left(fail(StatusCode.InternalServerError, err.getMessage)))
+            )
+
+    /** The per-kind effect sub-resources, one endpoint each. */
+    private val blockEffectKindEndpoints: List[ServerEndpoint[Any, IO]] =
+        List(
+          "initialization" -> EffectKind.Initialization,
+          "settlement" -> EffectKind.Settlement,
+          "fallback" -> EffectKind.Fallback,
+          "sec" -> EffectKind.Sec,
+          "finalization" -> EffectKind.Finalization
+        ).map(blockEffectKindEndpoint)
 
     private val requestsEndpoint: ServerEndpoint[Any, IO] =
         endpoint.get
@@ -384,10 +471,13 @@ class HydrozoaRoutes(
           blocksEndpoint,
           blockDetailsEndpoint,
           blockHeaderEndpoint,
+          blockEffectsEndpoint,
+          effectByIdEndpoint,
+          blockRolloutEndpoint,
           healthEndpoint,
           readyEndpoint,
           finalizeEndpoint
-        )
+        ) ++ blockEffectKindEndpoints
 
     /** Don't auto-document a body/param decode-failure response: our JSON bodies are raw strings
       * whose codec never fails, so tapir's default would advertise an unreachable `text/plain` 400
@@ -513,6 +603,79 @@ class HydrozoaRoutes(
                         case b: BlockBrief.Final => b.header.asJson
                     })
             }
+
+    /** The block's type — `initial` for block 0 (config), else read from its brief. `None` if a
+      * non-zero block does not exist.
+      */
+    private def blockTypeOf(num: BlockNumber): IO[Option[String]] =
+        if num == BlockNumber.zero then IO.pure(Some("initial"))
+        else
+            consensusReader
+                .blockBrief(num)
+                .map(_.map {
+                    case _: BlockBrief.Minor => "minor"
+                    case _: BlockBrief.Major => "major"
+                    case _: BlockBrief.Final => "final"
+                })
+
+    /** The block-effects listing (l1TxIds grouped by kind), or a 404 when the block does not exist.
+      */
+    private def blockEffectsListing(
+        num: BlockNumber
+    ): IO[Either[(StatusCode, ErrorResponse), BlockEffectsView]] =
+        effectsResolver.blockEffects(num).flatMap {
+            case None => IO.pure(Left(blockNotFound(num)))
+            case Some(effects) =>
+                blockTypeOf(num).map {
+                    case None            => Left(blockNotFound(num))
+                    case Some(blockType) => Right(ApiDto.mkBlockEffectsView(blockType, effects))
+                }
+        }
+
+    /** One kind of the block's effects in full, or a 404 (block missing, or no effect of that kind
+      * on this block).
+      */
+    private def blockEffectOfKind(
+        num: BlockNumber,
+        kind: EffectKind
+    ): IO[Either[(StatusCode, ErrorResponse), EffectView]] =
+        effectsResolver.blockEffects(num).map {
+            case None => Left(blockNotFound(num))
+            case Some(effects) =>
+                effects.find(_.kind == kind) match
+                    case Some(e) => Right(ApiDto.mkEffectView(e, headConfig.nHeadPeers))
+                    case None =>
+                        Left(fail(StatusCode.NotFound, s"Block ${num.convert} has no $kind effect"))
+        }
+
+    /** One rollout of the block's rollout chain by index, or a 404. */
+    private def blockRollout(
+        num: BlockNumber,
+        index: Int
+    ): IO[Either[(StatusCode, ErrorResponse), EffectView]] =
+        effectsResolver.blockEffects(num).map {
+            case None => Left(blockNotFound(num))
+            case Some(effects) =>
+                effects.collectFirst {
+                    case e: ResolvedEffect.Tx
+                        if e.kind == EffectKind.Rollout && e.rolloutIndex.contains(index) =>
+                        e
+                } match
+                    case Some(e) => Right(ApiDto.mkEffectView(e, headConfig.nHeadPeers))
+                    case None =>
+                        Left(
+                          fail(StatusCode.NotFound, s"Block ${num.convert} has no rollout $index")
+                        )
+        }
+
+    /** Any effect by its l1TxId, or a 404. */
+    private def effectById(
+        l1TxId: TransactionHash
+    ): IO[Either[(StatusCode, ErrorResponse), EffectView]] =
+        effectsResolver.effectById(l1TxId).map {
+            case None    => Left(fail(StatusCode.NotFound, s"No effect ${l1TxId.toHex}"))
+            case Some(e) => Right(ApiDto.mkEffectView(e, headConfig.nHeadPeers))
+        }
 
     /** Resolve a block's confirmation status from this node's records: the soft-confirmation
       * moment, and — through the block → stack index — the hard-confirmation moment.

--- a/src/test/scala/hydrozoa/multisig/persistence/StoreKeyTest.scala
+++ b/src/test/scala/hydrozoa/multisig/persistence/StoreKeyTest.scala
@@ -6,11 +6,17 @@ import hydrozoa.multisig.ledger.block.BlockNumber
 import hydrozoa.multisig.ledger.event.{RequestId, RequestNumber}
 import hydrozoa.multisig.ledger.stack.StackNumber
 import org.scalatest.funsuite.AnyFunSuite
+import scalus.cardano.ledger.TransactionHash
+import scalus.uplc.builtin.ByteString
 
 /** Sanity tests for [[StoreKey]] — every key knows its CF, encodes to the expected width, and
   * (where comparable) sorts the way the design assumes (big-endian numeric for spine-indexed CFs).
   */
 class StoreKeyTest extends AnyFunSuite:
+
+    /** A 32-byte hash for the effect-index key tests. */
+    private val sampleHash: TransactionHash =
+        TransactionHash.fromByteString(ByteString.fromArray(Array.tabulate(32)(_.toByte)))
 
     test("every StoreKey type maps to its expected Cf") {
         val cases: List[(StoreKey, Cf)] = List(
@@ -30,6 +36,7 @@ class StoreKeyTest extends AnyFunSuite:
           StoreKey.RequestBlockIndex(RequestId(HeadPeerNumber(0), RequestNumber(0))) ->
               Cf.RequestBlockIndex,
           StoreKey.BlockStackIndex(BlockNumber(0)) -> Cf.BlockStackIndex,
+          StoreKey.EffectStackIndex(sampleHash) -> Cf.EffectStackIndex,
           StoreKey.Meta("schema-version") -> Cf.Meta
         )
         cases.foreach { case (k, expected) =>
@@ -50,6 +57,11 @@ class StoreKeyTest extends AnyFunSuite:
         keys.foreach { k =>
             assert(k.encode.length == 4, s"$k encoded to ${k.encode.length} bytes, expected 4")
         }
+    }
+
+    test("EffectStackIndex keys encode as the 32 raw l1TxId bytes") {
+        val k = StoreKey.EffectStackIndex(sampleHash)
+        assert(java.util.Arrays.equals(k.encode, Array.tabulate(32)(_.toByte)))
     }
 
     test("RequestBlockIndex keys encode as the packed-i64 RequestId, author-prefix-ordered") {

--- a/src/test/scala/hydrozoa/multisig/server/HeadBlocksEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/HeadBlocksEndpointsTest.scala
@@ -14,7 +14,7 @@ import hydrozoa.multisig.consensus.{BlockWeaver, RequestSequencer, UserRequestWi
 import hydrozoa.multisig.ledger.block.{Block, BlockBody, BlockBrief, BlockHeader, BlockNumber, BlockVersion}
 import hydrozoa.multisig.ledger.event.RequestId
 import hydrozoa.multisig.ledger.joint.EvacuationMap
-import hydrozoa.multisig.ledger.stack.{PartitionEffects, StackEffects, StackNumber, StandaloneEvacuationCommitment}
+import hydrozoa.multisig.ledger.stack.{PartitionEffects, StackBrief, StackEffects, StackNumber, StandaloneEvacuationCommitment}
 import hydrozoa.multisig.persistence.{ArrivalStamp, ConsensusStoreReader, RequestBlockEntry, Timestamped}
 import hydrozoa.rulebased.ledger.l1.state.StandaloneEvacuationCommitmentOnchain
 import io.circe.Json
@@ -26,6 +26,7 @@ import org.scalacheck.Gen
 import org.scalacheck.rng.Seed
 import org.scalatest.funsuite.AnyFunSuite
 import scala.concurrent.duration.DurationInt
+import scalus.cardano.ledger.TransactionHash
 
 /** The `/head/blocks` queries through the HTTP layer, against a stubbed [[ConsensusStoreReader]]:
   * the listing (block 0 synthesized from config + the spine briefs), the details' confirmation
@@ -145,6 +146,8 @@ class HeadBlocksEndpointsTest extends AnyFunSuite:
                 IO.pure(Nil)
             def request(id: RequestId): IO[Option[Timestamped[UserRequestWithId]]] =
                 IO.pure(None)
+            def stackBrief(num: StackNumber): IO[Option[StackBrief]] = IO.pure(None)
+            def effectStack(l1TxId: TransactionHash): IO[Option[StackNumber]] = IO.pure(None)
             def wallClockOf(stamp: ArrivalStamp): IO[Option[Instant]] =
                 IO.pure(Some(instantOf(stamp)))
             def requestBlock(id: RequestId): IO[Option[RequestBlockEntry]] = IO.pure(None)

--- a/src/test/scala/hydrozoa/multisig/server/HeadEffectsEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/HeadEffectsEndpointsTest.scala
@@ -1,0 +1,236 @@
+package hydrozoa.multisig.server
+
+import cats.data.NonEmptyList
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import com.suprnation.actor.Actor.{Actor, Receive}
+import com.suprnation.actor.ActorSystem
+import hydrozoa.config.head.multisig.timing.TxTiming.BlockTimes.{BlockCreationEndTime, BlockCreationStartTime}
+import hydrozoa.config.head.multisig.timing.TxTiming.StackTimes.StackCreationEndTime
+import hydrozoa.config.node.MultiNodeConfig
+import hydrozoa.lib.cardano.scalus.QuantizedTime.QuantizedInstant
+import hydrozoa.lib.cardano.scalus.QuantizedTime.QuantizedInstant.realTimeQuantizedInstant
+import hydrozoa.lib.logging.ContraTracer
+import hydrozoa.multisig.NodeStatus
+import hydrozoa.multisig.consensus.peer.HeadPeerNumber
+import hydrozoa.multisig.consensus.{BlockWeaver, RequestSequencer, UserRequestWithId}
+import hydrozoa.multisig.ledger.block.{Block, BlockBody, BlockBrief, BlockHeader, BlockNumber, BlockVersion}
+import hydrozoa.multisig.ledger.event.RequestId
+import hydrozoa.multisig.ledger.joint.EvacuationMap
+import hydrozoa.multisig.ledger.stack.{EffectIds, PartitionEffects, StackBrief, StackEffects, StackNumber, StandaloneEvacuationCommitment}
+import hydrozoa.multisig.persistence.{ArrivalStamp, ConsensusStoreReader, RequestBlockEntry, Timestamped}
+import hydrozoa.rulebased.ledger.l1.state.StandaloneEvacuationCommitmentOnchain
+import io.circe.Json
+import java.time.Instant
+import org.http4s.circe.*
+import org.http4s.implicits.*
+import org.http4s.{HttpApp, Method, Request, Status, Uri}
+import org.scalacheck.Gen
+import org.scalacheck.rng.Seed
+import org.scalatest.funsuite.AnyFunSuite
+import scala.concurrent.duration.DurationInt
+import scalus.cardano.ledger.TransactionHash
+
+/** The block-effects queries through the HTTP layer against a stubbed [[ConsensusStoreReader]],
+  * exercising a single-minor stack whose only effect is a standalone evacuation commitment (SEC):
+  * the by-kind listing, the SEC sub-resource (head/coil signature split, synthetic l1TxId), the
+  * `GET /head/effects/<l1TxId>` reverse lookup, and the 404 / 400 edges. The real-tx effect kinds
+  * (settlement, rollout, finalization, refund) are exercised end-to-end by the stage suites.
+  */
+class HeadEffectsEndpointsTest extends AnyFunSuite:
+
+    private val multiNodeConfig: MultiNodeConfig =
+        MultiNodeConfig.generateDefault.pureApply(Gen.Parameters.default, Seed(0L))
+    private val headConfig = multiNodeConfig.headConfig
+    private val nHeadPeers = headConfig.nHeadPeers.convert
+
+    /** A minor brief for block 1. */
+    private def mkMinorBrief1: IO[BlockBrief.Minor] =
+        for now <- realTimeQuantizedInstant(headConfig.slotConfig)
+        yield {
+            val startTime = BlockCreationStartTime(now)
+            val endTime = BlockCreationEndTime(now + 1.second)
+            val fallbackTxStartTime = headConfig.txTiming.newFallbackStartTime(endTime)
+            BlockBrief.Minor(
+              BlockHeader.Minor(
+                blockNum = BlockNumber(1),
+                blockVersion = BlockVersion.Full(0, 0),
+                startTime = startTime,
+                endTime = endTime,
+                fallbackTxStartTime = fallbackTxStartTime,
+                forcedMajorBlockWakeupTime =
+                    headConfig.txTiming.forcedMajorBlockWakeupTime(fallbackTxStartTime),
+                mDepositDecisionWakeupTime = None
+              ),
+              BlockBody.Minor(events = List.empty, depositsRefunded = List.empty)
+            )
+        }
+
+    /** A hard-confirmed SEC committing block 1, with `nHeadPeers + 1` header signatures (so the
+      * head/coil split has a coil signature on the tail).
+      */
+    private val sec: StandaloneEvacuationCommitment.MultiSigned =
+        StandaloneEvacuationCommitment.MultiSigned(
+          commitment = StandaloneEvacuationCommitment(
+            blockNum = BlockNumber(1),
+            blockVersion = BlockVersion.Full(1, 0),
+            kzgCommitment = EvacuationMap.empty.kzgCommitment,
+            header = StandaloneEvacuationCommitmentOnchain(
+              StandaloneEvacuationCommitmentOnchain(
+                headId = headConfig.headTokenNames.treasuryTokenName.bytes,
+                versionMajor = BigInt(1),
+                versionMinor = BigInt(0),
+                commitment = EvacuationMap.empty.kzgCommitment
+              )
+            )
+          ),
+          headerMultiSigned = List.tabulate(nHeadPeers + 1)(i =>
+              BlockHeader.Minor.HeaderSignature(IArray(i.toByte, (i + 1).toByte))
+          )
+        )
+
+    private val secId: TransactionHash = EffectIds.secL1TxId(sec.commitment)
+
+    private val stackEffects: StackEffects.HardConfirmed =
+        StackEffects.HardConfirmed.Regular(
+          NonEmptyList.of(PartitionEffects.Minor(sec = sec, refunds = List.empty))
+        )
+
+    /** A stub reader over a single-minor stack (stack 1 = block 1) carrying just the SEC. */
+    private def stubReader(brief: BlockBrief.Minor): ConsensusStoreReader[IO] =
+        new ConsensusStoreReader[IO]:
+            def blockBriefs: IO[List[BlockBrief.Next]] = IO.pure(List(brief))
+            def blockBrief(num: BlockNumber): IO[Option[BlockBrief.Next]] =
+                IO.pure(Option.when(num == BlockNumber(1))(brief))
+            def softConfirmation(
+                num: BlockNumber
+            ): IO[Option[Timestamped[Block.SoftConfirmed.Next]]] = IO.pure(None)
+            def stackOf(num: BlockNumber): IO[Option[StackNumber]] =
+                IO.pure(Option.when(num == BlockNumber(1))(StackNumber(1)))
+            def hardConfirmation(
+                num: StackNumber
+            ): IO[Option[Timestamped[StackEffects.HardConfirmed]]] =
+                IO.pure(
+                  Option.when(num == StackNumber(1))(
+                    Timestamped(ArrivalStamp(0, 0L), stackEffects)
+                  )
+                )
+            def stackBrief(num: StackNumber): IO[Option[StackBrief]] =
+                IO.pure(
+                  Option.when(num == StackNumber(1))(
+                    StackBrief(
+                      StackNumber(1),
+                      BlockNumber(1),
+                      BlockNumber(1),
+                      StackCreationEndTime(
+                        QuantizedInstant.ofEpochSeconds(headConfig.slotConfig, 0L)
+                      )
+                    )
+                  )
+                )
+            def effectStack(l1TxId: TransactionHash): IO[Option[StackNumber]] =
+                IO.pure(Option.when(l1TxId == secId)(StackNumber(1)))
+            def requestsOf(peer: HeadPeerNumber): IO[List[Timestamped[UserRequestWithId]]] =
+                IO.pure(Nil)
+            def request(id: RequestId): IO[Option[Timestamped[UserRequestWithId]]] = IO.pure(None)
+            def requestBlock(id: RequestId): IO[Option[RequestBlockEntry]] = IO.pure(None)
+            def wallClockOf(stamp: ArrivalStamp): IO[Option[Instant]] = IO.pure(None)
+
+    private def withRoutes(check: HttpApp[IO] => IO[Unit]): Unit =
+        mkMinorBrief1
+            .flatMap(brief =>
+                ActorSystem[IO]("HeadEffectsEndpointsTest").use { system =>
+                    for {
+                        reqStub <- system.actorOf(new Actor[IO, RequestSequencer.Request] {
+                            override def receive: Receive[IO, RequestSequencer.Request] =
+                                _ => IO.pure(())
+                        })
+                        bwStub <- system.actorOf(new Actor[IO, BlockWeaver.Request] {
+                            override def receive: Receive[IO, BlockWeaver.Request] =
+                                _ => IO.pure(())
+                        })
+                        routes <- HydrozoaRoutes(
+                          reqStub,
+                          bwStub,
+                          IO.pure(NodeStatus.Active),
+                          stubReader(brief),
+                          None,
+                          headConfig,
+                          HydrozoaServer.Config(adminUsername = "admin", adminPassword = "admin"),
+                          ContraTracer[IO, HydrozoaHttpEvent](_ => IO.unit)
+                        )
+                        _ <- check(routes.routes.orNotFound)
+                    } yield ()
+                }
+            )
+            .unsafeRunSync()
+
+    private def get(app: HttpApp[IO], path: String): IO[(Status, Json)] =
+        for {
+            resp <- app.run(Request[IO](Method.GET, Uri.unsafeFromString(path)))
+            body <- resp.as[Json]
+        } yield (resp.status, body)
+
+    test("GET /head/blocks/1/effects lists the block's SEC by kind, no other effects") {
+        withRoutes { app =>
+            get(app, "/head/blocks/1/effects").map { (status, body) =>
+                val _ = assert(status == Status.Ok)
+                val c = body.hcursor
+                val _ = assert(c.get[String]("blockType") == Right("minor"))
+                val _ = assert(c.get[String]("sec") == Right(secId.toHex))
+                val _ = assert(c.get[List[String]]("refunds") == Right(Nil))
+                val _ = assert(c.get[List[String]]("rollouts") == Right(Nil))
+                val _ = assert(c.downField("settlement").focus.forall(_.isNull))
+                ()
+            }
+        }
+    }
+
+    test("GET /head/blocks/1/effects/sec returns the SEC in full with the head/coil split") {
+        withRoutes { app =>
+            get(app, "/head/blocks/1/effects/sec").map { (status, body) =>
+                val _ = assert(status == Status.Ok)
+                val c = body.hcursor
+                val _ = assert(c.get[String]("l1TxId") == Right(secId.toHex))
+                val _ = assert(c.get[String]("kind") == Right("sec"))
+                val _ = assert(c.get[Int]("blockNumber") == Right(1))
+                val _ = assert(c.downField("secOnchainSerialized").as[String].isRight)
+                // nHeadPeers head signatures, the remaining tail as coil signatures.
+                val _ = assert(c.get[List[String]]("headSignatures").exists(_.size == nHeadPeers))
+                val _ = assert(c.get[List[String]]("coilSignatures").exists(_.size == 1))
+                ()
+            }
+        }
+    }
+
+    test("GET /head/effects/<secId> resolves the same SEC via the reverse index") {
+        withRoutes { app =>
+            get(app, s"/head/effects/${secId.toHex}").map { (status, body) =>
+                val _ = assert(status == Status.Ok)
+                val _ = assert(body.hcursor.get[String]("l1TxId") == Right(secId.toHex))
+                val _ = assert(body.hcursor.get[String]("kind") == Right("sec"))
+                ()
+            }
+        }
+    }
+
+    test("absent effect kinds, unknown ids, and malformed ids are 404 / 400, not 500") {
+        withRoutes { app =>
+            for {
+                noSettlement <- get(app, "/head/blocks/1/effects/settlement")
+                missingBlock <- get(app, "/head/blocks/9/effects")
+                unknownId <- app.run(
+                  Request[IO](Method.GET, Uri.unsafeFromString(s"/head/effects/${"ab" * 32}"))
+                )
+                malformedId <- app.run(
+                  Request[IO](Method.GET, Uri.unsafeFromString("/head/effects/not-hex"))
+                )
+            } yield {
+                val _ = assert(noSettlement._1 == Status.NotFound)
+                val _ = assert(missingBlock._1 == Status.NotFound)
+                val _ = assert(unknownId.status == Status.NotFound)
+                val _ = assert(malformedId.status.code >= 400 && malformedId.status.code < 500)
+                ()
+            }
+        }
+    }

--- a/src/test/scala/hydrozoa/multisig/server/HeadRequestsEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/HeadRequestsEndpointsTest.scala
@@ -14,7 +14,7 @@ import hydrozoa.multisig.consensus.{BlockWeaver, RequestSequencer, UserRequestWi
 import hydrozoa.multisig.ledger.block.{Block, BlockBrief, BlockNumber}
 import hydrozoa.multisig.ledger.event.RequestId.ValidityFlag
 import hydrozoa.multisig.ledger.event.{RequestId, RequestNumber}
-import hydrozoa.multisig.ledger.stack.{StackEffects, StackNumber}
+import hydrozoa.multisig.ledger.stack.{StackBrief, StackEffects, StackNumber}
 import hydrozoa.multisig.persistence.{ArrivalStamp, ConsensusStoreReader, RequestBlockEntry, Timestamped}
 import io.circe.Json
 import java.time.Instant
@@ -24,6 +24,7 @@ import org.http4s.{HttpApp, Method, Request, Status, Uri}
 import org.scalacheck.Gen
 import org.scalacheck.rng.Seed
 import org.scalatest.funsuite.AnyFunSuite
+import scalus.cardano.ledger.TransactionHash
 import scalus.uplc.builtin.ByteString
 
 /** The `/head/requests` queries through the HTTP layer against a stubbed [[ConsensusStoreReader]]:
@@ -109,6 +110,8 @@ class HeadRequestsEndpointsTest extends AnyFunSuite:
                 IO.pure(
                   processed.filter(_ => id == RequestId(peer0, RequestNumber(0)))
                 )
+            def stackBrief(num: StackNumber): IO[Option[StackBrief]] = IO.pure(None)
+            def effectStack(l1TxId: TransactionHash): IO[Option[StackNumber]] = IO.pure(None)
             def wallClockOf(stamp: ArrivalStamp): IO[Option[Instant]] =
                 IO.pure(Some(instantOf(stamp)))
 


### PR DESCRIPTION
## Block-effects subsystem — per-block effect queries

Stacked on #545 (`feature/head-api-combined`). Adds the effect queries to the Head API.

### The problem it solves
Effects are persisted **per-stack / per-partition** (a partition is a run of blocks), but the API surfaces them **per-block**. `EffectsResolver` bridges the gap: it mirrors `StackPartition.partition` to attribute each effect to the block it belongs to.

**Attribution rules:**
- SEC → its commitment block (`sec.commitment.blockNum`)
- settlement / finalization / rollouts → the partition opener
- refunds → the request's processing block (via the `RequestBlockIndex`)

### Effect identity = the L1 tx id, everywhere
- real txs: `.tx.id`
- SEC: synthetic `blake2b_256(sec.header)`

A new `EffectStackIndex` CF reverse-maps an `l1TxId` → its stack for the `/head/effects/{l1TxId}` lookup.

### Endpoints added
- `GET /head/blocks/{n}/effects` — the block's effects, with per-kind sub-resources (initialization / settlement / fallback / sec / finalization) and a rollout listing
- the SEC sub-resource splits hard-ack signatures positionally into head (`.take(nHeadPeers)`) and coil (`.drop(nHeadPeers)`)
- `GET /head/effects/{l1TxId}` — reverse lookup from an effect's L1 tx id

### Notes
- Opaque `RequestId` is used throughout (`requestBlock(id)`), consistent with the refactor in the parent commit.
- `docs/openapi.yaml` regenerated; golden test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
