### PR TITLE
feat: deposit decision index + request-details status ladders

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -371,7 +371,7 @@ Pick a peer (its key signs), pick one of its L2 utxos (fetched from `GET /l2/car
 — the opening `l2-cardano-eutxo.json` outputs sit at the head peers' addresses), enter a
 destination (bech32, or a peer name like `head-1`) and a value. The tool builds the zero-fee
 native tx (with the CIP-67 output designations and the headId pin in the metadata), signs it with
-the peer wallet, and posts it to `POST /head/tx`. An example session — send 2 of head-0's
+the peer wallet, and posts it to `POST /head/requests`. An example session — send 2 of head-0's
 opening 5 ADA to head-1:
 
 ```
@@ -405,7 +405,7 @@ just deposit
 Pick a peer, pick one of its **L1** utxos (via the peer's Blockfrost backend — for the demo that
 is head peer 0, the funded one), and enter the L2 outputs the deposit should spawn. The tool
 serializes the L2 payload (its hash rides in the deposit tx metadata), registers the deposit with
-`POST /head/deposit`, then signs the deposit tx and submits it to L1 via Blockfrost,
+`POST /head/requests`, then signs the deposit tx and submits it to L1 via Blockfrost,
 polling until the utxo lands. An example session — deposit 3 ADA from head-0's L1 funds to
 coil-0's L2 address:
 

--- a/docs/l2-isomorphism.md
+++ b/docs/l2-isomorphism.md
@@ -82,7 +82,7 @@ no clock, so at apply it receives the block-creation time. What Hydrozoa keeps i
 *sequencing*: a request is screened first, admitted second.
 
 ```
-user ──POST /head/tx──► RequestSequencer
+user ──POST /head/requests──► RequestSequencer
                                    │  sendScreenTx(l2Payload)            (stateless)
                                    ▼
                               L2Ledger screening ── fail ──► rejected, no RequestId
@@ -105,7 +105,7 @@ tx id). Screening cannot resolve inputs, check balance, or test the validity win
 state. It returns pass/fail with an error reason; Hydrozoa itself never inspects or compares head
 identities — the pin check lives entirely inside the ledger. Passing is what assigns the
 `RequestId`, so an unparseable or unauthenticated payload is dropped before it consumes a durable
-id or any peer traffic. On the wire, `POST /head/tx` returns the assigned `RequestId` on
+id or any peer traffic. On the wire, `POST /head/requests` returns the assigned `RequestId` on
 acceptance and the rejection reason otherwise (`docs/openapi.yaml`).
 
 **Submission** is the stateful apply path at block production: the validity interval against the
@@ -131,7 +131,7 @@ and void the signatures.
 The deposit path, in order (client steps marked):
 
 1. **Client:** build the deposit tx (`DepositTx.Build` puts `blake2b_256(l2Payload)` in its
-   metadata) and register both payloads with `POST /head/deposit`.
+   metadata) and register both payloads with `POST /head/requests`.
 2. **Deposit L1 screening** — Hydrozoa's stage, before the ledger sees the deposit
    (`multisig/ledger/l1/tx/DepositL1Screening.scala`, called by `RequestSequencer`).
    `screen(l1Payload, l2Payload, now)`:

--- a/docs/l2-query-endpoints.md
+++ b/docs/l2-query-endpoints.md
@@ -2,7 +2,7 @@
 
 The user-facing HTTP server (`multisig/server/HydrozoaServer.scala`) exposes two read-only `GET`
 endpoints for inspecting the L2 ledger's current state and recent activity. They are the
-read counterpart to the existing write path (`POST /head/tx`, `POST /head/deposit`).
+read counterpart to the existing write path (`POST /head/requests`).
 
 | | `GET /l2/cardano-eutxo/utxos/{address}` | `GET /l2/cardano-eutxo/transactions` |
 |---|---|---|

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -3,35 +3,46 @@ info:
   title: Hydrozoa node API
   version: 0.1.0
 paths:
-  /head/tx:
-    post:
-      description: Submit an L2 transaction (a JSON UserRequest whose L2 payload is
-        a native, self-authenticating Cardano transaction).
-      operationId: postHeadTx
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: string
-        required: true
+  /head/requests:
+    get:
+      description: Requests the head has assigned an id — opaque request id, author
+        peer number, and type (transaction or deposit). Filter with ?type=transaction|deposit
+        and ?peer_number=<n>.
+      operationId: getHeadRequests
+      parameters:
+      - name: type
+        in: query
+        required: false
+        schema:
+          type: string
+      - name: peer_number
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int32
       responses:
         '200':
           description: ''
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RequestAcceptedResponse'
+                type: array
+                items:
+                  $ref: '#/components/schemas/RequestSummaryView'
         default:
           description: ''
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-  /head/deposit:
     post:
-      description: Register an L1 deposit (a JSON UserRequest carrying the unsigned
-        deposit tx CBOR and the serialized L2 outputs the deposit spawns on absorption).
-      operationId: postHeadDeposit
+      description: 'Submit a request. A root field tags the type: `{ "deposit": {
+        "l1Payload", "l2Payload" } }` registers an L1 deposit (the unsigned deposit-tx
+        CBOR plus the serialized L2 outputs it spawns on absorption); `{ "transaction":
+        { "l2Payload" } }` submits an L2 transaction (a native, self-authenticating
+        Cardano tx). Returns the assigned request id.'
+      operationId: postHeadRequest
       requestBody:
         content:
           application/json:
@@ -62,39 +73,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HeadInfoResponse'
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-  /head/requests:
-    get:
-      description: Requests the head has assigned an id — opaque request id, author
-        peer number, and type (transaction or deposit). Filter with ?type=transaction|deposit
-        and ?peer_number=<n>.
-      operationId: getHeadRequests
-      parameters:
-      - name: type
-        in: query
-        required: false
-        schema:
-          type: string
-      - name: peer_number
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/RequestSummaryView'
         default:
           description: ''
           content:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -523,6 +523,25 @@ components:
           format: int32
         blockType:
           type: string
+    DepositDecisionStatusView:
+      title: DepositDecisionStatusView
+      type: object
+      required:
+      - status
+      properties:
+        status:
+          type: string
+        blockNumber:
+          type: integer
+          format: int32
+        decision:
+          type: string
+        softConfirmedAt:
+          type: string
+        hardConfirmedAt:
+          type: string
+        settlementEffect:
+          type: string
     EffectRefView:
       title: EffectRefView
       type: object
@@ -648,6 +667,7 @@ components:
       - requestId
       - peerNumber
       - requestType
+      - receivedAt
       - status
       properties:
         requestId:
@@ -661,27 +681,11 @@ components:
         receivedAt:
           type: string
         status:
-          $ref: '#/components/schemas/Shape'
+          $ref: '#/components/schemas/RequestStatusView'
         decisionStatus:
-          $ref: '#/components/schemas/Shape1'
-    RequestSummaryView:
-      title: RequestSummaryView
-      type: object
-      required:
-      - requestId
-      - peerNumber
-      - requestType
-      properties:
-        requestId:
-          type: integer
-          format: int64
-        peerNumber:
-          type: integer
-          format: int32
-        requestType:
-          type: string
-    Shape:
-      title: Shape
+          $ref: '#/components/schemas/DepositDecisionStatusView'
+    RequestStatusView:
+      title: RequestStatusView
       type: object
       required:
       - status
@@ -701,24 +705,21 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/EffectRefView'
-    Shape1:
-      title: Shape
+    RequestSummaryView:
+      title: RequestSummaryView
       type: object
       required:
-      - status
+      - requestId
+      - peerNumber
+      - requestType
       properties:
-        status:
-          type: string
-        blockNumber:
+        requestId:
+          type: integer
+          format: int64
+        peerNumber:
           type: integer
           format: int32
-        decision:
-          type: string
-        softConfirmedAt:
-          type: string
-        hardConfirmedAt:
-          type: string
-        settlementEffect:
+        requestType:
           type: string
     TxInputView:
       title: TxInputView

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -661,9 +661,27 @@ components:
         receivedAt:
           type: string
         status:
-          $ref: '#/components/schemas/RequestStatusView'
-    RequestStatusView:
-      title: RequestStatusView
+          $ref: '#/components/schemas/Shape'
+        decisionStatus:
+          $ref: '#/components/schemas/Shape1'
+    RequestSummaryView:
+      title: RequestSummaryView
+      type: object
+      required:
+      - requestId
+      - peerNumber
+      - requestType
+      properties:
+        requestId:
+          type: integer
+          format: int64
+        peerNumber:
+          type: integer
+          format: int32
+        requestType:
+          type: string
+    Shape:
+      title: Shape
       type: object
       required:
       - status
@@ -683,21 +701,24 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/EffectRefView'
-    RequestSummaryView:
-      title: RequestSummaryView
+    Shape1:
+      title: Shape
       type: object
       required:
-      - requestId
-      - peerNumber
-      - requestType
+      - status
       properties:
-        requestId:
-          type: integer
-          format: int64
-        peerNumber:
+        status:
+          type: string
+        blockNumber:
           type: integer
           format: int32
-        requestType:
+        decision:
+          type: string
+        softConfirmedAt:
+          type: string
+        hardConfirmedAt:
+          type: string
+        settlementEffect:
           type: string
     TxInputView:
       title: TxInputView

--- a/examples/src/main/scala/hydrozoa/examples/demo/SubmitDeposit.scala
+++ b/examples/src/main/scala/hydrozoa/examples/demo/SubmitDeposit.scala
@@ -32,7 +32,7 @@ import scalus.uplc.builtin.ByteString
   * own Blockfrost backend), enter the L2 outputs the deposit should spawn on absorption (same
   * destination/value flow as [[SubmitL2Transaction]]), and the tool builds the L2 payload (its hash
   * pins the payload in the deposit tx metadata, docs/l2-isomorphism.md), registers the deposit with
-  * the head (`POST /head/deposit`), then signs the deposit tx and submits it to L1 via Blockfrost,
+  * the head (`POST /head/requests`), then signs the deposit tx and submits it to L1 via Blockfrost,
   * polling until the deposit utxo lands. The head absorbs it after maturity.
   *
   * Usage:

--- a/examples/src/main/scala/hydrozoa/examples/demo/SubmitL2Transaction.scala
+++ b/examples/src/main/scala/hydrozoa/examples/demo/SubmitL2Transaction.scala
@@ -33,7 +33,7 @@ import scalus.uplc.builtin.ByteString
   * `GET /l2/cardano-eutxo/utxos/{address}`), enter a destination + value, and the tool builds the
   * zero-fee native tx (destination output + change back to the sender, the CIP-67 all-L2 output
   * designation and the headId pin in the metadata), signs it with the peer wallet, and posts it to
-  * `POST /head/tx`.
+  * `POST /head/requests`.
   *
   * Usage:
   * {{{

--- a/integration/src/test/scala/hydrozoa/integration/stage1/Model.scala
+++ b/integration/src/test/scala/hydrozoa/integration/stage1/Model.scala
@@ -524,9 +524,9 @@ object Model:
                     mDepositDecisionWakeupTime = newDepositDecisionWakeupTime
                   ),
                   body = BlockBody.Major(
-                    events = events,
+                    requests = events,
                     depositsAbsorbed = absorbedThisBlock.map(_.cmd.request.requestId).toList,
-                    depositsRefunded = refundedThisBlock.map(_.cmd.request.requestId).toList
+                    depositsRejected = refundedThisBlock.map(_.cmd.request.requestId).toList
                   )
                 )
 
@@ -563,8 +563,8 @@ object Model:
                 mDepositDecisionWakeupTime = mDepositDecisionWakeupTime
               ),
               body = BlockBody.Minor(
-                events = events,
-                depositsRefunded = refundedThisBlock.map(_.cmd.request.requestId).toList
+                requests = events,
+                depositsRejected = refundedThisBlock.map(_.cmd.request.requestId).toList
               )
             )
         } yield minorBlock
@@ -587,8 +587,8 @@ object Model:
                 endTime = blockEndTime,
               ),
               body = BlockBody.Final(
-                events = events,
-                depositsRefunded = refundedThisBlock.map(_.cmd.request.requestId).toList
+                requests = events,
+                depositsRejected = refundedThisBlock.map(_.cmd.request.requestId).toList
               )
             )
         } yield finalBlock

--- a/integration/src/test/scala/hydrozoa/integration/stage4/Plugins.scala
+++ b/integration/src/test/scala/hydrozoa/integration/stage4/Plugins.scala
@@ -109,9 +109,9 @@ private[stage4] object Stage4Plugins {
                         perPeer.state(p).blockBriefs.get.map { briefs =>
                             val seen = briefs
                                 .flatMap(br =>
-                                    br.events.map(_._1) ++
+                                    br.requests.map(_._1) ++
                                         br.depositsAbsorbed ++
-                                        br.depositsRefunded
+                                        br.depositsRejected
                                 )
                                 .toSet
                             Option.when(submitted.forall(seen.contains))(())

--- a/integration/src/test/scala/hydrozoa/integration/stage4/Suite.scala
+++ b/integration/src/test/scala/hydrozoa/integration/stage4/Suite.scala
@@ -203,7 +203,7 @@ case class Stage4Suite(
                              .map(_.flatten)
             seen       = allBriefs
                              .flatMap(br =>
-                                 br.events.map(_._1) ++ br.depositsAbsorbed ++ br.depositsRefunded
+                                 br.requests.map(_._1) ++ br.depositsAbsorbed ++ br.depositsRejected
                              )
                              .toSet
             _ <- IO.whenA(submitted.forall(seen.contains))(
@@ -527,7 +527,7 @@ case class Stage4Suite(
 
     // TODO: side-channel validity-error tracking + propNoStaleRejections
     //
-    // `JointLedger.rejectEvent` records every rejection as `(reqId, ValidityFlag.Invalid)` in
+    // `JointLedger.invalidateRequest` records every rejection as `(reqId, ValidityFlag.Invalid)` in
     // the in-progress block, so propLiveness sees the request landed in a brief — it cannot
     // distinguish:
     //   1. Reordering-induced ledger errors (e.g. `BadAllInputsUTxOException`) — legitimate
@@ -540,7 +540,7 @@ case class Stage4Suite(
     //
     // Plan:
     //   - Add `Stage4Sut.rejections: Ref[IO, Vector[(RequestId, UserRequestError | L1/L2 err)]]`
-    //     populated from a tracer hook in `JointLedger.rejectEvent` (one entry per rejection,
+    //     populated from a tracer hook in `JointLedger.invalidateRequest` (one entry per rejection,
     //     across all peers).
     //   - Add `propNoStaleRejections`: assert no `BlockOutOfRequestValidityInterval` rejections
     //     occurred. Other rejection types are informational only (printed in the analysis
@@ -559,7 +559,7 @@ case class Stage4Suite(
     ): Prop = {
         val processedIds: Set[RequestId] =
             canonicalBriefs
-                .flatMap(b => b.events.map(_._1) ++ b.depositsAbsorbed ++ b.depositsRefunded)
+                .flatMap(b => b.requests.map(_._1) ++ b.depositsAbsorbed ++ b.depositsRejected)
                 .toSet
         val missing = submittedIds.toSet -- processedIds
         Prop(missing.isEmpty) :|
@@ -592,8 +592,8 @@ case class Stage4Suite(
       * permissive than the model. Compared as exact rationals via cross-multiplication.
       *
       * Both sides are restricted to L2-tx reqIds (excluding any deposit reqId — deposits go into
-      * `depositsAbsorbed` / `depositsRefunded` on the SUT side, but a rejected deposit registration
-      * ends up in `events` via `JointLedger.rejectEvent` and would otherwise inflate the SUT total
+      * `depositsAbsorbed` / `depositsRejected` on the SUT side, but a rejected deposit registration
+      * ends up in `requests` via `JointLedger.invalidateRequest` and would otherwise inflate the SUT total
       * relative to the model.
       */
     private def propValidRatio(
@@ -605,7 +605,7 @@ case class Stage4Suite(
         val modelValid = l2TxReqIds.count(lastState.modelFlags(_) == ValidityFlag.Valid).toLong
         val modelTotal = l2TxReqIds.size.toLong
         val sutL2Events =
-            canonicalBriefs.flatMap(_.events).filterNot { case (r, _) => depositIds.contains(r) }
+            canonicalBriefs.flatMap(_.requests).filterNot { case (r, _) => depositIds.contains(r) }
         val sutValid = sutL2Events.count(_._2 == ValidityFlag.Valid).toLong
         val sutTotal = sutL2Events.size.toLong
 
@@ -670,14 +670,14 @@ case class Stage4Suite(
             val vMaj = brief.blockVersion.major.convert
             val vMin = brief.blockVersion.minor.convert
             val leader = (brief.blockNum: Int) % nPeers
-            val evs = brief.events.map { case (reqId, flag) =>
+            val evs = brief.requests.map { case (reqId, flag) =>
                 val f = if flag == ValidityFlag.Valid then "V" else "I"
                 s"p${reqId.peerNum.convert}:r${reqId.requestNum.convert}=$f"
             }
             val abs = brief.depositsAbsorbed.map(r =>
                 s"abs:p${r.peerNum.convert}:r${r.requestNum.convert}"
             )
-            val ref = brief.depositsRefunded.map(r =>
+            val ref = brief.depositsRejected.map(r =>
                 s"ref:p${r.peerNum.convert}:r${r.requestNum.convert}"
             )
             val events = (evs ++ abs ++ ref).mkString(" ")
@@ -688,7 +688,7 @@ case class Stage4Suite(
 
         // SUT processing order — each block contributes its absorbed deposits, then its events.
         val sutOrder: Vector[RequestId] =
-            canonicalBriefs.flatMap(b => b.depositsAbsorbed ++ b.events.map(_._1)).toVector
+            canonicalBriefs.flatMap(b => b.depositsAbsorbed ++ b.requests.map(_._1)).toVector
         val commonPrefixLen =
             submittedIds.zip(sutOrder).takeWhile { case (a, b) => a == b }.length
 
@@ -697,7 +697,7 @@ case class Stage4Suite(
         val modelValid = l2TxReqIds.count(lastState.modelFlags(_) == ValidityFlag.Valid)
         val modelTotal = l2TxReqIds.size
         val sutL2Events =
-            canonicalBriefs.flatMap(_.events).filterNot { case (r, _) => depositIds.contains(r) }
+            canonicalBriefs.flatMap(_.requests).filterNot { case (r, _) => depositIds.contains(r) }
         val sutValid = sutL2Events.count(_._2 == ValidityFlag.Valid)
         val sutTotal = sutL2Events.size
 

--- a/src/main/scala/hydrozoa/multisig/consensus/BlockWeaver.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/BlockWeaver.scala
@@ -417,7 +417,7 @@ object BlockWeaver {
                 } yield newState
 
                 private def extractAndSendRequestsFromMempool: IO[Mempool.Extraction.Result] = {
-                    val requestIds: List[RequestId] = reproducingBlockBrief.events.map(_._1)
+                    val requestIds: List[RequestId] = reproducingBlockBrief.requests.map(_._1)
                     val newExtractionResult = mempool.extractRequestsWhile(requestIds)
                     import newExtractionResult.*
                     for {
@@ -586,7 +586,7 @@ object BlockWeaver {
                 private def extractAndSendRequestsFromMempool(
                     mempool: Mempool
                 ): IO[Mempool.Extraction.Result] = {
-                    val allRequestIds: List[RequestId] = reproducingBlockBrief.events.map(_._1)
+                    val allRequestIds: List[RequestId] = reproducingBlockBrief.requests.map(_._1)
                     val requestIds =
                         allRequestIds.dropWhile(_ != incompleteExtraction.awaitingRequestId)
                     val newExtractionResult = mempool.extractRequestsWhile(requestIds)

--- a/src/main/scala/hydrozoa/multisig/ledger/block/BlockBody.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/block/BlockBody.scala
@@ -16,15 +16,15 @@ trait BlockBody extends BlockBody.Section {
 object BlockBody {
     case object Initial extends BlockBody, BlockType.Initial {
         override transparent inline def body: BlockBody.Initial.type = this
-        override transparent inline def events: List[(RequestId, ValidityFlag)] = List()
+        override transparent inline def requests: List[(RequestId, ValidityFlag)] = List()
         override transparent inline def depositsAbsorbed: List[RequestId] = List()
-        override transparent inline def depositsRefunded: List[RequestId] = List()
+        override transparent inline def depositsRejected: List[RequestId] = List()
     }
 
     given Codec[Minor] = deriveCodec[Minor]
     final case class Minor(
-        override val events: List[(RequestId, ValidityFlag)],
-        override val depositsRefunded: List[RequestId]
+        override val requests: List[(RequestId, ValidityFlag)],
+        override val depositsRejected: List[RequestId]
     ) extends BlockBody,
           BlockType.Minor {
         override transparent inline def body: BlockBody.Minor = this
@@ -33,9 +33,9 @@ object BlockBody {
 
     given Codec[Major] = deriveCodec[Major]
     final case class Major(
-        override val events: List[(RequestId, ValidityFlag)],
+        override val requests: List[(RequestId, ValidityFlag)],
         override val depositsAbsorbed: List[RequestId],
-        override val depositsRefunded: List[RequestId]
+        override val depositsRejected: List[RequestId]
     ) extends BlockBody,
           BlockType.Major {
         override transparent inline def body: BlockBody.Major = this
@@ -43,8 +43,8 @@ object BlockBody {
 
     given Codec[Final] = deriveCodec[Final]
     final case class Final(
-        override val events: List[(RequestId, ValidityFlag)],
-        override val depositsRefunded: List[RequestId]
+        override val requests: List[(RequestId, ValidityFlag)],
+        override val depositsRejected: List[RequestId]
     ) extends BlockBody,
           BlockType.Final {
         override transparent inline def body: BlockBody.Final = this
@@ -56,8 +56,8 @@ object BlockBody {
 
     trait Section {
         def body: BlockBody
-        def events: List[(RequestId, ValidityFlag)]
+        def requests: List[(RequestId, ValidityFlag)]
         def depositsAbsorbed: List[RequestId]
-        def depositsRefunded: List[RequestId]
+        def depositsRejected: List[RequestId]
     }
 }

--- a/src/main/scala/hydrozoa/multisig/ledger/block/BlockBrief.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/block/BlockBrief.scala
@@ -74,11 +74,11 @@ object BlockBrief {
         override transparent inline def startTime: BlockCreationStartTime = header.startTime
         override transparent inline def endTime: BlockCreationEndTime = header.endTime
 
-        override transparent inline def events: List[(RequestId, ValidityFlag)] = body.events
+        override transparent inline def requests: List[(RequestId, ValidityFlag)] = body.requests
         override transparent inline def depositsAbsorbed: List[RequestId] =
             body.depositsAbsorbed
-        override transparent inline def depositsRefunded: List[RequestId] =
-            body.depositsRefunded
+        override transparent inline def depositsRejected: List[RequestId] =
+            body.depositsRejected
     }
 
     object Section {

--- a/src/main/scala/hydrozoa/multisig/ledger/eutxol2/EutxoL2Ledger.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/eutxol2/EutxoL2Ledger.scala
@@ -142,7 +142,7 @@ case class EutxoL2Ledger private (
               s.focus(_.activeUtxos)
                   .modify(_ ++ addedL2Utxos.map((i, o) => i -> o.value))
                   .focus(_.pendingDeposits)
-                  .modify(_.removedAll(req.absorbedDeposits ++ req.refundedDeposits))
+                  .modify(_.removedAll(req.absorbedDeposits ++ req.rejectedDeposits))
                   .focus(_.commandNumber)
                   .modify(_.increment)
             )

--- a/src/main/scala/hydrozoa/multisig/ledger/joint/JointLedger.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/joint/JointLedger.scala
@@ -33,7 +33,7 @@ import hydrozoa.multisig.ledger.l1.txseq.DepositRefundTxSeq
 import hydrozoa.multisig.ledger.l1.utxo.DepositUtxo
 import hydrozoa.multisig.ledger.l2.{L2Ledger, L2LedgerCommand, L2LedgerError, L2LedgerState}
 import hydrozoa.multisig.persistence.recovery.ReplayCursors
-import hydrozoa.multisig.persistence.{JournalKey, JournalValue, Markers, Persistence, RequestBlockEntry, StoreKey, WriteBatch}
+import hydrozoa.multisig.persistence.{DepositDecision, JournalKey, JournalValue, Markers, Persistence, RequestBlockEntry, StoreKey, WriteBatch}
 import monocle.Focus.focus
 
 private case class UserRequestState(
@@ -196,7 +196,7 @@ final case class JointLedger(
         case req: UserRequestWithId.TransactionRequest => applyTransaction(req)
     }
 
-    private def rejectEvent(
+    private def invalidateRequest(
         requestId: RequestId,
         e: JointLedger.UserRequestError | JointLedger.DepositLedgerError | L2LedgerError
     ): IO[Unit] =
@@ -208,7 +208,7 @@ final case class JointLedger(
                 .modify(_.appended((requestId, Invalid)))
             _ <- state.set(newState)
             _ <- tracer.traceWith(
-              JointLedgerEvent.RequestRejected(requestId, currentBlockNum, e.toString)
+              JointLedgerEvent.RequestInvalidated(requestId, currentBlockNum, e.toString)
             )
         } yield ()
 
@@ -216,7 +216,7 @@ final case class JointLedger(
       * deposits map — this actor's only L1-ledger surface. Parsing derives the deposit's accept-by
       * deadline (`validityEnd`) from the tx's mandatory TTL (`ttl − submissionDuration`) and stamps
       * it on the produced utxo. Returns the new map + the produced deposit utxo and its post-dated
-      * refund tx, or a [[DepositLedgerError]] (rejected via `rejectEvent`, never raised). The
+      * refund tx, or a [[DepositLedgerError]] (rejected via `invalidateRequest`, never raised). The
       * accept-by check itself is enforced by the caller, [[registerDeposit]].
       */
     private def registerDepositInMap(
@@ -258,7 +258,7 @@ final case class JointLedger(
             currentBlockNum = p.nextBlockNumber
 
             _ <- registerDepositInMap(p.deposits, req) match {
-                case Left(error) => rejectEvent(requestId, error)
+                case Left(error) => invalidateRequest(requestId, error)
                 case Right((newDeposits, (depositProduced, refundTx))) =>
                     // The accept-by deadline is derived from the deposit tx's TTL during the parse
                     // above (ttl − submissionDuration), so the check can only run post-parse.
@@ -267,7 +267,7 @@ final case class JointLedger(
                           depositProduced.requestValidityEndTime
                         )
                     then
-                        rejectEvent(
+                        invalidateRequest(
                           requestId,
                           JointLedger.UserRequestError.BlockOutOfRequestValidityInterval(
                             blockStartTime,
@@ -290,7 +290,7 @@ final case class JointLedger(
                             _ <- res match {
                                 // FIXME: Should we distinguish between genuine L2 failures and things like
                                 // network errors?
-                                case Left(e) => rejectEvent(requestId, e)
+                                case Left(e) => invalidateRequest(requestId, e)
                                 case Right(newL2State) =>
                                     for {
                                         _ <- state.set(
@@ -347,7 +347,7 @@ final case class JointLedger(
                 for {
                     res <- runL2Command(p, l2Command)
                     _ <- res match {
-                        case Left(e) => rejectEvent(requestId, e)
+                        case Left(e) => invalidateRequest(requestId, e)
                         case Right(newL2State) =>
                             for {
                                 _ <- state.set(
@@ -423,7 +423,7 @@ final case class JointLedger(
                 // Verify the produced brief against the reference brief (follower mode).
                 _ <- panicOnMismatchWithExpectedBrief(referenceBlockBrief, blockBrief)
 
-                // Drop the deposits we just absorbed/refunded from the L1 deposits map.
+                // Drop the deposits we just absorbed/rejected from the L1 deposits map.
                 newJlState = pBlockBrief.setDeposits(split.surviving)
 
                 _ <- state.set(newJlState.done(blockBrief.header))
@@ -460,25 +460,25 @@ final case class JointLedger(
         val blockCreationStartTime = p.BlockCreationStartTime
         val previousHeader = p.previousBlockHeader
         val blockWithdrawnUtxos = p.l2LedgerState.payouts
-        val events = p.userRequestState.requests
+        val requests = p.userRequestState.requests
         for {
             _ <- tracer.traceWith(
               JointLedgerEvent.BlockBriefBuilding(
                 previousHeader,
                 blockCreationStartTime,
                 p.competingFallbackTxTime,
-                events,
+                requests,
                 decisions.absorbed.requestIds,
-                decisions.refunded.requestIds
+                decisions.rejected.requestIds
               )
             )
 
-            depositEventDecisions: L2LedgerCommand.ApplyDepositDecisions =
+            depositRequestDecisions: L2LedgerCommand.ApplyDepositDecisions =
                 L2LedgerCommand.ApplyDepositDecisions(
                   blockNumber = p.nextBlockNumber,
                   blockCreationEndTime = blockCreationEndTime.toPosixTime,
                   absorbedDeposits = decisions.absorbed.requestIds,
-                  refundedDeposits = decisions.refunded.requestIds
+                  rejectedDeposits = decisions.rejected.requestIds
                 )
 
             // Block header
@@ -488,8 +488,8 @@ final case class JointLedger(
                     val evacDiffs = p.l2LedgerState.diffs
                     for {
                         newL2State <-
-                            if decisions.refunded.isEmpty then IO.pure(p.l2LedgerState)
-                            else executeL2Command(p, depositEventDecisions)
+                            if decisions.rejected.isEmpty then IO.pure(p.l2LedgerState)
+                            else executeL2Command(p, depositRequestDecisions)
 
                         // `evacDiffs` are surfaced to the slow side via `BlockResult`.
                         newJLState = p.setL2LedgerState(newL2State)
@@ -506,7 +506,7 @@ final case class JointLedger(
                     } yield (newJLState, headerIntermediate, evacDiffs)
                 else {
                     for {
-                        newL2State <- executeL2Command(p, depositEventDecisions)
+                        newL2State <- executeL2Command(p, depositRequestDecisions)
                         evacDiffs = newL2State.diffs
                         newJLState = p.setL2LedgerState(newL2State)
 
@@ -523,13 +523,13 @@ final case class JointLedger(
             // Block brief
             blockBrief: BlockBrief.Intermediate = headerIntermediate match {
                 case header: BlockHeader.Minor =>
-                    val blockBody = BlockBody.Minor(events, decisions.refunded.requestIds)
+                    val blockBody = BlockBody.Minor(requests, decisions.rejected.requestIds)
                     BlockBrief.Minor(header, blockBody)
                 case header: BlockHeader.Major =>
                     val blockBody = BlockBody.Major(
-                      events,
+                      requests,
                       decisions.absorbed.requestIds,
-                      decisions.refunded.requestIds
+                      decisions.rejected.requestIds
                     )
                     BlockBrief.Major(header, blockBody)
             }
@@ -563,9 +563,9 @@ final case class JointLedger(
                       args.blockCreationEndTime
                     )
                     val blockBody = BlockBody.Final(
-                      events = requests,
+                      requests = requests,
                       // Final block should reject all the deposits known.
-                      depositsRefunded = p.deposits.requestIds
+                      depositsRejected = p.deposits.requestIds
                     )
                     BlockBrief.Final(blockHeader, blockBody)
                 }
@@ -677,7 +677,7 @@ final case class JointLedger(
       *   - one request → (block, validity) reverse-index row per event in this block →
       *     `RequestBlockIndex[requestId]` (keyed by the opaque request id's packed i64);
       *   - one deposit-request → block reverse-index row per deposit absorbed in this (major) block
-      *     → `DepositAbsorptionIndex[requestId]`.
+      *     → `DepositDecisionIndex[requestId]`.
       *
       * A head peer adds its own `Block` (leader) + `SoftAck` lanes on top
       * ([[persistOwnAckBundle]]); a coil peer persists exactly this subset
@@ -693,7 +693,7 @@ final case class JointLedger(
             // and never pruned below the fast anchor, so the predecessor entry is always present
             // once past the first block).
             priorHighWater <- previousBlockHighWater(brief.blockNum)
-            highWater = ReplayCursors.mergeHighWater(priorHighWater, brief.events.map(_._1))
+            highWater = ReplayCursors.mergeHighWater(priorHighWater, brief.requests.map(_._1))
             // The L2 ledger has already committed this block's commands (JL is its sole, single-
             // message-at-a-time driver), so its command number now reflects this block; record it
             // so recover can co-anchor the L2 ledger to the fast anchor via restoreTo.
@@ -706,16 +706,25 @@ final case class JointLedger(
                 .put(StoreKey.L2CommandNumber(brief.blockNum))(commandNumber)
             // One reverse-index row per event, in the same atomic bundle: the request's id maps
             // to the block that processed it and the validity verdict it received.
-            val withRequestBlocks = brief.events.foldLeft(bundle) {
+            val withRequestBlocks = brief.requests.foldLeft(bundle) {
                 case (batch, (requestId, validity)) =>
                     batch.put(StoreKey.RequestBlockIndex(requestId))(
                       RequestBlockEntry(brief.blockNum, validity)
                     )
             }
-            // One row per deposit absorbed in this (major) block: the deposit request's id maps to
-            // the block whose settlement absorbs it into the treasury.
-            brief.depositsAbsorbed.foldLeft(withRequestBlocks) { (batch, requestId) =>
-                batch.put(StoreKey.DepositAbsorptionIndex(requestId))(brief.blockNum)
+            // One decision row per deposit decided in this block: absorbed (into the treasury by
+            // this major block's settlement) or rejected (repaid by its post-dated refund). Both
+            // map the deposit request's id to the deciding block; absence of a row means undecided.
+            val withAbsorptions =
+                brief.depositsAbsorbed.foldLeft(withRequestBlocks) { (batch, requestId) =>
+                    batch.put(StoreKey.DepositDecisionIndex(requestId))(
+                      DepositDecision.Absorbed(brief.blockNum)
+                    )
+                }
+            brief.depositsRejected.foldLeft(withAbsorptions) { (batch, requestId) =>
+                batch.put(StoreKey.DepositDecisionIndex(requestId))(
+                  DepositDecision.Rejected(brief.blockNum)
+                )
             }
         }
 
@@ -782,7 +791,7 @@ final case class JointLedger(
     /** Field-level diff of the leader's `expected` brief against this peer's `actual` one, so an
       * intermittent consensus-divergence panic names WHICH part flipped instead of dumping two
       * opaque briefs. The common cause is a deposit landing in a different compartment on the two
-      * peers (`depositsAbsorbed` vs `depositsRefunded`) because their `pollResults`/block-window
+      * peers (`depositsAbsorbed` vs `depositsRejected`) because their `pollResults`/block-window
       * timing differed — e.g. a deposit absorbed by the leader but `NotInPollResults` here, which
       * reflects a polling cadence violating the `cardanoLiaisonPollingPeriodSafetyFactor` margin on
       * `TxTiming`.
@@ -810,9 +819,9 @@ final case class JointLedger(
             s"endTime: expected=${expected.endTime} actual=${actual.endTime}"
           ),
           setDiff("depositsAbsorbed", expected.depositsAbsorbed, actual.depositsAbsorbed),
-          setDiff("depositsRefunded", expected.depositsRefunded, actual.depositsRefunded),
-          Option.when(expected.events != actual.events)(
-            s"events: expected=${expected.events} actual=${actual.events}"
+          setDiff("depositsRejected", expected.depositsRejected, actual.depositsRejected),
+          Option.when(expected.requests != actual.requests)(
+            s"requests: expected=${expected.requests} actual=${actual.requests}"
           )
         ).flatten match
             case Nil   => " (accessor fields equal; differs in header internals)"
@@ -862,7 +871,7 @@ object JointLedger {
 
     /** Failure registering a deposit into the fast-side L1 deposits map — either the deposit tx
       * fails to parse, or its submission deadline doesn't match the one expected from its
-      * validity-end. Rejected via `rejectEvent` (stringified into the L2 proxy error), never
+      * validity-end. Rejected via `invalidateRequest` (stringified into the L2 proxy error), never
       * raised, so it need not extend `Throwable`.
       */
     sealed trait DepositLedgerError

--- a/src/main/scala/hydrozoa/multisig/ledger/joint/JointLedgerEvent.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/joint/JointLedgerEvent.scala
@@ -38,7 +38,7 @@ object JointLedgerEvent:
     final case class TransactionApplicationStarted(requestId: RequestId) extends JointLedgerEvent
     final case class TransactionApplicationCompleted(requestId: RequestId, blockNum: BlockNumber)
         extends JointLedgerEvent
-    final case class RequestRejected(
+    final case class RequestInvalidated(
         requestId: RequestId,
         blockNum: BlockNumber,
         reason: String
@@ -67,7 +67,7 @@ object JointLedgerEvent:
         competingFallbackTxTime: FallbackTxStartTime,
         events: List[(RequestId, ValidityFlag)],
         decisionsAbsorbed: List[RequestId],
-        decisionsRefunded: List[RequestId]
+        decisionsRejected: List[RequestId]
     ) extends JointLedgerEvent
 
     final case class BlockBriefBuilt(brief: BlockBrief.Intermediate) extends JointLedgerEvent

--- a/src/main/scala/hydrozoa/multisig/ledger/joint/JointLedgerEventFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/joint/JointLedgerEventFormat.scala
@@ -24,7 +24,7 @@ object JointLedgerEventFormat:
             case BriefProduced(b) =>
                 val v = b.header.blockVersion
                 info(
-                  s"brief produced: block=${b.blockNum: Int} type=${briefTypeName(b)} v${v.major: Int}.${v.minor: Int} events=${b.body.events.size}",
+                  s"brief produced: block=${b.blockNum: Int} type=${briefTypeName(b)} v${v.major: Int}.${v.minor: Int} requests=${b.body.requests.size}",
                   "blockNum" -> s"${b.blockNum: Int}"
                 )
             case L2CommandFailed(err) =>
@@ -49,7 +49,7 @@ object JointLedgerEventFormat:
                   "requestId" -> rid.toString,
                   "blockNum" -> s"${bn: Int}"
                 )
-            case RequestRejected(rid, bn, reason) =>
+            case RequestInvalidated(rid, bn, reason) =>
                 warn(
                   s"Request rejected ($rid): $reason",
                   "requestId" -> rid.toString,
@@ -70,14 +70,14 @@ object JointLedgerEventFormat:
                   s"completing block $bn (blockCreationEndTime=$endTime, competingFallbackTxTime=$fallbackTime, split=$split)",
                   "blockNum" -> s"${bn: Int}"
                 )
-            case BlockBriefBuilding(prev, start, fallback, events, absorbed, refunded) =>
+            case BlockBriefBuilding(prev, start, fallback, events, absorbed, rejected) =>
                 trace(
                   s"mkBlockBrief: previousHeader=$prev\n" +
                       s"mkBlockBrief: blockStartTime=$start\n" +
                       s"mkBlockBrief: competingFallbackValidityStart=$fallback\n" +
                       s"mkBlockBrief: events=$events\n" +
                       s"mkBlockBrief: decisions.absorbed=$absorbed\n" +
-                      s"mkBlockBrief: decisions.refunded=$refunded"
+                      s"mkBlockBrief: decisions.rejected=$rejected"
                 )
             case BlockBriefBuilt(brief) =>
                 trace(

--- a/src/main/scala/hydrozoa/multisig/ledger/l1/deposits/map/DepositsMap.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/l1/deposits/map/DepositsMap.scala
@@ -104,7 +104,7 @@ final case class DepositsMap private[map] (
                         )
                     val isExistent = pollResults.utxos.contains(entry.depositUtxo.toUtxo.input)
                     // A deposit whose absorption window closes before the settlement tx's
-                    // validity ends can never be safely absorbed, so it must be refunded even
+                    // validity ends can never be safely absorbed, so it must be rejected even
                     // if it has not matured yet — `isExpired` takes precedence over `isImmature`.
                     val compartment =
                         if isExpired then Expired
@@ -184,7 +184,7 @@ object DepositsMap {
         val surviving: DepositsMap = unabsorbed.concat(immature)
         val decisions = Decisions(
           absorbed = absorbed.unzip,
-          refunded = DepositsMap(notInPollResults.treeMap ++ expired.treeMap).unzip,
+          rejected = DepositsMap(notInPollResults.treeMap ++ expired.treeMap).unzip,
           mNextAbsorptionStartTime = surviving.treeMap.keys.minOption
         )
 
@@ -202,7 +202,7 @@ object DepositsMap {
 
     final case class Decisions private[map] (
         absorbed: Unzip,
-        refunded: Unzip,
+        rejected: Unzip,
         mNextAbsorptionStartTime: Option[DepositAbsorptionStartTime]
     )
 

--- a/src/main/scala/hydrozoa/multisig/ledger/l2/L2LedgerCommand.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/l2/L2LedgerCommand.scala
@@ -122,7 +122,7 @@ object L2LedgerCommand {
         blockNumber: BlockNumber,
         blockCreationEndTime: PosixTime,
         absorbedDeposits: List[RequestId],
-        refundedDeposits: List[RequestId]
+        rejectedDeposits: List[RequestId]
     ) extends L2LedgerCommand.Real
 
     object ApplyDepositDecisions {

--- a/src/main/scala/hydrozoa/multisig/ledger/l2/L2TxSummary.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/l2/L2TxSummary.scala
@@ -14,14 +14,15 @@ final case class L2TxSummary(
 )
 
 /** What an [[L2TxSummary]] records: an applied L2 transaction, or a step in a deposit's lifecycle.
+  * TODO: rename - it or it may be gone when we revise utxo ledger API
   */
 enum L2TxKind:
-    case Transaction, DepositRegistered, DepositAbsorbed, DepositRefunded
+    case Transaction, DepositRegistered, DepositAbsorbed, DepositRejected
 
 object L2TxSummary:
     /** Expand one logged real command into its summaries, in the order they appear to a reader. A
       * transaction or a deposit registration is a single summary; a deposit-decisions command is
-      * one summary per absorbed deposit followed by one per refunded deposit (so a no-op decisions
+      * one summary per absorbed deposit followed by one per rejected deposit (so a no-op decisions
       * command with empty lists yields none).
       */
     def fromCommand(command: L2LedgerCommand.Real): Vector[L2TxSummary] = command match
@@ -32,5 +33,5 @@ object L2TxSummary:
         case c: L2LedgerCommand.ApplyDepositDecisions =>
             c.absorbedDeposits.toVector
                 .map(id => L2TxSummary(id, c.blockNumber, L2TxKind.DepositAbsorbed))
-                ++ c.refundedDeposits.toVector
-                    .map(id => L2TxSummary(id, c.blockNumber, L2TxKind.DepositRefunded))
+                ++ c.rejectedDeposits.toVector
+                    .map(id => L2TxSummary(id, c.blockNumber, L2TxKind.DepositRejected))

--- a/src/main/scala/hydrozoa/multisig/persistence/Cf.scala
+++ b/src/main/scala/hydrozoa/multisig/persistence/Cf.scala
@@ -101,12 +101,13 @@ object Cf:
     case object EffectStackIndex extends Cf:
         def name = "EffectStackIndex"
 
-    /** Deposit-request → absorbing-block reverse index: the deposit request's opaque id (packed
-      * i64) → the major `blockNum` that absorbed the deposit into the treasury. Written by JL in
-      * the same atomic bundle as that block.
+    /** Deposit-request → decision reverse index: the deposit request's opaque id (packed i64) → the
+      * [[DepositDecision]] (absorbed / rejected) and the `blockNum` that decided it. Absence of a
+      * row means the deposit is still undecided. Written by JL in the same atomic bundle as the
+      * deciding block.
       */
-    case object DepositAbsorptionIndex extends Cf:
-        def name = "DepositAbsorptionIndex"
+    case object DepositDecisionIndex extends Cf:
+        def name = "DepositDecisionIndex"
 
     /** Withdrawal-request → effect reverse index: a set of `(requestId, l1TxId)` pairs (both in the
       * key, empty value), so a prefix scan by the packed-i64 request id yields the settlement /
@@ -157,7 +158,7 @@ object Cf:
       Treasury,
       EvacuationMap,
       RequestBlockIndex,
-      DepositAbsorptionIndex,
+      DepositDecisionIndex,
       WithdrawalEffectIndex,
       BlockStackIndex,
       EffectStackIndex,

--- a/src/main/scala/hydrozoa/multisig/persistence/ConsensusStoreReader.scala
+++ b/src/main/scala/hydrozoa/multisig/persistence/ConsensusStoreReader.scala
@@ -74,9 +74,9 @@ trait ConsensusStoreReader[F[_]]:
     def withdrawalEffects(id: RequestId): F[List[TransactionHash]]
 
     /** The wall-clock instant an arrival stamp was recorded at, via the store's per-generation
-      * zero-time anchor. `None` for a stamp whose generation predates the anchor.
+      * zero-time anchor (total — see [[Persistence.wallClockOf]]).
       */
-    def wallClockOf(stamp: ArrivalStamp): F[Option[Instant]]
+    def wallClockOf(stamp: ArrivalStamp): F[Instant]
 
 object ConsensusStoreReader:
 
@@ -153,7 +153,7 @@ object ConsensusStoreReader:
                   stop = (k: (Long, TransactionHash)) => k._1 != id.asI64
                 )((k, _) => k._2)
 
-            def wallClockOf(stamp: ArrivalStamp): IO[Option[Instant]] =
+            def wallClockOf(stamp: ArrivalStamp): IO[Instant] =
                 persistence.wallClockOf(stamp)
 
     /** A reader over no data — every lookup is empty. For wiring the routes on a node whose store
@@ -178,4 +178,4 @@ object ConsensusStoreReader:
             def requestBlock(id: RequestId): IO[Option[RequestBlockEntry]] = IO.pure(None)
             def decision(id: RequestId): IO[Option[DepositDecision]] = IO.pure(None)
             def withdrawalEffects(id: RequestId): IO[List[TransactionHash]] = IO.pure(Nil)
-            def wallClockOf(stamp: ArrivalStamp): IO[Option[Instant]] = IO.pure(None)
+            def wallClockOf(stamp: ArrivalStamp): IO[Instant] = IO.pure(Instant.EPOCH)

--- a/src/main/scala/hydrozoa/multisig/persistence/ConsensusStoreReader.scala
+++ b/src/main/scala/hydrozoa/multisig/persistence/ConsensusStoreReader.scala
@@ -62,10 +62,10 @@ trait ConsensusStoreReader[F[_]]:
       */
     def requestBlock(id: RequestId): F[Option[RequestBlockEntry]]
 
-    /** The major block that absorbed a deposit into the treasury — absent while the deposit is
-      * unabsorbed (or the request is not a deposit).
+    /** A deposit's block-completion decision (absorbed / rejected) and the block that decided it —
+      * absent while the deposit is undecided (or the request is not a deposit).
       */
-    def absorptionBlock(id: RequestId): F[Option[BlockNumber]]
+    def decision(id: RequestId): F[Option[DepositDecision]]
 
     /** The L1 effect txs that pay a withdrawing request's L1-bound outputs (settlement / rollout /
       * finalization), by their `l1TxId`. Empty for a non-withdrawing request, or one whose covering
@@ -135,8 +135,8 @@ object ConsensusStoreReader:
             def requestBlock(id: RequestId): IO[Option[RequestBlockEntry]] =
                 persistence.get(StoreKey.RequestBlockIndex(id))
 
-            def absorptionBlock(id: RequestId): IO[Option[BlockNumber]] =
-                persistence.get(StoreKey.DepositAbsorptionIndex(id))
+            def decision(id: RequestId): IO[Option[DepositDecision]] =
+                persistence.get(StoreKey.DepositDecisionIndex(id))
 
             def withdrawalEffects(id: RequestId): IO[List[TransactionHash]] =
                 // Prefix scan the (requestId, l1TxId) index: seek to the 8-byte packed-i64 prefix,
@@ -176,6 +176,6 @@ object ConsensusStoreReader:
                 IO.pure(Nil)
             def request(id: RequestId): IO[Option[Timestamped[UserRequestWithId]]] = IO.pure(None)
             def requestBlock(id: RequestId): IO[Option[RequestBlockEntry]] = IO.pure(None)
-            def absorptionBlock(id: RequestId): IO[Option[BlockNumber]] = IO.pure(None)
+            def decision(id: RequestId): IO[Option[DepositDecision]] = IO.pure(None)
             def withdrawalEffects(id: RequestId): IO[List[TransactionHash]] = IO.pure(Nil)
             def wallClockOf(stamp: ArrivalStamp): IO[Option[Instant]] = IO.pure(None)

--- a/src/main/scala/hydrozoa/multisig/persistence/DepositDecision.scala
+++ b/src/main/scala/hydrozoa/multisig/persistence/DepositDecision.scala
@@ -1,0 +1,49 @@
+package hydrozoa.multisig.persistence
+
+import hydrozoa.multisig.ledger.block.BlockNumber
+import io.circe.syntax.*
+import io.circe.{Codec, Decoder, DecodingFailure, Encoder, Json}
+
+/** A registered deposit's block-completion decision, stored in [[Cf.DepositDecisionIndex]] keyed by
+  * the deposit request's id. A deposit is decided at the block that either absorbs it into the
+  * treasury or rejects it; the deciding block is a later block than the deposit's registration
+  * block, so it is not reachable from [[Cf.RequestBlockIndex]] and needs its own reverse index.
+  *
+  * Absence of a row means the deposit is still **undecided** (pending) — carried to a future block.
+  *
+  * The block-only value is sufficient: the absorbing settlement is derived from the block's Major
+  * partition, and the post-dated refund from the deposit's registration partition.
+  */
+sealed trait DepositDecision:
+    /** The block at which the decision was made. */
+    def block: BlockNumber
+
+object DepositDecision:
+    /** Absorbed into the treasury by `block`'s settlement. */
+    final case class Absorbed(block: BlockNumber) extends DepositDecision
+
+    /** Rejected at `block` (not absorbed); the depositor is repaid by the post-dated refund. */
+    final case class Rejected(block: BlockNumber) extends DepositDecision
+
+    private val absorbed = "Absorbed"
+    private val rejected = "Rejected"
+
+    given Codec[DepositDecision] = Codec.from(
+      Decoder.instance { c =>
+          for {
+              kind <- c.downField("kind").as[String]
+              block <- c.downField("block").as[BlockNumber]
+              decision <- kind match
+                  case `absorbed` => Right(Absorbed(block))
+                  case `rejected` => Right(Rejected(block))
+                  case other =>
+                      Left(DecodingFailure(s"unknown DepositDecision kind: $other", c.history))
+          } yield decision
+      },
+      Encoder.instance { decision =>
+          val kind = decision match
+              case _: Absorbed => absorbed
+              case _: Rejected => rejected
+          Json.obj("kind" -> kind.asJson, "block" -> decision.block.asJson)
+      }
+    )

--- a/src/main/scala/hydrozoa/multisig/persistence/JournalKey.scala
+++ b/src/main/scala/hydrozoa/multisig/persistence/JournalKey.scala
@@ -128,9 +128,8 @@ object JournalKey:
             HubHardAck(hub, HubHardAckNumber(readIntBE(bytes, 0)))
         case Cf.BlockResult | Cf.SoftConfirmation | Cf.HardConfirmation | Cf.DepositMap |
             Cf.Treasury | Cf.EvacuationMap | Cf.RequestHighWater | Cf.CoilStampMark |
-            Cf.L2CommandNumber | Cf.UnsignedStack | Cf.RequestBlockIndex |
-            Cf.DepositAbsorptionIndex | Cf.WithdrawalEffectIndex | Cf.BlockStackIndex |
-            Cf.EffectStackIndex | Cf.Meta =>
+            Cf.L2CommandNumber | Cf.UnsignedStack | Cf.RequestBlockIndex | Cf.DepositDecisionIndex |
+            Cf.WithdrawalEffectIndex | Cf.BlockStackIndex | Cf.EffectStackIndex | Cf.Meta =>
             throw new IllegalArgumentException(
               s"$cf is not a journal CF; JournalKey.decode is undefined for it"
             )

--- a/src/main/scala/hydrozoa/multisig/persistence/Persistence.scala
+++ b/src/main/scala/hydrozoa/multisig/persistence/Persistence.scala
@@ -68,11 +68,12 @@ trait Persistence[F[_]]:
       */
     def zeroTimes: F[Map[Int, Long]]
 
-    /** Convert an arrival stamp to the wall-clock instant it was recorded at, using this
-      * generation's [[zeroTimes]] anchor (`wall = zeroTime[generation] + monotonicNanos`). `None`
-      * if the generation has no anchor (an entry written before anchors existed).
+    /** Convert an arrival stamp to the wall-clock instant it was recorded at, using its
+      * generation's [[zeroTimes]] anchor (`wall = zeroTime[generation] + monotonicNanos`). Total:
+      * every generation is anchored at open before any of its stamps can exist, and anchors are
+      * never pruned, so a stamp produced by a running node always has its anchor.
       */
-    def wallClockOf(stamp: ArrivalStamp): F[Option[Instant]]
+    def wallClockOf(stamp: ArrivalStamp): F[Instant]
 
 object Persistence:
     /** The arrival-stamp generation counter's key in `Cf.Meta` (a 4-byte big-endian `Int`). */
@@ -159,11 +160,14 @@ object Persistence:
 
             def zeroTimes: IO[Map[Int, Long]] = IO.pure(anchors)
 
-            def wallClockOf(stamp: ArrivalStamp): IO[Option[Instant]] =
+            def wallClockOf(stamp: ArrivalStamp): IO[Instant] =
+                // Every generation is anchored at open, so `stamp.generation` is present for any
+                // real stamp; fall back to this generation's anchor for the unreachable
+                // (legacy / synthetic) case rather than reintroduce a partial result.
                 IO.pure(
-                  anchors
-                      .get(stamp.generation)
-                      .map(zero => epochNanosToInstant(zero + stamp.monotonicNanos))
+                  epochNanosToInstant(
+                    anchors.getOrElse(stamp.generation, anchors(generation)) + stamp.monotonicNanos
+                  )
                 )
 
             def get(key: StoreKey): IO[Option[key.Value]] =

--- a/src/main/scala/hydrozoa/multisig/persistence/StoreDump.scala
+++ b/src/main/scala/hydrozoa/multisig/persistence/StoreDump.scala
@@ -130,9 +130,8 @@ object StoreDump:
             case Cf.RequestBlockIndex =>
                 if key.length == 8 then s"RequestBlockIndex(i64=${ByteBuffer.wrap(key).getLong})"
                 else hex(key)
-            case Cf.DepositAbsorptionIndex =>
-                if key.length == 8 then
-                    s"DepositAbsorptionIndex(i64=${ByteBuffer.wrap(key).getLong})"
+            case Cf.DepositDecisionIndex =>
+                if key.length == 8 then s"DepositDecisionIndex(i64=${ByteBuffer.wrap(key).getLong})"
                 else hex(key)
             case Cf.WithdrawalEffectIndex =>
                 if key.length == 40 then

--- a/src/main/scala/hydrozoa/multisig/persistence/StoreKey.scala
+++ b/src/main/scala/hydrozoa/multisig/persistence/StoreKey.scala
@@ -33,12 +33,11 @@ import scalus.cardano.ledger.TransactionHash
   *     [[StoreKey.L2CommandNumber]] — `Cf.L2CommandNumber`, keyed by `blockNum`.
   *     [[StoreKey.UnsignedStack]] — `Cf.UnsignedStack`, keyed by `stackNum`.
   *   - Reverse-index CFs: [[StoreKey.RequestBlockIndex]] — `Cf.RequestBlockIndex`, keyed by the
-  *     request id (its packed i64). [[StoreKey.DepositAbsorptionIndex]] —
-  *     `Cf.DepositAbsorptionIndex`, keyed by the deposit request's id (its packed i64).
-  *     [[StoreKey.WithdrawalEffectIndex]] — `Cf.WithdrawalEffectIndex`, keyed by
-  *     `(requestId i64, l1TxId)` (many effects per request). [[StoreKey.BlockStackIndex]] —
-  *     `Cf.BlockStackIndex`, keyed by `blockNum`. [[StoreKey.EffectStackIndex]] —
-  *     `Cf.EffectStackIndex`, keyed by the effect's `l1TxId`.
+  *     request id (its packed i64). [[StoreKey.DepositDecisionIndex]] — `Cf.DepositDecisionIndex`,
+  *     keyed by the deposit request's id (its packed i64). [[StoreKey.WithdrawalEffectIndex]] —
+  *     `Cf.WithdrawalEffectIndex`, keyed by `(requestId i64, l1TxId)` (many effects per request).
+  *     [[StoreKey.BlockStackIndex]] — `Cf.BlockStackIndex`, keyed by `blockNum`.
+  *     [[StoreKey.EffectStackIndex]] — `Cf.EffectStackIndex`, keyed by the effect's `l1TxId`.
   *   - Singleton snapshot CFs (one entry total): [[StoreKey.DepositMap]], [[StoreKey.Treasury]],
   *     [[StoreKey.CoilStampMark]] (a hub's per-coil-peer stamped marks, one keyed blob).
   *   - Store-level metadata: [[StoreKey.Meta]] — `Cf.Meta`, name-keyed.
@@ -147,16 +146,17 @@ object StoreKey:
         val cf: Cf = Cf.EffectStackIndex
         def encode: Array[Byte] = l1TxId.bytes.toArray
 
-    /** Key for [[Cf.DepositAbsorptionIndex]] — the deposit-request → absorbing-block reverse index,
-      * keyed by the opaque [[RequestId]] via its packed i64 (`asI64`), holding the [[BlockNumber]]
-      * of the major block that absorbed the deposit into the treasury. Written by JL in the same
-      * atomic bundle as that block. (A deposit's *registration* block is [[RequestBlockIndex]];
-      * absorption happens later, in a different block, so it needs its own index.)
+    /** Key for [[Cf.DepositDecisionIndex]] — the deposit-request → decision reverse index, keyed by
+      * the opaque [[RequestId]] via its packed i64 (`asI64`), holding the [[DepositDecision]]
+      * (absorbed / rejected) and the block that decided it. Absence of a row means the deposit is
+      * still undecided. Written by JL in the same atomic bundle as the deciding block. (A deposit's
+      * *registration* block is [[RequestBlockIndex]]; the decision happens later, in a different
+      * block, so it needs its own index.)
       */
-    final case class DepositAbsorptionIndex(id: RequestId) extends StoreKey:
-        type Value = BlockNumber
+    final case class DepositDecisionIndex(id: RequestId) extends StoreKey:
+        type Value = DepositDecision
         given codec: StoreCodec[Value] = StoreCodec.fromCirce[Value]
-        val cf: Cf = Cf.DepositAbsorptionIndex
+        val cf: Cf = Cf.DepositDecisionIndex
         def encode: Array[Byte] = JournalKey.longBytes(id.asI64)
 
     /** Key for [[Cf.WithdrawalEffectIndex]] — the withdrawal-request → effect reverse index. Both

--- a/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
+++ b/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
@@ -91,7 +91,7 @@ object ApiDto {
         case L2TxKind.Transaction       => "transaction"
         case L2TxKind.DepositRegistered => "depositRegistered"
         case L2TxKind.DepositAbsorbed   => "depositAbsorbed"
-        case L2TxKind.DepositRefunded   => "depositRefunded"
+        case L2TxKind.DepositRejected   => "depositRejected"
 
     /** One row of the block listing: number, fast-cycle leader (absent for the initial block, which
       * is config, not woven), and block type.

--- a/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
+++ b/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
@@ -7,13 +7,15 @@ import hydrozoa.multisig.ledger.block.BlockBrief
 import hydrozoa.multisig.ledger.event.RequestId
 import hydrozoa.multisig.ledger.event.RequestId.ValidityFlag
 import hydrozoa.multisig.ledger.l2.{L2TxKind, L2TxSummary}
+import hydrozoa.multisig.persistence.DepositDecision
 import io.bullet.borer.Cbor
-import io.circe.Codec
 import io.circe.generic.semiauto.deriveCodec
+import io.circe.{Codec, Decoder, Encoder}
 import java.time.Instant
 import scalus.cardano.address.{Address, ShelleyAddress}
 import scalus.cardano.ledger.{DatumOption, TransactionInput, TransactionOutput, Value}
 import scalus.uplc.builtin.ByteString
+import sttp.tapir.Schema
 
 /** Flat data-transfer objects for the HTTP API responses.
   *
@@ -164,38 +166,234 @@ object ApiDto {
       */
     final case class EffectRefView(l1TxId: String, kind: String)
     given Codec[EffectRefView] = deriveCodec
+    given Schema[EffectRefView] = Schema.derived
 
     /** Map a resolved effect to its request-facing reference. */
     def mkEffectRefView(effect: ResolvedEffect): EffectRefView =
         EffectRefView(effect.l1TxId.toHex, effectKindName(effect.kind))
 
-    /** A request's lifecycle status from this node's viewpoint: `UNPROCESSED`, `LOCALLY_PROCESSED`,
-      * `SOFT_CONFIRMED`, or `HARD_CONFIRMED`, with the fields each stage adds. Each confirmation
-      * time records a **local event at this peer**, so different peers report different times for
-      * the same request. This is by design. `relatedEffects` — the L1 effects the request became —
-      * is present once those effects are hard-confirmed (a transaction's
-      * settlement/SEC/finalization carriers, a deposit's post-dated refund), absent otherwise.
+    /** A request's lifecycle status from this node's viewpoint, as a ladder where each stage adds
+      * the fields of the one below plus its own: `UNPROCESSED` → `LOCALLY_PROCESSED` (block,
+      * verdict) → `SOFT_CONFIRMED` (soft time) → `HARD_CONFIRMED` (hard time, effects). The ladder
+      * is modeled as traits that extend one another; the concrete statuses are the final case
+      * classes below. Each confirmation time records a **local event at this peer** — different
+      * peers report different times for the same request, by design. `relatedEffects` — the L1
+      * effects the request became (a transaction's settlement/SEC/finalization carriers, a
+      * deposit's post-dated refund) — is present once those effects are hard-confirmed.
+      *
+      * The wire form is flat (a `status` string plus the accumulated fields, nulls dropped): the
+      * codec / schema round-trip through the private [[RequestStatusView.Shape]].
       */
-    final case class RequestStatusView(
-        status: String,
-        blockNumber: Option[Int],
-        validity: Option[String],
-        softConfirmedAt: Option[String],
-        hardConfirmedAt: Option[String],
-        relatedEffects: Option[List[EffectRefView]]
-    )
-    given Codec[RequestStatusView] = deriveCodec
+    sealed trait RequestStatusView:
+        def status: String
+
+    /** `LOCALLY_PROCESSED` and up: the request landed in a block with a validity verdict. */
+    sealed trait LocallyProcessedStatus extends RequestStatusView:
+        def blockNumber: Int
+        def validity: String
+
+    /** `SOFT_CONFIRMED` and up: this peer soft-confirmed the block. The time is optional — a
+      * confirmation whose arrival-stamp generation predates the store's zero-time anchor has no
+      * derivable wall clock, though the rung itself still holds.
+      */
+    sealed trait SoftConfirmedStatus extends LocallyProcessedStatus:
+        def softConfirmedAt: Option[String]
+
+    /** `HARD_CONFIRMED`: this peer hard-confirmed the covering stack; effects are resolvable. */
+    sealed trait HardConfirmedStatus extends SoftConfirmedStatus:
+        def hardConfirmedAt: Option[String]
+        def relatedEffects: List[EffectRefView]
+
+    object RequestStatusView:
+        case object Unprocessed extends RequestStatusView:
+            val status = "UNPROCESSED"
+
+        final case class LocallyProcessed(blockNumber: Int, validity: String)
+            extends LocallyProcessedStatus:
+            val status = "LOCALLY_PROCESSED"
+
+        final case class SoftConfirmed(
+            blockNumber: Int,
+            validity: String,
+            softConfirmedAt: Option[String]
+        ) extends SoftConfirmedStatus:
+            val status = "SOFT_CONFIRMED"
+
+        final case class HardConfirmed(
+            blockNumber: Int,
+            validity: String,
+            softConfirmedAt: Option[String],
+            hardConfirmedAt: Option[String],
+            relatedEffects: List[EffectRefView]
+        ) extends HardConfirmedStatus:
+            val status = "HARD_CONFIRMED"
+
+        /** The flat serialization shape — one object, the status string plus every ladder field as
+          * an option; the drop-null printer omits the absent ones.
+          */
+        private final case class Shape(
+            status: String,
+            blockNumber: Option[Int],
+            validity: Option[String],
+            softConfirmedAt: Option[String],
+            hardConfirmedAt: Option[String],
+            relatedEffects: Option[List[EffectRefView]]
+        )
+        private object Shape:
+            given Codec[Shape] = deriveCodec
+            given Schema[Shape] = Schema.derived
+
+        private def toShape(v: RequestStatusView): Shape = v match
+            case Unprocessed => Shape("UNPROCESSED", None, None, None, None, None)
+            case LocallyProcessed(b, v) =>
+                Shape("LOCALLY_PROCESSED", Some(b), Some(v), None, None, None)
+            case SoftConfirmed(b, v, s) =>
+                Shape("SOFT_CONFIRMED", Some(b), Some(v), s, None, None)
+            case HardConfirmed(b, v, s, h, effects) =>
+                Shape(
+                  "HARD_CONFIRMED",
+                  Some(b),
+                  Some(v),
+                  s,
+                  h,
+                  Option.when(effects.nonEmpty)(effects)
+                )
+
+        private def fromShape(s: Shape): RequestStatusView = s.status match
+            case "LOCALLY_PROCESSED" =>
+                LocallyProcessed(s.blockNumber.getOrElse(0), s.validity.getOrElse(""))
+            case "SOFT_CONFIRMED" =>
+                SoftConfirmed(
+                  s.blockNumber.getOrElse(0),
+                  s.validity.getOrElse(""),
+                  s.softConfirmedAt
+                )
+            case "HARD_CONFIRMED" =>
+                HardConfirmed(
+                  s.blockNumber.getOrElse(0),
+                  s.validity.getOrElse(""),
+                  s.softConfirmedAt,
+                  s.hardConfirmedAt,
+                  s.relatedEffects.getOrElse(Nil)
+                )
+            case _ => Unprocessed
+
+        given Codec[RequestStatusView] = Codec.from(
+          summon[Decoder[Shape]].map(fromShape),
+          summon[Encoder[Shape]].contramap(toShape)
+        )
+        given Schema[RequestStatusView] =
+            summon[Schema[Shape]].map(s => Some(fromShape(s)))(toShape)
+
+    /** A valid deposit's decision status, a ladder parallel to [[RequestStatusView]] but tracking
+      * the absorb-or-reject decision: `UNDECIDED` → `LOCAL_DECISION` (deciding block + `ABSORBED` /
+      * `REJECTED`) → `SOFT_CONFIRMED` (soft time) → `HARD_CONFIRMED` (hard time, and — only for an
+      * absorbed deposit — the absorbing settlement's `l1TxId`). Times are of the **deciding**
+      * block. Present only for valid deposit requests; absent for transactions and invalid
+      * deposits.
+      */
+    sealed trait DepositDecisionStatusView:
+        def status: String
+
+    /** `LOCAL_DECISION` and up: a block decided the deposit. */
+    sealed trait LocalDecisionStatus extends DepositDecisionStatusView:
+        def blockNumber: Int
+        def decision: String
+
+    /** `SOFT_CONFIRMED` and up: this peer soft-confirmed the deciding block (time optional; see
+      * [[SoftConfirmedStatus]]).
+      */
+    sealed trait DecisionSoftConfirmedStatus extends LocalDecisionStatus:
+        def softConfirmedAt: Option[String]
+
+    /** `HARD_CONFIRMED`: this peer hard-confirmed the deciding block's stack. */
+    sealed trait DecisionHardConfirmedStatus extends DecisionSoftConfirmedStatus:
+        def hardConfirmedAt: Option[String]
+        def settlementEffect: Option[String]
+
+    object DepositDecisionStatusView:
+        case object Undecided extends DepositDecisionStatusView:
+            val status = "UNDECIDED"
+
+        final case class LocalDecision(blockNumber: Int, decision: String)
+            extends LocalDecisionStatus:
+            val status = "LOCAL_DECISION"
+
+        final case class SoftConfirmed(
+            blockNumber: Int,
+            decision: String,
+            softConfirmedAt: Option[String]
+        ) extends DecisionSoftConfirmedStatus:
+            val status = "SOFT_CONFIRMED"
+
+        final case class HardConfirmed(
+            blockNumber: Int,
+            decision: String,
+            softConfirmedAt: Option[String],
+            hardConfirmedAt: Option[String],
+            settlementEffect: Option[String]
+        ) extends DecisionHardConfirmedStatus:
+            val status = "HARD_CONFIRMED"
+
+        private final case class Shape(
+            status: String,
+            blockNumber: Option[Int],
+            decision: Option[String],
+            softConfirmedAt: Option[String],
+            hardConfirmedAt: Option[String],
+            settlementEffect: Option[String]
+        )
+        private object Shape:
+            given Codec[Shape] = deriveCodec
+            given Schema[Shape] = Schema.derived
+
+        private def toShape(v: DepositDecisionStatusView): Shape = v match
+            case Undecided => Shape("UNDECIDED", None, None, None, None, None)
+            case LocalDecision(b, d) =>
+                Shape("LOCAL_DECISION", Some(b), Some(d), None, None, None)
+            case SoftConfirmed(b, d, s) =>
+                Shape("SOFT_CONFIRMED", Some(b), Some(d), s, None, None)
+            case HardConfirmed(b, d, s, h, settlement) =>
+                Shape("HARD_CONFIRMED", Some(b), Some(d), s, h, settlement)
+
+        private def fromShape(s: Shape): DepositDecisionStatusView = s.status match
+            case "LOCAL_DECISION" =>
+                LocalDecision(s.blockNumber.getOrElse(0), s.decision.getOrElse(""))
+            case "SOFT_CONFIRMED" =>
+                SoftConfirmed(
+                  s.blockNumber.getOrElse(0),
+                  s.decision.getOrElse(""),
+                  s.softConfirmedAt
+                )
+            case "HARD_CONFIRMED" =>
+                HardConfirmed(
+                  s.blockNumber.getOrElse(0),
+                  s.decision.getOrElse(""),
+                  s.softConfirmedAt,
+                  s.hardConfirmedAt,
+                  s.settlementEffect
+                )
+            case _ => Undecided
+
+        given Codec[DepositDecisionStatusView] = Codec.from(
+          summon[Decoder[Shape]].map(fromShape),
+          summon[Encoder[Shape]].contramap(toShape)
+        )
+        given Schema[DepositDecisionStatusView] =
+            summon[Schema[Shape]].map(s => Some(fromShape(s)))(toShape)
 
     /** The request-details body: opaque id (echoed from the path), author peer, type, receive time
       * (when this peer received the request — a local event, so different peers report different
-      * times for the same request, by design), and the lifecycle status.
+      * times for the same request, by design), the lifecycle status, and — for valid deposit
+      * requests only — the absorb/reject decision status.
       */
     final case class RequestDetailsView(
         requestId: Long,
         peerNumber: Int,
         requestType: String,
         receivedAt: Option[String],
-        status: RequestStatusView
+        status: RequestStatusView,
+        decisionStatus: Option[DepositDecisionStatusView]
     )
     given Codec[RequestDetailsView] = deriveCodec
 
@@ -216,43 +414,93 @@ object ApiDto {
         case ValidityFlag.Valid   => "valid"
         case ValidityFlag.Invalid => "invalid"
 
-    /** Assemble the request-status view from its resolved lifecycle stages: the processing block
-      * and verdict (absent while unprocessed), the node-local confirmation moments, and the L1
-      * effects the request became (empty until they are hard-confirmed).
+    /** Assemble the request-status ladder from its resolved lifecycle stages: the processing block
+      * and verdict (absent while unprocessed), whether this peer has soft- / hard-confirmed (from
+      * the confirmation records, not the times — a hard-confirmed request with no derivable wall
+      * clock is still `HARD_CONFIRMED`), the node-local confirmation moments, and the L1 effects
+      * the request became (present once hard-confirmed).
       */
-    def mkRequestStatusView(
+    def mkRequestStatus(
         block: Option[(Int, ValidityFlag)],
+        softConfirmed: Boolean,
+        hardConfirmed: Boolean,
         softConfirmedAt: Option[Instant],
         hardConfirmedAt: Option[Instant],
         relatedEffects: List[EffectRefView]
     ): RequestStatusView =
-        val status = block match
-            case None => "UNPROCESSED"
-            case Some(_) =>
-                if hardConfirmedAt.isDefined then "HARD_CONFIRMED"
-                else if softConfirmedAt.isDefined then "SOFT_CONFIRMED"
-                else "LOCALLY_PROCESSED"
-        RequestStatusView(
-          status = status,
-          blockNumber = block.map(_._1),
-          validity = block.map((_, v) => validityName(v)),
-          softConfirmedAt = softConfirmedAt.map(_.toString),
-          hardConfirmedAt = hardConfirmedAt.map(_.toString),
-          relatedEffects = Option.when(relatedEffects.nonEmpty)(relatedEffects)
-        )
+        block match
+            case None => RequestStatusView.Unprocessed
+            case Some((blockNumber, v)) =>
+                val validity = validityName(v)
+                if hardConfirmed then
+                    RequestStatusView.HardConfirmed(
+                      blockNumber,
+                      validity,
+                      softConfirmedAt.map(_.toString),
+                      hardConfirmedAt.map(_.toString),
+                      relatedEffects
+                    )
+                else if softConfirmed then
+                    RequestStatusView.SoftConfirmed(
+                      blockNumber,
+                      validity,
+                      softConfirmedAt.map(_.toString)
+                    )
+                else RequestStatusView.LocallyProcessed(blockNumber, validity)
 
-    /** Map a request, its derived receive time, and its resolved status to the details body. */
+    /** The `ABSORBED` / `REJECTED` label of a deposit decision. */
+    def decisionName(decision: DepositDecision): String = decision match
+        case _: DepositDecision.Absorbed => "ABSORBED"
+        case _: DepositDecision.Rejected => "REJECTED"
+
+    /** Assemble the deposit decision-status ladder: undecided (no decision row yet), else the
+      * deciding block + `ABSORBED`/`REJECTED`, promoted by the deciding block's node-local
+      * confirmation moments. The absorbing settlement's `l1TxId` (`ABSORBED`, hard-confirmed only)
+      * rides on the hard-confirmed rung.
+      */
+    def mkDecisionStatus(
+        decided: Option[(Int, String)],
+        softConfirmed: Boolean,
+        hardConfirmed: Boolean,
+        softConfirmedAt: Option[Instant],
+        hardConfirmedAt: Option[Instant],
+        settlementEffect: Option[String]
+    ): DepositDecisionStatusView =
+        decided match
+            case None => DepositDecisionStatusView.Undecided
+            case Some((blockNumber, decision)) =>
+                if hardConfirmed then
+                    DepositDecisionStatusView.HardConfirmed(
+                      blockNumber,
+                      decision,
+                      softConfirmedAt.map(_.toString),
+                      hardConfirmedAt.map(_.toString),
+                      settlementEffect
+                    )
+                else if softConfirmed then
+                    DepositDecisionStatusView.SoftConfirmed(
+                      blockNumber,
+                      decision,
+                      softConfirmedAt.map(_.toString)
+                    )
+                else DepositDecisionStatusView.LocalDecision(blockNumber, decision)
+
+    /** Map a request, its derived receive time, its lifecycle status, and — for valid deposits —
+      * its decision status to the details body.
+      */
     def mkRequestDetailsView(
         request: UserRequestWithId,
         receivedAt: Option[Instant],
-        status: RequestStatusView
+        status: RequestStatusView,
+        decisionStatus: Option[DepositDecisionStatusView]
     ): RequestDetailsView =
         RequestDetailsView(
           requestId = request.requestId.asI64,
           peerNumber = request.requestId.peerNum.convert,
           requestType = requestTypeName(request),
           receivedAt = receivedAt.map(_.toString),
-          status = status
+          status = status,
+          decisionStatus = decisionStatus
         )
 
     /** A block's L1 effects as `l1TxId`s, grouped by kind — the fields present depend on the block

--- a/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
+++ b/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
@@ -192,9 +192,9 @@ object ApiDto {
         def blockNumber: Int
         def validity: String
 
-    /** `SOFT_CONFIRMED` and up: this peer soft-confirmed the block. The time is optional — a
-      * confirmation whose arrival-stamp generation predates the store's zero-time anchor has no
-      * derivable wall clock, though the rung itself still holds.
+    /** `SOFT_CONFIRMED` and up: this peer soft-confirmed the block. The time is optional because a
+      * hard-confirmed request that (exceptionally) has no soft-confirmation record still sits on
+      * the `HardConfirmed` rung, which inherits this field.
       */
     sealed trait SoftConfirmedStatus extends LocallyProcessedStatus:
         def softConfirmedAt: Option[String]
@@ -283,7 +283,9 @@ object ApiDto {
           summon[Encoder[Shape]].contramap(toShape)
         )
         given Schema[RequestStatusView] =
-            summon[Schema[Shape]].map(s => Some(fromShape(s)))(toShape)
+            summon[Schema[Shape]]
+                .map(s => Some(fromShape(s)))(toShape)
+                .name(Schema.SName("RequestStatusView"))
 
     /** A valid deposit's decision status, a ladder parallel to [[RequestStatusView]] but tracking
       * the absorb-or-reject decision: `UNDECIDED` → `LOCAL_DECISION` (deciding block + `ABSORBED` /
@@ -300,8 +302,8 @@ object ApiDto {
         def blockNumber: Int
         def decision: String
 
-    /** `SOFT_CONFIRMED` and up: this peer soft-confirmed the deciding block (time optional; see
-      * [[SoftConfirmedStatus]]).
+    /** `SOFT_CONFIRMED` and up: this peer soft-confirmed the deciding block (time optional for the
+      * same reason as [[SoftConfirmedStatus]]).
       */
     sealed trait DecisionSoftConfirmedStatus extends LocalDecisionStatus:
         def softConfirmedAt: Option[String]
@@ -380,7 +382,9 @@ object ApiDto {
           summon[Encoder[Shape]].contramap(toShape)
         )
         given Schema[DepositDecisionStatusView] =
-            summon[Schema[Shape]].map(s => Some(fromShape(s)))(toShape)
+            summon[Schema[Shape]]
+                .map(s => Some(fromShape(s)))(toShape)
+                .name(Schema.SName("DepositDecisionStatusView"))
 
     /** The request-details body: opaque id (echoed from the path), author peer, type, receive time
       * (when this peer received the request — a local event, so different peers report different
@@ -391,7 +395,7 @@ object ApiDto {
         requestId: Long,
         peerNumber: Int,
         requestType: String,
-        receivedAt: Option[String],
+        receivedAt: String,
         status: RequestStatusView,
         decisionStatus: Option[DepositDecisionStatusView]
     )
@@ -415,15 +419,12 @@ object ApiDto {
         case ValidityFlag.Invalid => "invalid"
 
     /** Assemble the request-status ladder from its resolved lifecycle stages: the processing block
-      * and verdict (absent while unprocessed), whether this peer has soft- / hard-confirmed (from
-      * the confirmation records, not the times — a hard-confirmed request with no derivable wall
-      * clock is still `HARD_CONFIRMED`), the node-local confirmation moments, and the L1 effects
+      * and verdict (absent while unprocessed), the node-local confirmation moments (each present
+      * iff this peer holds that confirmation record — `wallClockOf` is total), and the L1 effects
       * the request became (present once hard-confirmed).
       */
     def mkRequestStatus(
         block: Option[(Int, ValidityFlag)],
-        softConfirmed: Boolean,
-        hardConfirmed: Boolean,
         softConfirmedAt: Option[Instant],
         hardConfirmedAt: Option[Instant],
         relatedEffects: List[EffectRefView]
@@ -432,7 +433,7 @@ object ApiDto {
             case None => RequestStatusView.Unprocessed
             case Some((blockNumber, v)) =>
                 val validity = validityName(v)
-                if hardConfirmed then
+                if hardConfirmedAt.isDefined then
                     RequestStatusView.HardConfirmed(
                       blockNumber,
                       validity,
@@ -440,7 +441,7 @@ object ApiDto {
                       hardConfirmedAt.map(_.toString),
                       relatedEffects
                     )
-                else if softConfirmed then
+                else if softConfirmedAt.isDefined then
                     RequestStatusView.SoftConfirmed(
                       blockNumber,
                       validity,
@@ -460,8 +461,6 @@ object ApiDto {
       */
     def mkDecisionStatus(
         decided: Option[(Int, String)],
-        softConfirmed: Boolean,
-        hardConfirmed: Boolean,
         softConfirmedAt: Option[Instant],
         hardConfirmedAt: Option[Instant],
         settlementEffect: Option[String]
@@ -469,7 +468,7 @@ object ApiDto {
         decided match
             case None => DepositDecisionStatusView.Undecided
             case Some((blockNumber, decision)) =>
-                if hardConfirmed then
+                if hardConfirmedAt.isDefined then
                     DepositDecisionStatusView.HardConfirmed(
                       blockNumber,
                       decision,
@@ -477,7 +476,7 @@ object ApiDto {
                       hardConfirmedAt.map(_.toString),
                       settlementEffect
                     )
-                else if softConfirmed then
+                else if softConfirmedAt.isDefined then
                     DepositDecisionStatusView.SoftConfirmed(
                       blockNumber,
                       decision,
@@ -490,7 +489,7 @@ object ApiDto {
       */
     def mkRequestDetailsView(
         request: UserRequestWithId,
-        receivedAt: Option[Instant],
+        receivedAt: Instant,
         status: RequestStatusView,
         decisionStatus: Option[DepositDecisionStatusView]
     ): RequestDetailsView =
@@ -498,7 +497,7 @@ object ApiDto {
           requestId = request.requestId.asI64,
           peerNumber = request.requestId.peerNum.convert,
           requestType = requestTypeName(request),
-          receivedAt = receivedAt.map(_.toString),
+          receivedAt = receivedAt.toString,
           status = status,
           decisionStatus = decisionStatus
         )

--- a/src/main/scala/hydrozoa/multisig/server/EffectsResolver.scala
+++ b/src/main/scala/hydrozoa/multisig/server/EffectsResolver.scala
@@ -130,29 +130,33 @@ final class EffectsResolver(reader: ConsensusStoreReader[IO]):
     /** A deposit's effects: its post-dated refund (registration-block partition) and, once
       * absorbed, the settlement of its absorbing block's partition.
       */
+    // A deposit's related effects are just its always-present post-dated refund. The absorbing
+    // settlement (for an absorbed deposit) is NOT a related effect — it rides on the deposit's
+    // decision status instead (see [[depositSettlement]]).
     private def depositEffects(requestId: RequestId): IO[List[ResolvedEffect]] =
-        val refund: IO[List[ResolvedEffect]] =
-            reader.requestBlock(requestId).flatMap {
-                case None => IO.pure(Nil)
-                case Some(entry) =>
-                    partitionForBlock(entry.blockNum).map {
-                        case None => Nil
-                        case Some((_, pe)) =>
-                            depositRefundEffect(requestId, entry.blockNum, pe).toList
-                    }
-            }
-        // Only an absorbed deposit has an absorbing settlement; a rejected or still-undecided
-        // deposit contributes none (it is repaid by the always-present post-dated refund above).
-        val settlement: IO[List[ResolvedEffect]] =
-            reader.decision(requestId).flatMap {
-                case Some(DepositDecision.Absorbed(block)) =>
-                    partitionForBlock(block).map {
-                        case None                  => Nil
-                        case Some((blockNums, pe)) => settlementEffect(blockNums.head, pe).toList
-                    }
-                case _ => IO.pure(Nil)
-            }
-        (refund, settlement).mapN(_ ++ _)
+        reader.requestBlock(requestId).flatMap {
+            case None => IO.pure(Nil)
+            case Some(entry) =>
+                partitionForBlock(entry.blockNum).map {
+                    case None          => Nil
+                    case Some((_, pe)) => depositRefundEffect(requestId, entry.blockNum, pe).toList
+                }
+        }
+
+    /** The settlement that absorbed a deposit — present only once the deposit is `Absorbed` AND the
+      * absorbing (major) block's stack is hard-confirmed; absent for a rejected / undecided deposit
+      * or before hard-confirmation. Surfaced on the deposit's decision status, not its related
+      * effects.
+      */
+    def depositSettlement(requestId: RequestId): IO[Option[ResolvedEffect]] =
+        reader.decision(requestId).flatMap {
+            case Some(DepositDecision.Absorbed(block)) =>
+                partitionForBlock(block).map {
+                    case None                  => None
+                    case Some((blockNums, pe)) => settlementEffect(blockNums.head, pe)
+                }
+            case _ => IO.pure(None)
+        }
 
     /** Every effect a hard-confirmed stack carries, attributed per block. Empty when the stack is
       * not hard-confirmed.

--- a/src/main/scala/hydrozoa/multisig/server/EffectsResolver.scala
+++ b/src/main/scala/hydrozoa/multisig/server/EffectsResolver.scala
@@ -9,7 +9,7 @@ import hydrozoa.multisig.ledger.event.RequestId
 import hydrozoa.multisig.ledger.l1.tx.RefundTx
 import hydrozoa.multisig.ledger.stack.PartitionEffects.{Final, Major, Minor}
 import hydrozoa.multisig.ledger.stack.{EffectIds, PartitionEffects, StackEffects, StackNumber, StandaloneEvacuationCommitment}
-import hydrozoa.multisig.persistence.ConsensusStoreReader
+import hydrozoa.multisig.persistence.{ConsensusStoreReader, DepositDecision}
 import scalus.cardano.ledger.{Transaction, TransactionHash}
 
 /** The kind of L1 effect an entry represents. */
@@ -141,14 +141,16 @@ final class EffectsResolver(reader: ConsensusStoreReader[IO]):
                             depositRefundEffect(requestId, entry.blockNum, pe).toList
                     }
             }
+        // Only an absorbed deposit has an absorbing settlement; a rejected or still-undecided
+        // deposit contributes none (it is repaid by the always-present post-dated refund above).
         val settlement: IO[List[ResolvedEffect]] =
-            reader.absorptionBlock(requestId).flatMap {
-                case None => IO.pure(Nil)
-                case Some(block) =>
+            reader.decision(requestId).flatMap {
+                case Some(DepositDecision.Absorbed(block)) =>
                     partitionForBlock(block).map {
                         case None                  => Nil
                         case Some((blockNums, pe)) => settlementEffect(blockNums.head, pe).toList
                     }
+                case _ => IO.pure(Nil)
             }
         (refund, settlement).mapN(_ ++ _)
 

--- a/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
+++ b/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
@@ -684,15 +684,12 @@ class HydrozoaRoutes(
     private def blockConfirmation(num: BlockNumber): IO[BlockConfirmationView] =
         confirmationTimes(num).map((soft, hard) => ApiDto.mkBlockConfirmationView(soft, hard))
 
-    /** This node's confirmation state for a block: whether it is soft- / hard-confirmed (the
-      * records exist), plus the `(soft, hard)` wall-clock moments derived from those records'
-      * arrival stamps — the soft-confirmation record, and, through the block → stack index, the
-      * hard-confirmation record. A moment is absent (though its rung still holds) when the stamp's
-      * generation predates the store's zero-time anchor.
+    /** This node's `(soft, hard)` confirmation moments for a block, as wall-clock instants derived
+      * from the records' arrival stamps: the soft-confirmation record, and — through the block →
+      * stack index — the hard-confirmation record. Each moment is present exactly when this peer
+      * holds that record (`wallClockOf` is total), so it also serves as the rung discriminant.
       */
-    private def confirmationState(
-        num: BlockNumber
-    ): IO[(Boolean, Boolean, Option[Instant], Option[Instant])] =
+    private def confirmationTimes(num: BlockNumber): IO[(Option[Instant], Option[Instant])] =
         for {
             soft <- consensusReader.softConfirmation(num)
             stack <- consensusReader.stackOf(num)
@@ -700,15 +697,9 @@ class HydrozoaRoutes(
                 case None    => IO.pure(None)
                 case Some(s) => consensusReader.hardConfirmation(s)
             }
-            softAt <- soft.flatTraverse(t => consensusReader.wallClockOf(t.stamp))
-            hardAt <- hard.flatTraverse(t => consensusReader.wallClockOf(t.stamp))
-        } yield (soft.isDefined, hard.isDefined, softAt, hardAt)
-
-    /** This node's `(soft, hard)` confirmation moments for a block (the time projection of
-      * [[confirmationState]]).
-      */
-    private def confirmationTimes(num: BlockNumber): IO[(Option[Instant], Option[Instant])] =
-        confirmationState(num).map((_, _, softAt, hardAt) => (softAt, hardAt))
+            softAt <- soft.traverse(t => consensusReader.wallClockOf(t.stamp))
+            hardAt <- hard.traverse(t => consensusReader.wallClockOf(t.stamp))
+        } yield (softAt, hardAt)
 
     /** The request-details body for a request id, or a 404 when the head has assigned no such id.
       * The lifecycle status resolves through the request → block index and the block's confirmation
@@ -741,17 +732,14 @@ class HydrozoaRoutes(
                 for {
                     receivedAt <- consensusReader.wallClockOf(stamped.stamp)
                     processed <- consensusReader.requestBlock(id)
-                    conf <- processed match {
-                        case None =>
-                            IO.pure((false, false, Option.empty[Instant], Option.empty[Instant]))
-                        case Some(entry) => confirmationState(entry.blockNum)
+                    times <- processed match {
+                        case None        => IO.pure((Option.empty[Instant], Option.empty[Instant]))
+                        case Some(entry) => confirmationTimes(entry.blockNum)
                     }
-                    (softC, hardC, softAt, hardAt) = conf
+                    (softAt, hardAt) = times
                     effects <- effectsResolver.relatedEffects(id)
                     status = ApiDto.mkRequestStatus(
                       block = processed.map(e => (e.blockNum.convert, e.validity)),
-                      softConfirmed = softC,
-                      hardConfirmed = hardC,
                       softConfirmedAt = softAt,
                       hardConfirmedAt = hardAt,
                       relatedEffects = effects.map(ApiDto.mkEffectRefView)
@@ -777,18 +765,15 @@ class HydrozoaRoutes(
         else
             for {
                 decision <- consensusReader.decision(id)
-                conf <- decision match {
-                    case None =>
-                        IO.pure((false, false, Option.empty[Instant], Option.empty[Instant]))
-                    case Some(d) => confirmationState(d.block)
+                times <- decision match {
+                    case None    => IO.pure((Option.empty[Instant], Option.empty[Instant]))
+                    case Some(d) => confirmationTimes(d.block)
                 }
-                (softC, hardC, softAt, hardAt) = conf
+                (softAt, hardAt) = times
                 settlement <- effectsResolver.depositSettlement(id)
             } yield Some(
               ApiDto.mkDecisionStatus(
                 decided = decision.map(d => (d.block.convert, ApiDto.decisionName(d))),
-                softConfirmed = softC,
-                hardConfirmed = hardC,
                 softConfirmedAt = softAt,
                 hardConfirmedAt = hardAt,
                 settlementEffect = settlement.map(_.l1TxId.toHex)

--- a/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
+++ b/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
@@ -87,31 +87,21 @@ class HydrozoaRoutes(
 
     // ---- Endpoint definitions (the single source of truth for routes + schema) ----
 
-    private val submitEndpoint: ServerEndpoint[Any, IO] =
+    private val submitRequestEndpoint: ServerEndpoint[Any, IO] =
         endpoint.post
-            .in("head" / "tx")
-            .name("postHeadTx")
+            .in("head" / "requests")
+            .name("postHeadRequest")
             .in(stringJsonBody)
             .out(jsonBody[RequestAcceptedResponse])
             .errorOut(errorOut)
             .description(
-              "Submit an L2 transaction (a JSON UserRequest whose L2 payload is a native, " +
-                  "self-authenticating Cardano transaction)."
+              "Submit a request. A root field tags the type: " +
+                  "`{ \"deposit\": { \"l1Payload\", \"l2Payload\" } }` registers an L1 deposit " +
+                  "(the unsigned deposit-tx CBOR plus the serialized L2 outputs it spawns on " +
+                  "absorption); `{ \"transaction\": { \"l2Payload\" } }` submits an L2 transaction " +
+                  "(a native, self-authenticating Cardano tx). Returns the assigned request id."
             )
-            .serverLogic(body => acceptUserRequest("POST /head/tx", body))
-
-    private val registerDepositEndpoint: ServerEndpoint[Any, IO] =
-        endpoint.post
-            .in("head" / "deposit")
-            .name("postHeadDeposit")
-            .in(stringJsonBody)
-            .out(jsonBody[RequestAcceptedResponse])
-            .errorOut(errorOut)
-            .description(
-              "Register an L1 deposit (a JSON UserRequest carrying the unsigned deposit tx " +
-                  "CBOR and the serialized L2 outputs the deposit spawns on absorption)."
-            )
-            .serverLogic(body => acceptUserRequest("POST /head/deposit", body))
+            .serverLogic(body => acceptUserRequest("POST /head/requests", body))
 
     private val headInfoEndpoint: ServerEndpoint[Any, IO] =
         endpoint.get
@@ -464,8 +454,7 @@ class HydrozoaRoutes(
     /** The core API endpoints, in the order they appear in the docs — always served. */
     private val coreEndpoints: List[ServerEndpoint[Any, IO]] =
         List(
-          submitEndpoint,
-          registerDepositEndpoint,
+          submitRequestEndpoint,
           headInfoEndpoint,
           requestsEndpoint,
           requestDetailsEndpoint,

--- a/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
+++ b/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
@@ -7,11 +7,11 @@ import hydrozoa.config.head.network.CardanoNetwork
 import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.NodeStatus
 import hydrozoa.multisig.consensus.peer.HeadPeerNumber
-import hydrozoa.multisig.consensus.{BlockWeaver, RequestSequencer}
+import hydrozoa.multisig.consensus.{BlockWeaver, RequestSequencer, UserRequestWithId}
 import hydrozoa.multisig.ledger.block.{BlockBrief, BlockNumber}
 import hydrozoa.multisig.ledger.event.RequestId
 import hydrozoa.multisig.ledger.l2.EutxoL2LedgerReader
-import hydrozoa.multisig.persistence.ConsensusStoreReader
+import hydrozoa.multisig.persistence.{ConsensusStoreReader, RequestBlockEntry}
 import hydrozoa.multisig.server.ApiDto.*
 import hydrozoa.multisig.server.HydrozoaHttpEvent.*
 import hydrozoa.multisig.server.JsonCodecs.UserRequestDecoder
@@ -684,11 +684,15 @@ class HydrozoaRoutes(
     private def blockConfirmation(num: BlockNumber): IO[BlockConfirmationView] =
         confirmationTimes(num).map((soft, hard) => ApiDto.mkBlockConfirmationView(soft, hard))
 
-    /** This node's `(soft, hard)` confirmation moments for a block, as wall-clock instants derived
-      * from the records' arrival stamps: the soft-confirmation record, and — through the block →
-      * stack index — the hard-confirmation record.
+    /** This node's confirmation state for a block: whether it is soft- / hard-confirmed (the
+      * records exist), plus the `(soft, hard)` wall-clock moments derived from those records'
+      * arrival stamps — the soft-confirmation record, and, through the block → stack index, the
+      * hard-confirmation record. A moment is absent (though its rung still holds) when the stamp's
+      * generation predates the store's zero-time anchor.
       */
-    private def confirmationTimes(num: BlockNumber): IO[(Option[Instant], Option[Instant])] =
+    private def confirmationState(
+        num: BlockNumber
+    ): IO[(Boolean, Boolean, Option[Instant], Option[Instant])] =
         for {
             soft <- consensusReader.softConfirmation(num)
             stack <- consensusReader.stackOf(num)
@@ -698,7 +702,13 @@ class HydrozoaRoutes(
             }
             softAt <- soft.flatTraverse(t => consensusReader.wallClockOf(t.stamp))
             hardAt <- hard.flatTraverse(t => consensusReader.wallClockOf(t.stamp))
-        } yield (softAt, hardAt)
+        } yield (soft.isDefined, hard.isDefined, softAt, hardAt)
+
+    /** This node's `(soft, hard)` confirmation moments for a block (the time projection of
+      * [[confirmationState]]).
+      */
+    private def confirmationTimes(num: BlockNumber): IO[(Option[Instant], Option[Instant])] =
+        confirmationState(num).map((_, _, softAt, hardAt) => (softAt, hardAt))
 
     /** The request-details body for a request id, or a 404 when the head has assigned no such id.
       * The lifecycle status resolves through the request → block index and the block's confirmation
@@ -731,20 +741,59 @@ class HydrozoaRoutes(
                 for {
                     receivedAt <- consensusReader.wallClockOf(stamped.stamp)
                     processed <- consensusReader.requestBlock(id)
-                    confirmation <- processed match {
-                        case None        => IO.pure((Option.empty[Instant], Option.empty[Instant]))
-                        case Some(entry) => confirmationTimes(entry.blockNum)
+                    conf <- processed match {
+                        case None =>
+                            IO.pure((false, false, Option.empty[Instant], Option.empty[Instant]))
+                        case Some(entry) => confirmationState(entry.blockNum)
                     }
-                    (softAt, hardAt) = confirmation
+                    (softC, hardC, softAt, hardAt) = conf
                     effects <- effectsResolver.relatedEffects(id)
-                    status = ApiDto.mkRequestStatusView(
+                    status = ApiDto.mkRequestStatus(
                       block = processed.map(e => (e.blockNum.convert, e.validity)),
+                      softConfirmed = softC,
+                      hardConfirmed = hardC,
                       softConfirmedAt = softAt,
                       hardConfirmedAt = hardAt,
                       relatedEffects = effects.map(ApiDto.mkEffectRefView)
                     )
-                } yield Right(ApiDto.mkRequestDetailsView(stamped.payload, receivedAt, status))
+                    decisionStatus <- depositDecisionStatus(id, stamped.payload, processed)
+                } yield Right(
+                  ApiDto.mkRequestDetailsView(stamped.payload, receivedAt, status, decisionStatus)
+                )
         }
+
+    /** A valid deposit request's decision status (undecided / local-decision / confirmed), or
+      * `None` for a transaction or a deposit already ruled invalid. The confirmation moments are of
+      * the **deciding** block; the absorbing settlement rides on the hard-confirmed rung.
+      */
+    private def depositDecisionStatus(
+        id: RequestId,
+        request: UserRequestWithId,
+        processed: Option[RequestBlockEntry]
+    ): IO[Option[DepositDecisionStatusView]] =
+        val isDeposit = ApiDto.requestTypeName(request) == "deposit"
+        val isInvalid = processed.exists(_.validity == RequestId.ValidityFlag.Invalid)
+        if !isDeposit || isInvalid then IO.pure(None)
+        else
+            for {
+                decision <- consensusReader.decision(id)
+                conf <- decision match {
+                    case None =>
+                        IO.pure((false, false, Option.empty[Instant], Option.empty[Instant]))
+                    case Some(d) => confirmationState(d.block)
+                }
+                (softC, hardC, softAt, hardAt) = conf
+                settlement <- effectsResolver.depositSettlement(id)
+            } yield Some(
+              ApiDto.mkDecisionStatus(
+                decided = decision.map(d => (d.block.convert, ApiDto.decisionName(d))),
+                softConfirmed = softC,
+                hardConfirmed = hardC,
+                softConfirmedAt = softAt,
+                hardConfirmedAt = hardAt,
+                settlementEffect = settlement.map(_.l1TxId.toHex)
+              )
+            )
 
     private def requestNotFound(id: RequestId): (StatusCode, ErrorResponse) =
         fail(StatusCode.NotFound, s"Request ${id.asI64} not found")

--- a/src/main/scala/hydrozoa/multisig/server/JsonCodecs.scala
+++ b/src/main/scala/hydrozoa/multisig/server/JsonCodecs.scala
@@ -172,7 +172,7 @@ object JsonCodecs {
             case L2TxKind.Transaction       => "transaction"
             case L2TxKind.DepositRegistered => "depositRegistered"
             case L2TxKind.DepositAbsorbed   => "depositAbsorbed"
-            case L2TxKind.DepositRefunded   => "depositRefunded"
+            case L2TxKind.DepositRejected   => "depositRejected"
         }
 
     given l2TxSummaryEncoder: Encoder[L2TxSummary] =

--- a/src/main/scala/hydrozoa/multisig/server/SubmissionClient.scala
+++ b/src/main/scala/hydrozoa/multisig/server/SubmissionClient.scala
@@ -34,10 +34,10 @@ object SubmissionClient:
                 }
 
     /** http4s-based impl: posts the request body (no header, no signature envelope — auth is the
-      * native tx's own witnesses, verified at the ledger's screening) to the deposit-register or
-      * l2-submit endpoint by variant, and expects a [[RequestAccepted]] JSON response. `client` can
-      * be a real http4s `Client[IO]` or an in-memory `Client.fromHttpApp` — the harness uses the
-      * latter.
+      * native tx's own witnesses, verified at the ledger's screening) to the single submission
+      * endpoint and expects a [[RequestAccepted]] JSON response. The body's root tag ("deposit" /
+      * "transaction") selects the type (see [[requestJson]]). `client` can be a real http4s
+      * `Client[IO]` or an in-memory `Client.fromHttpApp` — the harness uses the latter.
       */
     def http(
         client: Client[IO],
@@ -46,15 +46,11 @@ object SubmissionClient:
         new SubmissionClient:
             def submit(userRequest: UserRequest): IO[RequestId] =
                 val bodyJson = requestJson(userRequest)
-                val path = pathFor(userRequest)
-                val req = Http4sRequest[IO](Method.POST, baseUri.withPath(path))
-                    .withEntity(bodyJson)
+                val req = Http4sRequest[IO](
+                  Method.POST,
+                  baseUri.withPath(Uri.Path.unsafeFromString("/head/requests"))
+                ).withEntity(bodyJson)
                 client.expect[RequestAccepted](req).map(_.requestId)
-
-    private def pathFor(request: UserRequest): Uri.Path =
-        request match
-            case _: UserRequest.DepositRequest     => Uri.Path.unsafeFromString("/head/deposit")
-            case _: UserRequest.TransactionRequest => Uri.Path.unsafeFromString("/head/tx")
 
     private def requestJson(request: UserRequest): Json =
         request.body match

--- a/src/test/scala/hydrozoa/multisig/consensus/BlockWeaverTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/BlockWeaverTest.scala
@@ -96,8 +96,8 @@ object BlockWeaverTestHelpers {
               endTime = BlockCreationEndTime(now + 1.second)
             ),
             BlockBody.Final(
-              events = List.empty,
-              depositsRefunded = List.empty
+              requests = List.empty,
+              depositsRejected = List.empty
             )
           )
         )
@@ -124,8 +124,8 @@ object BlockWeaverTestHelpers {
                 mDepositDecisionWakeupTime = None
               ),
               BlockBody.Minor(
-                events = List.empty,
-                depositsRefunded = List.empty
+                requests = List.empty,
+                depositsRejected = List.empty
               )
             )
         })

--- a/src/test/scala/hydrozoa/multisig/consensus/ReplayActorTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/ReplayActorTest.scala
@@ -397,7 +397,7 @@ class ReplayActorTest extends AnyFunSuite:
                     headConfig.txTiming.forcedMajorBlockWakeupTime(fallback),
                 mDepositDecisionWakeupTime = None
               ),
-              BlockBody.Minor(events = List.empty, depositsRefunded = List.empty)
+              BlockBody.Minor(requests = List.empty, depositsRejected = List.empty)
             )
         }
 

--- a/src/test/scala/hydrozoa/multisig/consensus/StackEffectsBuilderTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/StackEffectsBuilderTest.scala
@@ -72,7 +72,7 @@ class StackEffectsBuilderTest extends AnyFunSuite {
               startTime = BlockCreationStartTime(now),
               endTime = BlockCreationEndTime(now + 1.second)
             ),
-            BlockBody.Final(events = List.empty, depositsRefunded = List.empty)
+            BlockBody.Final(requests = List.empty, depositsRejected = List.empty)
           ),
           evacuationMapDiff = Seq(EvacuationDiff.Delete(keyX)),
           payoutObligations = List(oblY),

--- a/src/test/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonCoilRecoveryTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonCoilRecoveryTest.scala
@@ -166,7 +166,7 @@ class PeerLiaisonCoilRecoveryTest extends AnyFunSuite:
                     headConfig.txTiming.forcedMajorBlockWakeupTime(fallback),
                 mDepositDecisionWakeupTime = None
               ),
-              BlockBody.Minor(events = List.empty, depositsRefunded = List.empty)
+              BlockBody.Minor(requests = List.empty, depositsRejected = List.empty)
             )
         }
 

--- a/src/test/scala/hydrozoa/multisig/ledger/JointLedgerTest.scala
+++ b/src/test/scala/hydrozoa/multisig/ledger/JointLedgerTest.scala
@@ -713,8 +713,8 @@ object JointLedgerTest extends Properties("Joint Ledger Test") {
                   )
 
                   _ <- assertWith(
-                    msg = "Block's deposit absorbed and deposits refunded should both be empty",
-                    condition = block.body.depositsRefunded.isEmpty
+                    msg = "Block's deposit absorbed and deposits rejected should both be empty",
+                    condition = block.body.depositsRejected.isEmpty
                         && block.body.depositsAbsorbed.isEmpty
                   )
                   // Post-dated refund txs are slow-cycle (`StackEffects`), not block-attached,
@@ -786,7 +786,7 @@ object JointLedgerTest extends Properties("Joint Ledger Test") {
               _ <- assertWith(
                 msg = "Deposits should be correct with absorbed deposit",
                 condition = majorBlock.body.depositsAbsorbed == List(depositReq.requestId) &&
-                    majorBlock.body.depositsRefunded == List.empty
+                    majorBlock.body.depositsRejected == List.empty
               )
 
               // No evacuation-map / KZG assertions here: that state lives in StackComposer, not

--- a/src/test/scala/hydrozoa/multisig/ledger/eutxol2/EutxoL2LedgerRecoveryTest.scala
+++ b/src/test/scala/hydrozoa/multisig/ledger/eutxol2/EutxoL2LedgerRecoveryTest.scala
@@ -37,7 +37,7 @@ class EutxoL2LedgerRecoveryTest extends AnyFunSuite:
           blockNumber = BlockNumber(n),
           blockCreationEndTime = BigInt(n),
           absorbedDeposits = Nil,
-          refundedDeposits = Nil
+          rejectedDeposits = Nil
         )
 
     private final case class Run(

--- a/src/test/scala/hydrozoa/multisig/ledger/eutxol2/store/RocksDbL2StoreTest.scala
+++ b/src/test/scala/hydrozoa/multisig/ledger/eutxol2/store/RocksDbL2StoreTest.scala
@@ -34,7 +34,7 @@ class RocksDbL2StoreTest extends AnyFunSuite:
           blockNumber = BlockNumber(n),
           blockCreationEndTime = BigInt(n),
           absorbedDeposits = Nil,
-          refundedDeposits = Nil
+          rejectedDeposits = Nil
         )
 
     /** A fresh RocksDB store in a temp directory, cleaned up on release. */

--- a/src/test/scala/hydrozoa/multisig/persistence/PersistenceTest.scala
+++ b/src/test/scala/hydrozoa/multisig/persistence/PersistenceTest.scala
@@ -158,9 +158,7 @@ class PersistenceTest extends AnyFunSuite:
                 wall <- p.wallClockOf(stamp)
                 after <- IO.realTimeInstant
             yield assert(
-              wall.exists(w =>
-                  !w.isBefore(before.minusSeconds(5)) && !w.isAfter(after.plusSeconds(5))
-              ),
+              !wall.isBefore(before.minusSeconds(5)) && !wall.isAfter(after.plusSeconds(5)),
               s"wallClockOf($stamp) = $wall, expected within [$before, $after]"
             )
         }
@@ -192,7 +190,7 @@ class PersistenceTest extends AnyFunSuite:
                         Persistence.fromBackend(backend, tracer).flatMap(_.wallClockOf(oldStamp))
                     )
             yield assert(
-              firstWall.isDefined && secondWall == firstWall,
+              secondWall == firstWall,
               s"old-generation stamp converted to $firstWall before re-open, $secondWall after"
             )
             program.unsafeRunSync()

--- a/src/test/scala/hydrozoa/multisig/persistence/StoreKeyTest.scala
+++ b/src/test/scala/hydrozoa/multisig/persistence/StoreKeyTest.scala
@@ -35,8 +35,8 @@ class StoreKeyTest extends AnyFunSuite:
           StoreKey.L2CommandNumber(BlockNumber(0)) -> Cf.L2CommandNumber,
           StoreKey.RequestBlockIndex(RequestId(HeadPeerNumber(0), RequestNumber(0))) ->
               Cf.RequestBlockIndex,
-          StoreKey.DepositAbsorptionIndex(RequestId(HeadPeerNumber(0), RequestNumber(0))) ->
-              Cf.DepositAbsorptionIndex,
+          StoreKey.DepositDecisionIndex(RequestId(HeadPeerNumber(0), RequestNumber(0))) ->
+              Cf.DepositDecisionIndex,
           StoreKey
               .WithdrawalEffectIndex(RequestId(HeadPeerNumber(0), RequestNumber(0)), sampleHash) ->
               Cf.WithdrawalEffectIndex,

--- a/src/test/scala/hydrozoa/multisig/persistence/recovery/RecoverSeamsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/persistence/recovery/RecoverSeamsTest.scala
@@ -545,7 +545,7 @@ class RecoverSeamsTest extends AnyFunSuite:
           blockNumber = BlockNumber(n),
           blockCreationEndTime = BigInt(n),
           absorbedDeposits = Nil,
-          refundedDeposits = Nil
+          rejectedDeposits = Nil
         )
 
     /** A minimal `BlockBrief.Next` (a Minor) at `blockNum` — mirrors `BlockWeaverTest`'s builder.
@@ -566,7 +566,7 @@ class RecoverSeamsTest extends AnyFunSuite:
             forcedMajorBlockWakeupTime = headConfig.txTiming.forcedMajorBlockWakeupTime(fallback),
             mDepositDecisionWakeupTime = None
           ),
-          BlockBody.Minor(events = List.empty, depositsRefunded = List.empty)
+          BlockBody.Minor(requests = List.empty, depositsRejected = List.empty)
         )
     }
 

--- a/src/test/scala/hydrozoa/multisig/server/EffectsResolverTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/EffectsResolverTest.scala
@@ -178,7 +178,7 @@ class EffectsResolverTest extends AnyFunSuite:
                 IO.pure(
                   Option.when(id == depositRequestId)(DepositDecision.Absorbed(BlockNumber(1)))
                 )
-            def wallClockOf(stamp: ArrivalStamp): IO[Option[Instant]] = IO.pure(None)
+            def wallClockOf(stamp: ArrivalStamp): IO[Instant] = IO.pure(Instant.EPOCH)
 
     private val resolver = EffectsResolver(reader)
 

--- a/src/test/scala/hydrozoa/multisig/server/EffectsResolverTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/EffectsResolverTest.scala
@@ -18,7 +18,7 @@ import hydrozoa.multisig.ledger.joint.EvacuationMap
 import hydrozoa.multisig.ledger.l1.tx.RefundTx
 import hydrozoa.multisig.ledger.l2.Destination
 import hydrozoa.multisig.ledger.stack.{EffectIds, PartitionEffects, StackBrief, StackEffects, StackNumber, StandaloneEvacuationCommitment}
-import hydrozoa.multisig.persistence.{ArrivalStamp, ConsensusStoreReader, RequestBlockEntry, Timestamped}
+import hydrozoa.multisig.persistence.{ArrivalStamp, ConsensusStoreReader, DepositDecision, RequestBlockEntry, Timestamped}
 import hydrozoa.rulebased.ledger.l1.state.StandaloneEvacuationCommitmentOnchain
 import java.time.Instant
 import org.scalacheck.Gen
@@ -72,7 +72,7 @@ class EffectsResolverTest extends AnyFunSuite:
                 headConfig.txTiming.forcedMajorBlockWakeupTime(fallbackTxStartTime),
             mDepositDecisionWakeupTime = None
           ),
-          BlockBody.Minor(events = List.empty, depositsRefunded = List.empty)
+          BlockBody.Minor(requests = List.empty, depositsRejected = List.empty)
         )
 
     private val sec: StandaloneEvacuationCommitment.MultiSigned =
@@ -171,11 +171,13 @@ class EffectsResolverTest extends AnyFunSuite:
                     RequestBlockEntry(BlockNumber(1), ValidityFlag.Valid)
                   )
                 )
-            // The deposit's absorbing block is the minor block 1 (its partition has no settlement),
-            // so absorption resolves to no effect — the positive major-settlement path is exercised
+            // The deposit is absorbed at the minor block 1 (its partition has no settlement), so
+            // the absorption resolves to no effect — the positive major-settlement path is exercised
             // by the stage suites, which build real settlement transactions.
-            def absorptionBlock(id: RequestId): IO[Option[BlockNumber]] =
-                IO.pure(Option.when(id == depositRequestId)(BlockNumber(1)))
+            def decision(id: RequestId): IO[Option[DepositDecision]] =
+                IO.pure(
+                  Option.when(id == depositRequestId)(DepositDecision.Absorbed(BlockNumber(1)))
+                )
             def wallClockOf(stamp: ArrivalStamp): IO[Option[Instant]] = IO.pure(None)
 
     private val resolver = EffectsResolver(reader)

--- a/src/test/scala/hydrozoa/multisig/server/HeadBlocksEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/HeadBlocksEndpointsTest.scala
@@ -148,8 +148,8 @@ class HeadBlocksEndpointsTest extends AnyFunSuite:
                 IO.pure(None)
             def stackBrief(num: StackNumber): IO[Option[StackBrief]] = IO.pure(None)
             def effectStack(l1TxId: TransactionHash): IO[Option[StackNumber]] = IO.pure(None)
-            def wallClockOf(stamp: ArrivalStamp): IO[Option[Instant]] =
-                IO.pure(Some(instantOf(stamp)))
+            def wallClockOf(stamp: ArrivalStamp): IO[Instant] =
+                IO.pure(instantOf(stamp))
             def requestBlock(id: RequestId): IO[Option[RequestBlockEntry]] = IO.pure(None)
             def decision(id: RequestId): IO[Option[DepositDecision]] = IO.pure(None)
             def withdrawalEffects(id: RequestId): IO[List[TransactionHash]] = IO.pure(Nil)

--- a/src/test/scala/hydrozoa/multisig/server/HeadBlocksEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/HeadBlocksEndpointsTest.scala
@@ -15,7 +15,7 @@ import hydrozoa.multisig.ledger.block.{Block, BlockBody, BlockBrief, BlockHeader
 import hydrozoa.multisig.ledger.event.RequestId
 import hydrozoa.multisig.ledger.joint.EvacuationMap
 import hydrozoa.multisig.ledger.stack.{PartitionEffects, StackBrief, StackEffects, StackNumber, StandaloneEvacuationCommitment}
-import hydrozoa.multisig.persistence.{ArrivalStamp, ConsensusStoreReader, RequestBlockEntry, Timestamped}
+import hydrozoa.multisig.persistence.{ArrivalStamp, ConsensusStoreReader, DepositDecision, RequestBlockEntry, Timestamped}
 import hydrozoa.rulebased.ledger.l1.state.StandaloneEvacuationCommitmentOnchain
 import io.circe.Json
 import java.time.Instant
@@ -74,7 +74,7 @@ class HeadBlocksEndpointsTest extends AnyFunSuite:
                     headConfig.txTiming.forcedMajorBlockWakeupTime(fallbackTxStartTime),
                 mDepositDecisionWakeupTime = None
               ),
-              BlockBody.Minor(events = List.empty, depositsRefunded = List.empty)
+              BlockBody.Minor(requests = List.empty, depositsRejected = List.empty)
             )
         }
 
@@ -151,7 +151,7 @@ class HeadBlocksEndpointsTest extends AnyFunSuite:
             def wallClockOf(stamp: ArrivalStamp): IO[Option[Instant]] =
                 IO.pure(Some(instantOf(stamp)))
             def requestBlock(id: RequestId): IO[Option[RequestBlockEntry]] = IO.pure(None)
-            def absorptionBlock(id: RequestId): IO[Option[BlockNumber]] = IO.pure(None)
+            def decision(id: RequestId): IO[Option[DepositDecision]] = IO.pure(None)
             def withdrawalEffects(id: RequestId): IO[List[TransactionHash]] = IO.pure(Nil)
 
     private def withRoutes(reader: ConsensusStoreReader[IO])(check: HttpApp[IO] => IO[Unit]): Unit =

--- a/src/test/scala/hydrozoa/multisig/server/HeadEffectsEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/HeadEffectsEndpointsTest.scala
@@ -21,7 +21,7 @@ import hydrozoa.multisig.ledger.event.RequestId.ValidityFlag
 import hydrozoa.multisig.ledger.event.{RequestId, RequestNumber}
 import hydrozoa.multisig.ledger.joint.EvacuationMap
 import hydrozoa.multisig.ledger.stack.{EffectIds, PartitionEffects, StackBrief, StackEffects, StackNumber, StandaloneEvacuationCommitment}
-import hydrozoa.multisig.persistence.{ArrivalStamp, ConsensusStoreReader, RequestBlockEntry, Timestamped}
+import hydrozoa.multisig.persistence.{ArrivalStamp, ConsensusStoreReader, DepositDecision, RequestBlockEntry, Timestamped}
 import hydrozoa.rulebased.ledger.l1.state.StandaloneEvacuationCommitmentOnchain
 import io.circe.Json
 import java.time.Instant
@@ -66,7 +66,7 @@ class HeadEffectsEndpointsTest extends AnyFunSuite:
                     headConfig.txTiming.forcedMajorBlockWakeupTime(fallbackTxStartTime),
                 mDepositDecisionWakeupTime = None
               ),
-              BlockBody.Minor(events = List.empty, depositsRefunded = List.empty)
+              BlockBody.Minor(requests = List.empty, depositsRejected = List.empty)
             )
         }
 
@@ -151,7 +151,7 @@ class HeadEffectsEndpointsTest extends AnyFunSuite:
                     RequestBlockEntry(BlockNumber(1), ValidityFlag.Valid)
                   )
                 )
-            def absorptionBlock(id: RequestId): IO[Option[BlockNumber]] = IO.pure(None)
+            def decision(id: RequestId): IO[Option[DepositDecision]] = IO.pure(None)
             def withdrawalEffects(id: RequestId): IO[List[TransactionHash]] = IO.pure(Nil)
             def wallClockOf(stamp: ArrivalStamp): IO[Option[Instant]] = IO.pure(None)
 

--- a/src/test/scala/hydrozoa/multisig/server/HeadEffectsEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/HeadEffectsEndpointsTest.scala
@@ -153,7 +153,7 @@ class HeadEffectsEndpointsTest extends AnyFunSuite:
                 )
             def decision(id: RequestId): IO[Option[DepositDecision]] = IO.pure(None)
             def withdrawalEffects(id: RequestId): IO[List[TransactionHash]] = IO.pure(Nil)
-            def wallClockOf(stamp: ArrivalStamp): IO[Option[Instant]] = IO.pure(None)
+            def wallClockOf(stamp: ArrivalStamp): IO[Instant] = IO.pure(Instant.EPOCH)
 
     private def withRoutes(check: HttpApp[IO] => IO[Unit]): Unit =
         mkMinorBrief1

--- a/src/test/scala/hydrozoa/multisig/server/HeadRequestsEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/HeadRequestsEndpointsTest.scala
@@ -15,7 +15,7 @@ import hydrozoa.multisig.ledger.block.{Block, BlockBrief, BlockNumber}
 import hydrozoa.multisig.ledger.event.RequestId.ValidityFlag
 import hydrozoa.multisig.ledger.event.{RequestId, RequestNumber}
 import hydrozoa.multisig.ledger.stack.{StackBrief, StackEffects, StackNumber}
-import hydrozoa.multisig.persistence.{ArrivalStamp, ConsensusStoreReader, RequestBlockEntry, Timestamped}
+import hydrozoa.multisig.persistence.{ArrivalStamp, ConsensusStoreReader, DepositDecision, RequestBlockEntry, Timestamped}
 import io.circe.Json
 import java.time.Instant
 import org.http4s.circe.*
@@ -110,7 +110,7 @@ class HeadRequestsEndpointsTest extends AnyFunSuite:
                 IO.pure(
                   processed.filter(_ => id == RequestId(peer0, RequestNumber(0)))
                 )
-            def absorptionBlock(id: RequestId): IO[Option[BlockNumber]] = IO.pure(None)
+            def decision(id: RequestId): IO[Option[DepositDecision]] = IO.pure(None)
             def withdrawalEffects(id: RequestId): IO[List[TransactionHash]] = IO.pure(Nil)
             def stackBrief(num: StackNumber): IO[Option[StackBrief]] = IO.pure(None)
             def effectStack(l1TxId: TransactionHash): IO[Option[StackNumber]] = IO.pure(None)

--- a/src/test/scala/hydrozoa/multisig/server/HeadRequestsEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/HeadRequestsEndpointsTest.scala
@@ -76,7 +76,8 @@ class HeadRequestsEndpointsTest extends AnyFunSuite:
         requests: Map[HeadPeerNumber, List[UserRequestWithId]],
         processed: Option[RequestBlockEntry] = None,
         softBlock: Option[(BlockNumber, Instant)] = None,
-        hardStack: Option[(BlockNumber, StackNumber, Instant)] = None
+        hardStack: Option[(BlockNumber, StackNumber, Instant)] = None,
+        decisionRow: Option[DepositDecision] = None
     ): ConsensusStoreReader[IO] =
         new ConsensusStoreReader[IO]:
             def blockBriefs: IO[List[BlockBrief.Next]] = IO.pure(Nil)
@@ -110,7 +111,7 @@ class HeadRequestsEndpointsTest extends AnyFunSuite:
                 IO.pure(
                   processed.filter(_ => id == RequestId(peer0, RequestNumber(0)))
                 )
-            def decision(id: RequestId): IO[Option[DepositDecision]] = IO.pure(None)
+            def decision(id: RequestId): IO[Option[DepositDecision]] = IO.pure(decisionRow)
             def withdrawalEffects(id: RequestId): IO[List[TransactionHash]] = IO.pure(Nil)
             def stackBrief(num: StackNumber): IO[Option[StackBrief]] = IO.pure(None)
             def effectStack(l1TxId: TransactionHash): IO[Option[StackNumber]] = IO.pure(None)
@@ -238,6 +239,64 @@ class HeadRequestsEndpointsTest extends AnyFunSuite:
               hardStack = Some((BlockNumber(3), StackNumber(1), hardAt))
             )
           ) == ("HARD_CONFIRMED", Some(3), Some(hardAt.toString))
+        )
+    }
+
+    test("GET /head/requests/{id} exposes a valid deposit's decision status") {
+        val depositId = RequestId(peer0, RequestNumber(0))
+        val base = Map(peer0 -> List(depositRequest(peer0, 0)))
+        val valid = RequestBlockEntry(BlockNumber(3), ValidityFlag.Valid)
+
+        // (decisionStatus.status, blockNumber, decision), or None when the field is absent.
+        def decisionOf(
+            reader: ConsensusStoreReader[IO]
+        ): Option[(String, Option[Int], Option[String])] =
+            var out: Option[(String, Option[Int], Option[String])] = None
+            withRoutes(reader) { app =>
+                get(app, s"/head/requests/${depositId.asI64}").map { (status, body) =>
+                    val _ = assert(status == Status.Ok)
+                    val d = body.hcursor.downField("decisionStatus")
+                    out = d
+                        .get[String]("status")
+                        .toOption
+                        .map(s =>
+                            (
+                              s,
+                              d.get[Int]("blockNumber").toOption,
+                              d.get[String]("decision").toOption
+                            )
+                        )
+                }
+            }
+            out
+
+        // A transaction carries no decision status.
+        val _ = assert(
+          decisionOf(stubReader(Map(peer0 -> List(txRequest(peer0, 0))), processed = Some(valid)))
+              == None
+        )
+        // A valid deposit with no decision row yet is UNDECIDED.
+        val _ = assert(
+          decisionOf(stubReader(base, processed = Some(valid))) == Some(("UNDECIDED", None, None))
+        )
+        // A decided-but-unconfirmed deposit reports LOCAL_DECISION with its block and outcome.
+        val _ = assert(
+          decisionOf(
+            stubReader(
+              base,
+              processed = Some(valid),
+              decisionRow = Some(DepositDecision.Absorbed(BlockNumber(3)))
+            )
+          ) == Some(("LOCAL_DECISION", Some(3), Some("ABSORBED")))
+        )
+        assert(
+          decisionOf(
+            stubReader(
+              base,
+              processed = Some(valid),
+              decisionRow = Some(DepositDecision.Rejected(BlockNumber(3)))
+            )
+          ) == Some(("LOCAL_DECISION", Some(3), Some("REJECTED")))
         )
     }
 

--- a/src/test/scala/hydrozoa/multisig/server/HeadRequestsEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/HeadRequestsEndpointsTest.scala
@@ -115,8 +115,8 @@ class HeadRequestsEndpointsTest extends AnyFunSuite:
             def withdrawalEffects(id: RequestId): IO[List[TransactionHash]] = IO.pure(Nil)
             def stackBrief(num: StackNumber): IO[Option[StackBrief]] = IO.pure(None)
             def effectStack(l1TxId: TransactionHash): IO[Option[StackNumber]] = IO.pure(None)
-            def wallClockOf(stamp: ArrivalStamp): IO[Option[Instant]] =
-                IO.pure(Some(instantOf(stamp)))
+            def wallClockOf(stamp: ArrivalStamp): IO[Instant] =
+                IO.pure(instantOf(stamp))
 
     private def withRoutes(reader: ConsensusStoreReader[IO])(check: HttpApp[IO] => IO[Unit]): Unit =
         ActorSystem[IO]("HeadRequestsEndpointsTest")

--- a/src/test/scala/hydrozoa/multisig/server/L2QueryEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/L2QueryEndpointsTest.scala
@@ -43,20 +43,20 @@ class L2QueryEndpointsTest extends AnyFunSuite:
             .pureApply(Gen.Parameters.default, Seed(0L))
     private val nodeConfig = multiNodeConfig.nodeConfigs(HeadPeerNumber.zero)
 
-    /** A refunded-deposit decision at `blockNum` — a real command that logs (so it shows up in
+    /** A rejected-deposit decision at `blockNum` — a real command that logs (so it shows up in
       * `/l2/cardano-eutxo/transactions`) without needing a constructed deposit/tx payload:
-      * `refundedDeposits` are only removed from the pending set, which tolerates ids that were
+      * `rejectedDeposits` are only removed from the pending set, which tolerates ids that were
       * never registered.
       */
-    private def refundDecision(
+    private def rejectDecision(
         blockNum: Int,
-        refunded: RequestId
+        rejected: RequestId
     ): L2LedgerCommand.ApplyDepositDecisions =
         L2LedgerCommand.ApplyDepositDecisions(
           blockNumber = BlockNumber(blockNum),
           blockCreationEndTime = BigInt(blockNum),
           absorbedDeposits = Nil,
-          refundedDeposits = List(refunded)
+          rejectedDeposits = List(rejected)
         )
 
     /** Build the routes against a seeded ledger + stub actors, then run `check` with the HTTP app
@@ -70,10 +70,10 @@ class L2QueryEndpointsTest extends AnyFunSuite:
                 for {
                     store <- InMemoryL2Store.create
                     ledger <- EutxoL2Ledger(nodeConfig, store)
-                    // Seed a small transaction log: three refunded-deposit decisions, blocks 1..3.
+                    // Seed a small transaction log: three rejected-deposit decisions, blocks 1..3.
                     _ <- List(1, 2, 3).traverse_ { n =>
                         ledger
-                            .sendApplyDepositDecisions(refundDecision(n, RequestId(0, n.toLong)))
+                            .sendApplyDepositDecisions(rejectDecision(n, RequestId(0, n.toLong)))
                             .value
                             .flatMap(IO.fromEither)
                     }
@@ -233,7 +233,7 @@ class L2QueryEndpointsTest extends AnyFunSuite:
                 blockNums = entries.flatMap(_.hcursor.downField("blockNumber").as[Int].toOption)
                 _ <- IO(assert(blockNums == Vector(3, 2, 1), s"block order was $blockNums"))
                 kinds = entries.flatMap(_.hcursor.downField("kind").as[String].toOption)
-                _ <- IO(assert(kinds.forall(_ == "depositRefunded"), s"kinds were $kinds"))
+                _ <- IO(assert(kinds.forall(_ == "depositRejected"), s"kinds were $kinds"))
                 // requestId is the object shape {headPeerNumber, requestNumber} (the HTTP default).
                 _ <- IO(
                   assert(


### PR DESCRIPTION
Stacked on `feature/head-api-withdrawal-effects` (#458). Four commits.

## Deposit decision index (`ef01a28d`)
Generalize the absorption index into a decision index so a registered deposit's outcome — **absorbed** into the treasury or **rejected** — is tracked, not just absorption.

- New `DepositDecision` ADT (`Absorbed(block)` | `Rejected(block)`) and `Cf.DepositDecisionIndex` (was `DepositAbsorptionIndex`); `JointLedger.snapshotBundleBatch` writes both `depositsAbsorbed` and `depositsRejected`; absence of a row = undecided.
- `ConsensusStoreReader.decision` replaces `absorptionBlock`; the resolver gates the absorbing settlement on `Absorbed`.
- Terminology: the deposit *decision* `refunded` → `rejected` (block bodies, `DepositsMap`, `ApplyDepositDecisions`, `L2TxKind`, the API string). The refund *tx* effect stays "refund". Also `BlockBody.events` → `requests` and JointLedger's request-level `rejectEvent` → `invalidateRequest`.

## Request-details status ladders (`b1649e53`)
Model `GET /head/requests/{id}` as trait ladders (each status a trait extending the one below; concrete statuses final case classes), flat JSON via a private shape codec/schema:

- **Request status** (tx + deposit): `UNPROCESSED → LOCALLY_PROCESSED → SOFT_CONFIRMED → HARD_CONFIRMED`.
- **Deposit decision status** (valid deposits only): `UNDECIDED → LOCAL_DECISION (ABSORBED|REJECTED) → SOFT_CONFIRMED → HARD_CONFIRMED` (+ the absorbing settlement's `l1TxId` for an absorbed deposit), fed by the decision index.

A deposit's related effects are its post-dated refund; the absorbing settlement rides on the decision status.

## `wallClockOf` made total (`a905f9f8`)
Every arrival-stamp generation is anchored at store-open before any of its stamps exist and anchors are never pruned, so `wallClockOf` always resolves — make it return a plain `Instant`. The status ladder then derives its rung straight from the confirmation times, and `receivedAt` becomes non-optional. Also names the two flat status schemas (instead of leaking a private `Shape` name into the OpenAPI).

## Combined submission endpoint (`19cbd433`)
Collapse `POST /head/tx` and `POST /head/deposit` into one `POST /head/requests`. The body already carries a root tag selecting the type — `{ "deposit": { l1Payload, l2Payload } }` or `{ "transaction": { l2Payload } }`. `SubmissionClient` and the demo clients post there; docs updated.

---
Compile + unit tests green under `-Werror`; `docs/openapi.yaml` regenerated. Integration tests not run.

**Known follow-ups (pre-existing head-API drift, not addressed here):** `GET /head/blocks/{n}/body` (block content / transactions — currently only `/header` exists) and `stackId` on block details.