### PR TITLE
feat(api): request → effects tracking (relatedEffects)

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -105,10 +105,11 @@ paths:
     get:
       description: 'One request''s peer, type, receive time, and lifecycle status:
         UNPROCESSED, LOCALLY_PROCESSED (block + validity), SOFT_CONFIRMED (+ soft-confirmation
-        time), or HARD_CONFIRMED (+ hard-confirmation time). Every time records a
-        local event at this peer — when it received the request, and when it produced
-        the soft/hard confirmation — so different peers report different times for
-        the same request. This is by design.'
+        time), or HARD_CONFIRMED (+ hard-confirmation time and the related L1 effects
+        — the l1TxIds the request became). Every time records a local event at this
+        peer — when it received the request, and when it produced the soft/hard confirmation
+        — so different peers report different times for the same request. This is
+        by design.'
       operationId: getHeadRequest
       parameters:
       - name: request-id
@@ -522,6 +523,17 @@ components:
           format: int32
         blockType:
           type: string
+    EffectRefView:
+      title: EffectRefView
+      type: object
+      required:
+      - l1TxId
+      - kind
+      properties:
+        l1TxId:
+          type: string
+        kind:
+          type: string
     EffectView:
       title: EffectView
       type: object
@@ -670,8 +682,7 @@ components:
         relatedEffects:
           type: array
           items:
-            type: integer
-            format: int32
+            $ref: '#/components/schemas/EffectRefView'
     RequestSummaryView:
       title: RequestSummaryView
       type: object

--- a/src/main/scala/hydrozoa/multisig/ledger/joint/JointLedger.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/joint/JointLedger.scala
@@ -668,7 +668,9 @@ final case class JointLedger(
       *     `L2CommandNumber[blockNum]` (recover reads the fast-anchor entry and calls
       *     `l2Ledger.restoreTo` to co-anchor the committed L2 state, §R2b);
       *   - one request → (block, validity) reverse-index row per event in this block →
-      *     `RequestBlockIndex[requestId]` (keyed by the opaque request id's packed i64).
+      *     `RequestBlockIndex[requestId]` (keyed by the opaque request id's packed i64);
+      *   - one deposit-request → block reverse-index row per deposit absorbed in this (major) block
+      *     → `DepositAbsorptionIndex[requestId]`.
       *
       * A head peer adds its own `Block` (leader) + `SoftAck` lanes on top
       * ([[persistOwnAckBundle]]); a coil peer persists exactly this subset
@@ -697,10 +699,16 @@ final case class JointLedger(
                 .put(StoreKey.L2CommandNumber(brief.blockNum))(commandNumber)
             // One reverse-index row per event, in the same atomic bundle: the request's id maps
             // to the block that processed it and the validity verdict it received.
-            brief.events.foldLeft(bundle) { case (batch, (requestId, validity)) =>
-                batch.put(StoreKey.RequestBlockIndex(requestId))(
-                  RequestBlockEntry(brief.blockNum, validity)
-                )
+            val withRequestBlocks = brief.events.foldLeft(bundle) {
+                case (batch, (requestId, validity)) =>
+                    batch.put(StoreKey.RequestBlockIndex(requestId))(
+                      RequestBlockEntry(brief.blockNum, validity)
+                    )
+            }
+            // One row per deposit absorbed in this (major) block: the deposit request's id maps to
+            // the block whose settlement absorbs it into the treasury.
+            brief.depositsAbsorbed.foldLeft(withRequestBlocks) { (batch, requestId) =>
+                batch.put(StoreKey.DepositAbsorptionIndex(requestId))(brief.blockNum)
             }
         }
 

--- a/src/main/scala/hydrozoa/multisig/persistence/Cf.scala
+++ b/src/main/scala/hydrozoa/multisig/persistence/Cf.scala
@@ -101,6 +101,13 @@ object Cf:
     case object EffectStackIndex extends Cf:
         def name = "EffectStackIndex"
 
+    /** Deposit-request → absorbing-block reverse index: the deposit request's opaque id (packed
+      * i64) → the major `blockNum` that absorbed the deposit into the treasury. Written by JL in
+      * the same atomic bundle as that block.
+      */
+    case object DepositAbsorptionIndex extends Cf:
+        def name = "DepositAbsorptionIndex"
+
     /** Store-level metadata (schema version + arrival-stamp generation). */
     case object Meta extends Cf:
         def name = "Meta"
@@ -142,6 +149,7 @@ object Cf:
       Treasury,
       EvacuationMap,
       RequestBlockIndex,
+      DepositAbsorptionIndex,
       BlockStackIndex,
       EffectStackIndex,
       Meta

--- a/src/main/scala/hydrozoa/multisig/persistence/ConsensusStoreReader.scala
+++ b/src/main/scala/hydrozoa/multisig/persistence/ConsensusStoreReader.scala
@@ -61,6 +61,11 @@ trait ConsensusStoreReader[F[_]]:
       */
     def requestBlock(id: RequestId): F[Option[RequestBlockEntry]]
 
+    /** The major block that absorbed a deposit into the treasury — absent while the deposit is
+      * unabsorbed (or the request is not a deposit).
+      */
+    def absorptionBlock(id: RequestId): F[Option[BlockNumber]]
+
     /** The wall-clock instant an arrival stamp was recorded at, via the store's per-generation
       * zero-time anchor. `None` for a stamp whose generation predates the anchor.
       */
@@ -123,6 +128,9 @@ object ConsensusStoreReader:
             def requestBlock(id: RequestId): IO[Option[RequestBlockEntry]] =
                 persistence.get(StoreKey.RequestBlockIndex(id))
 
+            def absorptionBlock(id: RequestId): IO[Option[BlockNumber]] =
+                persistence.get(StoreKey.DepositAbsorptionIndex(id))
+
             def wallClockOf(stamp: ArrivalStamp): IO[Option[Instant]] =
                 persistence.wallClockOf(stamp)
 
@@ -146,4 +154,5 @@ object ConsensusStoreReader:
                 IO.pure(Nil)
             def request(id: RequestId): IO[Option[Timestamped[UserRequestWithId]]] = IO.pure(None)
             def requestBlock(id: RequestId): IO[Option[RequestBlockEntry]] = IO.pure(None)
+            def absorptionBlock(id: RequestId): IO[Option[BlockNumber]] = IO.pure(None)
             def wallClockOf(stamp: ArrivalStamp): IO[Option[Instant]] = IO.pure(None)

--- a/src/main/scala/hydrozoa/multisig/persistence/JournalKey.scala
+++ b/src/main/scala/hydrozoa/multisig/persistence/JournalKey.scala
@@ -128,8 +128,8 @@ object JournalKey:
             HubHardAck(hub, HubHardAckNumber(readIntBE(bytes, 0)))
         case Cf.BlockResult | Cf.SoftConfirmation | Cf.HardConfirmation | Cf.DepositMap |
             Cf.Treasury | Cf.EvacuationMap | Cf.RequestHighWater | Cf.CoilStampMark |
-            Cf.L2CommandNumber | Cf.UnsignedStack | Cf.RequestBlockIndex | Cf.BlockStackIndex |
-            Cf.EffectStackIndex | Cf.Meta =>
+            Cf.L2CommandNumber | Cf.UnsignedStack | Cf.RequestBlockIndex |
+            Cf.DepositAbsorptionIndex | Cf.BlockStackIndex | Cf.EffectStackIndex | Cf.Meta =>
             throw new IllegalArgumentException(
               s"$cf is not a journal CF; JournalKey.decode is undefined for it"
             )

--- a/src/main/scala/hydrozoa/multisig/persistence/StoreDump.scala
+++ b/src/main/scala/hydrozoa/multisig/persistence/StoreDump.scala
@@ -130,6 +130,10 @@ object StoreDump:
             case Cf.RequestBlockIndex =>
                 if key.length == 8 then s"RequestBlockIndex(i64=${ByteBuffer.wrap(key).getLong})"
                 else hex(key)
+            case Cf.DepositAbsorptionIndex =>
+                if key.length == 8 then
+                    s"DepositAbsorptionIndex(i64=${ByteBuffer.wrap(key).getLong})"
+                else hex(key)
             case Cf.EffectStackIndex =>
                 s"EffectStackIndex(${hex(key)})"
             case Cf.DepositMap | Cf.Treasury | Cf.CoilStampMark =>

--- a/src/main/scala/hydrozoa/multisig/persistence/StoreKey.scala
+++ b/src/main/scala/hydrozoa/multisig/persistence/StoreKey.scala
@@ -21,7 +21,7 @@ import scalus.cardano.ledger.TransactionHash
   * is keyed by one. A *journal* (the recovery concept: an arrival-stamped, index-ordered
   * append-only replay sequence, §3) is the **subset** of column families reached through
   * [[JournalKey]], which **extends** `StoreKey` (the 6 of those are documented there, not here).
-  * The 14 non-journal CFs — snapshots and key-ordered / `max(key)` reconstruction reads, unstamped
+  * The 15 non-journal CFs — snapshots and key-ordered / `max(key)` reconstruction reads, unstamped
   * and never arrival-merged — are the cases declared in the companion below:
   *
   *   - Spine-indexed metadata CFs (one entry per block / stack): [[StoreKey.BlockResult]] —
@@ -33,9 +33,10 @@ import scalus.cardano.ledger.TransactionHash
   *     [[StoreKey.L2CommandNumber]] — `Cf.L2CommandNumber`, keyed by `blockNum`.
   *     [[StoreKey.UnsignedStack]] — `Cf.UnsignedStack`, keyed by `stackNum`.
   *   - Reverse-index CFs: [[StoreKey.RequestBlockIndex]] — `Cf.RequestBlockIndex`, keyed by the
-  *     request id (its packed i64). [[StoreKey.BlockStackIndex]] — `Cf.BlockStackIndex`, keyed by
-  *     `blockNum`. [[StoreKey.EffectStackIndex]] — `Cf.EffectStackIndex`, keyed by the effect's
-  *     `l1TxId`.
+  *     request id (its packed i64). [[StoreKey.DepositAbsorptionIndex]] —
+  *     `Cf.DepositAbsorptionIndex`, keyed by the deposit request's id (its packed i64).
+  *     [[StoreKey.BlockStackIndex]] — `Cf.BlockStackIndex`, keyed by `blockNum`.
+  *     [[StoreKey.EffectStackIndex]] — `Cf.EffectStackIndex`, keyed by the effect's `l1TxId`.
   *   - Singleton snapshot CFs (one entry total): [[StoreKey.DepositMap]], [[StoreKey.Treasury]],
   *     [[StoreKey.CoilStampMark]] (a hub's per-coil-peer stamped marks, one keyed blob).
   *   - Store-level metadata: [[StoreKey.Meta]] — `Cf.Meta`, name-keyed.
@@ -143,6 +144,18 @@ object StoreKey:
         given codec: StoreCodec[Value] = StoreCodec.fromCirce[Value]
         val cf: Cf = Cf.EffectStackIndex
         def encode: Array[Byte] = l1TxId.bytes.toArray
+
+    /** Key for [[Cf.DepositAbsorptionIndex]] — the deposit-request → absorbing-block reverse index,
+      * keyed by the opaque [[RequestId]] via its packed i64 (`asI64`), holding the [[BlockNumber]]
+      * of the major block that absorbed the deposit into the treasury. Written by JL in the same
+      * atomic bundle as that block. (A deposit's *registration* block is [[RequestBlockIndex]];
+      * absorption happens later, in a different block, so it needs its own index.)
+      */
+    final case class DepositAbsorptionIndex(id: RequestId) extends StoreKey:
+        type Value = BlockNumber
+        given codec: StoreCodec[Value] = StoreCodec.fromCirce[Value]
+        val cf: Cf = Cf.DepositAbsorptionIndex
+        def encode: Array[Byte] = JournalKey.longBytes(id.asI64)
 
     /** Key for [[Cf.DepositMap]] — the single blob holding JL's deposits map at `softAcked`. */
     case object DepositMap extends StoreKey:

--- a/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
+++ b/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
@@ -159,11 +159,22 @@ object ApiDto {
     final case class RequestSummaryView(requestId: Long, peerNumber: Int, requestType: String)
     given Codec[RequestSummaryView] = deriveCodec
 
+    /** One L1 effect a request became: its `l1TxId` (hex — the same value the `/head/effects/{id}`
+      * and block-effects queries use) and its kind (`settlement`, `finalization`, `sec`, `refund`).
+      */
+    final case class EffectRefView(l1TxId: String, kind: String)
+    given Codec[EffectRefView] = deriveCodec
+
+    /** Map a resolved effect to its request-facing reference. */
+    def mkEffectRefView(effect: ResolvedEffect): EffectRefView =
+        EffectRefView(effect.l1TxId.toHex, effectKindName(effect.kind))
+
     /** A request's lifecycle status from this node's viewpoint: `UNPROCESSED`, `LOCALLY_PROCESSED`,
       * `SOFT_CONFIRMED`, or `HARD_CONFIRMED`, with the fields each stage adds. Each confirmation
       * time records a **local event at this peer**, so different peers report different times for
-      * the same request. This is by design. `relatedEffects` is always absent for now (per-request
-      * effect tracking is a separate change).
+      * the same request. This is by design. `relatedEffects` — the L1 effects the request became —
+      * is present once those effects are hard-confirmed (a transaction's
+      * settlement/SEC/finalization carriers, a deposit's post-dated refund), absent otherwise.
       */
     final case class RequestStatusView(
         status: String,
@@ -171,7 +182,7 @@ object ApiDto {
         validity: Option[String],
         softConfirmedAt: Option[String],
         hardConfirmedAt: Option[String],
-        relatedEffects: Option[List[Int]]
+        relatedEffects: Option[List[EffectRefView]]
     )
     given Codec[RequestStatusView] = deriveCodec
 
@@ -206,12 +217,14 @@ object ApiDto {
         case ValidityFlag.Invalid => "invalid"
 
     /** Assemble the request-status view from its resolved lifecycle stages: the processing block
-      * and verdict (absent while unprocessed) and the node-local confirmation moments.
+      * and verdict (absent while unprocessed), the node-local confirmation moments, and the L1
+      * effects the request became (empty until they are hard-confirmed).
       */
     def mkRequestStatusView(
         block: Option[(Int, ValidityFlag)],
         softConfirmedAt: Option[Instant],
-        hardConfirmedAt: Option[Instant]
+        hardConfirmedAt: Option[Instant],
+        relatedEffects: List[EffectRefView]
     ): RequestStatusView =
         val status = block match
             case None => "UNPROCESSED"
@@ -225,7 +238,7 @@ object ApiDto {
           validity = block.map((_, v) => validityName(v)),
           softConfirmedAt = softConfirmedAt.map(_.toString),
           hardConfirmedAt = hardConfirmedAt.map(_.toString),
-          relatedEffects = None
+          relatedEffects = Option.when(relatedEffects.nonEmpty)(relatedEffects)
         )
 
     /** Map a request, its derived receive time, and its resolved status to the details body. */

--- a/src/main/scala/hydrozoa/multisig/server/EffectsResolver.scala
+++ b/src/main/scala/hydrozoa/multisig/server/EffectsResolver.scala
@@ -3,10 +3,12 @@ package hydrozoa.multisig.server
 import cats.data.NonEmptyList
 import cats.effect.IO
 import cats.syntax.all.*
+import hydrozoa.multisig.consensus.UserRequestWithId
 import hydrozoa.multisig.ledger.block.{BlockBrief, BlockNumber}
+import hydrozoa.multisig.ledger.event.RequestId
 import hydrozoa.multisig.ledger.l1.tx.RefundTx
 import hydrozoa.multisig.ledger.stack.PartitionEffects.{Final, Major, Minor}
-import hydrozoa.multisig.ledger.stack.{EffectIds, StackEffects, StackNumber, StandaloneEvacuationCommitment}
+import hydrozoa.multisig.ledger.stack.{EffectIds, PartitionEffects, StackEffects, StackNumber, StandaloneEvacuationCommitment}
 import hydrozoa.multisig.persistence.ConsensusStoreReader
 import scalus.cardano.ledger.{Transaction, TransactionHash}
 
@@ -80,6 +82,34 @@ final class EffectsResolver(reader: ConsensusStoreReader[IO]):
         reader.effectStack(l1TxId).flatMap {
             case None           => IO.pure(None)
             case Some(stackNum) => resolveStack(stackNum).map(_.find(_.l1TxId == l1TxId))
+        }
+
+    /** The L1 effects a request became — addressed by `l1TxId`, empty until the covering stack is
+      * hard-confirmed.
+      *
+      * A transaction's effects are the carriers of its inclusion-block partition: the SEC for a
+      * minor partition, the settlement for a major, the finalization for the final. A deposit's
+      * effect is its post-dated refund, matched by the `requestId` the refund carries, in the
+      * partition of the block where the deposit was registered. (A deposit's absorbing settlement
+      * is a separate link, tracked via the deposit-absorption index.)
+      */
+    def relatedEffects(requestId: RequestId): IO[List[ResolvedEffect]] =
+        reader.request(requestId).flatMap {
+            case None => IO.pure(Nil)
+            case Some(stamped) =>
+                reader.requestBlock(requestId).flatMap {
+                    case None => IO.pure(Nil)
+                    case Some(entry) =>
+                        partitionForBlock(entry.blockNum).map {
+                            case None => Nil
+                            case Some((blockNums, pe)) =>
+                                stamped.payload match
+                                    case _: UserRequestWithId.DepositRequest =>
+                                        depositRefundEffect(requestId, entry.blockNum, pe).toList
+                                    case _: UserRequestWithId.TransactionRequest =>
+                                        carrierEffects(blockNums.head, pe)
+                        }
+                }
         }
 
     /** Every effect a hard-confirmed stack carries, attributed per block. Empty when the stack is
@@ -189,6 +219,86 @@ final class EffectsResolver(reader: ConsensusStoreReader[IO]):
                     .requestBlock(p.requestId)
                     .map(_.map(_.blockNum).getOrElse(fallbackBlock))
         block.map(b => ResolvedEffect.Tx(refund.tx.id, b, EffectKind.Refund, refund.tx, None))
+
+    /** The block-number group and per-partition effects of the partition containing `block`, or
+      * `None` when the block's stack is not hard-confirmed (or has no such partition). Needs the
+      * stack's briefs to reconstruct the partition grouping, so an unbriefed stack yields `None`.
+      */
+    private def partitionForBlock(
+        block: BlockNumber
+    ): IO[Option[
+      (NonEmptyList[BlockNumber], PartitionEffects[StandaloneEvacuationCommitment.MultiSigned])
+    ]] =
+        reader.stackOf(block).flatMap {
+            case None => IO.pure(None)
+            case Some(stackNum) =>
+                stackBriefs(stackNum).flatMap { briefs =>
+                    if briefs.isEmpty then IO.pure(None)
+                    else
+                        reader.hardConfirmation(stackNum).map {
+                            case None => None
+                            case Some(timestamped) =>
+                                timestamped.payload match
+                                    case r: StackEffects.HardConfirmed.Regular =>
+                                        val groups = partitionGroups(briefs)
+                                        if groups.length != r.partitions.length then None
+                                        else
+                                            groups
+                                                .zip(r.partitions.toList)
+                                                .find((g, _) => g.toList.contains(block))
+                                    case _: StackEffects.HardConfirmed.Initial => None
+                        }
+                }
+        }
+
+    /** A transaction's L1 carriers in its partition: the settlement (Major, plus its SEC), the
+      * finalization (Final), or the SEC (Minor).
+      */
+    private def carrierEffects(
+        opener: BlockNumber,
+        pe: PartitionEffects[StandaloneEvacuationCommitment.MultiSigned]
+    ): List[ResolvedEffect] =
+        pe match
+            case p: Major[StandaloneEvacuationCommitment.MultiSigned] =>
+                ResolvedEffect
+                    .Tx(p.settlement.tx.id, opener, EffectKind.Settlement, p.settlement.tx, None) ::
+                    p.sec.toList.map(ms =>
+                        ResolvedEffect
+                            .Sec(EffectIds.secL1TxId(ms.commitment), ms.commitment.blockNum, ms)
+                    )
+            case p: Final =>
+                List(
+                  ResolvedEffect
+                      .Tx(
+                        p.finalization.tx.id,
+                        opener,
+                        EffectKind.Finalization,
+                        p.finalization.tx,
+                        None
+                      )
+                )
+            case p: Minor[StandaloneEvacuationCommitment.MultiSigned] =>
+                List(
+                  ResolvedEffect
+                      .Sec(EffectIds.secL1TxId(p.sec.commitment), p.sec.commitment.blockNum, p.sec)
+                )
+
+    /** A deposit's post-dated refund in `pe`, matched by the `requestId` it carries; attributed to
+      * the deposit's registration block.
+      */
+    private def depositRefundEffect(
+        requestId: RequestId,
+        block: BlockNumber,
+        pe: PartitionEffects[StandaloneEvacuationCommitment.MultiSigned]
+    ): Option[ResolvedEffect] =
+        val refunds: List[RefundTx] = pe match
+            case p: Major[StandaloneEvacuationCommitment.MultiSigned] => p.refunds
+            case p: Minor[StandaloneEvacuationCommitment.MultiSigned] => p.refunds
+            case _: Final                                             => Nil
+        refunds.collectFirst {
+            case r: RefundTx.PostDated if r.requestId == requestId =>
+                ResolvedEffect.Tx(r.tx.id, block, EffectKind.Refund, r.tx, None)
+        }
 
     /** The stack's block briefs in block order (its `[firstBlockNum, lastBlockNum]` range). */
     private def stackBriefs(stackNum: StackNumber): IO[List[BlockBrief.Next]] =

--- a/src/main/scala/hydrozoa/multisig/server/EffectsResolver.scala
+++ b/src/main/scala/hydrozoa/multisig/server/EffectsResolver.scala
@@ -89,28 +89,54 @@ final class EffectsResolver(reader: ConsensusStoreReader[IO]):
       *
       * A transaction's effects are the carriers of its inclusion-block partition: the SEC for a
       * minor partition, the settlement for a major, the finalization for the final. A deposit's
-      * effect is its post-dated refund, matched by the `requestId` the refund carries, in the
-      * partition of the block where the deposit was registered. (A deposit's absorbing settlement
-      * is a separate link, tracked via the deposit-absorption index.)
+      * effects are its post-dated refund (matched by the `requestId` the refund carries, in the
+      * registration-block partition) and, once absorbed, the settlement of its absorbing block's
+      * partition (via the deposit-absorption index).
       */
     def relatedEffects(requestId: RequestId): IO[List[ResolvedEffect]] =
         reader.request(requestId).flatMap {
             case None => IO.pure(Nil)
             case Some(stamped) =>
-                reader.requestBlock(requestId).flatMap {
-                    case None => IO.pure(Nil)
-                    case Some(entry) =>
-                        partitionForBlock(entry.blockNum).map {
-                            case None => Nil
-                            case Some((blockNums, pe)) =>
-                                stamped.payload match
-                                    case _: UserRequestWithId.DepositRequest =>
-                                        depositRefundEffect(requestId, entry.blockNum, pe).toList
-                                    case _: UserRequestWithId.TransactionRequest =>
-                                        carrierEffects(blockNums.head, pe)
-                        }
+                stamped.payload match
+                    case _: UserRequestWithId.TransactionRequest => transactionEffects(requestId)
+                    case _: UserRequestWithId.DepositRequest     => depositEffects(requestId)
+        }
+
+    /** A transaction's carriers: the effects of its inclusion-block partition. */
+    private def transactionEffects(requestId: RequestId): IO[List[ResolvedEffect]] =
+        reader.requestBlock(requestId).flatMap {
+            case None => IO.pure(Nil)
+            case Some(entry) =>
+                partitionForBlock(entry.blockNum).map {
+                    case None                  => Nil
+                    case Some((blockNums, pe)) => carrierEffects(blockNums.head, pe)
                 }
         }
+
+    /** A deposit's effects: its post-dated refund (registration-block partition) and, once
+      * absorbed, the settlement of its absorbing block's partition.
+      */
+    private def depositEffects(requestId: RequestId): IO[List[ResolvedEffect]] =
+        val refund: IO[List[ResolvedEffect]] =
+            reader.requestBlock(requestId).flatMap {
+                case None => IO.pure(Nil)
+                case Some(entry) =>
+                    partitionForBlock(entry.blockNum).map {
+                        case None => Nil
+                        case Some((_, pe)) =>
+                            depositRefundEffect(requestId, entry.blockNum, pe).toList
+                    }
+            }
+        val settlement: IO[List[ResolvedEffect]] =
+            reader.absorptionBlock(requestId).flatMap {
+                case None => IO.pure(Nil)
+                case Some(block) =>
+                    partitionForBlock(block).map {
+                        case None                  => Nil
+                        case Some((blockNums, pe)) => settlementEffect(blockNums.head, pe).toList
+                    }
+            }
+        (refund, settlement).mapN(_ ++ _)
 
     /** Every effect a hard-confirmed stack carries, attributed per block. Empty when the stack is
       * not hard-confirmed.
@@ -282,6 +308,19 @@ final class EffectsResolver(reader: ConsensusStoreReader[IO]):
                   ResolvedEffect
                       .Sec(EffectIds.secL1TxId(p.sec.commitment), p.sec.commitment.blockNum, p.sec)
                 )
+
+    /** The settlement of a major partition — the effect that absorbs its deposits — if any. */
+    private def settlementEffect(
+        opener: BlockNumber,
+        pe: PartitionEffects[StandaloneEvacuationCommitment.MultiSigned]
+    ): Option[ResolvedEffect] =
+        pe match
+            case p: Major[StandaloneEvacuationCommitment.MultiSigned] =>
+                Some(
+                  ResolvedEffect
+                      .Tx(p.settlement.tx.id, opener, EffectKind.Settlement, p.settlement.tx, None)
+                )
+            case _ => None
 
     /** A deposit's post-dated refund in `pe`, matched by the `requestId` it carries; attributed to
       * the deposit's registration block.

--- a/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
+++ b/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
@@ -317,7 +317,8 @@ class HydrozoaRoutes(
             .description(
               "One request's peer, type, receive time, and lifecycle status: UNPROCESSED, " +
                   "LOCALLY_PROCESSED (block + validity), SOFT_CONFIRMED (+ soft-confirmation " +
-                  "time), or HARD_CONFIRMED (+ hard-confirmation time). Every time records a " +
+                  "time), or HARD_CONFIRMED (+ hard-confirmation time and the related L1 effects — " +
+                  "the l1TxIds the request became). Every time records a " +
                   "local event at this peer — when it received the request, and when it produced " +
                   "the soft/hard confirmation — so different peers report different times for the " +
                   "same request. This is by design."
@@ -735,10 +736,12 @@ class HydrozoaRoutes(
                         case Some(entry) => confirmationTimes(entry.blockNum)
                     }
                     (softAt, hardAt) = confirmation
+                    effects <- effectsResolver.relatedEffects(id)
                     status = ApiDto.mkRequestStatusView(
                       block = processed.map(e => (e.blockNum.convert, e.validity)),
                       softConfirmedAt = softAt,
-                      hardConfirmedAt = hardAt
+                      hardConfirmedAt = hardAt,
+                      relatedEffects = effects.map(ApiDto.mkEffectRefView)
                     )
                 } yield Right(ApiDto.mkRequestDetailsView(stamped.payload, receivedAt, status))
         }

--- a/src/test/scala/hydrozoa/multisig/persistence/StoreKeyTest.scala
+++ b/src/test/scala/hydrozoa/multisig/persistence/StoreKeyTest.scala
@@ -35,6 +35,8 @@ class StoreKeyTest extends AnyFunSuite:
           StoreKey.L2CommandNumber(BlockNumber(0)) -> Cf.L2CommandNumber,
           StoreKey.RequestBlockIndex(RequestId(HeadPeerNumber(0), RequestNumber(0))) ->
               Cf.RequestBlockIndex,
+          StoreKey.DepositAbsorptionIndex(RequestId(HeadPeerNumber(0), RequestNumber(0))) ->
+              Cf.DepositAbsorptionIndex,
           StoreKey.BlockStackIndex(BlockNumber(0)) -> Cf.BlockStackIndex,
           StoreKey.EffectStackIndex(sampleHash) -> Cf.EffectStackIndex,
           StoreKey.Meta("schema-version") -> Cf.Meta

--- a/src/test/scala/hydrozoa/multisig/server/EffectsResolverTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/EffectsResolverTest.scala
@@ -1,0 +1,185 @@
+package hydrozoa.multisig.server
+
+import cats.data.NonEmptyList
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import hydrozoa.config.head.multisig.timing.TxTiming.BlockTimes.{BlockCreationEndTime, BlockCreationStartTime}
+import hydrozoa.config.head.multisig.timing.TxTiming.StackTimes.StackCreationEndTime
+import hydrozoa.config.node.MultiNodeConfig
+import hydrozoa.lib.cardano.scalus.QuantizedTime.QuantizedInstant
+import hydrozoa.multisig.consensus.UserRequest.{DepositRequest, TransactionRequest}
+import hydrozoa.multisig.consensus.UserRequestBody.{DepositRequestBody, TransactionRequestBody}
+import hydrozoa.multisig.consensus.UserRequestWithId
+import hydrozoa.multisig.consensus.peer.HeadPeerNumber
+import hydrozoa.multisig.ledger.block.{Block, BlockBody, BlockBrief, BlockHeader, BlockNumber, BlockVersion}
+import hydrozoa.multisig.ledger.event.RequestId.ValidityFlag
+import hydrozoa.multisig.ledger.event.{RequestId, RequestNumber}
+import hydrozoa.multisig.ledger.joint.EvacuationMap
+import hydrozoa.multisig.ledger.l1.tx.RefundTx
+import hydrozoa.multisig.ledger.l2.Destination
+import hydrozoa.multisig.ledger.stack.{EffectIds, PartitionEffects, StackBrief, StackEffects, StackNumber, StandaloneEvacuationCommitment}
+import hydrozoa.multisig.persistence.{ArrivalStamp, ConsensusStoreReader, RequestBlockEntry, Timestamped}
+import hydrozoa.rulebased.ledger.l1.state.StandaloneEvacuationCommitmentOnchain
+import java.time.Instant
+import org.scalacheck.Gen
+import org.scalacheck.rng.Seed
+import org.scalatest.funsuite.AnyFunSuite
+import scalus.cardano.address.{Network, ShelleyAddress, ShelleyDelegationPart, ShelleyPaymentPart}
+import scalus.cardano.ledger.{AddrKeyHash, Transaction, TransactionHash}
+import scalus.cardano.txbuilder.TransactionBuilder.ResolvedUtxos
+import scalus.uplc.builtin.ByteString
+
+/** Unit tests for [[EffectsResolver.relatedEffects]] — the request → effects resolution: a
+  * transaction resolves to its inclusion-block partition's carriers (here, a minor block's SEC), a
+  * deposit to its post-dated refund (matched by `requestId`), and an unknown / unprocessed request
+  * to nothing.
+  */
+class EffectsResolverTest extends AnyFunSuite:
+
+    private val multiNodeConfig: MultiNodeConfig =
+        MultiNodeConfig.generateDefault.pureApply(Gen.Parameters.default, Seed(0L))
+    private val headConfig = multiNodeConfig.headConfig
+    private val peer0 = HeadPeerNumber(0)
+
+    private val txRequestId = RequestId(peer0, RequestNumber(0))
+    private val depositRequestId = RequestId(peer0, RequestNumber(1))
+
+    private val txRequest: UserRequestWithId =
+        UserRequestWithId(TransactionRequest(TransactionRequestBody(ByteString.empty)), txRequestId)
+    private val depositRequest: UserRequestWithId =
+        UserRequestWithId(
+          DepositRequest(DepositRequestBody(ByteString.empty, ByteString.empty)),
+          depositRequestId
+        )
+
+    /** A minor brief for block 1 (its stack's single partition). */
+    private val minorBrief: BlockBrief.Minor =
+        val startTime = BlockCreationStartTime(
+          QuantizedInstant.ofEpochSeconds(headConfig.slotConfig, 0L)
+        )
+        val endTime = BlockCreationEndTime(
+          QuantizedInstant.ofEpochSeconds(headConfig.slotConfig, 1L)
+        )
+        val fallbackTxStartTime = headConfig.txTiming.newFallbackStartTime(endTime)
+        BlockBrief.Minor(
+          BlockHeader.Minor(
+            blockNum = BlockNumber(1),
+            blockVersion = BlockVersion.Full(0, 0),
+            startTime = startTime,
+            endTime = endTime,
+            fallbackTxStartTime = fallbackTxStartTime,
+            forcedMajorBlockWakeupTime =
+                headConfig.txTiming.forcedMajorBlockWakeupTime(fallbackTxStartTime),
+            mDepositDecisionWakeupTime = None
+          ),
+          BlockBody.Minor(events = List.empty, depositsRefunded = List.empty)
+        )
+
+    private val sec: StandaloneEvacuationCommitment.MultiSigned =
+        StandaloneEvacuationCommitment.MultiSigned(
+          commitment = StandaloneEvacuationCommitment(
+            blockNum = BlockNumber(1),
+            blockVersion = BlockVersion.Full(1, 0),
+            kzgCommitment = EvacuationMap.empty.kzgCommitment,
+            header = StandaloneEvacuationCommitmentOnchain(
+              StandaloneEvacuationCommitmentOnchain(
+                headId = headConfig.headTokenNames.treasuryTokenName.bytes,
+                versionMajor = BigInt(1),
+                versionMinor = BigInt(0),
+                commitment = EvacuationMap.empty.kzgCommitment
+              )
+            )
+          ),
+          headerMultiSigned = List(BlockHeader.Minor.HeaderSignature(IArray(0.toByte)))
+        )
+    private val secId: TransactionHash = EffectIds.secL1TxId(sec.commitment)
+
+    /** A post-dated refund carrying the deposit request's id; its `l1TxId` is the empty tx's id. */
+    private val refund: RefundTx.PostDated =
+        RefundTx.PostDated(
+          tx = Transaction.empty,
+          refundStart = QuantizedInstant(headConfig.slotConfig, Instant.ofEpochMilli(0L)),
+          refundDestination = Destination(
+            ShelleyAddress(
+              network = Network.Testnet,
+              payment = ShelleyPaymentPart.Key(AddrKeyHash(ByteString.fromHex("00" * 28))),
+              delegation = ShelleyDelegationPart.Null
+            ),
+            datum = None
+          ),
+          requestId = depositRequestId,
+          resolvedUtxos = ResolvedUtxos.empty
+        )
+    private val refundId: TransactionHash = Transaction.empty.id
+
+    private val stackEffects: StackEffects.HardConfirmed =
+        StackEffects.HardConfirmed.Regular(
+          NonEmptyList.of(PartitionEffects.Minor(sec = sec, refunds = List(refund)))
+        )
+
+    /** A reader over a single-minor stack (stack 1 = block 1) carrying the SEC and the refund, with
+      * both the transaction and the deposit registered/processed in block 1.
+      */
+    private val reader: ConsensusStoreReader[IO] =
+        new ConsensusStoreReader[IO]:
+            def blockBriefs: IO[List[BlockBrief.Next]] = IO.pure(List(minorBrief))
+            def blockBrief(num: BlockNumber): IO[Option[BlockBrief.Next]] =
+                IO.pure(Option.when(num == BlockNumber(1))(minorBrief))
+            def softConfirmation(
+                num: BlockNumber
+            ): IO[Option[Timestamped[Block.SoftConfirmed.Next]]] = IO.pure(None)
+            def stackOf(num: BlockNumber): IO[Option[StackNumber]] =
+                IO.pure(Option.when(num == BlockNumber(1))(StackNumber(1)))
+            def hardConfirmation(
+                num: StackNumber
+            ): IO[Option[Timestamped[StackEffects.HardConfirmed]]] =
+                IO.pure(
+                  Option.when(num == StackNumber(1))(Timestamped(ArrivalStamp(0, 0L), stackEffects))
+                )
+            def stackBrief(num: StackNumber): IO[Option[StackBrief]] =
+                IO.pure(
+                  Option.when(num == StackNumber(1))(
+                    StackBrief(
+                      StackNumber(1),
+                      BlockNumber(1),
+                      BlockNumber(1),
+                      StackCreationEndTime(
+                        QuantizedInstant.ofEpochSeconds(headConfig.slotConfig, 0L)
+                      )
+                    )
+                  )
+                )
+            def effectStack(l1TxId: TransactionHash): IO[Option[StackNumber]] = IO.pure(None)
+            def requestsOf(peer: HeadPeerNumber): IO[List[Timestamped[UserRequestWithId]]] =
+                IO.pure(Nil)
+            def request(id: RequestId): IO[Option[Timestamped[UserRequestWithId]]] =
+                IO.pure {
+                    if id == txRequestId then Some(Timestamped(ArrivalStamp(0, 0L), txRequest))
+                    else if id == depositRequestId then
+                        Some(Timestamped(ArrivalStamp(0, 0L), depositRequest))
+                    else None
+                }
+            def requestBlock(id: RequestId): IO[Option[RequestBlockEntry]] =
+                IO.pure(
+                  Option.when(id == txRequestId || id == depositRequestId)(
+                    RequestBlockEntry(BlockNumber(1), ValidityFlag.Valid)
+                  )
+                )
+            def wallClockOf(stamp: ArrivalStamp): IO[Option[Instant]] = IO.pure(None)
+
+    private val resolver = EffectsResolver(reader)
+
+    test("a transaction resolves to its inclusion-block partition's carrier (the minor SEC)") {
+        val effects = resolver.relatedEffects(txRequestId).unsafeRunSync()
+        assert(effects.map(e => (e.l1TxId, e.kind)) == List((secId, EffectKind.Sec)))
+    }
+
+    test("a deposit resolves to its post-dated refund, matched by requestId") {
+        val effects = resolver.relatedEffects(depositRequestId).unsafeRunSync()
+        assert(effects.map(e => (e.l1TxId, e.kind)) == List((refundId, EffectKind.Refund)))
+    }
+
+    test("an unknown request resolves to no effects") {
+        val effects = resolver.relatedEffects(RequestId(peer0, RequestNumber(99))).unsafeRunSync()
+        assert(effects.isEmpty)
+    }

--- a/src/test/scala/hydrozoa/multisig/server/EffectsResolverTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/EffectsResolverTest.scala
@@ -165,6 +165,11 @@ class EffectsResolverTest extends AnyFunSuite:
                     RequestBlockEntry(BlockNumber(1), ValidityFlag.Valid)
                   )
                 )
+            // The deposit's absorbing block is the minor block 1 (its partition has no settlement),
+            // so absorption resolves to no effect — the positive major-settlement path is exercised
+            // by the stage suites, which build real settlement transactions.
+            def absorptionBlock(id: RequestId): IO[Option[BlockNumber]] =
+                IO.pure(Option.when(id == depositRequestId)(BlockNumber(1)))
             def wallClockOf(stamp: ArrivalStamp): IO[Option[Instant]] = IO.pure(None)
 
     private val resolver = EffectsResolver(reader)

--- a/src/test/scala/hydrozoa/multisig/server/HeadBlocksEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/HeadBlocksEndpointsTest.scala
@@ -151,6 +151,7 @@ class HeadBlocksEndpointsTest extends AnyFunSuite:
             def wallClockOf(stamp: ArrivalStamp): IO[Option[Instant]] =
                 IO.pure(Some(instantOf(stamp)))
             def requestBlock(id: RequestId): IO[Option[RequestBlockEntry]] = IO.pure(None)
+            def absorptionBlock(id: RequestId): IO[Option[BlockNumber]] = IO.pure(None)
 
     private def withRoutes(reader: ConsensusStoreReader[IO])(check: HttpApp[IO] => IO[Unit]): Unit =
         ActorSystem[IO]("HeadBlocksEndpointsTest")

--- a/src/test/scala/hydrozoa/multisig/server/HeadEffectsEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/HeadEffectsEndpointsTest.scala
@@ -12,10 +12,13 @@ import hydrozoa.lib.cardano.scalus.QuantizedTime.QuantizedInstant
 import hydrozoa.lib.cardano.scalus.QuantizedTime.QuantizedInstant.realTimeQuantizedInstant
 import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.NodeStatus
+import hydrozoa.multisig.consensus.UserRequest.TransactionRequest
+import hydrozoa.multisig.consensus.UserRequestBody.TransactionRequestBody
 import hydrozoa.multisig.consensus.peer.HeadPeerNumber
 import hydrozoa.multisig.consensus.{BlockWeaver, RequestSequencer, UserRequestWithId}
 import hydrozoa.multisig.ledger.block.{Block, BlockBody, BlockBrief, BlockHeader, BlockNumber, BlockVersion}
-import hydrozoa.multisig.ledger.event.RequestId
+import hydrozoa.multisig.ledger.event.RequestId.ValidityFlag
+import hydrozoa.multisig.ledger.event.{RequestId, RequestNumber}
 import hydrozoa.multisig.ledger.joint.EvacuationMap
 import hydrozoa.multisig.ledger.stack.{EffectIds, PartitionEffects, StackBrief, StackEffects, StackNumber, StandaloneEvacuationCommitment}
 import hydrozoa.multisig.persistence.{ArrivalStamp, ConsensusStoreReader, RequestBlockEntry, Timestamped}
@@ -30,6 +33,7 @@ import org.scalacheck.rng.Seed
 import org.scalatest.funsuite.AnyFunSuite
 import scala.concurrent.duration.DurationInt
 import scalus.cardano.ledger.TransactionHash
+import scalus.uplc.builtin.ByteString
 
 /** The block-effects queries through the HTTP layer against a stubbed [[ConsensusStoreReader]],
   * exercising a single-minor stack whose only effect is a standalone evacuation commitment (SEC):
@@ -91,6 +95,11 @@ class HeadEffectsEndpointsTest extends AnyFunSuite:
 
     private val secId: TransactionHash = EffectIds.secL1TxId(sec.commitment)
 
+    /** A transaction request processed in block 1 — its related effect is that block's SEC. */
+    private val txRequestId: RequestId = RequestId(HeadPeerNumber(0), RequestNumber(0))
+    private val txRequest: UserRequestWithId =
+        UserRequestWithId(TransactionRequest(TransactionRequestBody(ByteString.empty)), txRequestId)
+
     private val stackEffects: StackEffects.HardConfirmed =
         StackEffects.HardConfirmed.Regular(
           NonEmptyList.of(PartitionEffects.Minor(sec = sec, refunds = List.empty))
@@ -132,8 +141,16 @@ class HeadEffectsEndpointsTest extends AnyFunSuite:
                 IO.pure(Option.when(l1TxId == secId)(StackNumber(1)))
             def requestsOf(peer: HeadPeerNumber): IO[List[Timestamped[UserRequestWithId]]] =
                 IO.pure(Nil)
-            def request(id: RequestId): IO[Option[Timestamped[UserRequestWithId]]] = IO.pure(None)
-            def requestBlock(id: RequestId): IO[Option[RequestBlockEntry]] = IO.pure(None)
+            def request(id: RequestId): IO[Option[Timestamped[UserRequestWithId]]] =
+                IO.pure(
+                  Option.when(id == txRequestId)(Timestamped(ArrivalStamp(0, 0L), txRequest))
+                )
+            def requestBlock(id: RequestId): IO[Option[RequestBlockEntry]] =
+                IO.pure(
+                  Option.when(id == txRequestId)(
+                    RequestBlockEntry(BlockNumber(1), ValidityFlag.Valid)
+                  )
+                )
             def wallClockOf(stamp: ArrivalStamp): IO[Option[Instant]] = IO.pure(None)
 
     private def withRoutes(check: HttpApp[IO] => IO[Unit]): Unit =
@@ -209,6 +226,18 @@ class HeadEffectsEndpointsTest extends AnyFunSuite:
                 val _ = assert(status == Status.Ok)
                 val _ = assert(body.hcursor.get[String]("l1TxId") == Right(secId.toHex))
                 val _ = assert(body.hcursor.get[String]("kind") == Right("sec"))
+                ()
+            }
+        }
+    }
+
+    test("GET /head/requests/<id> carries the transaction's related effect (its block's SEC)") {
+        withRoutes { app =>
+            get(app, s"/head/requests/${txRequestId.asI64}").map { (status, body) =>
+                val _ = assert(status == Status.Ok)
+                val effects = body.hcursor.downField("status").downField("relatedEffects")
+                val _ = assert(effects.downN(0).get[String]("l1TxId") == Right(secId.toHex))
+                val _ = assert(effects.downN(0).get[String]("kind") == Right("sec"))
                 ()
             }
         }

--- a/src/test/scala/hydrozoa/multisig/server/HeadEffectsEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/HeadEffectsEndpointsTest.scala
@@ -151,6 +151,7 @@ class HeadEffectsEndpointsTest extends AnyFunSuite:
                     RequestBlockEntry(BlockNumber(1), ValidityFlag.Valid)
                   )
                 )
+            def absorptionBlock(id: RequestId): IO[Option[BlockNumber]] = IO.pure(None)
             def wallClockOf(stamp: ArrivalStamp): IO[Option[Instant]] = IO.pure(None)
 
     private def withRoutes(check: HttpApp[IO] => IO[Unit]): Unit =

--- a/src/test/scala/hydrozoa/multisig/server/HeadRequestsEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/HeadRequestsEndpointsTest.scala
@@ -110,6 +110,7 @@ class HeadRequestsEndpointsTest extends AnyFunSuite:
                 IO.pure(
                   processed.filter(_ => id == RequestId(peer0, RequestNumber(0)))
                 )
+            def absorptionBlock(id: RequestId): IO[Option[BlockNumber]] = IO.pure(None)
             def stackBrief(num: StackNumber): IO[Option[StackBrief]] = IO.pure(None)
             def effectStack(l1TxId: TransactionHash): IO[Option[StackNumber]] = IO.pure(None)
             def wallClockOf(stamp: ArrivalStamp): IO[Option[Instant]] =


### PR DESCRIPTION
## Request → effects tracking (`relatedEffects`)

Stacked on #546 (`feature/head-api-effects`). Fills the `relatedEffects` field on the request-details response — the reverse-index #3 that was deferred throughout the head-api work.

Effect identity is the `l1TxId` (from #546); every effect lives in a hard-confirmed partition. `EffectsResolver.relatedEffects` walks *request → block → stack → partition → effect*, reusing #546's partition machinery.

### What a request resolves to

| Request | Related effect(s) | How |
|---|---|---|
| **Transaction** | the carriers of its inclusion-block partition — SEC (minor), settlement (major), finalization (final) | `RequestBlockIndex` → partition — **no new storage** |
| **Deposit (refund)** | its post-dated `RefundTx.PostDated`, matched by the `requestId` the refund carries | registration-block partition — **no new storage** (the refund self-identifies) |
| **Deposit (absorption)** | the settlement of its *absorbing* block's partition | **new `DepositAbsorptionIndex` CF** — the absorbing block is a later major block, distinct from the registration block, so JL records `requestId → absorbing blockNum` at absorption |

Withdrawals → settlement/finalization/rollouts is **out of scope** (deferred): `Payout.Obligation` keeps only raw output bytes with no back-reference to the request/output, so it needs new tracking in the settlement/rollout builders — a follow-up.

### Read side
`RequestStatusView.relatedEffects` was a stale `Option[List[Int]]` placeholder (the old "effect numbers" idea). Reshaped to `Option[List[EffectRefView]]` — `{ l1TxId (hex), kind }` — so a client can drill into each via `GET /head/effects/{l1TxId}`. Present once the effects are hard-confirmed, absent otherwise. `docs/openapi.yaml` regenerated.

### Commits
1. `feat(api): resolve a request's related L1 effects (transactions, deposit refunds)` — read-side + slices 1 & 3 (query-time, no new storage).
2. `feat(api): link a deposit to its absorbing settlement effect` — slice 2: the `DepositAbsorptionIndex` CF + JL write + resolver.

### Testing
- `EffectsResolverTest` — tx→SEC, deposit→refund, absorption plumbing, unknown→empty.
- `HeadEffectsEndpointsTest` — the `relatedEffects` wire shape over HTTP.
- `StoreKeyTest` — the new CF's key wiring.
- The positive major→settlement resolution (like the other real-tx effect kinds) is exercised by the stage suites, which build real settlement transactions — the unit layer can't fixture a `SettlementTx`/`FallbackTx` cheaply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
