### PR TITLE
feat(api): block body endpoint + stackId; drop /header

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -71,7 +71,7 @@ process talking to Cardano L1 (a public testnet) via Blockfrost:
   cwd; give each node its own.
 - **User HTTP API** (head peers only, port 8080). One REST surface:
   - **submit** — `POST /head/requests` (deposits and L2 transactions, distinguished by the body's
-    wrapper key — `{ "deposit": {…} }` or `{ "transaction": {…} }`);
+    `type` field — `{ "type": "deposit", … }` or `{ "type": "transaction", … }`);
   - **queries** — `GET /head/blocks[/{n}[/body]]`, `GET /head/requests[/{id}]` (lifecycle status per
     request), `GET /head/effects/{l1TxId}` (L1 effect by tx id);
   - **observability** — `GET /health` (liveness), `GET /ready` (readiness);

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -69,9 +69,18 @@ process talking to Cardano L1 (a public testnet) via Blockfrost:
   (`peer-<label>/rocksdb`) and the EUTXO ledger store
   (`peer-<label>/l2-rocksdb`). Default data dir `.hydrozoa-data` relative to
   cwd; give each node its own.
-- **L2 query API** (head peers only, EUTXO only): `GET /l2/cardano-eutxo/utxos/{address}` and
-  `GET /l2/cardano-eutxo/transactions` are served only when the node runs the EUTXO ledger; a remote-ledger
-  node serves neither.
+- **User HTTP API** (head peers only, port 8080). One REST surface:
+  - **submit** — `POST /head/requests` (deposits and L2 transactions, distinguished by the body's
+    `type` tag);
+  - **queries** — `GET /head/blocks[/{n}[/body]]`, `GET /head/requests[/{id}]` (lifecycle status per
+    request), `GET /head/effects/{l1TxId}` (L1 effect by tx id);
+  - **observability** — `GET /health` (liveness), `GET /ready` (readiness);
+  - **admin** — `POST /api/admin/finalize` (basic-auth);
+  - **L2 EUTXO queries** (EUTXO ledger only — a remote-ledger node serves neither):
+    `GET /l2/cardano-eutxo/utxos/{address}`, `GET /l2/cardano-eutxo/transactions`.
+
+  Interactive **Swagger UI at `/docs`**; the authoritative machine-readable contract is
+  [`docs/openapi.yaml`](docs/openapi.yaml) (regenerated from the endpoint definitions).
 
 ### Network matrix
 
@@ -445,6 +454,9 @@ curl "http://localhost:8080/l2/cardano-eutxo/utxos/<bech32-address>"     # curre
 `/l2/cardano-eutxo/transactions` covers plain L2 transactions plus deposit registrations, absorptions, and
 refunds (the `kind` field tells them apart); `/l2/cardano-eutxo/utxos` returns the utxos as CIP-0116 JSON.
 Both are the quickest way to watch a submitted tx or deposit land.
+
+Point a browser at `http://localhost:8080/docs` for the interactive Swagger UI over the full API
+(blocks, requests, effects, health/readiness, and the L2 queries above).
 
 ### Teardown / recovery of funds
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -71,7 +71,7 @@ process talking to Cardano L1 (a public testnet) via Blockfrost:
   cwd; give each node its own.
 - **User HTTP API** (head peers only, port 8080). One REST surface:
   - **submit** — `POST /head/requests` (deposits and L2 transactions, distinguished by the body's
-    `type` tag);
+    wrapper key — `{ "deposit": {…} }` or `{ "transaction": {…} }`);
   - **queries** — `GET /head/blocks[/{n}[/body]]`, `GET /head/requests[/{id}]` (lifecycle status per
     request), `GET /head/effects/{l1TxId}` (L1 effect by tx id);
   - **observability** — `GET /health` (liveness), `GET /ready` (readiness);

--- a/docs/effect-tracking.md
+++ b/docs/effect-tracking.md
@@ -40,7 +40,7 @@ by recovery — they exist only to serve these queries.
 | CF | key → value | written by / when |
 |---|---|---|
 | `RequestBlockIndex` | request id (packed i64) → `(blockNum, validity)` | `JointLedger`, in the block bundle — the block that locally processed the request |
-| `DepositAbsorptionIndex` | deposit request id (packed i64) → `blockNum` | `JointLedger`, in the block bundle — the **major** block that absorbed the deposit |
+| `DepositDecisionIndex` | deposit request id (packed i64) → `DepositDecision` (`Absorbed(block)` \| `Rejected(block)`) | `JointLedger`, in the block bundle — the block that **decided** the deposit (folding both `depositsAbsorbed` and `depositsRejected`); absence = still pending |
 | `WithdrawalEffectIndex` | `(request id i64 : 8)(l1TxId : 32)` → *(empty)* | `StackComposer` at stack close — one row per (withdrawing request, paying effect); prefix-scan by request id yields many effects |
 | `BlockStackIndex` | `blockNum` → `stackNum` | `SlowConsensusActor` at hard-confirmation |
 | `EffectStackIndex` | `l1TxId` → `stackNum` | `SlowConsensusActor` at hard-confirmation — backs `GET /head/effects/{l1TxId}` |
@@ -81,15 +81,38 @@ withdrew, the effect tx(s) that pay its L1-bound outputs (see the withdrawal sec
 unioned and **deduped by `l1TxId`** (a withdrawal's settlement is also a carrier when settled in the
 same partition).
 
-**Deposit.** Two links, disjoint from the transaction path:
+**Deposit.** A deposit's `relatedEffects` is just its **post-dated refund** — the
+`RefundTx.PostDated` in the deposit's *registration*-block partition whose `requestId` matches. The
+refund carries the request id and is attributed to the registration block, so `RequestBlockIndex`
+reaches it with no extra storage. It is **always** presented (the post-dated refund exists from
+registration, whatever the deposit's eventual fate), so `relatedEffects` does not gate on the
+decision.
 
-- its **post-dated refund** — the `RefundTx.PostDated` in the deposit's *registration*-block
-  partition whose `requestId` matches. The refund carries the request id and is attributed to the
-  registration block, so `RequestBlockIndex` reaches it with no extra storage.
-- once absorbed, the **settlement** of its *absorbing* block's partition. The absorbing block is a
-  later major block, distinct from the registration block, so it is not derivable from
-  `RequestBlockIndex` — `DepositAbsorptionIndex` records it, and the resolver reads that block's
-  partition settlement.
+The **absorbing settlement** is *not* a related effect. It rides on the deposit's absorption-decision
+status instead (`GET /head/requests/{id}` → `absorptionDecisionStatus`), because it belongs to the
+*absorbing* block — a later major block, distinct from the registration block and not derivable from
+`RequestBlockIndex`. See the decision index below.
+
+### Deposit decision index
+
+A registered deposit has three fates, decided at block completion (`DepositsMap.Decisions`):
+
+- **absorbed** — folded into the treasury by a later major block's settlement;
+- **rejected** — repaid (its post-dated refund is the payout); the **final block rejects all
+  remaining deposits**;
+- **pending** — carried to a future block, no decision yet.
+
+`DepositDecisionIndex` records the first two as a `DepositDecision` (`Absorbed(block)` /
+`Rejected(block)`) keyed by request id; **pending is the absence of a row**. `JointLedger` writes it
+in the block bundle, folding both `brief.depositsAbsorbed` and `brief.depositsRejected` (covering
+minor / major / final decisions), and `ConsensusStoreReader.decision(id)` reads it. This backs the
+`absorptionDecisionStatus` ladder: the deciding block and `ABSORBED`/`REJECTED` outcome, plus — once
+an `Absorbed` deposit is hard-confirmed — the absorbing partition's settlement (`depositSettlement`).
+
+> **Terminology.** The deposit *decision* is `Rejected`; the *tx effect* that pays a rejected (or
+> expired) deposit is still a **refund** (`RefundTx`, `EffectKind.Refund`). Neither is the
+> request-level `Invalid` / `invalidateRequest` concept in `JointLedger`, which is a registration
+> request that failed to parse or fell outside its validity interval — a different rejection.
 
 ## Withdrawal effect tracking
 
@@ -228,7 +251,8 @@ were never removed from the treasury, since the final block never got settled).
   withdrawal tracking works for the built-in EUTXO ledger and the remote backend.
 - **Explicit withdrawals only.** Finalization also pays out *residual L2 balances* (everyone's
   leftover utxos); those are not requests and are not tracked (their `provenance` entries are `None`).
-- **Request → withdrawal effects is stored; transaction carriers and deposit refunds are query-time.**
-  The stored `WithdrawalEffectIndex` and `DepositAbsorptionIndex` exist because those links reach a
-  block the request's `RequestBlockIndex` entry does not; the transaction-carrier and deposit-refund
-  links fall out of `RequestBlockIndex` + the partition decomposition with no extra storage.
+- **Request → withdrawal effects and the deposit decision are stored; transaction carriers and
+  deposit refunds are query-time.** The stored `WithdrawalEffectIndex` and `DepositDecisionIndex`
+  exist because those links reach a block the request's `RequestBlockIndex` entry does not (the paying
+  effect's stack; the absorbing block); the transaction-carrier and deposit-refund links fall out of
+  `RequestBlockIndex` + the partition decomposition with no extra storage.

--- a/docs/openapi-eutxo-l2.yaml
+++ b/docs/openapi-eutxo-l2.yaml
@@ -21,7 +21,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/L2UtxoView'
+                  $ref: '#/components/schemas/L2Utxo'
         default:
           description: ''
           content:
@@ -47,7 +47,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/L2TxSummaryView'
+                  $ref: '#/components/schemas/L2TxSummary'
         default:
           description: ''
           content:
@@ -56,8 +56,8 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
 components:
   schemas:
-    DatumView:
-      title: DatumView
+    Datum:
+      title: Datum
       type: object
       properties:
         inline:
@@ -72,8 +72,8 @@ components:
       properties:
         error:
           type: string
-    L2OutputView:
-      title: L2OutputView
+    L2Output:
+      title: L2Output
       type: object
       required:
       - address
@@ -82,11 +82,11 @@ components:
         address:
           type: string
         value:
-          $ref: '#/components/schemas/ValueView'
+          $ref: '#/components/schemas/Value'
         datum:
-          $ref: '#/components/schemas/DatumView'
-    L2TxSummaryView:
-      title: L2TxSummaryView
+          $ref: '#/components/schemas/Datum'
+    L2TxSummary:
+      title: L2TxSummary
       type: object
       required:
       - requestId
@@ -94,23 +94,28 @@ components:
       - kind
       properties:
         requestId:
-          $ref: '#/components/schemas/RequestIdView'
+          $ref: '#/components/schemas/RequestId'
         blockNumber:
           type: integer
           format: int32
         kind:
           type: string
-    L2UtxoView:
-      title: L2UtxoView
+          enum:
+          - transaction
+          - depositRegistered
+          - depositAbsorbed
+          - depositRejected
+    L2Utxo:
+      title: L2Utxo
       type: object
       required:
       - input
       - output
       properties:
         input:
-          $ref: '#/components/schemas/TxInputView'
+          $ref: '#/components/schemas/TxInput'
         output:
-          $ref: '#/components/schemas/L2OutputView'
+          $ref: '#/components/schemas/L2Output'
     Map_Map_String_String:
       title: Map_Map_String_String
       type: object
@@ -121,8 +126,8 @@ components:
       type: object
       additionalProperties:
         type: string
-    RequestIdView:
-      title: RequestIdView
+    RequestId:
+      title: RequestId
       type: object
       required:
       - headPeerNumber
@@ -134,8 +139,8 @@ components:
         requestNumber:
           type: integer
           format: int64
-    TxInputView:
-      title: TxInputView
+    TxInput:
+      title: TxInput
       type: object
       required:
       - transaction_id
@@ -146,8 +151,8 @@ components:
         index:
           type: integer
           format: int32
-    ValueView:
-      title: ValueView
+    Value:
+      title: Value
       type: object
       required:
       - coin

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -5,6 +5,8 @@ info:
 paths:
   /head/requests:
     get:
+      tags:
+      - Requests
       description: Requests the head has assigned an id — opaque request id, author
         peer number, and type (transaction or deposit). Filter with ?type=transaction|deposit
         and ?peer_number=<n>.
@@ -29,7 +31,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/RequestSummaryView'
+                  $ref: '#/components/schemas/RequestSummary'
         default:
           description: ''
           content:
@@ -37,17 +39,20 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
     post:
-      description: 'Submit a request. A root field tags the type: `{ "deposit": {
-        "l1Payload", "l2Payload" } }` registers an L1 deposit (the unsigned deposit-tx
-        CBOR plus the serialized L2 outputs it spawns on absorption); `{ "transaction":
-        { "l2Payload" } }` submits an L2 transaction (a native, self-authenticating
-        Cardano tx). Returns the assigned request id.'
+      tags:
+      - Requests
+      description: 'Submit a request. A wrapper key tags the type — set exactly one:
+        `{ "deposit": { "l1Payload", "l2Payload" } }` registers an L1 deposit (the
+        unsigned deposit-tx CBOR plus the serialized L2 outputs it spawns on absorption);
+        `{ "transaction": { "l2Payload" } }` submits an L2 transaction (a native,
+        self-authenticating Cardano tx). Payloads are lowercase hex. Returns the assigned
+        request id.'
       operationId: postHeadRequest
       requestBody:
         content:
           application/json:
             schema:
-              type: string
+              $ref: '#/components/schemas/SubmitRequest'
         required: true
       responses:
         '200':
@@ -81,6 +86,8 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
   /head/requests/{request-id}:
     get:
+      tags:
+      - Requests
       description: 'One request''s peer, type, receive time, and lifecycle status:
         UNPROCESSED, PROPOSED (block + validity), SOFT_CONFIRMED (+ soft-confirmation
         time), or HARD_CONFIRMED (+ hard-confirmation time and the related L1 effects
@@ -102,7 +109,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RequestDetailsView'
+                $ref: '#/components/schemas/RequestDetails'
         default:
           description: ''
           content:
@@ -111,6 +118,8 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
   /head/blocks:
     get:
+      tags:
+      - Blocks
       description: Every block of the head in block order — number, fast-cycle leader,
         and type. Block 0 is the head's initial block (config, no leader).
       operationId: getHeadBlocks
@@ -122,7 +131,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/BlockSummaryView'
+                  $ref: '#/components/schemas/BlockSummary'
         default:
           description: ''
           content:
@@ -131,11 +140,13 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
   /head/blocks/{block-number}:
     get:
-      description: 'One block''s type, leader, and confirmation status: PROPOSED,
-        SOFT (+ soft-confirmation time), or HARD (+ hard-confirmation time). Each
-        confirmation time records a local event at this peer — when it produced the
-        soft/hard confirmation — so different peers report different times for the
-        same block. This is by design.'
+      tags:
+      - Blocks
+      description: 'One block''s type, leader, hard-confirming stack, full header,
+        and confirmation status: PROPOSED, SOFT_CONFIRMED (+ soft-confirmation time),
+        or HARD_CONFIRMED (+ hard-confirmation time). Each confirmation time records
+        a local event at this peer — when it produced the soft/hard confirmation —
+        so different peers report different times for the same block. This is by design.'
       operationId: getHeadBlock
       parameters:
       - name: block-number
@@ -150,7 +161,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BlockDetailsView'
+                $ref: '#/components/schemas/BlockDetails'
         default:
           description: ''
           content:
@@ -159,6 +170,8 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
   /head/blocks/{block-number}/body:
     get:
+      tags:
+      - Blocks
       description: 'The block''s content: its transactions (the request ids woven
         into the block, each with its validity verdict) and its deposit decisions
         (the request ids absorbed into the treasury and those rejected). 404 if the
@@ -177,7 +190,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BlockBodyView'
+                $ref: '#/components/schemas/BlockBody'
         default:
           description: ''
           content:
@@ -186,6 +199,8 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
   /head/blocks/{block-number}/effects:
     get:
+      tags:
+      - Blocks
       description: A block's L1 effects as l1TxIds, grouped by kind (initialization,
         settlement, fallback, sec, rollouts, refunds, finalization) per block type.
         Empty until the block is hard-confirmed.
@@ -203,7 +218,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BlockEffectsView'
+                $ref: '#/components/schemas/BlockEffects'
         default:
           description: ''
           content:
@@ -212,6 +227,8 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
   /head/effects/{l1TxId}:
     get:
+      tags:
+      - Effects
       description: Any effect by its l1TxId (real tx id, or an SEC's synthetic hash).
       operationId: getHeadEffect
       parameters:
@@ -226,7 +243,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EffectView'
+                $ref: '#/components/schemas/Effect'
         default:
           description: ''
           content:
@@ -235,6 +252,8 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
   /head/blocks/{block-number}/effects/rollouts/{number}:
     get:
+      tags:
+      - Blocks
       description: One rollout of the block's rollout chain by index, or 404 if absent.
       operationId: getHeadBlockRollout
       parameters:
@@ -256,7 +275,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EffectView'
+                $ref: '#/components/schemas/Effect'
         default:
           description: ''
           content:
@@ -288,6 +307,8 @@ paths:
                 $ref: '#/components/schemas/ReadinessResponse'
   /api/admin/finalize:
     post:
+      tags:
+      - Governance
       description: Trigger head finalization (admin only).
       operationId: postAdminFinalize
       responses:
@@ -313,6 +334,8 @@ paths:
       - httpAuth: []
   /head/blocks/{block-number}/effects/initialization:
     get:
+      tags:
+      - Blocks
       description: The block's initialization effect in full, or 404 if it has none.
       operationId: getHeadBlockEffect_initialization
       parameters:
@@ -328,7 +351,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EffectView'
+                $ref: '#/components/schemas/Effect'
         default:
           description: ''
           content:
@@ -337,6 +360,8 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
   /head/blocks/{block-number}/effects/settlement:
     get:
+      tags:
+      - Blocks
       description: The block's settlement effect in full, or 404 if it has none.
       operationId: getHeadBlockEffect_settlement
       parameters:
@@ -352,7 +377,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EffectView'
+                $ref: '#/components/schemas/Effect'
         default:
           description: ''
           content:
@@ -361,6 +386,8 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
   /head/blocks/{block-number}/effects/fallback:
     get:
+      tags:
+      - Blocks
       description: The block's fallback effect in full, or 404 if it has none.
       operationId: getHeadBlockEffect_fallback
       parameters:
@@ -376,7 +403,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EffectView'
+                $ref: '#/components/schemas/Effect'
         default:
           description: ''
           content:
@@ -385,6 +412,8 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
   /head/blocks/{block-number}/effects/sec:
     get:
+      tags:
+      - Blocks
       description: The block's sec effect in full, or 404 if it has none.
       operationId: getHeadBlockEffect_sec
       parameters:
@@ -400,7 +429,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EffectView'
+                $ref: '#/components/schemas/Effect'
         default:
           description: ''
           content:
@@ -409,6 +438,8 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
   /head/blocks/{block-number}/effects/finalization:
     get:
+      tags:
+      - Blocks
       description: The block's finalization effect in full, or 404 if it has none.
       operationId: getHeadBlockEffect_finalization
       parameters:
@@ -424,7 +455,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EffectView'
+                $ref: '#/components/schemas/Effect'
         default:
           description: ''
           content:
@@ -433,8 +464,8 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
 components:
   schemas:
-    AbsorptionDecisionStatusView:
-      title: AbsorptionDecisionStatusView
+    AbsorptionDecisionStatus:
+      title: AbsorptionDecisionStatus
       oneOf:
       - $ref: '#/components/schemas/AbsorptionHardConfirmed'
       - $ref: '#/components/schemas/AbsorptionProposed'
@@ -461,6 +492,9 @@ components:
           format: int32
         decision:
           type: string
+          enum:
+          - ABSORBED
+          - REJECTED
         softConfirmedAt:
           type: string
         hardConfirmedAt:
@@ -483,6 +517,9 @@ components:
           format: int32
         decision:
           type: string
+          enum:
+          - ABSORBED
+          - REJECTED
         type:
           type: string
           const: PROPOSED
@@ -500,6 +537,9 @@ components:
           format: int32
         decision:
           type: string
+          enum:
+          - ABSORBED
+          - REJECTED
         softConfirmedAt:
           type: string
         type:
@@ -514,8 +554,8 @@ components:
         type:
           type: string
           const: UNPROCESSED
-    BlockBodyView:
-      title: BlockBodyView
+    BlockBody:
+      title: BlockBody
       type: object
       required:
       - number
@@ -526,10 +566,15 @@ components:
           format: int32
         blockType:
           type: string
+          enum:
+          - initial
+          - minor
+          - major
+          - final
         transactions:
           type: array
           items:
-            $ref: '#/components/schemas/BlockRequestView'
+            $ref: '#/components/schemas/BlockRequest'
         depositsAbsorbed:
           type: array
           items:
@@ -540,8 +585,8 @@ components:
           items:
             type: integer
             format: int64
-    BlockConfirmationView:
-      title: BlockConfirmationView
+    BlockConfirmation:
+      title: BlockConfirmation
       oneOf:
       - $ref: '#/components/schemas/BlockHardConfirmed'
       - $ref: '#/components/schemas/BlockProposed'
@@ -552,8 +597,8 @@ components:
           HARD_CONFIRMED: '#/components/schemas/BlockHardConfirmed'
           PROPOSED: '#/components/schemas/BlockProposed'
           SOFT_CONFIRMED: '#/components/schemas/BlockSoftConfirmed'
-    BlockDetailsView:
-      title: BlockDetailsView
+    BlockDetails:
+      title: BlockDetails
       type: object
       required:
       - number
@@ -568,21 +613,31 @@ components:
           format: int32
         blockType:
           type: string
+          enum:
+          - initial
+          - minor
+          - major
+          - final
         stackId:
           type: integer
           format: int32
         confirmation:
-          $ref: '#/components/schemas/BlockConfirmationView'
+          $ref: '#/components/schemas/BlockConfirmation'
         header:
-          $ref: '#/components/schemas/BlockHeaderView'
-    BlockEffectsView:
-      title: BlockEffectsView
+          $ref: '#/components/schemas/BlockHeader'
+    BlockEffects:
+      title: BlockEffects
       type: object
       required:
       - blockType
       properties:
         blockType:
           type: string
+          enum:
+          - initial
+          - minor
+          - major
+          - final
         initialization:
           type: string
         settlement:
@@ -615,8 +670,8 @@ components:
         type:
           type: string
           const: HARD_CONFIRMED
-    BlockHeaderView:
-      title: BlockHeaderView
+    BlockHeader:
+      title: BlockHeader
       oneOf:
       - $ref: '#/components/schemas/Final'
       - $ref: '#/components/schemas/Initial'
@@ -638,8 +693,8 @@ components:
         type:
           type: string
           const: PROPOSED
-    BlockRequestView:
-      title: BlockRequestView
+    BlockRequest:
+      title: BlockRequest
       type: object
       required:
       - requestId
@@ -650,6 +705,9 @@ components:
           format: int64
         validity:
           type: string
+          enum:
+          - valid
+          - invalid
     BlockSoftConfirmed:
       title: BlockSoftConfirmed
       type: object
@@ -662,8 +720,8 @@ components:
         type:
           type: string
           const: SOFT_CONFIRMED
-    BlockSummaryView:
-      title: BlockSummaryView
+    BlockSummary:
+      title: BlockSummary
       type: object
       required:
       - number
@@ -677,6 +735,11 @@ components:
           format: int32
         blockType:
           type: string
+          enum:
+          - initial
+          - minor
+          - major
+          - final
     Deposit:
       title: Deposit
       type: object
@@ -697,25 +760,14 @@ components:
         receivedAt:
           type: string
         status:
-          $ref: '#/components/schemas/RequestStatusView'
+          $ref: '#/components/schemas/RequestStatus'
         absorptionDecisionStatus:
-          $ref: '#/components/schemas/AbsorptionDecisionStatusView'
+          $ref: '#/components/schemas/AbsorptionDecisionStatus'
         type:
           type: string
           const: deposit
-    EffectRefView:
-      title: EffectRefView
-      type: object
-      required:
-      - l1TxId
-      - kind
-      properties:
-        l1TxId:
-          type: string
-        kind:
-          type: string
-    EffectView:
-      title: EffectView
+    Effect:
+      title: Effect
       type: object
       required:
       - l1TxId
@@ -726,6 +778,14 @@ components:
           type: string
         kind:
           type: string
+          enum:
+          - initialization
+          - settlement
+          - fallback
+          - rollout
+          - finalization
+          - refund
+          - sec
         blockNumber:
           type: integer
           format: int32
@@ -741,6 +801,25 @@ components:
           type: array
           items:
             type: string
+    EffectRef:
+      title: EffectRef
+      type: object
+      required:
+      - l1TxId
+      - kind
+      properties:
+        l1TxId:
+          type: string
+        kind:
+          type: string
+          enum:
+          - initialization
+          - settlement
+          - fallback
+          - rollout
+          - finalization
+          - refund
+          - sec
     ErrorResponse:
       title: ErrorResponse
       type: object
@@ -806,7 +885,7 @@ components:
         headAddress:
           type: string
         multisigRegimeUtxo:
-          $ref: '#/components/schemas/TxInputView'
+          $ref: '#/components/schemas/TxInput'
         treasuryBeaconToken:
           type: string
         submissionDurationSeconds:
@@ -944,6 +1023,11 @@ components:
       properties:
         status:
           type: string
+          enum:
+          - initializing
+          - active
+          - finalized
+          - handed-off-to-rule-based
     RequestAcceptedResponse:
       title: RequestAcceptedResponse
       type: object
@@ -953,8 +1037,8 @@ components:
         requestId:
           type: integer
           format: int64
-    RequestDetailsView:
-      title: RequestDetailsView
+    RequestDetails:
+      title: RequestDetails
       oneOf:
       - $ref: '#/components/schemas/Deposit'
       - $ref: '#/components/schemas/Transaction'
@@ -977,6 +1061,9 @@ components:
           format: int32
         validity:
           type: string
+          enum:
+          - valid
+          - invalid
         softConfirmedAt:
           type: string
         hardConfirmedAt:
@@ -984,7 +1071,7 @@ components:
         relatedEffects:
           type: array
           items:
-            $ref: '#/components/schemas/EffectRefView'
+            $ref: '#/components/schemas/EffectRef'
         type:
           type: string
           const: HARD_CONFIRMED
@@ -1001,6 +1088,9 @@ components:
           format: int32
         validity:
           type: string
+          enum:
+          - valid
+          - invalid
         type:
           type: string
           const: PROPOSED
@@ -1018,13 +1108,16 @@ components:
           format: int32
         validity:
           type: string
+          enum:
+          - valid
+          - invalid
         softConfirmedAt:
           type: string
         type:
           type: string
           const: SOFT_CONFIRMED
-    RequestStatusView:
-      title: RequestStatusView
+    RequestStatus:
+      title: RequestStatus
       oneOf:
       - $ref: '#/components/schemas/RequestHardConfirmed'
       - $ref: '#/components/schemas/RequestProposed'
@@ -1037,8 +1130,8 @@ components:
           PROPOSED: '#/components/schemas/RequestProposed'
           SOFT_CONFIRMED: '#/components/schemas/RequestSoftConfirmed'
           UNPROCESSED: '#/components/schemas/RequestUnprocessed'
-    RequestSummaryView:
-      title: RequestSummaryView
+    RequestSummary:
+      title: RequestSummary
       type: object
       required:
       - requestId
@@ -1053,6 +1146,9 @@ components:
           format: int32
         requestType:
           type: string
+          enum:
+          - deposit
+          - transaction
     RequestUnprocessed:
       title: RequestUnprocessed
       type: object
@@ -1062,6 +1158,33 @@ components:
         type:
           type: string
           const: UNPROCESSED
+    SubmitDeposit:
+      title: SubmitDeposit
+      type: object
+      required:
+      - l1Payload
+      - l2Payload
+      properties:
+        l1Payload:
+          type: string
+        l2Payload:
+          type: string
+    SubmitRequest:
+      title: SubmitRequest
+      type: object
+      properties:
+        deposit:
+          $ref: '#/components/schemas/SubmitDeposit'
+        transaction:
+          $ref: '#/components/schemas/SubmitTransaction'
+    SubmitTransaction:
+      title: SubmitTransaction
+      type: object
+      required:
+      - l2Payload
+      properties:
+        l2Payload:
+          type: string
     Transaction:
       title: Transaction
       type: object
@@ -1081,12 +1204,12 @@ components:
         receivedAt:
           type: string
         status:
-          $ref: '#/components/schemas/RequestStatusView'
+          $ref: '#/components/schemas/RequestStatus'
         type:
           type: string
           const: transaction
-    TxInputView:
-      title: TxInputView
+    TxInput:
+      title: TxInput
       type: object
       required:
       - transaction_id

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -41,12 +41,11 @@ paths:
     post:
       tags:
       - Requests
-      description: 'Submit a request. A wrapper key tags the type — set exactly one:
-        `{ "deposit": { "l1Payload", "l2Payload" } }` registers an L1 deposit (the
-        unsigned deposit-tx CBOR plus the serialized L2 outputs it spawns on absorption);
-        `{ "transaction": { "l2Payload" } }` submits an L2 transaction (a native,
-        self-authenticating Cardano tx). Payloads are lowercase hex. Returns the assigned
-        request id.'
+      description: 'Submit a request. A `type` field tags the kind: `{ "type": "deposit",
+        "l1Payload", "l2Payload" }` registers an L1 deposit (the unsigned deposit-tx
+        CBOR plus the serialized L2 outputs it spawns on absorption); `{ "type": "transaction",
+        "l2Payload" }` submits an L2 transaction (a native, self-authenticating Cardano
+        tx). Payloads are lowercase hex. Returns the assigned request id.'
       operationId: postHeadRequest
       requestBody:
         content:
@@ -604,7 +603,7 @@ components:
       required:
       - number
       - blockType
-      - confirmation
+      - status
       properties:
         number:
           type: integer
@@ -622,32 +621,61 @@ components:
         stackId:
           type: integer
           format: int32
-        confirmation:
+        status:
           $ref: '#/components/schemas/BlockConfirmation'
         header:
           $ref: '#/components/schemas/BlockHeader'
     BlockEffects:
       title: BlockEffects
+      oneOf:
+      - $ref: '#/components/schemas/BlockEffectsFinal'
+      - $ref: '#/components/schemas/BlockEffectsInitial'
+      - $ref: '#/components/schemas/BlockEffectsMajor'
+      - $ref: '#/components/schemas/BlockEffectsMinor'
+      discriminator:
+        propertyName: type
+        mapping:
+          final: '#/components/schemas/BlockEffectsFinal'
+          initial: '#/components/schemas/BlockEffectsInitial'
+          major: '#/components/schemas/BlockEffectsMajor'
+          minor: '#/components/schemas/BlockEffectsMinor'
+    BlockEffectsFinal:
+      title: BlockEffectsFinal
       type: object
       required:
-      - blockType
+      - type
       properties:
-        blockType:
-          type: string
-          enum:
-          - initial
-          - minor
-          - major
-          - final
-        initialization:
-          type: string
-        settlement:
-          type: string
         finalization:
+          type: string
+        rollouts:
+          type: array
+          items:
+            type: string
+        type:
+          type: string
+          const: final
+    BlockEffectsInitial:
+      title: BlockEffectsInitial
+      type: object
+      required:
+      - type
+      properties:
+        initialization:
           type: string
         fallback:
           type: string
-        sec:
+        type:
+          type: string
+          const: initial
+    BlockEffectsMajor:
+      title: BlockEffectsMajor
+      type: object
+      required:
+      - type
+      properties:
+        settlement:
+          type: string
+        fallback:
           type: string
         rollouts:
           type: array
@@ -657,6 +685,24 @@ components:
           type: array
           items:
             type: string
+        type:
+          type: string
+          const: major
+    BlockEffectsMinor:
+      title: BlockEffectsMinor
+      type: object
+      required:
+      - type
+      properties:
+        sec:
+          type: string
+        refunds:
+          type: array
+          items:
+            type: string
+        type:
+          type: string
+          const: minor
     BlockHardConfirmed:
       title: BlockHardConfirmed
       type: object
@@ -713,7 +759,6 @@ components:
       title: BlockSoftConfirmed
       type: object
       required:
-      - softConfirmedAt
       - type
       properties:
         softConfirmedAt:
@@ -1293,27 +1338,37 @@ components:
       required:
       - l1Payload
       - l2Payload
+      - type
       properties:
         l1Payload:
           type: string
         l2Payload:
           type: string
+        type:
+          type: string
+          const: deposit
     SubmitRequest:
       title: SubmitRequest
-      type: object
-      properties:
-        deposit:
-          $ref: '#/components/schemas/SubmitDeposit'
-        transaction:
-          $ref: '#/components/schemas/SubmitTransaction'
+      oneOf:
+      - $ref: '#/components/schemas/SubmitDeposit'
+      - $ref: '#/components/schemas/SubmitTransaction'
+      discriminator:
+        propertyName: type
+        mapping:
+          deposit: '#/components/schemas/SubmitDeposit'
+          transaction: '#/components/schemas/SubmitTransaction'
     SubmitTransaction:
       title: SubmitTransaction
       type: object
       required:
       - l2Payload
+      - type
       properties:
         l2Payload:
           type: string
+        type:
+          type: string
+          const: transaction
     Transaction:
       title: Transaction
       type: object

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -643,6 +643,7 @@ components:
       title: BlockEffectsFinal
       type: object
       required:
+      - finalization
       - type
       properties:
         finalization:
@@ -658,6 +659,8 @@ components:
       title: BlockEffectsInitial
       type: object
       required:
+      - initialization
+      - fallback
       - type
       properties:
         initialization:
@@ -671,6 +674,8 @@ components:
       title: BlockEffectsMajor
       type: object
       required:
+      - settlement
+      - fallback
       - type
       properties:
         settlement:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -82,7 +82,7 @@ paths:
   /head/requests/{request-id}:
     get:
       description: 'One request''s peer, type, receive time, and lifecycle status:
-        UNPROCESSED, LOCALLY_PROCESSED (block + validity), SOFT_CONFIRMED (+ soft-confirmation
+        UNPROCESSED, PROPOSED (block + validity), SOFT_CONFIRMED (+ soft-confirmation
         time), or HARD_CONFIRMED (+ hard-confirmation time and the related L1 effects
         — the l1TxIds the request became). Every time records a local event at this
         peer — when it received the request, and when it produced the soft/hard confirmation
@@ -433,6 +433,87 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
 components:
   schemas:
+    AbsorptionDecisionStatusView:
+      title: AbsorptionDecisionStatusView
+      oneOf:
+      - $ref: '#/components/schemas/AbsorptionHardConfirmed'
+      - $ref: '#/components/schemas/AbsorptionProposed'
+      - $ref: '#/components/schemas/AbsorptionSoftConfirmed'
+      - $ref: '#/components/schemas/AbsorptionUnprocessed'
+      discriminator:
+        propertyName: type
+        mapping:
+          HARD_CONFIRMED: '#/components/schemas/AbsorptionHardConfirmed'
+          PROPOSED: '#/components/schemas/AbsorptionProposed'
+          SOFT_CONFIRMED: '#/components/schemas/AbsorptionSoftConfirmed'
+          UNPROCESSED: '#/components/schemas/AbsorptionUnprocessed'
+    AbsorptionHardConfirmed:
+      title: AbsorptionHardConfirmed
+      type: object
+      required:
+      - blockNumber
+      - decision
+      - hardConfirmedAt
+      - type
+      properties:
+        blockNumber:
+          type: integer
+          format: int32
+        decision:
+          type: string
+        softConfirmedAt:
+          type: string
+        hardConfirmedAt:
+          type: string
+        settlementEffect:
+          type: string
+        type:
+          type: string
+          const: HARD_CONFIRMED
+    AbsorptionProposed:
+      title: AbsorptionProposed
+      type: object
+      required:
+      - blockNumber
+      - decision
+      - type
+      properties:
+        blockNumber:
+          type: integer
+          format: int32
+        decision:
+          type: string
+        type:
+          type: string
+          const: PROPOSED
+    AbsorptionSoftConfirmed:
+      title: AbsorptionSoftConfirmed
+      type: object
+      required:
+      - blockNumber
+      - decision
+      - softConfirmedAt
+      - type
+      properties:
+        blockNumber:
+          type: integer
+          format: int32
+        decision:
+          type: string
+        softConfirmedAt:
+          type: string
+        type:
+          type: string
+          const: SOFT_CONFIRMED
+    AbsorptionUnprocessed:
+      title: AbsorptionUnprocessed
+      type: object
+      required:
+      - type
+      properties:
+        type:
+          type: string
+          const: UNPROCESSED
     BlockBodyView:
       title: BlockBodyView
       type: object
@@ -461,16 +542,16 @@ components:
             format: int64
     BlockConfirmationView:
       title: BlockConfirmationView
-      type: object
-      required:
-      - status
-      properties:
-        status:
-          type: string
-        softConfirmedAt:
-          type: string
-        hardConfirmedAt:
-          type: string
+      oneOf:
+      - $ref: '#/components/schemas/BlockHardConfirmed'
+      - $ref: '#/components/schemas/BlockProposed'
+      - $ref: '#/components/schemas/BlockSoftConfirmed'
+      discriminator:
+        propertyName: type
+        mapping:
+          HARD_CONFIRMED: '#/components/schemas/BlockHardConfirmed'
+          PROPOSED: '#/components/schemas/BlockProposed'
+          SOFT_CONFIRMED: '#/components/schemas/BlockSoftConfirmed'
     BlockDetailsView:
       title: BlockDetailsView
       type: object
@@ -492,6 +573,8 @@ components:
           format: int32
         confirmation:
           $ref: '#/components/schemas/BlockConfirmationView'
+        header:
+          $ref: '#/components/schemas/BlockHeaderView'
     BlockEffectsView:
       title: BlockEffectsView
       type: object
@@ -518,6 +601,43 @@ components:
           type: array
           items:
             type: string
+    BlockHardConfirmed:
+      title: BlockHardConfirmed
+      type: object
+      required:
+      - hardConfirmedAt
+      - type
+      properties:
+        softConfirmedAt:
+          type: string
+        hardConfirmedAt:
+          type: string
+        type:
+          type: string
+          const: HARD_CONFIRMED
+    BlockHeaderView:
+      title: BlockHeaderView
+      oneOf:
+      - $ref: '#/components/schemas/Final'
+      - $ref: '#/components/schemas/Initial'
+      - $ref: '#/components/schemas/Major'
+      - $ref: '#/components/schemas/Minor'
+      discriminator:
+        propertyName: type
+        mapping:
+          final: '#/components/schemas/Final'
+          initial: '#/components/schemas/Initial'
+          major: '#/components/schemas/Major'
+          minor: '#/components/schemas/Minor'
+    BlockProposed:
+      title: BlockProposed
+      type: object
+      required:
+      - type
+      properties:
+        type:
+          type: string
+          const: PROPOSED
     BlockRequestView:
       title: BlockRequestView
       type: object
@@ -530,6 +650,18 @@ components:
           format: int64
         validity:
           type: string
+    BlockSoftConfirmed:
+      title: BlockSoftConfirmed
+      type: object
+      required:
+      - softConfirmedAt
+      - type
+      properties:
+        softConfirmedAt:
+          type: string
+        type:
+          type: string
+          const: SOFT_CONFIRMED
     BlockSummaryView:
       title: BlockSummaryView
       type: object
@@ -545,25 +677,32 @@ components:
           format: int32
         blockType:
           type: string
-    DepositDecisionStatusView:
-      title: DepositDecisionStatusView
+    Deposit:
+      title: Deposit
       type: object
       required:
+      - requestId
+      - peerNumber
+      - receivedAt
       - status
+      - absorptionDecisionStatus
+      - type
       properties:
-        status:
-          type: string
-        blockNumber:
+        requestId:
+          type: integer
+          format: int64
+        peerNumber:
           type: integer
           format: int32
-        decision:
+        receivedAt:
           type: string
-        softConfirmedAt:
+        status:
+          $ref: '#/components/schemas/RequestStatusView'
+        absorptionDecisionStatus:
+          $ref: '#/components/schemas/AbsorptionDecisionStatusView'
+        type:
           type: string
-        hardConfirmedAt:
-          type: string
-        settlementEffect:
-          type: string
+          const: deposit
     EffectRefView:
       title: EffectRefView
       type: object
@@ -610,6 +749,33 @@ components:
       properties:
         error:
           type: string
+    Final:
+      title: Final
+      type: object
+      required:
+      - number
+      - versionMajor
+      - versionMinor
+      - startTime
+      - endTime
+      - type
+      properties:
+        number:
+          type: integer
+          format: int32
+        versionMajor:
+          type: integer
+          format: int32
+        versionMinor:
+          type: integer
+          format: int32
+        startTime:
+          type: string
+        endTime:
+          type: string
+        type:
+          type: string
+          const: final
     FinalizeResponse:
       title: FinalizeResponse
       type: object
@@ -665,6 +831,111 @@ components:
       properties:
         status:
           type: string
+    Initial:
+      title: Initial
+      type: object
+      required:
+      - number
+      - versionMajor
+      - versionMinor
+      - startTime
+      - endTime
+      - fallbackTxStartTime
+      - forcedMajorBlockWakeupTime
+      - type
+      properties:
+        number:
+          type: integer
+          format: int32
+        versionMajor:
+          type: integer
+          format: int32
+        versionMinor:
+          type: integer
+          format: int32
+        startTime:
+          type: string
+        endTime:
+          type: string
+        fallbackTxStartTime:
+          type: string
+        forcedMajorBlockWakeupTime:
+          type: string
+        depositDecisionWakeupTime:
+          type: string
+        type:
+          type: string
+          const: initial
+    Major:
+      title: Major
+      type: object
+      required:
+      - number
+      - versionMajor
+      - versionMinor
+      - startTime
+      - endTime
+      - fallbackTxStartTime
+      - forcedMajorBlockWakeupTime
+      - type
+      properties:
+        number:
+          type: integer
+          format: int32
+        versionMajor:
+          type: integer
+          format: int32
+        versionMinor:
+          type: integer
+          format: int32
+        startTime:
+          type: string
+        endTime:
+          type: string
+        fallbackTxStartTime:
+          type: string
+        forcedMajorBlockWakeupTime:
+          type: string
+        depositDecisionWakeupTime:
+          type: string
+        type:
+          type: string
+          const: major
+    Minor:
+      title: Minor
+      type: object
+      required:
+      - number
+      - versionMajor
+      - versionMinor
+      - startTime
+      - endTime
+      - fallbackTxStartTime
+      - forcedMajorBlockWakeupTime
+      - type
+      properties:
+        number:
+          type: integer
+          format: int32
+        versionMajor:
+          type: integer
+          format: int32
+        versionMinor:
+          type: integer
+          format: int32
+        startTime:
+          type: string
+        endTime:
+          type: string
+        fallbackTxStartTime:
+          type: string
+        forcedMajorBlockWakeupTime:
+          type: string
+        depositDecisionWakeupTime:
+          type: string
+        type:
+          type: string
+          const: minor
     ReadinessResponse:
       title: ReadinessResponse
       type: object
@@ -684,36 +955,23 @@ components:
           format: int64
     RequestDetailsView:
       title: RequestDetailsView
+      oneOf:
+      - $ref: '#/components/schemas/Deposit'
+      - $ref: '#/components/schemas/Transaction'
+      discriminator:
+        propertyName: type
+        mapping:
+          deposit: '#/components/schemas/Deposit'
+          transaction: '#/components/schemas/Transaction'
+    RequestHardConfirmed:
+      title: RequestHardConfirmed
       type: object
       required:
-      - requestId
-      - peerNumber
-      - requestType
-      - receivedAt
-      - status
+      - blockNumber
+      - validity
+      - hardConfirmedAt
+      - type
       properties:
-        requestId:
-          type: integer
-          format: int64
-        peerNumber:
-          type: integer
-          format: int32
-        requestType:
-          type: string
-        receivedAt:
-          type: string
-        status:
-          $ref: '#/components/schemas/RequestStatusView'
-        decisionStatus:
-          $ref: '#/components/schemas/DepositDecisionStatusView'
-    RequestStatusView:
-      title: RequestStatusView
-      type: object
-      required:
-      - status
-      properties:
-        status:
-          type: string
         blockNumber:
           type: integer
           format: int32
@@ -727,6 +985,58 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/EffectRefView'
+        type:
+          type: string
+          const: HARD_CONFIRMED
+    RequestProposed:
+      title: RequestProposed
+      type: object
+      required:
+      - blockNumber
+      - validity
+      - type
+      properties:
+        blockNumber:
+          type: integer
+          format: int32
+        validity:
+          type: string
+        type:
+          type: string
+          const: PROPOSED
+    RequestSoftConfirmed:
+      title: RequestSoftConfirmed
+      type: object
+      required:
+      - blockNumber
+      - validity
+      - softConfirmedAt
+      - type
+      properties:
+        blockNumber:
+          type: integer
+          format: int32
+        validity:
+          type: string
+        softConfirmedAt:
+          type: string
+        type:
+          type: string
+          const: SOFT_CONFIRMED
+    RequestStatusView:
+      title: RequestStatusView
+      oneOf:
+      - $ref: '#/components/schemas/RequestHardConfirmed'
+      - $ref: '#/components/schemas/RequestProposed'
+      - $ref: '#/components/schemas/RequestSoftConfirmed'
+      - $ref: '#/components/schemas/RequestUnprocessed'
+      discriminator:
+        propertyName: type
+        mapping:
+          HARD_CONFIRMED: '#/components/schemas/RequestHardConfirmed'
+          PROPOSED: '#/components/schemas/RequestProposed'
+          SOFT_CONFIRMED: '#/components/schemas/RequestSoftConfirmed'
+          UNPROCESSED: '#/components/schemas/RequestUnprocessed'
     RequestSummaryView:
       title: RequestSummaryView
       type: object
@@ -743,6 +1053,38 @@ components:
           format: int32
         requestType:
           type: string
+    RequestUnprocessed:
+      title: RequestUnprocessed
+      type: object
+      required:
+      - type
+      properties:
+        type:
+          type: string
+          const: UNPROCESSED
+    Transaction:
+      title: Transaction
+      type: object
+      required:
+      - requestId
+      - peerNumber
+      - receivedAt
+      - status
+      - type
+      properties:
+        requestId:
+          type: integer
+          format: int64
+        peerNumber:
+          type: integer
+          format: int32
+        receivedAt:
+          type: string
+        status:
+          $ref: '#/components/schemas/RequestStatusView'
+        type:
+          type: string
+          const: transaction
     TxInputView:
       title: TxInputView
       type: object

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -275,7 +275,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Effect'
+                $ref: '#/components/schemas/TxEffect'
         default:
           description: ''
           content:
@@ -351,7 +351,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Effect'
+                $ref: '#/components/schemas/TxEffect'
         default:
           description: ''
           content:
@@ -377,7 +377,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Effect'
+                $ref: '#/components/schemas/TxEffect'
         default:
           description: ''
           content:
@@ -403,33 +403,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Effect'
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-  /head/blocks/{block-number}/effects/sec:
-    get:
-      tags:
-      - Blocks
-      description: The block's sec effect in full, or 404 if it has none.
-      operationId: getHeadBlockEffect_sec
-      parameters:
-      - name: block-number
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int32
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Effect'
+                $ref: '#/components/schemas/TxEffect'
         default:
           description: ''
           content:
@@ -455,7 +429,34 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Effect'
+                $ref: '#/components/schemas/TxEffect'
+        default:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /head/blocks/{block-number}/effects/sec:
+    get:
+      tags:
+      - Blocks
+      description: The block's SEC (standalone evacuation commitment), or 404 if it
+        has none.
+      operationId: getHeadBlockEffect_sec
+      parameters:
+      - name: block-number
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int32
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SecEffect'
         default:
           description: ''
           content:
@@ -768,39 +769,24 @@ components:
           const: deposit
     Effect:
       title: Effect
-      type: object
-      required:
-      - l1TxId
-      - kind
-      - blockNumber
-      properties:
-        l1TxId:
-          type: string
-        kind:
-          type: string
-          enum:
-          - initialization
-          - settlement
-          - fallback
-          - rollout
-          - finalization
-          - refund
-          - sec
-        blockNumber:
-          type: integer
-          format: int32
-        txCbor:
-          type: string
-        secOnchainSerialized:
-          type: string
-        headSignatures:
-          type: array
-          items:
-            type: string
-        coilSignatures:
-          type: array
-          items:
-            type: string
+      oneOf:
+      - $ref: '#/components/schemas/Fallback'
+      - $ref: '#/components/schemas/Finalization'
+      - $ref: '#/components/schemas/Initialization'
+      - $ref: '#/components/schemas/Refund'
+      - $ref: '#/components/schemas/Rollout'
+      - $ref: '#/components/schemas/Sec'
+      - $ref: '#/components/schemas/Settlement'
+      discriminator:
+        propertyName: type
+        mapping:
+          fallback: '#/components/schemas/Fallback'
+          finalization: '#/components/schemas/Finalization'
+          initialization: '#/components/schemas/Initialization'
+          refund: '#/components/schemas/Refund'
+          rollout: '#/components/schemas/Rollout'
+          sec: '#/components/schemas/Sec'
+          settlement: '#/components/schemas/Settlement'
     EffectRef:
       title: EffectRef
       type: object
@@ -828,6 +814,22 @@ components:
       properties:
         error:
           type: string
+    Fallback:
+      title: Fallback
+      type: object
+      required:
+      - blockNumber
+      - txCbor
+      - type
+      properties:
+        blockNumber:
+          type: integer
+          format: int32
+        txCbor:
+          type: string
+        type:
+          type: string
+          const: fallback
     Final:
       title: Final
       type: object
@@ -855,6 +857,22 @@ components:
         type:
           type: string
           const: final
+    Finalization:
+      title: Finalization
+      type: object
+      required:
+      - blockNumber
+      - txCbor
+      - type
+      properties:
+        blockNumber:
+          type: integer
+          format: int32
+        txCbor:
+          type: string
+        type:
+          type: string
+          const: finalization
     FinalizeResponse:
       title: FinalizeResponse
       type: object
@@ -945,6 +963,22 @@ components:
         type:
           type: string
           const: initial
+    Initialization:
+      title: Initialization
+      type: object
+      required:
+      - blockNumber
+      - txCbor
+      - type
+      properties:
+        blockNumber:
+          type: integer
+          format: int32
+        txCbor:
+          type: string
+        type:
+          type: string
+          const: initialization
     Major:
       title: Major
       type: object
@@ -1028,6 +1062,22 @@ components:
           - active
           - finalized
           - handed-off-to-rule-based
+    Refund:
+      title: Refund
+      type: object
+      required:
+      - blockNumber
+      - txCbor
+      - type
+      properties:
+        blockNumber:
+          type: integer
+          format: int32
+        txCbor:
+          type: string
+        type:
+          type: string
+          const: refund
     RequestAcceptedResponse:
       title: RequestAcceptedResponse
       type: object
@@ -1158,6 +1208,85 @@ components:
         type:
           type: string
           const: UNPROCESSED
+    Rollout:
+      title: Rollout
+      type: object
+      required:
+      - blockNumber
+      - txCbor
+      - type
+      properties:
+        blockNumber:
+          type: integer
+          format: int32
+        txCbor:
+          type: string
+        type:
+          type: string
+          const: rollout
+    Sec:
+      title: Sec
+      type: object
+      required:
+      - blockNumber
+      - secOnchainSerialized
+      - type
+      properties:
+        blockNumber:
+          type: integer
+          format: int32
+        secOnchainSerialized:
+          type: string
+        headSignatures:
+          type: array
+          items:
+            type: string
+        coilSignatures:
+          type: array
+          items:
+            type: string
+        type:
+          type: string
+          const: sec
+    SecEffect:
+      title: SecEffect
+      type: object
+      required:
+      - l1TxId
+      - blockNumber
+      - secOnchainSerialized
+      properties:
+        l1TxId:
+          type: string
+        blockNumber:
+          type: integer
+          format: int32
+        secOnchainSerialized:
+          type: string
+        headSignatures:
+          type: array
+          items:
+            type: string
+        coilSignatures:
+          type: array
+          items:
+            type: string
+    Settlement:
+      title: Settlement
+      type: object
+      required:
+      - blockNumber
+      - txCbor
+      - type
+      properties:
+        blockNumber:
+          type: integer
+          format: int32
+        txCbor:
+          type: string
+        type:
+          type: string
+          const: settlement
     SubmitDeposit:
       title: SubmitDeposit
       type: object
@@ -1208,6 +1337,21 @@ components:
         type:
           type: string
           const: transaction
+    TxEffect:
+      title: TxEffect
+      type: object
+      required:
+      - l1TxId
+      - blockNumber
+      - txCbor
+      properties:
+        l1TxId:
+          type: string
+        blockNumber:
+          type: integer
+          format: int32
+        txCbor:
+          type: string
     TxInput:
       title: TxInput
       type: object

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -157,11 +157,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-  /head/blocks/{block-number}/header:
+  /head/blocks/{block-number}/body:
     get:
-      description: The block's header content. The shape varies by block type (initial,
-        minor, major, final).
-      operationId: getHeadBlockHeader
+      description: 'The block''s content: its transactions (the request ids woven
+        into the block, each with its validity verdict) and its deposit decisions
+        (the request ids absorbed into the treasury and those rejected). 404 if the
+        block does not exist.'
+      operationId: getHeadBlockBody
       parameters:
       - name: block-number
         in: path
@@ -174,7 +176,8 @@ paths:
           description: ''
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/BlockBodyView'
         default:
           description: ''
           content:
@@ -430,6 +433,32 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
 components:
   schemas:
+    BlockBodyView:
+      title: BlockBodyView
+      type: object
+      required:
+      - number
+      - blockType
+      properties:
+        number:
+          type: integer
+          format: int32
+        blockType:
+          type: string
+        transactions:
+          type: array
+          items:
+            $ref: '#/components/schemas/BlockRequestView'
+        depositsAbsorbed:
+          type: array
+          items:
+            type: integer
+            format: int64
+        depositsRejected:
+          type: array
+          items:
+            type: integer
+            format: int64
     BlockConfirmationView:
       title: BlockConfirmationView
       type: object
@@ -458,6 +487,9 @@ components:
           format: int32
         blockType:
           type: string
+        stackId:
+          type: integer
+          format: int32
         confirmation:
           $ref: '#/components/schemas/BlockConfirmationView'
     BlockEffectsView:
@@ -486,6 +518,18 @@ components:
           type: array
           items:
             type: string
+    BlockRequestView:
+      title: BlockRequestView
+      type: object
+      required:
+      - requestId
+      - validity
+      properties:
+        requestId:
+          type: integer
+          format: int64
+        validity:
+          type: string
     BlockSummaryView:
       title: BlockSummaryView
       type: object

--- a/examples/src/main/scala/hydrozoa/examples/demo/SubmitL2Transaction.scala
+++ b/examples/src/main/scala/hydrozoa/examples/demo/SubmitL2Transaction.scala
@@ -68,7 +68,7 @@ object SubmitL2Transaction
                 _ <- IO.println(s"\nPeer $peerName, L2 address: $ownBech32")
 
                 views <- client.expect[List[L2UtxoView]](
-                  headUri / "api" / "l2" / "utxos" / ownBech32
+                  headUri / "l2" / "cardano-eutxo" / "utxos" / ownBech32
                 )
                 utxos <- IO.fromEither(
                   views

--- a/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
+++ b/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
@@ -714,21 +714,21 @@ object ApiDto {
         private given TapirConfig = tapirTag(blockEffectsTag)
 
         final case class BlockEffectsInitialView(
-            initialization: Option[String],
-            fallback: Option[String]
+            initialization: String,
+            fallback: String
         ) extends BlockEffectsView
         final case class BlockEffectsMinorView(
             sec: Option[String],
             refunds: List[String]
         ) extends BlockEffectsView
         final case class BlockEffectsMajorView(
-            settlement: Option[String],
-            fallback: Option[String],
+            settlement: String,
+            fallback: String,
             rollouts: List[String],
             refunds: List[String]
         ) extends BlockEffectsView
         final case class BlockEffectsFinalView(
-            finalization: Option[String],
+            finalization: String,
             rollouts: List[String]
         ) extends BlockEffectsView
         given Codec[BlockEffectsView] = ConfiguredCodec.derived
@@ -798,11 +798,17 @@ object ApiDto {
             effects.collectFirst { case e if e.kind == k => e.l1TxId.toHex }
         def idsOf(k: EffectKind): List[String] =
             effects.collect { case e if e.kind == k => e.l1TxId.toHex }
+        // A hard-confirmed block of a given type always carries its type's required effects (these
+        // views are only built for hard-confirmed blocks); a missing one is an invariant violation.
+        def requireId(k: EffectKind): String =
+            firstIdOf(k).getOrElse(
+              throw new IllegalStateException(s"$blockType block missing its $k effect")
+            )
         blockType match
             case BlockTypeView.Initial =>
                 BlockEffectsView.BlockEffectsInitialView(
-                  firstIdOf(EffectKind.Initialization),
-                  firstIdOf(EffectKind.Fallback)
+                  requireId(EffectKind.Initialization),
+                  requireId(EffectKind.Fallback)
                 )
             case BlockTypeView.Minor =>
                 BlockEffectsView.BlockEffectsMinorView(
@@ -811,14 +817,14 @@ object ApiDto {
                 )
             case BlockTypeView.Major =>
                 BlockEffectsView.BlockEffectsMajorView(
-                  firstIdOf(EffectKind.Settlement),
-                  firstIdOf(EffectKind.Fallback),
+                  requireId(EffectKind.Settlement),
+                  requireId(EffectKind.Fallback),
                   idsOf(EffectKind.Rollout),
                   idsOf(EffectKind.Refund)
                 )
             case BlockTypeView.Final =>
                 BlockEffectsView.BlockEffectsFinalView(
-                  firstIdOf(EffectKind.Finalization),
+                  requireId(EffectKind.Finalization),
                   idsOf(EffectKind.Rollout)
                 )
 

--- a/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
+++ b/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
@@ -1,14 +1,16 @@
 package hydrozoa.multisig.server
 
 import hydrozoa.config.head.HeadConfig
+import hydrozoa.config.head.multisig.timing.TxTiming.BlockTimes.given
 import hydrozoa.multisig.NodeStatus
 import hydrozoa.multisig.consensus.UserRequestWithId
-import hydrozoa.multisig.ledger.block.BlockBrief
+import hydrozoa.multisig.ledger.block.{BlockBrief, BlockHeader}
 import hydrozoa.multisig.ledger.event.RequestId
 import hydrozoa.multisig.ledger.event.RequestId.ValidityFlag
 import hydrozoa.multisig.ledger.l2.{L2TxKind, L2TxSummary}
 import hydrozoa.multisig.persistence.DepositDecision
 import io.bullet.borer.Cbor
+import io.circe.derivation.{Configuration as CirceConfig, ConfiguredCodec}
 import io.circe.generic.semiauto.deriveCodec
 import io.circe.{Codec, Decoder, Encoder}
 import java.time.Instant
@@ -16,6 +18,7 @@ import scalus.cardano.address.{Address, ShelleyAddress}
 import scalus.cardano.ledger.{DatumOption, TransactionInput, TransactionOutput, Value}
 import scalus.uplc.builtin.ByteString
 import sttp.tapir.Schema
+import sttp.tapir.generic.Configuration as TapirConfig
 
 /** Flat data-transfer objects for the HTTP API responses.
   *
@@ -26,6 +29,41 @@ import sttp.tapir.Schema
   * conventions (bech32 addresses, hex hashes, decimal-string coins/quantities).
   */
 object ApiDto {
+
+    /** Screaming-snake-case a PascalCase constructor name — `SoftConfirmed` -> `SOFT_CONFIRMED` —
+      * so the `type` discriminator reads as the API's status vocabulary.
+      */
+    private def screamingSnake(name: String): String =
+        name.replaceAll("([a-z0-9])([A-Z])", "$1_$2").toUpperCase
+
+    /** Sum-type DTOs are **internally tagged**: a `type` field selects the constructor (no
+      * flattening / duck typing). [[circeTag]] gives the codec that writes/reads `type`;
+      * [[tapirTag]] gives the schema that renders a `oneOf` with an OpenAPI `discriminator`, so the
+      * closed constructor set is expressed in the spec. Both take the SAME constructor-name
+      * transform, so the codec and the schema agree on every discriminator value.
+      *
+      * A discriminator value derives from a variant's constructor name, but the OpenAPI schema name
+      * derives from it too — so sums that share a status vocabulary (`SOFT_CONFIRMED`, ...) give
+      * their variants a sum-specific prefix (`RequestSoftConfirmed`) for a unique schema name, and
+      * the transform strips the prefix so the `type` value stays the shared word. See
+      * [[statusTag]].
+      */
+    private def circeTag(discriminatorValue: String => String): CirceConfig =
+        CirceConfig.default
+            .withDiscriminator("type")
+            .withTransformConstructorNames(discriminatorValue)
+    private def tapirTag(discriminatorValue: String => String): TapirConfig =
+        TapirConfig.default
+            .withDiscriminator("type")
+            .copy(toDiscriminatorValue =
+                sname => discriminatorValue(sname.fullName.split('.').last)
+            )
+
+    /** The name transform for a status ladder: strip the sum-specific `prefix`, then
+      * screaming-snake (`BlockSoftConfirmed` with prefix `Block` -> `SOFT_CONFIRMED`).
+      */
+    private def statusTag(prefix: String): String => String =
+        name => screamingSnake(name.stripPrefix(prefix))
 
     /** `{ "status": "ok" }` — the liveness body. */
     final case class HealthResponse(status: String)
@@ -101,27 +139,89 @@ object ApiDto {
     final case class BlockSummaryView(number: Int, leader: Option[Int], blockType: String)
     given Codec[BlockSummaryView] = deriveCodec
 
-    /** A block's confirmation from this node's viewpoint: `PROPOSED`, `SOFT`, or `HARD`, with the
-      * confirmation moments (ISO-8601) where reached. Each time records a **local event at this
-      * peer** — when it produced the confirmation — so different peers report different times for
-      * the same block. This is by design.
+    /** A block's confirmation from this node's viewpoint, `type`-tagged: `PROPOSED` (woven, not yet
+      * soft-confirmed) -> `SOFT_CONFIRMED` (+ soft time) -> `HARD_CONFIRMED` (+ hard time; soft
+      * time optional, since a block may be hard-confirmed with no local soft-confirmation record).
+      * Each time records a **local event at this peer**, so different peers report different times
+      * for the same block. This is by design.
       */
-    final case class BlockConfirmationView(
-        status: String,
-        softConfirmedAt: Option[String],
-        hardConfirmedAt: Option[String]
-    )
-    given Codec[BlockConfirmationView] = deriveCodec
+    sealed trait BlockConfirmationView
+    object BlockConfirmationView:
+        private given CirceConfig = circeTag(statusTag("Block"))
+        private given TapirConfig = tapirTag(statusTag("Block"))
+
+        case object BlockProposed extends BlockConfirmationView
+        final case class BlockSoftConfirmed(softConfirmedAt: String) extends BlockConfirmationView
+        final case class BlockHardConfirmed(
+            softConfirmedAt: Option[String],
+            hardConfirmedAt: String
+        ) extends BlockConfirmationView
+        given Codec[BlockConfirmationView] = ConfiguredCodec.derived
+        given Schema[BlockConfirmationView] = Schema.derived
+
+    /** A block header from this node's viewpoint, `type`-tagged by block type. All headers carry
+      * the block number, version (`major`.`minor`) and creation window (`startTime`/`endTime`,
+      * ISO-8601); `initial`, `minor` and `major` additionally carry the fallback and wakeup timing.
+      * `final` carries only the common fields.
+      */
+    sealed trait BlockHeaderView
+    object BlockHeaderView:
+        // Tag with the lowercase block type (`minor` / `major` / `final` / `initial`), matching
+        // `BlockDetailsView.blockType`; shadows the screaming-snake status tagging.
+        private given CirceConfig = circeTag(_.toLowerCase)
+        private given TapirConfig = tapirTag(_.toLowerCase)
+
+        final case class Initial(
+            number: Int,
+            versionMajor: Int,
+            versionMinor: Int,
+            startTime: String,
+            endTime: String,
+            fallbackTxStartTime: String,
+            forcedMajorBlockWakeupTime: String,
+            depositDecisionWakeupTime: Option[String]
+        ) extends BlockHeaderView
+        final case class Minor(
+            number: Int,
+            versionMajor: Int,
+            versionMinor: Int,
+            startTime: String,
+            endTime: String,
+            fallbackTxStartTime: String,
+            forcedMajorBlockWakeupTime: String,
+            depositDecisionWakeupTime: Option[String]
+        ) extends BlockHeaderView
+        final case class Major(
+            number: Int,
+            versionMajor: Int,
+            versionMinor: Int,
+            startTime: String,
+            endTime: String,
+            fallbackTxStartTime: String,
+            forcedMajorBlockWakeupTime: String,
+            depositDecisionWakeupTime: Option[String]
+        ) extends BlockHeaderView
+        final case class Final(
+            number: Int,
+            versionMajor: Int,
+            versionMinor: Int,
+            startTime: String,
+            endTime: String
+        ) extends BlockHeaderView
+        given Codec[BlockHeaderView] = ConfiguredCodec.derived
+        given Schema[BlockHeaderView] = Schema.derived
 
     /** The block-details body: the listing row, the hard-confirming stack's number (absent until
-      * the block is hard-confirmed), and the confirmation status.
+      * the block is hard-confirmed), the confirmation status, and the full block header (absent for
+      * the initial block, which has no persisted brief).
       */
     final case class BlockDetailsView(
         number: Int,
         leader: Option[Int],
         blockType: String,
         stackId: Option[Int],
-        confirmation: BlockConfirmationView
+        confirmation: BlockConfirmationView,
+        header: Option[BlockHeaderView]
     )
     given Codec[BlockDetailsView] = deriveCodec
 
@@ -171,25 +271,67 @@ object ApiDto {
     def mkInitialBlockSummaryView: BlockSummaryView =
         BlockSummaryView(number = 0, leader = None, blockType = "initial")
 
-    /** Assemble the confirmation view from the optional node-local confirmation moments. */
+    /** Assemble the confirmation rung from the node-local confirmation moments (present iff their
+      * record is held — `wallClockOf` is total).
+      */
     def mkBlockConfirmationView(
         softConfirmedAt: Option[Instant],
         hardConfirmedAt: Option[Instant]
     ): BlockConfirmationView =
-        val status =
-            if hardConfirmedAt.isDefined then "HARD"
-            else if softConfirmedAt.isDefined then "SOFT"
-            else "PROPOSED"
-        BlockConfirmationView(
-          status = status,
-          softConfirmedAt = softConfirmedAt.map(_.toString),
-          hardConfirmedAt = hardConfirmedAt.map(_.toString)
-        )
+        (softConfirmedAt, hardConfirmedAt) match
+            case (soft, Some(hard)) =>
+                BlockConfirmationView.BlockHardConfirmed(soft.map(_.toString), hard.toString)
+            case (Some(soft), None) => BlockConfirmationView.BlockSoftConfirmed(soft.toString)
+            case (None, None)       => BlockConfirmationView.BlockProposed
 
     private def blockTypeName(brief: BlockBrief.Next): String = brief match
         case _: BlockBrief.Minor => "minor"
         case _: BlockBrief.Major => "major"
         case _: BlockBrief.Final => "final"
+
+    /** Map a block header to its `type`-tagged view, rendering the quantized timing as ISO-8601. */
+    def mkBlockHeaderView(header: BlockHeader): BlockHeaderView =
+        val number = header.blockNum.convert
+        val versionMajor = header.blockVersion.major.convert
+        val versionMinor = header.blockVersion.minor.convert
+        val startTime = header.startTime.instant.toString
+        val endTime = header.endTime.instant.toString
+        header match
+            case h: BlockHeader.Initial =>
+                BlockHeaderView.Initial(
+                  number,
+                  versionMajor,
+                  versionMinor,
+                  startTime,
+                  endTime,
+                  h.fallbackTxStartTime.instant.toString,
+                  h.forcedMajorBlockWakeupTime.instant.toString,
+                  h.mDepositDecisionWakeupTime.map(_.convert.instant.toString)
+                )
+            case h: BlockHeader.Minor =>
+                BlockHeaderView.Minor(
+                  number,
+                  versionMajor,
+                  versionMinor,
+                  startTime,
+                  endTime,
+                  h.fallbackTxStartTime.instant.toString,
+                  h.forcedMajorBlockWakeupTime.instant.toString,
+                  h.mDepositDecisionWakeupTime.map(_.convert.instant.toString)
+                )
+            case h: BlockHeader.Major =>
+                BlockHeaderView.Major(
+                  number,
+                  versionMajor,
+                  versionMinor,
+                  startTime,
+                  endTime,
+                  h.fallbackTxStartTime.instant.toString,
+                  h.forcedMajorBlockWakeupTime.instant.toString,
+                  h.mDepositDecisionWakeupTime.map(_.convert.instant.toString)
+                )
+            case _: BlockHeader.Final =>
+                BlockHeaderView.Final(number, versionMajor, versionMinor, startTime, endTime)
 
     /** One row of the request listing: the opaque request id (the packed i64, the same value the
       * submit response returns), the author peer number, and the request type.
@@ -208,234 +350,94 @@ object ApiDto {
     def mkEffectRefView(effect: ResolvedEffect): EffectRefView =
         EffectRefView(effect.l1TxId.toHex, effectKindName(effect.kind))
 
-    /** A request's lifecycle status from this node's viewpoint, as a ladder where each stage adds
-      * the fields of the one below plus its own: `UNPROCESSED` → `LOCALLY_PROCESSED` (block,
-      * verdict) → `SOFT_CONFIRMED` (soft time) → `HARD_CONFIRMED` (hard time, effects). The ladder
-      * is modeled as traits that extend one another; the concrete statuses are the final case
-      * classes below. Each confirmation time records a **local event at this peer** — different
-      * peers report different times for the same request, by design. `relatedEffects` — the L1
-      * effects the request became (a transaction's settlement/SEC/finalization carriers, a
-      * deposit's post-dated refund) — is present once those effects are hard-confirmed.
-      *
-      * The wire form is flat (a `status` string plus the accumulated fields, nulls dropped): the
-      * codec / schema round-trip through the private [[RequestStatusView.Shape]].
+    /** A request's lifecycle status from this node's viewpoint, `type`-tagged, where each rung adds
+      * the fields of the one below plus its own: `UNPROCESSED` -> `PROPOSED` (block, verdict) ->
+      * `SOFT_CONFIRMED` (soft time) -> `HARD_CONFIRMED` (hard time; soft time optional, since a
+      * request may be hard-confirmed with no local soft record; and the effects). Each confirmation
+      * time records a **local event at this peer** — different peers report different times for the
+      * same request, by design. `relatedEffects` — the L1 effects the request became (a
+      * transaction's settlement/SEC/finalization carriers, a deposit's post-dated refund) — is
+      * present once those effects are hard-confirmed.
       */
-    sealed trait RequestStatusView:
-        def status: String
-
-    /** `LOCALLY_PROCESSED` and up: the request landed in a block with a validity verdict. */
-    sealed trait LocallyProcessedStatus extends RequestStatusView:
-        def blockNumber: Int
-        def validity: String
-
-    /** `SOFT_CONFIRMED` and up: this peer soft-confirmed the block. The time is optional because a
-      * hard-confirmed request that (exceptionally) has no soft-confirmation record still sits on
-      * the `HardConfirmed` rung, which inherits this field.
-      */
-    sealed trait SoftConfirmedStatus extends LocallyProcessedStatus:
-        def softConfirmedAt: Option[String]
-
-    /** `HARD_CONFIRMED`: this peer hard-confirmed the covering stack; effects are resolvable. */
-    sealed trait HardConfirmedStatus extends SoftConfirmedStatus:
-        def hardConfirmedAt: Option[String]
-        def relatedEffects: List[EffectRefView]
-
+    sealed trait RequestStatusView
     object RequestStatusView:
-        case object Unprocessed extends RequestStatusView:
-            val status = "UNPROCESSED"
+        private given CirceConfig = circeTag(statusTag("Request"))
+        private given TapirConfig = tapirTag(statusTag("Request"))
 
-        final case class LocallyProcessed(blockNumber: Int, validity: String)
-            extends LocallyProcessedStatus:
-            val status = "LOCALLY_PROCESSED"
-
-        final case class SoftConfirmed(
+        case object RequestUnprocessed extends RequestStatusView
+        final case class RequestProposed(blockNumber: Int, validity: String)
+            extends RequestStatusView
+        final case class RequestSoftConfirmed(
             blockNumber: Int,
             validity: String,
-            softConfirmedAt: Option[String]
-        ) extends SoftConfirmedStatus:
-            val status = "SOFT_CONFIRMED"
-
-        final case class HardConfirmed(
+            softConfirmedAt: String
+        ) extends RequestStatusView
+        final case class RequestHardConfirmed(
             blockNumber: Int,
             validity: String,
             softConfirmedAt: Option[String],
-            hardConfirmedAt: Option[String],
+            hardConfirmedAt: String,
             relatedEffects: List[EffectRefView]
-        ) extends HardConfirmedStatus:
-            val status = "HARD_CONFIRMED"
+        ) extends RequestStatusView
+        given Codec[RequestStatusView] = ConfiguredCodec.derived
+        given Schema[RequestStatusView] = Schema.derived
 
-        /** The flat serialization shape — one object, the status string plus every ladder field as
-          * an option; the drop-null printer omits the absent ones.
-          */
-        private final case class Shape(
-            status: String,
-            blockNumber: Option[Int],
-            validity: Option[String],
-            softConfirmedAt: Option[String],
-            hardConfirmedAt: Option[String],
-            relatedEffects: Option[List[EffectRefView]]
-        )
-        private object Shape:
-            given Codec[Shape] = deriveCodec
-            given Schema[Shape] = Schema.derived
-
-        private def toShape(v: RequestStatusView): Shape = v match
-            case Unprocessed => Shape("UNPROCESSED", None, None, None, None, None)
-            case LocallyProcessed(b, v) =>
-                Shape("LOCALLY_PROCESSED", Some(b), Some(v), None, None, None)
-            case SoftConfirmed(b, v, s) =>
-                Shape("SOFT_CONFIRMED", Some(b), Some(v), s, None, None)
-            case HardConfirmed(b, v, s, h, effects) =>
-                Shape(
-                  "HARD_CONFIRMED",
-                  Some(b),
-                  Some(v),
-                  s,
-                  h,
-                  Option.when(effects.nonEmpty)(effects)
-                )
-
-        private def fromShape(s: Shape): RequestStatusView = s.status match
-            case "LOCALLY_PROCESSED" =>
-                LocallyProcessed(s.blockNumber.getOrElse(0), s.validity.getOrElse(""))
-            case "SOFT_CONFIRMED" =>
-                SoftConfirmed(
-                  s.blockNumber.getOrElse(0),
-                  s.validity.getOrElse(""),
-                  s.softConfirmedAt
-                )
-            case "HARD_CONFIRMED" =>
-                HardConfirmed(
-                  s.blockNumber.getOrElse(0),
-                  s.validity.getOrElse(""),
-                  s.softConfirmedAt,
-                  s.hardConfirmedAt,
-                  s.relatedEffects.getOrElse(Nil)
-                )
-            case _ => Unprocessed
-
-        given Codec[RequestStatusView] = Codec.from(
-          summon[Decoder[Shape]].map(fromShape),
-          summon[Encoder[Shape]].contramap(toShape)
-        )
-        given Schema[RequestStatusView] =
-            summon[Schema[Shape]]
-                .map(s => Some(fromShape(s)))(toShape)
-                .name(Schema.SName("RequestStatusView"))
-
-    /** A valid deposit's decision status, a ladder parallel to [[RequestStatusView]] but tracking
-      * the absorb-or-reject decision: `UNDECIDED` → `LOCAL_DECISION` (deciding block + `ABSORBED` /
-      * `REJECTED`) → `SOFT_CONFIRMED` (soft time) → `HARD_CONFIRMED` (hard time, and — only for an
-      * absorbed deposit — the absorbing settlement's `l1TxId`). Times are of the **deciding**
-      * block. Present only for valid deposit requests; absent for transactions and invalid
-      * deposits.
+    /** A valid deposit's absorb-or-reject decision status, `type`-tagged in the same vocabulary as
+      * [[RequestStatusView]]: `UNPROCESSED` (no decision yet) -> `PROPOSED` (deciding block +
+      * `ABSORBED` / `REJECTED`) -> `SOFT_CONFIRMED` (soft time) -> `HARD_CONFIRMED` (hard time, and
+      * — only for an absorbed deposit — the absorbing settlement's `l1TxId`). Times are of the
+      * **deciding** block. Present only for valid deposit requests.
       */
-    sealed trait DepositDecisionStatusView:
-        def status: String
+    sealed trait AbsorptionDecisionStatusView
+    object AbsorptionDecisionStatusView:
+        private given CirceConfig = circeTag(statusTag("Absorption"))
+        private given TapirConfig = tapirTag(statusTag("Absorption"))
 
-    /** `LOCAL_DECISION` and up: a block decided the deposit. */
-    sealed trait LocalDecisionStatus extends DepositDecisionStatusView:
-        def blockNumber: Int
-        def decision: String
-
-    /** `SOFT_CONFIRMED` and up: this peer soft-confirmed the deciding block (time optional for the
-      * same reason as [[SoftConfirmedStatus]]).
-      */
-    sealed trait DecisionSoftConfirmedStatus extends LocalDecisionStatus:
-        def softConfirmedAt: Option[String]
-
-    /** `HARD_CONFIRMED`: this peer hard-confirmed the deciding block's stack. */
-    sealed trait DecisionHardConfirmedStatus extends DecisionSoftConfirmedStatus:
-        def hardConfirmedAt: Option[String]
-        def settlementEffect: Option[String]
-
-    object DepositDecisionStatusView:
-        case object Undecided extends DepositDecisionStatusView:
-            val status = "UNDECIDED"
-
-        final case class LocalDecision(blockNumber: Int, decision: String)
-            extends LocalDecisionStatus:
-            val status = "LOCAL_DECISION"
-
-        final case class SoftConfirmed(
+        case object AbsorptionUnprocessed extends AbsorptionDecisionStatusView
+        final case class AbsorptionProposed(blockNumber: Int, decision: String)
+            extends AbsorptionDecisionStatusView
+        final case class AbsorptionSoftConfirmed(
             blockNumber: Int,
             decision: String,
-            softConfirmedAt: Option[String]
-        ) extends DecisionSoftConfirmedStatus:
-            val status = "SOFT_CONFIRMED"
-
-        final case class HardConfirmed(
+            softConfirmedAt: String
+        ) extends AbsorptionDecisionStatusView
+        final case class AbsorptionHardConfirmed(
             blockNumber: Int,
             decision: String,
             softConfirmedAt: Option[String],
-            hardConfirmedAt: Option[String],
+            hardConfirmedAt: String,
             settlementEffect: Option[String]
-        ) extends DecisionHardConfirmedStatus:
-            val status = "HARD_CONFIRMED"
+        ) extends AbsorptionDecisionStatusView
+        given Codec[AbsorptionDecisionStatusView] = ConfiguredCodec.derived
+        given Schema[AbsorptionDecisionStatusView] = Schema.derived
 
-        private final case class Shape(
-            status: String,
-            blockNumber: Option[Int],
-            decision: Option[String],
-            softConfirmedAt: Option[String],
-            hardConfirmedAt: Option[String],
-            settlementEffect: Option[String]
-        )
-        private object Shape:
-            given Codec[Shape] = deriveCodec
-            given Schema[Shape] = Schema.derived
-
-        private def toShape(v: DepositDecisionStatusView): Shape = v match
-            case Undecided => Shape("UNDECIDED", None, None, None, None, None)
-            case LocalDecision(b, d) =>
-                Shape("LOCAL_DECISION", Some(b), Some(d), None, None, None)
-            case SoftConfirmed(b, d, s) =>
-                Shape("SOFT_CONFIRMED", Some(b), Some(d), s, None, None)
-            case HardConfirmed(b, d, s, h, settlement) =>
-                Shape("HARD_CONFIRMED", Some(b), Some(d), s, h, settlement)
-
-        private def fromShape(s: Shape): DepositDecisionStatusView = s.status match
-            case "LOCAL_DECISION" =>
-                LocalDecision(s.blockNumber.getOrElse(0), s.decision.getOrElse(""))
-            case "SOFT_CONFIRMED" =>
-                SoftConfirmed(
-                  s.blockNumber.getOrElse(0),
-                  s.decision.getOrElse(""),
-                  s.softConfirmedAt
-                )
-            case "HARD_CONFIRMED" =>
-                HardConfirmed(
-                  s.blockNumber.getOrElse(0),
-                  s.decision.getOrElse(""),
-                  s.softConfirmedAt,
-                  s.hardConfirmedAt,
-                  s.settlementEffect
-                )
-            case _ => Undecided
-
-        given Codec[DepositDecisionStatusView] = Codec.from(
-          summon[Decoder[Shape]].map(fromShape),
-          summon[Encoder[Shape]].contramap(toShape)
-        )
-        given Schema[DepositDecisionStatusView] =
-            summon[Schema[Shape]]
-                .map(s => Some(fromShape(s)))(toShape)
-                .name(Schema.SName("DepositDecisionStatusView"))
-
-    /** The request-details body: opaque id (echoed from the path), author peer, type, receive time
-      * (when this peer received the request — a local event, so different peers report different
-      * times for the same request, by design), the lifecycle status, and — for valid deposit
-      * requests only — the absorb/reject decision status.
+    /** The request-details body, `type`-tagged by request kind: `transaction` and `deposit` share
+      * the opaque id (echoed from the path), author peer, receive time (when this peer received the
+      * request — a local event, so different peers report different times, by design) and lifecycle
+      * status; only `deposit` carries the absorb/reject decision status.
       */
-    final case class RequestDetailsView(
-        requestId: Long,
-        peerNumber: Int,
-        requestType: String,
-        receivedAt: String,
-        status: RequestStatusView,
-        decisionStatus: Option[DepositDecisionStatusView]
-    )
-    given Codec[RequestDetailsView] = deriveCodec
+    sealed trait RequestDetailsView
+    object RequestDetailsView:
+        // Request-kind sums tag with the lowercase kind (`transaction` / `deposit`), shadowing the
+        // screaming-snake status tagging in the enclosing scope.
+        private given CirceConfig = circeTag(_.toLowerCase)
+        private given TapirConfig = tapirTag(_.toLowerCase)
+
+        final case class Transaction(
+            requestId: Long,
+            peerNumber: Int,
+            receivedAt: String,
+            status: RequestStatusView
+        ) extends RequestDetailsView
+        final case class Deposit(
+            requestId: Long,
+            peerNumber: Int,
+            receivedAt: String,
+            status: RequestStatusView,
+            absorptionDecisionStatus: AbsorptionDecisionStatusView
+        ) extends RequestDetailsView
+        given Codec[RequestDetailsView] = ConfiguredCodec.derived
+        given Schema[RequestDetailsView] = Schema.derived
 
     /** The request type discriminator, matching the submit-body field names. */
     def requestTypeName(request: UserRequestWithId): String = request match
@@ -466,77 +468,95 @@ object ApiDto {
         relatedEffects: List[EffectRefView]
     ): RequestStatusView =
         block match
-            case None => RequestStatusView.Unprocessed
+            case None => RequestStatusView.RequestUnprocessed
             case Some((blockNumber, v)) =>
                 val validity = validityName(v)
-                if hardConfirmedAt.isDefined then
-                    RequestStatusView.HardConfirmed(
-                      blockNumber,
-                      validity,
-                      softConfirmedAt.map(_.toString),
-                      hardConfirmedAt.map(_.toString),
-                      relatedEffects
-                    )
-                else if softConfirmedAt.isDefined then
-                    RequestStatusView.SoftConfirmed(
-                      blockNumber,
-                      validity,
-                      softConfirmedAt.map(_.toString)
-                    )
-                else RequestStatusView.LocallyProcessed(blockNumber, validity)
+                hardConfirmedAt match
+                    case Some(hard) =>
+                        RequestStatusView.RequestHardConfirmed(
+                          blockNumber,
+                          validity,
+                          softConfirmedAt.map(_.toString),
+                          hard.toString,
+                          relatedEffects
+                        )
+                    case None =>
+                        softConfirmedAt match
+                            case Some(soft) =>
+                                RequestStatusView.RequestSoftConfirmed(
+                                  blockNumber,
+                                  validity,
+                                  soft.toString
+                                )
+                            case None =>
+                                RequestStatusView.RequestProposed(blockNumber, validity)
 
     /** The `ABSORBED` / `REJECTED` label of a deposit decision. */
     def decisionName(decision: DepositDecision): String = decision match
         case _: DepositDecision.Absorbed => "ABSORBED"
         case _: DepositDecision.Rejected => "REJECTED"
 
-    /** Assemble the deposit decision-status ladder: undecided (no decision row yet), else the
+    /** Assemble the deposit absorption-decision ladder: unprocessed (no decision row yet), else the
       * deciding block + `ABSORBED`/`REJECTED`, promoted by the deciding block's node-local
       * confirmation moments. The absorbing settlement's `l1TxId` (`ABSORBED`, hard-confirmed only)
       * rides on the hard-confirmed rung.
       */
-    def mkDecisionStatus(
+    def mkAbsorptionDecisionStatus(
         decided: Option[(Int, String)],
         softConfirmedAt: Option[Instant],
         hardConfirmedAt: Option[Instant],
         settlementEffect: Option[String]
-    ): DepositDecisionStatusView =
+    ): AbsorptionDecisionStatusView =
         decided match
-            case None => DepositDecisionStatusView.Undecided
+            case None => AbsorptionDecisionStatusView.AbsorptionUnprocessed
             case Some((blockNumber, decision)) =>
-                if hardConfirmedAt.isDefined then
-                    DepositDecisionStatusView.HardConfirmed(
-                      blockNumber,
-                      decision,
-                      softConfirmedAt.map(_.toString),
-                      hardConfirmedAt.map(_.toString),
-                      settlementEffect
-                    )
-                else if softConfirmedAt.isDefined then
-                    DepositDecisionStatusView.SoftConfirmed(
-                      blockNumber,
-                      decision,
-                      softConfirmedAt.map(_.toString)
-                    )
-                else DepositDecisionStatusView.LocalDecision(blockNumber, decision)
+                hardConfirmedAt match
+                    case Some(hard) =>
+                        AbsorptionDecisionStatusView.AbsorptionHardConfirmed(
+                          blockNumber,
+                          decision,
+                          softConfirmedAt.map(_.toString),
+                          hard.toString,
+                          settlementEffect
+                        )
+                    case None =>
+                        softConfirmedAt match
+                            case Some(soft) =>
+                                AbsorptionDecisionStatusView.AbsorptionSoftConfirmed(
+                                  blockNumber,
+                                  decision,
+                                  soft.toString
+                                )
+                            case None =>
+                                AbsorptionDecisionStatusView.AbsorptionProposed(
+                                  blockNumber,
+                                  decision
+                                )
 
-    /** Map a request, its derived receive time, its lifecycle status, and — for valid deposits —
-      * its decision status to the details body.
+    /** Map a request, its derived receive time, its lifecycle status, and — for deposits — its
+      * absorption-decision status to the `type`-tagged details body.
       */
     def mkRequestDetailsView(
         request: UserRequestWithId,
         receivedAt: Instant,
         status: RequestStatusView,
-        decisionStatus: Option[DepositDecisionStatusView]
+        absorptionDecisionStatus: Option[AbsorptionDecisionStatusView]
     ): RequestDetailsView =
-        RequestDetailsView(
-          requestId = request.requestId.asI64,
-          peerNumber = request.requestId.peerNum.convert,
-          requestType = requestTypeName(request),
-          receivedAt = receivedAt.toString,
-          status = status,
-          decisionStatus = decisionStatus
-        )
+        val requestId = request.requestId.asI64
+        val peerNumber = request.requestId.peerNum.convert
+        request match
+            case _: UserRequestWithId.DepositRequest =>
+                RequestDetailsView.Deposit(
+                  requestId,
+                  peerNumber,
+                  receivedAt.toString,
+                  status,
+                  absorptionDecisionStatus.getOrElse(
+                    AbsorptionDecisionStatusView.AbsorptionUnprocessed
+                  )
+                )
+            case _: UserRequestWithId.TransactionRequest =>
+                RequestDetailsView.Transaction(requestId, peerNumber, receivedAt.toString, status)
 
     /** A block's L1 effects as `l1TxId`s, grouped by kind — the fields present depend on the block
       * type (INITIAL: initialization + fallback; MINOR: sec? + refunds; MAJOR: settlement +

--- a/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
+++ b/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
@@ -3,7 +3,7 @@ package hydrozoa.multisig.server
 import hydrozoa.config.head.HeadConfig
 import hydrozoa.config.head.multisig.timing.TxTiming.BlockTimes.given
 import hydrozoa.multisig.NodeStatus
-import hydrozoa.multisig.consensus.UserRequestWithId
+import hydrozoa.multisig.consensus.{UserRequest, UserRequestBody, UserRequestWithId}
 import hydrozoa.multisig.ledger.block.{BlockBrief, BlockHeader}
 import hydrozoa.multisig.ledger.event.RequestId
 import hydrozoa.multisig.ledger.event.RequestId.ValidityFlag
@@ -14,11 +14,12 @@ import io.circe.derivation.{Configuration as CirceConfig, ConfiguredCodec}
 import io.circe.generic.semiauto.deriveCodec
 import io.circe.{Codec, Decoder, Encoder}
 import java.time.Instant
+import scala.util.Try
 import scalus.cardano.address.{Address, ShelleyAddress}
 import scalus.cardano.ledger.{DatumOption, TransactionInput, TransactionOutput, Value}
 import scalus.uplc.builtin.ByteString
-import sttp.tapir.Schema
 import sttp.tapir.generic.Configuration as TapirConfig
+import sttp.tapir.{Schema, SchemaType, Validator}
 
 /** Flat data-transfer objects for the HTTP API responses.
   *
@@ -44,8 +45,8 @@ object ApiDto {
       *
       * A discriminator value derives from a variant's constructor name, but the OpenAPI schema name
       * derives from it too — so sums that share a status vocabulary (`SOFT_CONFIRMED`, ...) give
-      * their variants a sum-specific prefix (`RequestSoftConfirmed`) for a unique schema name, and
-      * the transform strips the prefix so the `type` value stays the shared word. See
+      * their variants a sum-specific prefix (`RequestSoftConfirmedView`) for a unique schema name,
+      * and the transform strips the prefix so the `type` value stays the shared word. See
       * [[statusTag]].
       */
     private def circeTag(discriminatorValue: String => String): CirceConfig =
@@ -59,11 +60,90 @@ object ApiDto {
                 sname => discriminatorValue(sname.fullName.split('.').last)
             )
 
-    /** The name transform for a status ladder: strip the sum-specific `prefix`, then
-      * screaming-snake (`BlockSoftConfirmed` with prefix `Block` -> `SOFT_CONFIRMED`).
+    /** The name transform for a status ladder: strip the sum-specific `prefix` and the `View`
+      * suffix, then screaming-snake (`BlockSoftConfirmedView` with prefix `Block` ->
+      * `SOFT_CONFIRMED`).
       */
     private def statusTag(prefix: String): String => String =
-        name => screamingSnake(name.stripPrefix(prefix))
+        name => screamingSnake(name.stripPrefix(prefix).stripSuffix("View"))
+
+    /** The name transform for a kind sum tagged by lowercase kind (`DepositView` -> `deposit`). */
+    private def kindTag: String => String =
+        name => name.stripSuffix("View").toLowerCase
+
+    /** A closed-vocabulary string field rendered as an OpenAPI `enum`: [[enumCodec]] maps to/from
+      * the wire label, [[enumSchema]] gives `type: string` + `enum: [...]`. Modeled as typed API
+      * enums so the enum propagates automatically wherever the field appears — including inside the
+      * discriminated status sums, where a per-field validator could not reach.
+      */
+    private def enumCodec[T](all: List[T])(label: T => String): Codec[T] =
+        Codec.from(
+          Decoder.decodeString.emap(s =>
+              all.find(t => label(t) == s).toRight(s"unexpected value: $s")
+          ),
+          Encoder.encodeString.contramap(label)
+        )
+    private def enumSchema[T](all: List[T])(label: T => String): Schema[T] =
+        Schema[T](SchemaType.SString()).validate(Validator.enumeration(all, t => Some(label(t))))
+
+    /** A request's validity verdict in a block. */
+    enum ValidityView(val label: String):
+        case Valid extends ValidityView("valid")
+        case Invalid extends ValidityView("invalid")
+    object ValidityView:
+        given Codec[ValidityView] = enumCodec(values.toList)(_.label)
+        given Schema[ValidityView] = enumSchema(values.toList)(_.label)
+
+    /** A deposit's absorb-or-reject decision. */
+    enum DecisionView(val label: String):
+        case Absorbed extends DecisionView("ABSORBED")
+        case Rejected extends DecisionView("REJECTED")
+    object DecisionView:
+        given Codec[DecisionView] = enumCodec(values.toList)(_.label)
+        given Schema[DecisionView] = enumSchema(values.toList)(_.label)
+
+    /** An L1 effect's kind. */
+    enum EffectKindView(val label: String):
+        case Initialization extends EffectKindView("initialization")
+        case Settlement extends EffectKindView("settlement")
+        case Fallback extends EffectKindView("fallback")
+        case Rollout extends EffectKindView("rollout")
+        case Finalization extends EffectKindView("finalization")
+        case Refund extends EffectKindView("refund")
+        case Sec extends EffectKindView("sec")
+    object EffectKindView:
+        given Codec[EffectKindView] = enumCodec(values.toList)(_.label)
+        given Schema[EffectKindView] = enumSchema(values.toList)(_.label)
+
+    /** A block's type. */
+    enum BlockTypeView(val label: String):
+        case Initial extends BlockTypeView("initial")
+        case Minor extends BlockTypeView("minor")
+        case Major extends BlockTypeView("major")
+        case Final extends BlockTypeView("final")
+    object BlockTypeView:
+        given Codec[BlockTypeView] = enumCodec(values.toList)(_.label)
+        given Schema[BlockTypeView] = enumSchema(values.toList)(_.label)
+
+    /** A recent-transaction feed entry's kind. */
+    enum L2TxKindView(val label: String):
+        case Transaction extends L2TxKindView("transaction")
+        case DepositRegistered extends L2TxKindView("depositRegistered")
+        case DepositAbsorbed extends L2TxKindView("depositAbsorbed")
+        case DepositRejected extends L2TxKindView("depositRejected")
+    object L2TxKindView:
+        given Codec[L2TxKindView] = enumCodec(values.toList)(_.label)
+        given Schema[L2TxKindView] = enumSchema(values.toList)(_.label)
+
+    /** The node's readiness lifecycle status. */
+    enum NodeStatusView(val label: String):
+        case Initializing extends NodeStatusView("initializing")
+        case Active extends NodeStatusView("active")
+        case Finalized extends NodeStatusView("finalized")
+        case HandedOffToRuleBased extends NodeStatusView("handed-off-to-rule-based")
+    object NodeStatusView:
+        given Codec[NodeStatusView] = enumCodec(values.toList)(_.label)
+        given Schema[NodeStatusView] = enumSchema(values.toList)(_.label)
 
     /** `{ "status": "ok" }` — the liveness body. */
     final case class HealthResponse(status: String)
@@ -72,18 +152,18 @@ object ApiDto {
     /** `{ "status": "<lifecycle>" }` — the readiness diagnostic body for `GET /ready`. The verdict
       * itself is the HTTP status (200 vs 503); this is only for diagnostics.
       */
-    final case class ReadinessResponse(status: String)
+    final case class ReadinessResponse(status: NodeStatusView)
     given Codec[ReadinessResponse] = deriveCodec
 
-    /** Map the node lifecycle status to its readiness body (kebab-case label). */
+    /** Map the node lifecycle status to its readiness body. */
     def mkReadinessResponse(status: NodeStatus): ReadinessResponse =
-        ReadinessResponse(nodeStatusLabel(status))
+        ReadinessResponse(nodeStatusView(status))
 
-    private def nodeStatusLabel(status: NodeStatus): String = status match
-        case NodeStatus.Initializing         => "initializing"
-        case NodeStatus.Active               => "active"
-        case NodeStatus.Finalized            => "finalized"
-        case NodeStatus.HandedOffToRuleBased => "handed-off-to-rule-based"
+    private def nodeStatusView(status: NodeStatus): NodeStatusView = status match
+        case NodeStatus.Initializing         => NodeStatusView.Initializing
+        case NodeStatus.Active               => NodeStatusView.Active
+        case NodeStatus.Finalized            => NodeStatusView.Finalized
+        case NodeStatus.HandedOffToRuleBased => NodeStatusView.HandedOffToRuleBased
 
     /** `{ "status": "success", "message": ... }` — the finalize-trigger body. */
     final case class FinalizeResponse(status: String, message: String)
@@ -97,6 +177,47 @@ object ApiDto {
     /** Map an accepted write request's id to its i64 response body. */
     def mkRequestAcceptedResponse(id: RequestId): RequestAcceptedResponse =
         RequestAcceptedResponse(id.asI64)
+
+    /** A deposit submission: the unsigned deposit-tx CBOR (`l1Payload`) and the serialized L2
+      * outputs it spawns on absorption (`l2Payload`), both lowercase hex.
+      */
+    final case class SubmitDepositView(l1Payload: String, l2Payload: String)
+    given Codec[SubmitDepositView] = deriveCodec
+
+    /** An L2-transaction submission: the native, self-authenticating Cardano tx (`l2Payload`, hex).
+      */
+    final case class SubmitTransactionView(l2Payload: String)
+    given Codec[SubmitTransactionView] = deriveCodec
+
+    /** The submit-request body for `POST /head/requests`, **externally tagged**: exactly one of
+      * `deposit` / `transaction` is present, and its wrapper key selects the kind.
+      */
+    final case class SubmitRequestView(
+        deposit: Option[SubmitDepositView],
+        transaction: Option[SubmitTransactionView]
+    )
+    given Codec[SubmitRequestView] = deriveCodec
+
+    /** Decode a submit body into a domain `UserRequest` (hex payloads to bytes), or a client-facing
+      * error message when the tagging or the hex is malformed.
+      */
+    def toUserRequest(view: SubmitRequestView): Either[String, UserRequest] =
+        def hex(field: String, value: String): Either[String, ByteString] =
+            Try(ByteString.fromHex(value)).toEither.left.map(_ => s"$field must be lowercase hex")
+        (view.deposit, view.transaction) match
+            case (Some(d), None) =>
+                for {
+                    l1 <- hex("l1Payload", d.l1Payload)
+                    l2 <- hex("l2Payload", d.l2Payload)
+                } yield UserRequest.DepositRequest(UserRequestBody.DepositRequestBody(l1, l2))
+            case (None, Some(t)) =>
+                hex("l2Payload", t.l2Payload).map(l2 =>
+                    UserRequest.TransactionRequest(UserRequestBody.TransactionRequestBody(l2))
+                )
+            case (None, None) =>
+                Left("request body must set `deposit` or `transaction`")
+            case (Some(_), Some(_)) =>
+                Left("request body must set exactly one of `deposit` / `transaction`")
 
     /** `{ "error": ... }` — the error body used across the API. */
     final case class ErrorResponse(error: String)
@@ -114,7 +235,7 @@ object ApiDto {
     final case class L2TxSummaryView(
         requestId: RequestIdView,
         blockNumber: Int,
-        kind: String
+        kind: L2TxKindView
     )
     given Codec[RequestIdView] = deriveCodec
     given Codec[L2TxSummaryView] = deriveCodec
@@ -124,19 +245,19 @@ object ApiDto {
         L2TxSummaryView(
           requestId = mkRequestIdView(summary.requestId),
           blockNumber = summary.blockNumber.convert,
-          kind = kindName(summary.kind)
+          kind = kindView(summary.kind)
         )
 
-    private def kindName(kind: L2TxKind): String = kind match
-        case L2TxKind.Transaction       => "transaction"
-        case L2TxKind.DepositRegistered => "depositRegistered"
-        case L2TxKind.DepositAbsorbed   => "depositAbsorbed"
-        case L2TxKind.DepositRejected   => "depositRejected"
+    private def kindView(kind: L2TxKind): L2TxKindView = kind match
+        case L2TxKind.Transaction       => L2TxKindView.Transaction
+        case L2TxKind.DepositRegistered => L2TxKindView.DepositRegistered
+        case L2TxKind.DepositAbsorbed   => L2TxKindView.DepositAbsorbed
+        case L2TxKind.DepositRejected   => L2TxKindView.DepositRejected
 
     /** One row of the block listing: number, fast-cycle leader (absent for the initial block, which
       * is config, not woven), and block type.
       */
-    final case class BlockSummaryView(number: Int, leader: Option[Int], blockType: String)
+    final case class BlockSummaryView(number: Int, leader: Option[Int], blockType: BlockTypeView)
     given Codec[BlockSummaryView] = deriveCodec
 
     /** A block's confirmation from this node's viewpoint, `type`-tagged: `PROPOSED` (woven, not yet
@@ -150,9 +271,10 @@ object ApiDto {
         private given CirceConfig = circeTag(statusTag("Block"))
         private given TapirConfig = tapirTag(statusTag("Block"))
 
-        case object BlockProposed extends BlockConfirmationView
-        final case class BlockSoftConfirmed(softConfirmedAt: String) extends BlockConfirmationView
-        final case class BlockHardConfirmed(
+        case object BlockProposedView extends BlockConfirmationView
+        final case class BlockSoftConfirmedView(softConfirmedAt: String)
+            extends BlockConfirmationView
+        final case class BlockHardConfirmedView(
             softConfirmedAt: Option[String],
             hardConfirmedAt: String
         ) extends BlockConfirmationView
@@ -168,10 +290,10 @@ object ApiDto {
     object BlockHeaderView:
         // Tag with the lowercase block type (`minor` / `major` / `final` / `initial`), matching
         // `BlockDetailsView.blockType`; shadows the screaming-snake status tagging.
-        private given CirceConfig = circeTag(_.toLowerCase)
-        private given TapirConfig = tapirTag(_.toLowerCase)
+        private given CirceConfig = circeTag(kindTag)
+        private given TapirConfig = tapirTag(kindTag)
 
-        final case class Initial(
+        final case class InitialView(
             number: Int,
             versionMajor: Int,
             versionMinor: Int,
@@ -181,7 +303,7 @@ object ApiDto {
             forcedMajorBlockWakeupTime: String,
             depositDecisionWakeupTime: Option[String]
         ) extends BlockHeaderView
-        final case class Minor(
+        final case class MinorView(
             number: Int,
             versionMajor: Int,
             versionMinor: Int,
@@ -191,7 +313,7 @@ object ApiDto {
             forcedMajorBlockWakeupTime: String,
             depositDecisionWakeupTime: Option[String]
         ) extends BlockHeaderView
-        final case class Major(
+        final case class MajorView(
             number: Int,
             versionMajor: Int,
             versionMinor: Int,
@@ -201,7 +323,7 @@ object ApiDto {
             forcedMajorBlockWakeupTime: String,
             depositDecisionWakeupTime: Option[String]
         ) extends BlockHeaderView
-        final case class Final(
+        final case class FinalView(
             number: Int,
             versionMajor: Int,
             versionMinor: Int,
@@ -218,7 +340,7 @@ object ApiDto {
     final case class BlockDetailsView(
         number: Int,
         leader: Option[Int],
-        blockType: String,
+        blockType: BlockTypeView,
         stackId: Option[Int],
         confirmation: BlockConfirmationView,
         header: Option[BlockHeaderView]
@@ -228,7 +350,7 @@ object ApiDto {
     /** One of a block's transactions: the opaque request id woven into the block and the validity
       * verdict it received there.
       */
-    final case class BlockRequestView(requestId: Long, validity: String)
+    final case class BlockRequestView(requestId: Long, validity: ValidityView)
     given Codec[BlockRequestView] = deriveCodec
 
     /** The block-body body — the block's content: its transactions (the requests woven into it,
@@ -237,7 +359,7 @@ object ApiDto {
       */
     final case class BlockBodyView(
         number: Int,
-        blockType: String,
+        blockType: BlockTypeView,
         transactions: List[BlockRequestView],
         depositsAbsorbed: List[Long],
         depositsRejected: List[Long]
@@ -248,28 +370,28 @@ object ApiDto {
     def mkBlockBodyView(brief: BlockBrief.Next): BlockBodyView =
         BlockBodyView(
           number = brief.blockNum.convert,
-          blockType = blockTypeName(brief),
-          transactions = brief.requests.map((id, v) => BlockRequestView(id.asI64, validityName(v))),
+          blockType = blockTypeView(brief),
+          transactions = brief.requests.map((id, v) => BlockRequestView(id.asI64, validityView(v))),
           depositsAbsorbed = brief.depositsAbsorbed.map(_.asI64),
           depositsRejected = brief.depositsRejected.map(_.asI64)
         )
 
     /** The initial block (block 0) has no woven content. */
     def mkInitialBlockBodyView: BlockBodyView =
-        BlockBodyView(number = 0, blockType = "initial", transactions = Nil, Nil, Nil)
+        BlockBodyView(number = 0, blockType = BlockTypeView.Initial, transactions = Nil, Nil, Nil)
 
     /** Map a brief to its listing row; `nHeadPeers` fixes the round-robin leader. */
     def mkBlockSummaryView(brief: BlockBrief.Next, nHeadPeers: Int): BlockSummaryView =
         BlockSummaryView(
           number = brief.blockNum.convert,
           leader = Some(brief.blockNum.convert % nHeadPeers),
-          blockType = blockTypeName(brief)
+          blockType = blockTypeView(brief)
         )
 
     /** The synthesized listing row for the initial block (block 0 is config, not a spine entry).
       */
     def mkInitialBlockSummaryView: BlockSummaryView =
-        BlockSummaryView(number = 0, leader = None, blockType = "initial")
+        BlockSummaryView(number = 0, leader = None, blockType = BlockTypeView.Initial)
 
     /** Assemble the confirmation rung from the node-local confirmation moments (present iff their
       * record is held — `wallClockOf` is total).
@@ -280,14 +402,14 @@ object ApiDto {
     ): BlockConfirmationView =
         (softConfirmedAt, hardConfirmedAt) match
             case (soft, Some(hard)) =>
-                BlockConfirmationView.BlockHardConfirmed(soft.map(_.toString), hard.toString)
-            case (Some(soft), None) => BlockConfirmationView.BlockSoftConfirmed(soft.toString)
-            case (None, None)       => BlockConfirmationView.BlockProposed
+                BlockConfirmationView.BlockHardConfirmedView(soft.map(_.toString), hard.toString)
+            case (Some(soft), None) => BlockConfirmationView.BlockSoftConfirmedView(soft.toString)
+            case (None, None)       => BlockConfirmationView.BlockProposedView
 
-    private def blockTypeName(brief: BlockBrief.Next): String = brief match
-        case _: BlockBrief.Minor => "minor"
-        case _: BlockBrief.Major => "major"
-        case _: BlockBrief.Final => "final"
+    private def blockTypeView(brief: BlockBrief.Next): BlockTypeView = brief match
+        case _: BlockBrief.Minor => BlockTypeView.Minor
+        case _: BlockBrief.Major => BlockTypeView.Major
+        case _: BlockBrief.Final => BlockTypeView.Final
 
     /** Map a block header to its `type`-tagged view, rendering the quantized timing as ISO-8601. */
     def mkBlockHeaderView(header: BlockHeader): BlockHeaderView =
@@ -298,7 +420,7 @@ object ApiDto {
         val endTime = header.endTime.instant.toString
         header match
             case h: BlockHeader.Initial =>
-                BlockHeaderView.Initial(
+                BlockHeaderView.InitialView(
                   number,
                   versionMajor,
                   versionMinor,
@@ -309,7 +431,7 @@ object ApiDto {
                   h.mDepositDecisionWakeupTime.map(_.convert.instant.toString)
                 )
             case h: BlockHeader.Minor =>
-                BlockHeaderView.Minor(
+                BlockHeaderView.MinorView(
                   number,
                   versionMajor,
                   versionMinor,
@@ -320,7 +442,7 @@ object ApiDto {
                   h.mDepositDecisionWakeupTime.map(_.convert.instant.toString)
                 )
             case h: BlockHeader.Major =>
-                BlockHeaderView.Major(
+                BlockHeaderView.MajorView(
                   number,
                   versionMajor,
                   versionMinor,
@@ -331,24 +453,32 @@ object ApiDto {
                   h.mDepositDecisionWakeupTime.map(_.convert.instant.toString)
                 )
             case _: BlockHeader.Final =>
-                BlockHeaderView.Final(number, versionMajor, versionMinor, startTime, endTime)
+                BlockHeaderView.FinalView(number, versionMajor, versionMinor, startTime, endTime)
 
     /** One row of the request listing: the opaque request id (the packed i64, the same value the
       * submit response returns), the author peer number, and the request type.
       */
     final case class RequestSummaryView(requestId: Long, peerNumber: Int, requestType: String)
     given Codec[RequestSummaryView] = deriveCodec
+    // `requestType` is the closed set `deposit` / `transaction`; validate it so the schema renders an
+    // OpenAPI enum, matching the submit / request-details `type` discriminator vocabulary.
+    given Schema[RequestSummaryView] =
+        Schema
+            .derived[RequestSummaryView]
+            .modify(_.requestType)(
+              _.validate(Validator.enumeration(List("deposit", "transaction"), s => Some(s)))
+            )
 
     /** One L1 effect a request became: its `l1TxId` (hex — the same value the `/head/effects/{id}`
       * and block-effects queries use) and its kind (`settlement`, `finalization`, `sec`, `refund`).
       */
-    final case class EffectRefView(l1TxId: String, kind: String)
+    final case class EffectRefView(l1TxId: String, kind: EffectKindView)
     given Codec[EffectRefView] = deriveCodec
     given Schema[EffectRefView] = Schema.derived
 
     /** Map a resolved effect to its request-facing reference. */
     def mkEffectRefView(effect: ResolvedEffect): EffectRefView =
-        EffectRefView(effect.l1TxId.toHex, effectKindName(effect.kind))
+        EffectRefView(effect.l1TxId.toHex, effectKindView(effect.kind))
 
     /** A request's lifecycle status from this node's viewpoint, `type`-tagged, where each rung adds
       * the fields of the one below plus its own: `UNPROCESSED` -> `PROPOSED` (block, verdict) ->
@@ -364,17 +494,17 @@ object ApiDto {
         private given CirceConfig = circeTag(statusTag("Request"))
         private given TapirConfig = tapirTag(statusTag("Request"))
 
-        case object RequestUnprocessed extends RequestStatusView
-        final case class RequestProposed(blockNumber: Int, validity: String)
+        case object RequestUnprocessedView extends RequestStatusView
+        final case class RequestProposedView(blockNumber: Int, validity: ValidityView)
             extends RequestStatusView
-        final case class RequestSoftConfirmed(
+        final case class RequestSoftConfirmedView(
             blockNumber: Int,
-            validity: String,
+            validity: ValidityView,
             softConfirmedAt: String
         ) extends RequestStatusView
-        final case class RequestHardConfirmed(
+        final case class RequestHardConfirmedView(
             blockNumber: Int,
-            validity: String,
+            validity: ValidityView,
             softConfirmedAt: Option[String],
             hardConfirmedAt: String,
             relatedEffects: List[EffectRefView]
@@ -393,17 +523,17 @@ object ApiDto {
         private given CirceConfig = circeTag(statusTag("Absorption"))
         private given TapirConfig = tapirTag(statusTag("Absorption"))
 
-        case object AbsorptionUnprocessed extends AbsorptionDecisionStatusView
-        final case class AbsorptionProposed(blockNumber: Int, decision: String)
+        case object AbsorptionUnprocessedView extends AbsorptionDecisionStatusView
+        final case class AbsorptionProposedView(blockNumber: Int, decision: DecisionView)
             extends AbsorptionDecisionStatusView
-        final case class AbsorptionSoftConfirmed(
+        final case class AbsorptionSoftConfirmedView(
             blockNumber: Int,
-            decision: String,
+            decision: DecisionView,
             softConfirmedAt: String
         ) extends AbsorptionDecisionStatusView
-        final case class AbsorptionHardConfirmed(
+        final case class AbsorptionHardConfirmedView(
             blockNumber: Int,
-            decision: String,
+            decision: DecisionView,
             softConfirmedAt: Option[String],
             hardConfirmedAt: String,
             settlementEffect: Option[String]
@@ -420,16 +550,16 @@ object ApiDto {
     object RequestDetailsView:
         // Request-kind sums tag with the lowercase kind (`transaction` / `deposit`), shadowing the
         // screaming-snake status tagging in the enclosing scope.
-        private given CirceConfig = circeTag(_.toLowerCase)
-        private given TapirConfig = tapirTag(_.toLowerCase)
+        private given CirceConfig = circeTag(kindTag)
+        private given TapirConfig = tapirTag(kindTag)
 
-        final case class Transaction(
+        final case class TransactionView(
             requestId: Long,
             peerNumber: Int,
             receivedAt: String,
             status: RequestStatusView
         ) extends RequestDetailsView
-        final case class Deposit(
+        final case class DepositView(
             requestId: Long,
             peerNumber: Int,
             receivedAt: String,
@@ -452,9 +582,9 @@ object ApiDto {
           requestType = requestTypeName(request)
         )
 
-    private def validityName(validity: ValidityFlag): String = validity match
-        case ValidityFlag.Valid   => "valid"
-        case ValidityFlag.Invalid => "invalid"
+    private def validityView(validity: ValidityFlag): ValidityView = validity match
+        case ValidityFlag.Valid   => ValidityView.Valid
+        case ValidityFlag.Invalid => ValidityView.Invalid
 
     /** Assemble the request-status ladder from its resolved lifecycle stages: the processing block
       * and verdict (absent while unprocessed), the node-local confirmation moments (each present
@@ -468,12 +598,12 @@ object ApiDto {
         relatedEffects: List[EffectRefView]
     ): RequestStatusView =
         block match
-            case None => RequestStatusView.RequestUnprocessed
+            case None => RequestStatusView.RequestUnprocessedView
             case Some((blockNumber, v)) =>
-                val validity = validityName(v)
+                val validity = validityView(v)
                 hardConfirmedAt match
                     case Some(hard) =>
-                        RequestStatusView.RequestHardConfirmed(
+                        RequestStatusView.RequestHardConfirmedView(
                           blockNumber,
                           validity,
                           softConfirmedAt.map(_.toString),
@@ -483,18 +613,18 @@ object ApiDto {
                     case None =>
                         softConfirmedAt match
                             case Some(soft) =>
-                                RequestStatusView.RequestSoftConfirmed(
+                                RequestStatusView.RequestSoftConfirmedView(
                                   blockNumber,
                                   validity,
                                   soft.toString
                                 )
                             case None =>
-                                RequestStatusView.RequestProposed(blockNumber, validity)
+                                RequestStatusView.RequestProposedView(blockNumber, validity)
 
     /** The `ABSORBED` / `REJECTED` label of a deposit decision. */
-    def decisionName(decision: DepositDecision): String = decision match
-        case _: DepositDecision.Absorbed => "ABSORBED"
-        case _: DepositDecision.Rejected => "REJECTED"
+    def decisionView(decision: DepositDecision): DecisionView = decision match
+        case _: DepositDecision.Absorbed => DecisionView.Absorbed
+        case _: DepositDecision.Rejected => DecisionView.Rejected
 
     /** Assemble the deposit absorption-decision ladder: unprocessed (no decision row yet), else the
       * deciding block + `ABSORBED`/`REJECTED`, promoted by the deciding block's node-local
@@ -502,17 +632,17 @@ object ApiDto {
       * rides on the hard-confirmed rung.
       */
     def mkAbsorptionDecisionStatus(
-        decided: Option[(Int, String)],
+        decided: Option[(Int, DecisionView)],
         softConfirmedAt: Option[Instant],
         hardConfirmedAt: Option[Instant],
         settlementEffect: Option[String]
     ): AbsorptionDecisionStatusView =
         decided match
-            case None => AbsorptionDecisionStatusView.AbsorptionUnprocessed
+            case None => AbsorptionDecisionStatusView.AbsorptionUnprocessedView
             case Some((blockNumber, decision)) =>
                 hardConfirmedAt match
                     case Some(hard) =>
-                        AbsorptionDecisionStatusView.AbsorptionHardConfirmed(
+                        AbsorptionDecisionStatusView.AbsorptionHardConfirmedView(
                           blockNumber,
                           decision,
                           softConfirmedAt.map(_.toString),
@@ -522,13 +652,13 @@ object ApiDto {
                     case None =>
                         softConfirmedAt match
                             case Some(soft) =>
-                                AbsorptionDecisionStatusView.AbsorptionSoftConfirmed(
+                                AbsorptionDecisionStatusView.AbsorptionSoftConfirmedView(
                                   blockNumber,
                                   decision,
                                   soft.toString
                                 )
                             case None =>
-                                AbsorptionDecisionStatusView.AbsorptionProposed(
+                                AbsorptionDecisionStatusView.AbsorptionProposedView(
                                   blockNumber,
                                   decision
                                 )
@@ -546,24 +676,29 @@ object ApiDto {
         val peerNumber = request.requestId.peerNum.convert
         request match
             case _: UserRequestWithId.DepositRequest =>
-                RequestDetailsView.Deposit(
+                RequestDetailsView.DepositView(
                   requestId,
                   peerNumber,
                   receivedAt.toString,
                   status,
                   absorptionDecisionStatus.getOrElse(
-                    AbsorptionDecisionStatusView.AbsorptionUnprocessed
+                    AbsorptionDecisionStatusView.AbsorptionUnprocessedView
                   )
                 )
             case _: UserRequestWithId.TransactionRequest =>
-                RequestDetailsView.Transaction(requestId, peerNumber, receivedAt.toString, status)
+                RequestDetailsView.TransactionView(
+                  requestId,
+                  peerNumber,
+                  receivedAt.toString,
+                  status
+                )
 
     /** A block's L1 effects as `l1TxId`s, grouped by kind — the fields present depend on the block
       * type (INITIAL: initialization + fallback; MINOR: sec? + refunds; MAJOR: settlement +
       * fallback + rollouts + refunds; FINAL: finalization + rollouts). Absent kinds are omitted.
       */
     final case class BlockEffectsView(
-        blockType: String,
+        blockType: BlockTypeView,
         initialization: Option[String],
         settlement: Option[String],
         finalization: Option[String],
@@ -581,7 +716,7 @@ object ApiDto {
       */
     final case class EffectView(
         l1TxId: String,
-        kind: String,
+        kind: EffectKindView,
         blockNumber: Int,
         txCbor: Option[String],
         secOnchainSerialized: Option[String],
@@ -590,18 +725,21 @@ object ApiDto {
     )
     given Codec[EffectView] = deriveCodec
 
-    /** The effect-kind discriminator string (matches the sub-resource path segments). */
-    def effectKindName(kind: EffectKind): String = kind match
-        case EffectKind.Initialization => "initialization"
-        case EffectKind.Settlement     => "settlement"
-        case EffectKind.Fallback       => "fallback"
-        case EffectKind.Rollout        => "rollout"
-        case EffectKind.Finalization   => "finalization"
-        case EffectKind.Refund         => "refund"
-        case EffectKind.Sec            => "sec"
+    /** The effect-kind label (matches the sub-resource path segments). */
+    def effectKindView(kind: EffectKind): EffectKindView = kind match
+        case EffectKind.Initialization => EffectKindView.Initialization
+        case EffectKind.Settlement     => EffectKindView.Settlement
+        case EffectKind.Fallback       => EffectKindView.Fallback
+        case EffectKind.Rollout        => EffectKindView.Rollout
+        case EffectKind.Finalization   => EffectKindView.Finalization
+        case EffectKind.Refund         => EffectKindView.Refund
+        case EffectKind.Sec            => EffectKindView.Sec
 
     /** Group a block's resolved effects into the by-kind listing. */
-    def mkBlockEffectsView(blockType: String, effects: List[ResolvedEffect]): BlockEffectsView =
+    def mkBlockEffectsView(
+        blockType: BlockTypeView,
+        effects: List[ResolvedEffect]
+    ): BlockEffectsView =
         def firstIdOf(k: EffectKind): Option[String] =
             effects.collectFirst { case e if e.kind == k => e.l1TxId.toHex }
         def idsOf(k: EffectKind): List[String] =
@@ -624,7 +762,7 @@ object ApiDto {
         case tx: ResolvedEffect.Tx =>
             EffectView(
               l1TxId = tx.l1TxId.toHex,
-              kind = effectKindName(tx.kind),
+              kind = effectKindView(tx.kind),
               blockNumber = tx.blockNumber.convert,
               txCbor = Some(ByteString.fromArray(tx.tx.toCbor).toHex),
               secOnchainSerialized = None,
@@ -639,7 +777,7 @@ object ApiDto {
             val headerBytes: Array[Byte] = sec.commitment.commitment.header
             EffectView(
               l1TxId = sec.l1TxId.toHex,
-              kind = "sec",
+              kind = EffectKindView.Sec,
               blockNumber = sec.blockNumber.convert,
               txCbor = None,
               secOnchainSerialized = Some(ByteString.fromArray(headerBytes).toHex),

--- a/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
+++ b/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
@@ -181,43 +181,38 @@ object ApiDto {
     /** A deposit submission: the unsigned deposit-tx CBOR (`l1Payload`) and the serialized L2
       * outputs it spawns on absorption (`l2Payload`), both lowercase hex.
       */
-    final case class SubmitDepositView(l1Payload: String, l2Payload: String)
-    given Codec[SubmitDepositView] = deriveCodec
+    sealed trait SubmitRequestView
+    object SubmitRequestView:
+        // Internal tagging: a `type` field (`deposit` / `transaction`) selects the kind, with the
+        // payloads (`l1Payload` deposits only, `l2Payload` all) alongside it. The transform strips
+        // the `Submit` prefix and `View` suffix so the `type` value is the bare kind.
+        private val submitTag: String => String =
+            name => name.stripPrefix("Submit").stripSuffix("View").toLowerCase
+        private given CirceConfig = circeTag(submitTag)
+        private given TapirConfig = tapirTag(submitTag)
 
-    /** An L2-transaction submission: the native, self-authenticating Cardano tx (`l2Payload`, hex).
-      */
-    final case class SubmitTransactionView(l2Payload: String)
-    given Codec[SubmitTransactionView] = deriveCodec
-
-    /** The submit-request body for `POST /head/requests`, **externally tagged**: exactly one of
-      * `deposit` / `transaction` is present, and its wrapper key selects the kind.
-      */
-    final case class SubmitRequestView(
-        deposit: Option[SubmitDepositView],
-        transaction: Option[SubmitTransactionView]
-    )
-    given Codec[SubmitRequestView] = deriveCodec
+        final case class SubmitDepositView(l1Payload: String, l2Payload: String)
+            extends SubmitRequestView
+        final case class SubmitTransactionView(l2Payload: String) extends SubmitRequestView
+        given Codec[SubmitRequestView] = ConfiguredCodec.derived
+        given Schema[SubmitRequestView] = Schema.derived
 
     /** Decode a submit body into a domain `UserRequest` (hex payloads to bytes), or a client-facing
-      * error message when the tagging or the hex is malformed.
+      * error message when a payload is not lowercase hex.
       */
     def toUserRequest(view: SubmitRequestView): Either[String, UserRequest] =
         def hex(field: String, value: String): Either[String, ByteString] =
             Try(ByteString.fromHex(value)).toEither.left.map(_ => s"$field must be lowercase hex")
-        (view.deposit, view.transaction) match
-            case (Some(d), None) =>
+        view match
+            case SubmitRequestView.SubmitDepositView(l1Payload, l2Payload) =>
                 for {
-                    l1 <- hex("l1Payload", d.l1Payload)
-                    l2 <- hex("l2Payload", d.l2Payload)
+                    l1 <- hex("l1Payload", l1Payload)
+                    l2 <- hex("l2Payload", l2Payload)
                 } yield UserRequest.DepositRequest(UserRequestBody.DepositRequestBody(l1, l2))
-            case (None, Some(t)) =>
-                hex("l2Payload", t.l2Payload).map(l2 =>
+            case SubmitRequestView.SubmitTransactionView(l2Payload) =>
+                hex("l2Payload", l2Payload).map(l2 =>
                     UserRequest.TransactionRequest(UserRequestBody.TransactionRequestBody(l2))
                 )
-            case (None, None) =>
-                Left("request body must set `deposit` or `transaction`")
-            case (Some(_), Some(_)) =>
-                Left("request body must set exactly one of `deposit` / `transaction`")
 
     /** `{ "error": ... }` — the error body used across the API. */
     final case class ErrorResponse(error: String)
@@ -260,11 +255,21 @@ object ApiDto {
     final case class BlockSummaryView(number: Int, leader: Option[Int], blockType: BlockTypeView)
     given Codec[BlockSummaryView] = deriveCodec
 
-    /** A block's confirmation from this node's viewpoint, `type`-tagged: `PROPOSED` (woven, not yet
-      * soft-confirmed) -> `SOFT_CONFIRMED` (+ soft time) -> `HARD_CONFIRMED` (+ hard time; soft
-      * time optional, since a block may be hard-confirmed with no local soft-confirmation record).
-      * Each time records a **local event at this peer**, so different peers report different times
-      * for the same block. This is by design.
+    /** The soft-confirmation rung of the [[BlockConfirmationView]] ladder: this peer's local
+      * soft-confirmation moment (if held).
+      */
+    trait BlockSoftConfirmedRung:
+        def softConfirmedAt: Option[String]
+
+    /** The hard-confirmation rung — the one above, adding this peer's hard-confirmation moment. */
+    trait BlockHardConfirmedRung extends BlockSoftConfirmedRung:
+        def hardConfirmedAt: String
+
+    /** A block's confirmation status from this node's viewpoint, `type`-tagged and laddered:
+      * `PROPOSED` (woven, not yet soft-confirmed) -> `SOFT_CONFIRMED` (+ soft time) ->
+      * `HARD_CONFIRMED` (+ hard time; soft time optional, since a block may be hard-confirmed with
+      * no local soft-confirmation record). Each time records a **local event at this peer**, so
+      * different peers report different times for the same block. This is by design.
       */
     sealed trait BlockConfirmationView
     object BlockConfirmationView:
@@ -272,12 +277,14 @@ object ApiDto {
         private given TapirConfig = tapirTag(statusTag("Block"))
 
         case object BlockProposedView extends BlockConfirmationView
-        final case class BlockSoftConfirmedView(softConfirmedAt: String)
-            extends BlockConfirmationView
+        final case class BlockSoftConfirmedView(softConfirmedAt: Option[String])
+            extends BlockConfirmationView,
+              BlockSoftConfirmedRung
         final case class BlockHardConfirmedView(
             softConfirmedAt: Option[String],
             hardConfirmedAt: String
-        ) extends BlockConfirmationView
+        ) extends BlockConfirmationView,
+              BlockHardConfirmedRung
         given Codec[BlockConfirmationView] = ConfiguredCodec.derived
         given Schema[BlockConfirmationView] = Schema.derived
 
@@ -342,7 +349,7 @@ object ApiDto {
         leader: Option[Int],
         blockType: BlockTypeView,
         stackId: Option[Int],
-        confirmation: BlockConfirmationView,
+        status: BlockConfirmationView,
         header: Option[BlockHeaderView]
     )
     given Codec[BlockDetailsView] = deriveCodec
@@ -403,8 +410,9 @@ object ApiDto {
         (softConfirmedAt, hardConfirmedAt) match
             case (soft, Some(hard)) =>
                 BlockConfirmationView.BlockHardConfirmedView(soft.map(_.toString), hard.toString)
-            case (Some(soft), None) => BlockConfirmationView.BlockSoftConfirmedView(soft.toString)
-            case (None, None)       => BlockConfirmationView.BlockProposedView
+            case (Some(soft), None) =>
+                BlockConfirmationView.BlockSoftConfirmedView(Some(soft.toString))
+            case (None, None) => BlockConfirmationView.BlockProposedView
 
     private def blockTypeView(brief: BlockBrief.Next): BlockTypeView = brief match
         case _: BlockBrief.Minor => BlockTypeView.Minor
@@ -693,21 +701,38 @@ object ApiDto {
                   status
                 )
 
-    /** A block's L1 effects as `l1TxId`s, grouped by kind — the fields present depend on the block
-      * type (INITIAL: initialization + fallback; MINOR: sec? + refunds; MAJOR: settlement +
-      * fallback + rollouts + refunds; FINAL: finalization + rollouts). Absent kinds are omitted.
+    /** A block's L1 effects as `l1TxId`s, `type`-tagged by block type — each variant carries only
+      * the effect kinds that block type produces: `initial` (initialization + fallback), `minor`
+      * (an optional sec + refunds), `major` (settlement + fallback + rollouts + refunds), `final`
+      * (finalization + rollouts).
       */
-    final case class BlockEffectsView(
-        blockType: BlockTypeView,
-        initialization: Option[String],
-        settlement: Option[String],
-        finalization: Option[String],
-        fallback: Option[String],
-        sec: Option[String],
-        rollouts: List[String],
-        refunds: List[String]
-    )
-    given Codec[BlockEffectsView] = deriveCodec
+    sealed trait BlockEffectsView
+    object BlockEffectsView:
+        private val blockEffectsTag: String => String =
+            name => name.stripPrefix("BlockEffects").stripSuffix("View").toLowerCase
+        private given CirceConfig = circeTag(blockEffectsTag)
+        private given TapirConfig = tapirTag(blockEffectsTag)
+
+        final case class BlockEffectsInitialView(
+            initialization: Option[String],
+            fallback: Option[String]
+        ) extends BlockEffectsView
+        final case class BlockEffectsMinorView(
+            sec: Option[String],
+            refunds: List[String]
+        ) extends BlockEffectsView
+        final case class BlockEffectsMajorView(
+            settlement: Option[String],
+            fallback: Option[String],
+            rollouts: List[String],
+            refunds: List[String]
+        ) extends BlockEffectsView
+        final case class BlockEffectsFinalView(
+            finalization: Option[String],
+            rollouts: List[String]
+        ) extends BlockEffectsView
+        given Codec[BlockEffectsView] = ConfiguredCodec.derived
+        given Schema[BlockEffectsView] = Schema.derived
 
     /** An L1 effect in full, `type`-tagged by kind — the `GET /head/effects/{l1TxId}` response. Its
       * `l1TxId` is the queried path, so it is not echoed. Each real-tx kind carries its `txCbor`
@@ -764,7 +789,7 @@ object ApiDto {
         case EffectKind.Refund         => EffectKindView.Refund
         case EffectKind.Sec            => EffectKindView.Sec
 
-    /** Group a block's resolved effects into the by-kind listing. */
+    /** Group a block's resolved effects into the per-block-type listing. */
     def mkBlockEffectsView(
         blockType: BlockTypeView,
         effects: List[ResolvedEffect]
@@ -773,16 +798,29 @@ object ApiDto {
             effects.collectFirst { case e if e.kind == k => e.l1TxId.toHex }
         def idsOf(k: EffectKind): List[String] =
             effects.collect { case e if e.kind == k => e.l1TxId.toHex }
-        BlockEffectsView(
-          blockType = blockType,
-          initialization = firstIdOf(EffectKind.Initialization),
-          settlement = firstIdOf(EffectKind.Settlement),
-          finalization = firstIdOf(EffectKind.Finalization),
-          fallback = firstIdOf(EffectKind.Fallback),
-          sec = firstIdOf(EffectKind.Sec),
-          rollouts = idsOf(EffectKind.Rollout),
-          refunds = idsOf(EffectKind.Refund)
-        )
+        blockType match
+            case BlockTypeView.Initial =>
+                BlockEffectsView.BlockEffectsInitialView(
+                  firstIdOf(EffectKind.Initialization),
+                  firstIdOf(EffectKind.Fallback)
+                )
+            case BlockTypeView.Minor =>
+                BlockEffectsView.BlockEffectsMinorView(
+                  firstIdOf(EffectKind.Sec),
+                  idsOf(EffectKind.Refund)
+                )
+            case BlockTypeView.Major =>
+                BlockEffectsView.BlockEffectsMajorView(
+                  firstIdOf(EffectKind.Settlement),
+                  firstIdOf(EffectKind.Fallback),
+                  idsOf(EffectKind.Rollout),
+                  idsOf(EffectKind.Refund)
+                )
+            case BlockTypeView.Final =>
+                BlockEffectsView.BlockEffectsFinalView(
+                  firstIdOf(EffectKind.Finalization),
+                  idsOf(EffectKind.Rollout)
+                )
 
     /** Map any resolved effect to the `type`-tagged by-id view (no `l1TxId` — it is the queried
       * path); `nHeadPeers` splits an SEC's hard-ack signatures into head (first `nHeadPeers`) then

--- a/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
+++ b/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
@@ -113,14 +113,50 @@ object ApiDto {
     )
     given Codec[BlockConfirmationView] = deriveCodec
 
-    /** The block-details body: the listing row plus the confirmation status. */
+    /** The block-details body: the listing row, the hard-confirming stack's number (absent until
+      * the block is hard-confirmed), and the confirmation status.
+      */
     final case class BlockDetailsView(
         number: Int,
         leader: Option[Int],
         blockType: String,
+        stackId: Option[Int],
         confirmation: BlockConfirmationView
     )
     given Codec[BlockDetailsView] = deriveCodec
+
+    /** One of a block's transactions: the opaque request id woven into the block and the validity
+      * verdict it received there.
+      */
+    final case class BlockRequestView(requestId: Long, validity: String)
+    given Codec[BlockRequestView] = deriveCodec
+
+    /** The block-body body — the block's content: its transactions (the requests woven into it,
+      * each with its verdict) and its deposit decisions (the request ids absorbed into the treasury
+      * and those rejected).
+      */
+    final case class BlockBodyView(
+        number: Int,
+        blockType: String,
+        transactions: List[BlockRequestView],
+        depositsAbsorbed: List[Long],
+        depositsRejected: List[Long]
+    )
+    given Codec[BlockBodyView] = deriveCodec
+
+    /** Map a block's brief to its content view. */
+    def mkBlockBodyView(brief: BlockBrief.Next): BlockBodyView =
+        BlockBodyView(
+          number = brief.blockNum.convert,
+          blockType = blockTypeName(brief),
+          transactions = brief.requests.map((id, v) => BlockRequestView(id.asI64, validityName(v))),
+          depositsAbsorbed = brief.depositsAbsorbed.map(_.asI64),
+          depositsRejected = brief.depositsRejected.map(_.asI64)
+        )
+
+    /** The initial block (block 0) has no woven content. */
+    def mkInitialBlockBodyView: BlockBodyView =
+        BlockBodyView(number = 0, blockType = "initial", transactions = Nil, Nil, Nil)
 
     /** Map a brief to its listing row; `nHeadPeers` fixes the round-robin leader. */
     def mkBlockSummaryView(brief: BlockBrief.Next, nHeadPeers: Int): BlockSummaryView =

--- a/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
+++ b/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
@@ -709,21 +709,50 @@ object ApiDto {
     )
     given Codec[BlockEffectsView] = deriveCodec
 
-    /** One L1 effect in full. Every effect has an `l1TxId`, `kind`, and `blockNumber`. A real tx
-      * effect carries its `txCbor` (hex); a standalone evacuation commitment (kind `sec`) carries
-      * its serialized on-chain bytes (whose hash is the synthetic `l1TxId`) and the hard-ack
-      * signatures split into `headSignatures` then `coilSignatures`.
+    /** An L1 effect in full, `type`-tagged by kind — the `GET /head/effects/{l1TxId}` response. Its
+      * `l1TxId` is the queried path, so it is not echoed. Each real-tx kind carries its `txCbor`
+      * (hex); `sec` (a standalone evacuation commitment, whose synthetic hash is that l1TxId)
+      * carries its serialized on-chain bytes and the hard-ack signatures split `headSignatures`
+      * then `coilSignatures`.
       */
-    final case class EffectView(
+    sealed trait EffectView
+    object EffectView:
+        private given CirceConfig = circeTag(kindTag)
+        private given TapirConfig = tapirTag(kindTag)
+
+        final case class InitializationView(blockNumber: Int, txCbor: String) extends EffectView
+        final case class SettlementView(blockNumber: Int, txCbor: String) extends EffectView
+        final case class FallbackView(blockNumber: Int, txCbor: String) extends EffectView
+        final case class RolloutView(blockNumber: Int, txCbor: String) extends EffectView
+        final case class FinalizationView(blockNumber: Int, txCbor: String) extends EffectView
+        final case class RefundView(blockNumber: Int, txCbor: String) extends EffectView
+        final case class SecView(
+            blockNumber: Int,
+            secOnchainSerialized: String,
+            headSignatures: List[String],
+            coilSignatures: List[String]
+        ) extends EffectView
+        given Codec[EffectView] = ConfiguredCodec.derived
+        given Schema[EffectView] = Schema.derived
+
+    /** A real-tx effect at a path-fixed kind — the block-scoped by-kind endpoints' response (the
+      * kind is the path, so it is not discriminated). Carries its `l1TxId` and `txCbor` (hex).
+      */
+    final case class TxEffectView(l1TxId: String, blockNumber: Int, txCbor: String)
+    given Codec[TxEffectView] = deriveCodec
+
+    /** A standalone evacuation commitment (SEC) effect — the block-scoped `sec` endpoint's
+      * response. Carries its `l1TxId` (the synthetic hash), on-chain bytes, and split hard-ack
+      * signatures.
+      */
+    final case class SecEffectView(
         l1TxId: String,
-        kind: EffectKindView,
         blockNumber: Int,
-        txCbor: Option[String],
-        secOnchainSerialized: Option[String],
-        headSignatures: Option[List[String]],
-        coilSignatures: Option[List[String]]
+        secOnchainSerialized: String,
+        headSignatures: List[String],
+        coilSignatures: List[String]
     )
-    given Codec[EffectView] = deriveCodec
+    given Codec[SecEffectView] = deriveCodec
 
     /** The effect-kind label (matches the sub-resource path segments). */
     def effectKindView(kind: EffectKind): EffectKindView = kind match
@@ -755,35 +784,64 @@ object ApiDto {
           refunds = idsOf(EffectKind.Refund)
         )
 
-    /** Map a resolved effect to its full view; `nHeadPeers` splits an SEC's hard-ack signatures
-      * into head (first `nHeadPeers`) then coil.
+    /** Map any resolved effect to the `type`-tagged by-id view (no `l1TxId` — it is the queried
+      * path); `nHeadPeers` splits an SEC's hard-ack signatures into head (first `nHeadPeers`) then
+      * coil.
       */
     def mkEffectView(effect: ResolvedEffect, nHeadPeers: Int): EffectView = effect match
         case tx: ResolvedEffect.Tx =>
-            EffectView(
-              l1TxId = tx.l1TxId.toHex,
-              kind = effectKindView(tx.kind),
-              blockNumber = tx.blockNumber.convert,
-              txCbor = Some(ByteString.fromArray(tx.tx.toCbor).toHex),
-              secOnchainSerialized = None,
-              headSignatures = None,
-              coilSignatures = None
-            )
+            val blockNumber = tx.blockNumber.convert
+            val cbor = txCborHex(tx)
+            tx.kind match
+                case EffectKind.Initialization => EffectView.InitializationView(blockNumber, cbor)
+                case EffectKind.Settlement     => EffectView.SettlementView(blockNumber, cbor)
+                case EffectKind.Fallback       => EffectView.FallbackView(blockNumber, cbor)
+                case EffectKind.Rollout        => EffectView.RolloutView(blockNumber, cbor)
+                case EffectKind.Finalization   => EffectView.FinalizationView(blockNumber, cbor)
+                case EffectKind.Refund         => EffectView.RefundView(blockNumber, cbor)
+                case EffectKind.Sec =>
+                    throw new IllegalStateException(s"tx effect ${tx.l1TxId.toHex} tagged Sec")
         case sec: ResolvedEffect.Sec =>
-            val sigsHex = sec.commitment.headerMultiSigned.map { sig =>
-                val bytes: Array[Byte] = sig
-                ByteString.fromArray(bytes).toHex
-            }
-            val headerBytes: Array[Byte] = sec.commitment.commitment.header
-            EffectView(
-              l1TxId = sec.l1TxId.toHex,
-              kind = EffectKindView.Sec,
-              blockNumber = sec.blockNumber.convert,
-              txCbor = None,
-              secOnchainSerialized = Some(ByteString.fromArray(headerBytes).toHex),
-              headSignatures = Some(sigsHex.take(nHeadPeers)),
-              coilSignatures = Some(sigsHex.drop(nHeadPeers))
+            val (headSignatures, coilSignatures) = secSignatures(sec, nHeadPeers)
+            EffectView.SecView(
+              sec.blockNumber.convert,
+              secOnchainHex(sec),
+              headSignatures,
+              coilSignatures
             )
+
+    /** Map a real-tx effect to the block-scoped by-kind view (carries `l1TxId`). */
+    def mkTxEffectView(tx: ResolvedEffect.Tx): TxEffectView =
+        TxEffectView(tx.l1TxId.toHex, tx.blockNumber.convert, txCborHex(tx))
+
+    /** Map an SEC effect to the block-scoped `sec` view (carries `l1TxId`). */
+    def mkSecEffectView(sec: ResolvedEffect.Sec, nHeadPeers: Int): SecEffectView =
+        val (headSignatures, coilSignatures) = secSignatures(sec, nHeadPeers)
+        SecEffectView(
+          sec.l1TxId.toHex,
+          sec.blockNumber.convert,
+          secOnchainHex(sec),
+          headSignatures,
+          coilSignatures
+        )
+
+    private def txCborHex(tx: ResolvedEffect.Tx): String =
+        ByteString.fromArray(tx.tx.toCbor).toHex
+
+    private def secOnchainHex(sec: ResolvedEffect.Sec): String =
+        val headerBytes: Array[Byte] = sec.commitment.commitment.header
+        ByteString.fromArray(headerBytes).toHex
+
+    /** An SEC's hard-ack signatures (hex), split into head (first `nHeadPeers`) then coil. */
+    private def secSignatures(
+        sec: ResolvedEffect.Sec,
+        nHeadPeers: Int
+    ): (List[String], List[String]) =
+        val sigsHex = sec.commitment.headerMultiSigned.map { sig =>
+            val bytes: Array[Byte] = sig
+            ByteString.fromArray(bytes).toHex
+        }
+        (sigsHex.take(nHeadPeers), sigsHex.drop(nHeadPeers))
 
     /** A utxo reference, `{ transaction_id, index }` (CIP-0116). */
     final case class TxInputView(transaction_id: String, index: Int)

--- a/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
+++ b/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
@@ -299,7 +299,7 @@ class HydrozoaRoutes(
             .errorOut(errorOut)
             .description(
               "One request's peer, type, receive time, and lifecycle status: UNPROCESSED, " +
-                  "LOCALLY_PROCESSED (block + validity), SOFT_CONFIRMED (+ soft-confirmation " +
+                  "PROPOSED (block + validity), SOFT_CONFIRMED (+ soft-confirmation " +
                   "time), or HARD_CONFIRMED (+ hard-confirmation time and the related L1 effects — " +
                   "the l1TxIds the request became). Every time records a " +
                   "local event at this peer — when it received the request, and when it produced " +
@@ -558,7 +558,8 @@ class HydrozoaRoutes(
                     summary.leader,
                     summary.blockType,
                     stack.map(_.convert),
-                    confirmation
+                    confirmation,
+                    header = None
                   )
                 )
             }
@@ -577,7 +578,8 @@ class HydrozoaRoutes(
                             summary.leader,
                             summary.blockType,
                             stack.map(_.convert),
-                            confirmation
+                            confirmation,
+                            header = Some(ApiDto.mkBlockHeaderView(brief.header))
                           )
                         )
                     }
@@ -735,21 +737,27 @@ class HydrozoaRoutes(
                       hardConfirmedAt = hardAt,
                       relatedEffects = effects.map(ApiDto.mkEffectRefView)
                     )
-                    decisionStatus <- depositDecisionStatus(id, stamped.payload, processed)
+                    absorptionDecisionStatus <-
+                        depositAbsorptionDecisionStatus(id, stamped.payload, processed)
                 } yield Right(
-                  ApiDto.mkRequestDetailsView(stamped.payload, receivedAt, status, decisionStatus)
+                  ApiDto.mkRequestDetailsView(
+                    stamped.payload,
+                    receivedAt,
+                    status,
+                    absorptionDecisionStatus
+                  )
                 )
         }
 
-    /** A valid deposit request's decision status (undecided / local-decision / confirmed), or
-      * `None` for a transaction or a deposit already ruled invalid. The confirmation moments are of
-      * the **deciding** block; the absorbing settlement rides on the hard-confirmed rung.
+    /** A valid deposit request's absorption-decision status (unprocessed / proposed / confirmed),
+      * or `None` for a transaction or a deposit already ruled invalid. The confirmation moments are
+      * of the **deciding** block; the absorbing settlement rides on the hard-confirmed rung.
       */
-    private def depositDecisionStatus(
+    private def depositAbsorptionDecisionStatus(
         id: RequestId,
         request: UserRequestWithId,
         processed: Option[RequestBlockEntry]
-    ): IO[Option[DepositDecisionStatusView]] =
+    ): IO[Option[AbsorptionDecisionStatusView]] =
         val isDeposit = ApiDto.requestTypeName(request) == "deposit"
         val isInvalid = processed.exists(_.validity == RequestId.ValidityFlag.Invalid)
         if !isDeposit || isInvalid then IO.pure(None)
@@ -763,7 +771,7 @@ class HydrozoaRoutes(
                 (softAt, hardAt) = times
                 settlement <- effectsResolver.depositSettlement(id)
             } yield Some(
-              ApiDto.mkDecisionStatus(
+              ApiDto.mkAbsorptionDecisionStatus(
                 decided = decision.map(d => (d.block.convert, ApiDto.decisionName(d))),
                 softConfirmedAt = softAt,
                 hardConfirmedAt = hardAt,

--- a/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
+++ b/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
@@ -13,7 +13,6 @@ import hydrozoa.multisig.ledger.l2.EutxoL2LedgerReader
 import hydrozoa.multisig.persistence.{ConsensusStoreReader, RequestBlockEntry}
 import hydrozoa.multisig.server.ApiDto.*
 import hydrozoa.multisig.server.HydrozoaHttpEvent.*
-import hydrozoa.multisig.server.JsonCodecs.UserRequestDecoder
 import hydrozoa.multisig.server.TapirJson.*
 import java.time.Instant
 import org.http4s.HttpRoutes
@@ -57,9 +56,6 @@ class HydrozoaRoutes(
     /** How many recent L2 transactions to return when `?count=` is omitted. */
     private val defaultRecentTxCount = 50
 
-    /** The decoder for user requests (deposit registrations and L2 transactions). */
-    private val userRequestDecoder: UserRequestDecoder = UserRequestDecoder()
-
     /** The shared error output: an HTTP status plus an `{ error }` body. */
     private val errorOut: EndpointOutput[(StatusCode, ErrorResponse)] =
         statusCode.and(jsonBody[ErrorResponse])
@@ -83,15 +79,17 @@ class HydrozoaRoutes(
         endpoint.post
             .in("head" / "requests")
             .name("postHeadRequest")
-            .in(stringJsonBody)
+            .tag("Requests")
+            .in(jsonBody[SubmitRequestView])
             .out(jsonBody[RequestAcceptedResponse])
             .errorOut(errorOut)
             .description(
-              "Submit a request. A root field tags the type: " +
+              "Submit a request. A wrapper key tags the type — set exactly one: " +
                   "`{ \"deposit\": { \"l1Payload\", \"l2Payload\" } }` registers an L1 deposit " +
                   "(the unsigned deposit-tx CBOR plus the serialized L2 outputs it spawns on " +
                   "absorption); `{ \"transaction\": { \"l2Payload\" } }` submits an L2 transaction " +
-                  "(a native, self-authenticating Cardano tx). Returns the assigned request id."
+                  "(a native, self-authenticating Cardano tx). Payloads are lowercase hex. Returns " +
+                  "the assigned request id."
             )
             .serverLogic(body => acceptUserRequest("POST /head/requests", body))
 
@@ -151,6 +149,7 @@ class HydrozoaRoutes(
         endpoint.get
             .in("head" / "blocks")
             .name("getHeadBlocks")
+            .tag("Blocks")
             .out(jsonBody[List[BlockSummaryView]])
             .errorOut(errorOut)
             .description(
@@ -172,14 +171,15 @@ class HydrozoaRoutes(
         endpoint.get
             .in("head" / "blocks" / path[BlockNumber]("block-number"))
             .name("getHeadBlock")
+            .tag("Blocks")
             .out(jsonBody[BlockDetailsView])
             .errorOut(errorOut)
             .description(
-              "One block's type, leader, and confirmation status: PROPOSED, SOFT (+ " +
-                  "soft-confirmation time), or HARD (+ hard-confirmation time). Each confirmation " +
-                  "time records a local event at this peer — when it produced the soft/hard " +
-                  "confirmation — so different peers report different times for the same block. " +
-                  "This is by design."
+              "One block's type, leader, hard-confirming stack, full header, and confirmation " +
+                  "status: PROPOSED, SOFT_CONFIRMED (+ soft-confirmation time), or HARD_CONFIRMED " +
+                  "(+ hard-confirmation time). Each confirmation time records a local event at this " +
+                  "peer — when it produced the soft/hard confirmation — so different peers report " +
+                  "different times for the same block. This is by design."
             )
             .serverLogic(num =>
                 blockDetails(num)
@@ -190,6 +190,7 @@ class HydrozoaRoutes(
         endpoint.get
             .in("head" / "blocks" / path[BlockNumber]("block-number") / "body")
             .name("getHeadBlockBody")
+            .tag("Blocks")
             .out(jsonBody[BlockBodyView])
             .errorOut(errorOut)
             .description(
@@ -206,6 +207,7 @@ class HydrozoaRoutes(
         endpoint.get
             .in("head" / "blocks" / path[BlockNumber]("block-number") / "effects")
             .name("getHeadBlockEffects")
+            .tag("Blocks")
             .out(jsonBody[BlockEffectsView])
             .errorOut(errorOut)
             .description(
@@ -228,6 +230,7 @@ class HydrozoaRoutes(
         endpoint.get
             .in("head" / "blocks" / path[BlockNumber]("block-number") / "effects" / segment)
             .name(s"getHeadBlockEffect_$segment")
+            .tag("Blocks")
             .out(jsonBody[EffectView])
             .errorOut(errorOut)
             .description(s"The block's $segment effect in full, or 404 if it has none.")
@@ -243,6 +246,7 @@ class HydrozoaRoutes(
                   path[Int]("number")
             )
             .name("getHeadBlockRollout")
+            .tag("Blocks")
             .out(jsonBody[EffectView])
             .errorOut(errorOut)
             .description("One rollout of the block's rollout chain by index, or 404 if absent.")
@@ -255,6 +259,7 @@ class HydrozoaRoutes(
         endpoint.get
             .in("head" / "effects" / path[TransactionHash]("l1TxId"))
             .name("getHeadEffect")
+            .tag("Effects")
             .out(jsonBody[EffectView])
             .errorOut(errorOut)
             .description("Any effect by its l1TxId (real tx id, or an SEC's synthetic hash).")
@@ -279,6 +284,7 @@ class HydrozoaRoutes(
             .in(query[Option[String]]("type"))
             .in(query[Option[Int]]("peer_number"))
             .name("getHeadRequests")
+            .tag("Requests")
             .out(jsonBody[List[RequestSummaryView]])
             .errorOut(errorOut)
             .description(
@@ -295,6 +301,7 @@ class HydrozoaRoutes(
         endpoint.get
             .in("head" / "requests" / path[RequestId]("request-id"))
             .name("getHeadRequest")
+            .tag("Requests")
             .out(jsonBody[RequestDetailsView])
             .errorOut(errorOut)
             .description(
@@ -400,6 +407,7 @@ class HydrozoaRoutes(
             .securityIn(auth.basic[Option[UsernamePassword]](adminChallenge))
             .in("api" / "admin" / "finalize")
             .name("postAdminFinalize")
+            .tag("Governance")
             .out(jsonBody[FinalizeResponse])
             .errorOut(finalizeErrorOut)
             .description("Trigger head finalization (admin only).")
@@ -462,13 +470,17 @@ class HydrozoaRoutes(
           finalizeEndpoint
         ) ++ blockEffectKindEndpoints
 
-    /** Don't auto-document a body/param decode-failure response: our JSON bodies are raw strings
-      * whose codec never fails, so tapir's default would advertise an unreachable `text/plain` 400
-      * that contradicts the real JSON `ErrorResponse`. The genuine errors are on each endpoint's
-      * declared error output.
+    /** OpenAPI doc options:
+      *   - drop the `View` suffix from every DTO's component-schema name (the Scala types keep it
+      *     as a domain-vs-DTO convention; the spec reads cleaner without it);
+      *   - don't auto-document a body/param decode-failure response — tapir's default advertises a
+      *     `text/plain` 400 that contradicts each endpoint's declared JSON `ErrorResponse`.
       */
     private val docsOptions: OpenAPIDocsOptions =
-        OpenAPIDocsOptions.default.copy(defaultDecodeFailureOutput = _ => None)
+        OpenAPIDocsOptions.default.copy(
+          defaultDecodeFailureOutput = _ => None,
+          schemaName = sname => OpenAPIDocsOptions.default.schemaName(sname).stripSuffix("View")
+        )
 
     /** Swagger UI (served at `/docs`) + the raw OpenAPI document for the core API. */
     private val coreDocsEndpoints: List[ServerEndpoint[Any, IO]] =
@@ -505,23 +517,14 @@ class HydrozoaRoutes(
       */
     private def acceptUserRequest(
         path: String,
-        bodyText: String
+        body: SubmitRequestView
     ): IO[Either[(StatusCode, ErrorResponse), RequestAcceptedResponse]] =
         val handled =
             for {
-                _ <- tracer.traceWith(RequestBody(path, bodyText))
-                json <- io.circe.parser.parse(bodyText) match {
-                    case Left(parseError) =>
-                        tracer.traceWith(JsonParseError(path, parseError)) *>
-                            IO.raiseError(parseError)
-                    case Right(json) => IO.pure(json)
-                }
-                userRequest <- userRequestDecoder.decodeJson(json) match {
-                    case Left(decodeError) =>
-                        tracer.traceWith(JsonDecodeError(path, decodeError)) *>
-                            tracer.traceWith(
-                              JsonDecodeErrorHistory(path, decodeError.history.toString)
-                            ) *> IO.raiseError(decodeError)
+                userRequest <- ApiDto.toUserRequest(body) match {
+                    case Left(message) =>
+                        val error = new RuntimeException(message)
+                        tracer.traceWith(JsonDecodeError(path, error)) *> IO.raiseError(error)
                     case Right(request) => IO.pure(request)
                 }
                 _ <- tracer.traceWith(RequestDecoded(path, userRequest.toString))
@@ -601,15 +604,15 @@ class HydrozoaRoutes(
     /** The block's type — `initial` for block 0 (config), else read from its brief. `None` if a
       * non-zero block does not exist.
       */
-    private def blockTypeOf(num: BlockNumber): IO[Option[String]] =
-        if num == BlockNumber.zero then IO.pure(Some("initial"))
+    private def blockTypeOf(num: BlockNumber): IO[Option[ApiDto.BlockTypeView]] =
+        if num == BlockNumber.zero then IO.pure(Some(ApiDto.BlockTypeView.Initial))
         else
             consensusReader
                 .blockBrief(num)
                 .map(_.map {
-                    case _: BlockBrief.Minor => "minor"
-                    case _: BlockBrief.Major => "major"
-                    case _: BlockBrief.Final => "final"
+                    case _: BlockBrief.Minor => ApiDto.BlockTypeView.Minor
+                    case _: BlockBrief.Major => ApiDto.BlockTypeView.Major
+                    case _: BlockBrief.Final => ApiDto.BlockTypeView.Final
                 })
 
     /** The block-effects listing (l1TxIds grouped by kind), or a 404 when the block does not exist.
@@ -772,7 +775,7 @@ class HydrozoaRoutes(
                 settlement <- effectsResolver.depositSettlement(id)
             } yield Some(
               ApiDto.mkAbsorptionDecisionStatus(
-                decided = decision.map(d => (d.block.convert, ApiDto.decisionName(d))),
+                decided = decision.map(d => (d.block.convert, ApiDto.decisionView(d))),
                 softConfirmedAt = softAt,
                 hardConfirmedAt = hardAt,
                 settlementEffect = settlement.map(_.l1TxId.toHex)

--- a/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
+++ b/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
@@ -3,7 +3,6 @@ package hydrozoa.multisig.server
 import cats.effect.IO
 import cats.syntax.traverse.*
 import hydrozoa.config.head.HeadConfig
-import hydrozoa.config.head.network.CardanoNetwork
 import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.NodeStatus
 import hydrozoa.multisig.consensus.peer.HeadPeerNumber
@@ -16,8 +15,6 @@ import hydrozoa.multisig.server.ApiDto.*
 import hydrozoa.multisig.server.HydrozoaHttpEvent.*
 import hydrozoa.multisig.server.JsonCodecs.UserRequestDecoder
 import hydrozoa.multisig.server.TapirJson.*
-import io.circe.Json
-import io.circe.syntax.*
 import java.time.Instant
 import org.http4s.HttpRoutes
 import scala.util.Try
@@ -53,11 +50,6 @@ class HydrozoaRoutes(
     tracer: ContraTracer[IO, HydrozoaHttpEvent]
 ) {
     import HydrozoaRoutes.{apiTitle, apiVersion, l2ApiTitle}
-
-    /** The block-0 header encoder and the brief codecs are `CardanoNetwork.Section`-dependent;
-      * `headConfig` satisfies the section.
-      */
-    private given CardanoNetwork.Section = headConfig
 
     /** Decomposes hard-confirmed stacks' effects onto blocks for the effect queries. */
     private val effectsResolver: EffectsResolver = EffectsResolver(consensusReader)
@@ -194,18 +186,19 @@ class HydrozoaRoutes(
                     .handleError(err => Left(fail(StatusCode.InternalServerError, err.getMessage)))
             )
 
-    private val blockHeaderEndpoint: ServerEndpoint[Any, IO] =
+    private val blockBodyEndpoint: ServerEndpoint[Any, IO] =
         endpoint.get
-            .in("head" / "blocks" / path[BlockNumber]("block-number") / "header")
-            .name("getHeadBlockHeader")
-            .out(jsonBody[Json])
+            .in("head" / "blocks" / path[BlockNumber]("block-number") / "body")
+            .name("getHeadBlockBody")
+            .out(jsonBody[BlockBodyView])
             .errorOut(errorOut)
             .description(
-              "The block's header content. The shape varies by block type (initial, minor, " +
-                  "major, final)."
+              "The block's content: its transactions (the request ids woven into the block, each " +
+                  "with its validity verdict) and its deposit decisions (the request ids absorbed " +
+                  "into the treasury and those rejected). 404 if the block does not exist."
             )
             .serverLogic(num =>
-                blockHeader(num)
+                blockBody(num)
                     .handleError(err => Left(fail(StatusCode.InternalServerError, err.getMessage)))
             )
 
@@ -460,7 +453,7 @@ class HydrozoaRoutes(
           requestDetailsEndpoint,
           blocksEndpoint,
           blockDetailsEndpoint,
-          blockHeaderEndpoint,
+          blockBodyEndpoint,
           blockEffectsEndpoint,
           effectByIdEndpoint,
           blockRolloutEndpoint,
@@ -554,44 +547,53 @@ class HydrozoaRoutes(
         num: BlockNumber
     ): IO[Either[(StatusCode, ErrorResponse), BlockDetailsView]] =
         if num == BlockNumber.zero then
-            blockConfirmation(num).map(confirmation =>
+            for {
+                confirmation <- blockConfirmation(num)
+                stack <- consensusReader.stackOf(num)
+            } yield {
                 val summary = ApiDto.mkInitialBlockSummaryView
                 Right(
-                  BlockDetailsView(summary.number, summary.leader, summary.blockType, confirmation)
+                  BlockDetailsView(
+                    summary.number,
+                    summary.leader,
+                    summary.blockType,
+                    stack.map(_.convert),
+                    confirmation
+                  )
                 )
-            )
+            }
         else
             consensusReader.blockBrief(num).flatMap {
                 case None => IO.pure(Left(blockNotFound(num)))
                 case Some(brief) =>
-                    blockConfirmation(num).map(confirmation =>
+                    for {
+                        confirmation <- blockConfirmation(num)
+                        stack <- consensusReader.stackOf(num)
+                    } yield {
                         val summary = ApiDto.mkBlockSummaryView(brief, headConfig.nHeadPeers)
                         Right(
                           BlockDetailsView(
                             summary.number,
                             summary.leader,
                             summary.blockType,
+                            stack.map(_.convert),
                             confirmation
                           )
                         )
-                    )
+                    }
             }
 
-    /** The block's header as JSON: block 0's comes from the head config, the rest from their
-      * persisted briefs.
+    /** The block's content: block 0 (config) has none; the rest read their transactions and deposit
+      * decisions from their persisted briefs.
       */
-    private def blockHeader(num: BlockNumber): IO[Either[(StatusCode, ErrorResponse), Json]] =
-        if num == BlockNumber.zero then
-            IO.pure(Right(headConfig.initialBlock.blockBrief.header.asJson))
+    private def blockBody(
+        num: BlockNumber
+    ): IO[Either[(StatusCode, ErrorResponse), BlockBodyView]] =
+        if num == BlockNumber.zero then IO.pure(Right(ApiDto.mkInitialBlockBodyView))
         else
             consensusReader.blockBrief(num).map {
-                case None => Left(blockNotFound(num))
-                case Some(brief) =>
-                    Right(brief match {
-                        case b: BlockBrief.Minor => b.header.asJson
-                        case b: BlockBrief.Major => b.header.asJson
-                        case b: BlockBrief.Final => b.header.asJson
-                    })
+                case None        => Left(blockNotFound(num))
+                case Some(brief) => Right(ApiDto.mkBlockBodyView(brief))
             }
 
     /** The block's type — `initial` for block 0 (config), else read from its brief. `None` if a

--- a/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
+++ b/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
@@ -84,12 +84,12 @@ class HydrozoaRoutes(
             .out(jsonBody[RequestAcceptedResponse])
             .errorOut(errorOut)
             .description(
-              "Submit a request. A wrapper key tags the type — set exactly one: " +
-                  "`{ \"deposit\": { \"l1Payload\", \"l2Payload\" } }` registers an L1 deposit " +
+              "Submit a request. A `type` field tags the kind: " +
+                  "`{ \"type\": \"deposit\", \"l1Payload\", \"l2Payload\" }` registers an L1 deposit " +
                   "(the unsigned deposit-tx CBOR plus the serialized L2 outputs it spawns on " +
-                  "absorption); `{ \"transaction\": { \"l2Payload\" } }` submits an L2 transaction " +
-                  "(a native, self-authenticating Cardano tx). Payloads are lowercase hex. Returns " +
-                  "the assigned request id."
+                  "absorption); `{ \"type\": \"transaction\", \"l2Payload\" }` submits an L2 " +
+                  "transaction (a native, self-authenticating Cardano tx). Payloads are lowercase " +
+                  "hex. Returns the assigned request id."
             )
             .serverLogic(body => acceptUserRequest("POST /head/requests", body))
 

--- a/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
+++ b/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
@@ -220,10 +220,11 @@ class HydrozoaRoutes(
                     .handleError(err => Left(fail(StatusCode.InternalServerError, err.getMessage)))
             )
 
-    /** One `GET /head/blocks/<n>/effects/<kind>` endpoint per fixed kind — the effect in full, or a
-      * 404 when this block carries no effect of that kind.
+    /** One `GET /head/blocks/<n>/effects/<kind>` endpoint per real-tx kind — the effect in full
+      * (with its l1TxId; the kind is the path, so it is not discriminated), or a 404 when this
+      * block carries no effect of that kind.
       */
-    private def blockEffectKindEndpoint(
+    private def blockTxEffectEndpoint(
         segment: String,
         kind: EffectKind
     ): ServerEndpoint[Any, IO] =
@@ -231,11 +232,27 @@ class HydrozoaRoutes(
             .in("head" / "blocks" / path[BlockNumber]("block-number") / "effects" / segment)
             .name(s"getHeadBlockEffect_$segment")
             .tag("Blocks")
-            .out(jsonBody[EffectView])
+            .out(jsonBody[TxEffectView])
             .errorOut(errorOut)
             .description(s"The block's $segment effect in full, or 404 if it has none.")
             .serverLogic(num =>
-                blockEffectOfKind(num, kind)
+                blockTxEffectOfKind(num, kind)
+                    .handleError(err => Left(fail(StatusCode.InternalServerError, err.getMessage)))
+            )
+
+    /** `GET /head/blocks/<n>/effects/sec` — the block's SEC in full, or a 404. */
+    private val blockSecEffectEndpoint: ServerEndpoint[Any, IO] =
+        endpoint.get
+            .in("head" / "blocks" / path[BlockNumber]("block-number") / "effects" / "sec")
+            .name("getHeadBlockEffect_sec")
+            .tag("Blocks")
+            .out(jsonBody[SecEffectView])
+            .errorOut(errorOut)
+            .description(
+              "The block's SEC (standalone evacuation commitment), or 404 if it has none."
+            )
+            .serverLogic(num =>
+                blockSecEffect(num)
                     .handleError(err => Left(fail(StatusCode.InternalServerError, err.getMessage)))
             )
 
@@ -247,7 +264,7 @@ class HydrozoaRoutes(
             )
             .name("getHeadBlockRollout")
             .tag("Blocks")
-            .out(jsonBody[EffectView])
+            .out(jsonBody[TxEffectView])
             .errorOut(errorOut)
             .description("One rollout of the block's rollout chain by index, or 404 if absent.")
             .serverLogic((num, i) =>
@@ -274,9 +291,8 @@ class HydrozoaRoutes(
           "initialization" -> EffectKind.Initialization,
           "settlement" -> EffectKind.Settlement,
           "fallback" -> EffectKind.Fallback,
-          "sec" -> EffectKind.Sec,
           "finalization" -> EffectKind.Finalization
-        ).map(blockEffectKindEndpoint)
+        ).map(blockTxEffectEndpoint) :+ blockSecEffectEndpoint
 
     private val requestsEndpoint: ServerEndpoint[Any, IO] =
         endpoint.get
@@ -629,27 +645,40 @@ class HydrozoaRoutes(
                 }
         }
 
-    /** One kind of the block's effects in full, or a 404 (block missing, or no effect of that kind
-      * on this block).
+    /** One real-tx kind of the block's effects in full, or a 404 (block missing, or no effect of
+      * that kind on this block).
       */
-    private def blockEffectOfKind(
+    private def blockTxEffectOfKind(
         num: BlockNumber,
         kind: EffectKind
-    ): IO[Either[(StatusCode, ErrorResponse), EffectView]] =
+    ): IO[Either[(StatusCode, ErrorResponse), TxEffectView]] =
         effectsResolver.blockEffects(num).map {
             case None => Left(blockNotFound(num))
             case Some(effects) =>
-                effects.find(_.kind == kind) match
-                    case Some(e) => Right(ApiDto.mkEffectView(e, headConfig.nHeadPeers))
+                effects.collectFirst { case e: ResolvedEffect.Tx if e.kind == kind => e } match
+                    case Some(e) => Right(ApiDto.mkTxEffectView(e))
                     case None =>
                         Left(fail(StatusCode.NotFound, s"Block ${num.convert} has no $kind effect"))
+        }
+
+    /** The block's SEC in full, or a 404 (block missing, or no SEC on this block). */
+    private def blockSecEffect(
+        num: BlockNumber
+    ): IO[Either[(StatusCode, ErrorResponse), SecEffectView]] =
+        effectsResolver.blockEffects(num).map {
+            case None => Left(blockNotFound(num))
+            case Some(effects) =>
+                effects.collectFirst { case e: ResolvedEffect.Sec => e } match
+                    case Some(e) => Right(ApiDto.mkSecEffectView(e, headConfig.nHeadPeers))
+                    case None =>
+                        Left(fail(StatusCode.NotFound, s"Block ${num.convert} has no sec effect"))
         }
 
     /** One rollout of the block's rollout chain by index, or a 404. */
     private def blockRollout(
         num: BlockNumber,
         index: Int
-    ): IO[Either[(StatusCode, ErrorResponse), EffectView]] =
+    ): IO[Either[(StatusCode, ErrorResponse), TxEffectView]] =
         effectsResolver.blockEffects(num).map {
             case None => Left(blockNotFound(num))
             case Some(effects) =>
@@ -658,7 +687,7 @@ class HydrozoaRoutes(
                         if e.kind == EffectKind.Rollout && e.rolloutIndex.contains(index) =>
                         e
                 } match
-                    case Some(e) => Right(ApiDto.mkEffectView(e, headConfig.nHeadPeers))
+                    case Some(e) => Right(ApiDto.mkTxEffectView(e))
                     case None =>
                         Left(
                           fail(StatusCode.NotFound, s"Block ${num.convert} has no rollout $index")

--- a/src/main/scala/hydrozoa/multisig/server/JsonCodecs.scala
+++ b/src/main/scala/hydrozoa/multisig/server/JsonCodecs.scala
@@ -9,7 +9,7 @@ import hydrozoa.multisig.ledger.l2.{L2TxKind, L2TxSummary}
 import hydrozoa.multisig.server.ApiResponse.RequestAccepted
 import io.bullet.borer.Cbor
 import io.circe.syntax.*
-import io.circe.{Decoder, DecodingFailure, Encoder, Json}
+import io.circe.{Decoder, Encoder, Json}
 import scalus.cardano.address.ShelleyAddress
 import scalus.cardano.ledger.*
 import scalus.uplc.builtin.ByteString
@@ -64,19 +64,18 @@ object JsonCodecs {
 
     case class UserRequestDecoder() extends Decoder[UserRequest] {
 
-        // The request is internally tagged: a `type` field (`deposit` / `transaction`) selects the
-        // kind, and the body fields (`l1Payload` deposits only, `l2Payload` all) sit alongside it.
-        // Authentication is not done here: the L2 payload is a native, self-authenticating tx, and
-        // the ledger's stateless screening verifies its signatures before a RequestId is assigned.
+        // The request is externally tagged: its body sits under a `deposit` or `transaction` wrapper
+        // key. Authentication is not done here: the L2 payload is a native, self-authenticating tx,
+        // and the ledger's stateless screening verifies its signatures before a RequestId is assigned.
         def apply(c: io.circe.HCursor): Decoder.Result[UserRequest] =
-            c.downField("type").as[String].flatMap {
-                case "deposit" =>
-                    c.as[DepositRequestBody].map(UserRequest.DepositRequest(_))
-                case "transaction" =>
-                    c.as[TransactionRequestBody].map(UserRequest.TransactionRequest(_))
-                case other =>
-                    Left(DecodingFailure(s"unknown request type: $other", c.history))
-            }
+            c.downField("deposit")
+                .as[DepositRequestBody]
+                .map(UserRequest.DepositRequest(_))
+                .orElse(
+                  c.downField("transaction")
+                      .as[TransactionRequestBody]
+                      .map(UserRequest.TransactionRequest(_))
+                )
     }
 
     given Decoder[UserRequest] = UserRequestDecoder()

--- a/src/main/scala/hydrozoa/multisig/server/JsonCodecs.scala
+++ b/src/main/scala/hydrozoa/multisig/server/JsonCodecs.scala
@@ -9,7 +9,7 @@ import hydrozoa.multisig.ledger.l2.{L2TxKind, L2TxSummary}
 import hydrozoa.multisig.server.ApiResponse.RequestAccepted
 import io.bullet.borer.Cbor
 import io.circe.syntax.*
-import io.circe.{Decoder, Encoder, Json}
+import io.circe.{Decoder, DecodingFailure, Encoder, Json}
 import scalus.cardano.address.ShelleyAddress
 import scalus.cardano.ledger.*
 import scalus.uplc.builtin.ByteString
@@ -64,18 +64,19 @@ object JsonCodecs {
 
     case class UserRequestDecoder() extends Decoder[UserRequest] {
 
-        // The request is externally tagged: its body sits under a `deposit` or `transaction` wrapper
-        // key. Authentication is not done here: the L2 payload is a native, self-authenticating tx,
-        // and the ledger's stateless screening verifies its signatures before a RequestId is assigned.
+        // The request is internally tagged: a `type` field (`deposit` / `transaction`) selects the
+        // kind, with the body fields (`l1Payload` deposits only, `l2Payload` all) alongside it.
+        // Authentication is not done here: the L2 payload is a native, self-authenticating tx, and
+        // the ledger's stateless screening verifies its signatures before a RequestId is assigned.
         def apply(c: io.circe.HCursor): Decoder.Result[UserRequest] =
-            c.downField("deposit")
-                .as[DepositRequestBody]
-                .map(UserRequest.DepositRequest(_))
-                .orElse(
-                  c.downField("transaction")
-                      .as[TransactionRequestBody]
-                      .map(UserRequest.TransactionRequest(_))
-                )
+            c.downField("type").as[String].flatMap {
+                case "deposit" =>
+                    c.as[DepositRequestBody].map(UserRequest.DepositRequest(_))
+                case "transaction" =>
+                    c.as[TransactionRequestBody].map(UserRequest.TransactionRequest(_))
+                case other =>
+                    Left(DecodingFailure(s"unknown request type: $other", c.history))
+            }
     }
 
     given Decoder[UserRequest] = UserRequestDecoder()

--- a/src/main/scala/hydrozoa/multisig/server/JsonCodecs.scala
+++ b/src/main/scala/hydrozoa/multisig/server/JsonCodecs.scala
@@ -9,7 +9,7 @@ import hydrozoa.multisig.ledger.l2.{L2TxKind, L2TxSummary}
 import hydrozoa.multisig.server.ApiResponse.RequestAccepted
 import io.bullet.borer.Cbor
 import io.circe.syntax.*
-import io.circe.{Decoder, Encoder, Json}
+import io.circe.{Decoder, DecodingFailure, Encoder, Json}
 import scalus.cardano.address.ShelleyAddress
 import scalus.cardano.ledger.*
 import scalus.uplc.builtin.ByteString
@@ -64,18 +64,19 @@ object JsonCodecs {
 
     case class UserRequestDecoder() extends Decoder[UserRequest] {
 
-        // The request is its body under a "deposit" or "transaction" field. Authentication is not
-        // done here: the L2 payload is a native, self-authenticating tx, and the ledger's stateless
-        // screening verifies its signatures before a RequestId is assigned.
+        // The request is internally tagged: a `type` field (`deposit` / `transaction`) selects the
+        // kind, and the body fields (`l1Payload` deposits only, `l2Payload` all) sit alongside it.
+        // Authentication is not done here: the L2 payload is a native, self-authenticating tx, and
+        // the ledger's stateless screening verifies its signatures before a RequestId is assigned.
         def apply(c: io.circe.HCursor): Decoder.Result[UserRequest] =
-            c.downField("deposit")
-                .as[DepositRequestBody]
-                .map(UserRequest.DepositRequest(_))
-                .orElse(
-                  c.downField("transaction")
-                      .as[TransactionRequestBody]
-                      .map(UserRequest.TransactionRequest(_))
-                )
+            c.downField("type").as[String].flatMap {
+                case "deposit" =>
+                    c.as[DepositRequestBody].map(UserRequest.DepositRequest(_))
+                case "transaction" =>
+                    c.as[TransactionRequestBody].map(UserRequest.TransactionRequest(_))
+                case other =>
+                    Left(DecodingFailure(s"unknown request type: $other", c.history))
+            }
     }
 
     given Decoder[UserRequest] = UserRequestDecoder()

--- a/src/main/scala/hydrozoa/multisig/server/SubmissionClient.scala
+++ b/src/main/scala/hydrozoa/multisig/server/SubmissionClient.scala
@@ -35,9 +35,10 @@ object SubmissionClient:
 
     /** http4s-based impl: posts the request body (no header, no signature envelope — auth is the
       * native tx's own witnesses, verified at the ledger's screening) to the single submission
-      * endpoint and expects a [[RequestAccepted]] JSON response. The body's root tag ("deposit" /
-      * "transaction") selects the type (see [[requestJson]]). `client` can be a real http4s
-      * `Client[IO]` or an in-memory `Client.fromHttpApp` — the harness uses the latter.
+      * endpoint and expects a [[RequestAccepted]] JSON response. The body is internally tagged — a
+      * `type` field ("deposit" / "transaction") selects the kind (see [[requestJson]]). `client`
+      * can be a real http4s `Client[IO]` or an in-memory `Client.fromHttpApp` — the harness uses
+      * the latter.
       */
     def http(
         client: Client[IO],
@@ -53,6 +54,7 @@ object SubmissionClient:
                 client.expect[RequestAccepted](req).map(_.requestId)
 
     private def requestJson(request: UserRequest): Json =
-        request.body match
-            case b: UserRequestBody.DepositRequestBody     => Json.obj("deposit" -> b.asJson)
-            case b: UserRequestBody.TransactionRequestBody => Json.obj("transaction" -> b.asJson)
+        val (tag, body) = request.body match
+            case b: UserRequestBody.DepositRequestBody     => ("deposit", b.asJson)
+            case b: UserRequestBody.TransactionRequestBody => ("transaction", b.asJson)
+        Json.obj("type" -> Json.fromString(tag)).deepMerge(body)

--- a/src/main/scala/hydrozoa/multisig/server/SubmissionClient.scala
+++ b/src/main/scala/hydrozoa/multisig/server/SubmissionClient.scala
@@ -35,10 +35,10 @@ object SubmissionClient:
 
     /** http4s-based impl: posts the request body (no header, no signature envelope — auth is the
       * native tx's own witnesses, verified at the ledger's screening) to the single submission
-      * endpoint and expects a [[RequestAccepted]] JSON response. The body is externally tagged — a
-      * `deposit` / `transaction` wrapper key selects the kind (see [[requestJson]]). `client` can
-      * be a real http4s `Client[IO]` or an in-memory `Client.fromHttpApp` — the harness uses the
-      * latter.
+      * endpoint and expects a [[RequestAccepted]] JSON response. The body is internally tagged — a
+      * `type` field (`deposit` / `transaction`) selects the kind, with the payloads alongside it
+      * (see [[requestJson]]). `client` can be a real http4s `Client[IO]` or an in-memory
+      * `Client.fromHttpApp` — the harness uses the latter.
       */
     def http(
         client: Client[IO],
@@ -54,6 +54,7 @@ object SubmissionClient:
                 client.expect[RequestAccepted](req).map(_.requestId)
 
     private def requestJson(request: UserRequest): Json =
-        request.body match
-            case b: UserRequestBody.DepositRequestBody     => Json.obj("deposit" -> b.asJson)
-            case b: UserRequestBody.TransactionRequestBody => Json.obj("transaction" -> b.asJson)
+        val (tag, body) = request.body match
+            case b: UserRequestBody.DepositRequestBody     => ("deposit", b.asJson)
+            case b: UserRequestBody.TransactionRequestBody => ("transaction", b.asJson)
+        Json.obj("type" -> Json.fromString(tag)).deepMerge(body)

--- a/src/main/scala/hydrozoa/multisig/server/SubmissionClient.scala
+++ b/src/main/scala/hydrozoa/multisig/server/SubmissionClient.scala
@@ -35,10 +35,10 @@ object SubmissionClient:
 
     /** http4s-based impl: posts the request body (no header, no signature envelope — auth is the
       * native tx's own witnesses, verified at the ledger's screening) to the single submission
-      * endpoint and expects a [[RequestAccepted]] JSON response. The body is internally tagged — a
-      * `type` field ("deposit" / "transaction") selects the kind (see [[requestJson]]). `client`
-      * can be a real http4s `Client[IO]` or an in-memory `Client.fromHttpApp` — the harness uses
-      * the latter.
+      * endpoint and expects a [[RequestAccepted]] JSON response. The body is externally tagged — a
+      * `deposit` / `transaction` wrapper key selects the kind (see [[requestJson]]). `client` can
+      * be a real http4s `Client[IO]` or an in-memory `Client.fromHttpApp` — the harness uses the
+      * latter.
       */
     def http(
         client: Client[IO],
@@ -54,7 +54,6 @@ object SubmissionClient:
                 client.expect[RequestAccepted](req).map(_.requestId)
 
     private def requestJson(request: UserRequest): Json =
-        val (tag, body) = request.body match
-            case b: UserRequestBody.DepositRequestBody     => ("deposit", b.asJson)
-            case b: UserRequestBody.TransactionRequestBody => ("transaction", b.asJson)
-        Json.obj("type" -> Json.fromString(tag)).deepMerge(body)
+        request.body match
+            case b: UserRequestBody.DepositRequestBody     => Json.obj("deposit" -> b.asJson)
+            case b: UserRequestBody.TransactionRequestBody => Json.obj("transaction" -> b.asJson)

--- a/src/test/scala/hydrozoa/multisig/server/HeadBlocksEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/HeadBlocksEndpointsTest.scala
@@ -228,7 +228,7 @@ class HeadBlocksEndpointsTest extends AnyFunSuite:
                     withRoutes(stubReader(brief, soft, hard)) { app =>
                         get(app, "/head/blocks/1").map { (status, body) =>
                             val _ = assert(status == Status.Ok)
-                            val c = body.hcursor.downField("confirmation")
+                            val c = body.hcursor.downField("status")
                             out = (
                               c.get[String]("type").toOption.get,
                               c.get[String]("softConfirmedAt").toOption,

--- a/src/test/scala/hydrozoa/multisig/server/HeadBlocksEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/HeadBlocksEndpointsTest.scala
@@ -249,18 +249,21 @@ class HeadBlocksEndpointsTest extends AnyFunSuite:
             .unsafeRunSync()
     }
 
-    test("GET /head/blocks/0 and /head/blocks/0/header serve the config-derived initial block") {
+    test("GET /head/blocks/0 and /head/blocks/0/body serve the config-derived initial block") {
         mkMinorBrief1
             .flatMap(brief =>
                 IO(withRoutes(stubReader(brief, soft = false, hard = false)) { app =>
                     for {
                         details <- get(app, "/head/blocks/0")
-                        header <- get(app, "/head/blocks/0/header")
+                        body <- get(app, "/head/blocks/0/body")
                     } yield {
                         val _ = assert(details._1 == Status.Ok)
                         val _ =
                             assert(details._2.hcursor.get[String]("blockType") == Right("initial"))
-                        val _ = assert(header._1 == Status.Ok)
+                        val _ = assert(body._1 == Status.Ok)
+                        val bc = body._2.hcursor
+                        val _ = assert(bc.get[String]("blockType") == Right("initial"))
+                        val _ = assert(bc.get[List[Json]]("transactions") == Right(Nil))
                         ()
                     }
                 })
@@ -268,17 +271,41 @@ class HeadBlocksEndpointsTest extends AnyFunSuite:
             .unsafeRunSync()
     }
 
-    test("GET /head/blocks/1/header returns the brief's header content") {
+    test("GET /head/blocks/1/body returns the block's content") {
         mkMinorBrief1
             .flatMap(brief =>
                 IO(withRoutes(stubReader(brief, soft = false, hard = false)) { app =>
-                    get(app, "/head/blocks/1/header").map { (status, body) =>
+                    get(app, "/head/blocks/1/body").map { (status, body) =>
                         val _ = assert(status == Status.Ok)
-                        val _ = assert(body.hcursor.downField("blockNum").succeeded)
+                        val c = body.hcursor
+                        val _ = assert(c.get[String]("blockType") == Right("minor"))
+                        val _ = assert(c.downField("transactions").succeeded)
+                        val _ = assert(c.downField("depositsAbsorbed").succeeded)
+                        val _ = assert(c.downField("depositsRejected").succeeded)
                         ()
                     }
                 })
             )
+            .unsafeRunSync()
+    }
+
+    test("GET /head/blocks/1 includes stackId once hard-confirmed, absent before") {
+        mkMinorBrief1
+            .flatMap { brief =>
+                def stackIdOf(hard: Boolean): Option[Int] =
+                    var out: Option[Int] = None
+                    withRoutes(stubReader(brief, soft = true, hard = hard)) { app =>
+                        get(app, "/head/blocks/1").map { (status, body) =>
+                            val _ = assert(status == Status.Ok)
+                            out = body.hcursor.get[Int]("stackId").toOption
+                        }
+                    }
+                    out
+                IO {
+                    val _ = assert(stackIdOf(hard = false).isEmpty)
+                    assert(stackIdOf(hard = true) == Some(1))
+                }
+            }
             .unsafeRunSync()
     }
 
@@ -288,13 +315,13 @@ class HeadBlocksEndpointsTest extends AnyFunSuite:
                 IO(withRoutes(stubReader(brief, soft = false, hard = false)) { app =>
                     for {
                         missing <- get(app, "/head/blocks/99")
-                        missingHeader <- get(app, "/head/blocks/99/header")
+                        missingBody <- get(app, "/head/blocks/99/body")
                         malformed <- app.run(
                           Request[IO](Method.GET, Uri.unsafeFromString("/head/blocks/oops"))
                         )
                     } yield {
                         val _ = assert(missing._1 == Status.NotFound)
-                        val _ = assert(missingHeader._1 == Status.NotFound)
+                        val _ = assert(missingBody._1 == Status.NotFound)
                         val _ = assert(malformed.status.code < 500)
                         ()
                     }

--- a/src/test/scala/hydrozoa/multisig/server/HeadBlocksEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/HeadBlocksEndpointsTest.scala
@@ -215,7 +215,9 @@ class HeadBlocksEndpointsTest extends AnyFunSuite:
             .unsafeRunSync()
     }
 
-    test("GET /head/blocks/1 walks the confirmation ladder: PROPOSED, SOFT, HARD") {
+    test(
+      "GET /head/blocks/1 walks the confirmation ladder: PROPOSED, SOFT_CONFIRMED, HARD_CONFIRMED"
+    ) {
         mkMinorBrief1
             .flatMap { brief =>
                 def statusOf(
@@ -228,7 +230,7 @@ class HeadBlocksEndpointsTest extends AnyFunSuite:
                             val _ = assert(status == Status.Ok)
                             val c = body.hcursor.downField("confirmation")
                             out = (
-                              c.get[String]("status").toOption.get,
+                              c.get[String]("type").toOption.get,
                               c.get[String]("softConfirmedAt").toOption,
                               c.get[String]("hardConfirmedAt").toOption
                             )
@@ -238,11 +240,12 @@ class HeadBlocksEndpointsTest extends AnyFunSuite:
                 IO {
                     val _ = assert(statusOf(soft = false, hard = false) == ("PROPOSED", None, None))
                     val _ = assert(
-                      statusOf(soft = true, hard = false) == ("SOFT", Some(softAt.toString), None)
+                      statusOf(soft = true, hard = false) ==
+                          ("SOFT_CONFIRMED", Some(softAt.toString), None)
                     )
                     assert(
                       statusOf(soft = true, hard = true) ==
-                          ("HARD", Some(softAt.toString), Some(hardAt.toString))
+                          ("HARD_CONFIRMED", Some(softAt.toString), Some(hardAt.toString))
                     )
                 }
             }

--- a/src/test/scala/hydrozoa/multisig/server/HeadEffectsEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/HeadEffectsEndpointsTest.scala
@@ -210,8 +210,9 @@ class HeadEffectsEndpointsTest extends AnyFunSuite:
             get(app, "/head/blocks/1/effects/sec").map { (status, body) =>
                 val _ = assert(status == Status.Ok)
                 val c = body.hcursor
+                // The by-kind SEC response carries its l1TxId; the kind is fixed by the path (no
+                // `kind` field).
                 val _ = assert(c.get[String]("l1TxId") == Right(secId.toHex))
-                val _ = assert(c.get[String]("kind") == Right("sec"))
                 val _ = assert(c.get[Int]("blockNumber") == Right(1))
                 val _ = assert(c.downField("secOnchainSerialized").as[String].isRight)
                 // nHeadPeers head signatures, the remaining tail as coil signatures.
@@ -226,8 +227,9 @@ class HeadEffectsEndpointsTest extends AnyFunSuite:
         withRoutes { app =>
             get(app, s"/head/effects/${secId.toHex}").map { (status, body) =>
                 val _ = assert(status == Status.Ok)
-                val _ = assert(body.hcursor.get[String]("l1TxId") == Right(secId.toHex))
-                val _ = assert(body.hcursor.get[String]("kind") == Right("sec"))
+                // The by-id response is type-tagged by kind and omits l1TxId (it is the queried path).
+                val _ = assert(body.hcursor.get[String]("type") == Right("sec"))
+                val _ = assert(body.hcursor.downField("secOnchainSerialized").as[String].isRight)
                 ()
             }
         }

--- a/src/test/scala/hydrozoa/multisig/server/HeadEffectsEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/HeadEffectsEndpointsTest.scala
@@ -195,11 +195,10 @@ class HeadEffectsEndpointsTest extends AnyFunSuite:
             get(app, "/head/blocks/1/effects").map { (status, body) =>
                 val _ = assert(status == Status.Ok)
                 val c = body.hcursor
-                val _ = assert(c.get[String]("blockType") == Right("minor"))
+                // A minor block's effects carry only its (optional) SEC and refunds.
+                val _ = assert(c.get[String]("type") == Right("minor"))
                 val _ = assert(c.get[String]("sec") == Right(secId.toHex))
                 val _ = assert(c.get[List[String]]("refunds") == Right(Nil))
-                val _ = assert(c.get[List[String]]("rollouts") == Right(Nil))
-                val _ = assert(c.downField("settlement").focus.forall(_.isNull))
                 ()
             }
         }

--- a/src/test/scala/hydrozoa/multisig/server/HeadRequestsEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/HeadRequestsEndpointsTest.scala
@@ -29,8 +29,8 @@ import scalus.uplc.builtin.ByteString
 
 /** The `/head/requests` queries through the HTTP layer against a stubbed [[ConsensusStoreReader]]:
   * the listing (with its `?type=` / `?peer_number=` filters), keyed by the opaque request id, and
-  * the request-details lifecycle ladder (UNPROCESSED → LOCALLY_PROCESSED → SOFT_CONFIRMED →
-  * HARD_CONFIRMED), plus the 404 / 400 edges.
+  * the request-details lifecycle ladder (UNPROCESSED → PROPOSED → SOFT_CONFIRMED → HARD_CONFIRMED),
+  * plus the 404 / 400 edges.
   */
 class HeadRequestsEndpointsTest extends AnyFunSuite:
 
@@ -209,7 +209,7 @@ class HeadRequestsEndpointsTest extends AnyFunSuite:
                     val _ = assert(status == Status.Ok)
                     val s = body.hcursor.downField("status")
                     out = (
-                      s.get[String]("status").toOption.get,
+                      s.get[String]("type").toOption.get,
                       s.get[Int]("blockNumber").toOption,
                       s.get[String]("hardConfirmedAt").toOption
                     )
@@ -223,7 +223,7 @@ class HeadRequestsEndpointsTest extends AnyFunSuite:
         val _ = assert(statusOf(stubReader(base)) == ("UNPROCESSED", None, None))
         val _ = assert(
           statusOf(stubReader(base, processed = Some(entry))) ==
-              ("LOCALLY_PROCESSED", Some(3), None)
+              ("PROPOSED", Some(3), None)
         )
         val _ = assert(
           statusOf(
@@ -247,7 +247,7 @@ class HeadRequestsEndpointsTest extends AnyFunSuite:
         val base = Map(peer0 -> List(depositRequest(peer0, 0)))
         val valid = RequestBlockEntry(BlockNumber(3), ValidityFlag.Valid)
 
-        // (decisionStatus.status, blockNumber, decision), or None when the field is absent.
+        // (absorptionDecisionStatus.type, blockNumber, decision), or None when the field is absent.
         def decisionOf(
             reader: ConsensusStoreReader[IO]
         ): Option[(String, Option[Int], Option[String])] =
@@ -255,9 +255,9 @@ class HeadRequestsEndpointsTest extends AnyFunSuite:
             withRoutes(reader) { app =>
                 get(app, s"/head/requests/${depositId.asI64}").map { (status, body) =>
                     val _ = assert(status == Status.Ok)
-                    val d = body.hcursor.downField("decisionStatus")
+                    val d = body.hcursor.downField("absorptionDecisionStatus")
                     out = d
-                        .get[String]("status")
+                        .get[String]("type")
                         .toOption
                         .map(s =>
                             (
@@ -275,11 +275,11 @@ class HeadRequestsEndpointsTest extends AnyFunSuite:
           decisionOf(stubReader(Map(peer0 -> List(txRequest(peer0, 0))), processed = Some(valid)))
               == None
         )
-        // A valid deposit with no decision row yet is UNDECIDED.
+        // A valid deposit with no decision row yet is UNPROCESSED.
         val _ = assert(
-          decisionOf(stubReader(base, processed = Some(valid))) == Some(("UNDECIDED", None, None))
+          decisionOf(stubReader(base, processed = Some(valid))) == Some(("UNPROCESSED", None, None))
         )
-        // A decided-but-unconfirmed deposit reports LOCAL_DECISION with its block and outcome.
+        // A decided-but-unconfirmed deposit reports PROPOSED with its block and outcome.
         val _ = assert(
           decisionOf(
             stubReader(
@@ -287,7 +287,7 @@ class HeadRequestsEndpointsTest extends AnyFunSuite:
               processed = Some(valid),
               decisionRow = Some(DepositDecision.Absorbed(BlockNumber(3)))
             )
-          ) == Some(("LOCAL_DECISION", Some(3), Some("ABSORBED")))
+          ) == Some(("PROPOSED", Some(3), Some("ABSORBED")))
         )
         assert(
           decisionOf(
@@ -296,7 +296,7 @@ class HeadRequestsEndpointsTest extends AnyFunSuite:
               processed = Some(valid),
               decisionRow = Some(DepositDecision.Rejected(BlockNumber(3)))
             )
-          ) == Some(("LOCAL_DECISION", Some(3), Some("REJECTED")))
+          ) == Some(("PROPOSED", Some(3), Some("REJECTED")))
         )
     }
 

--- a/src/test/scala/hydrozoa/multisig/server/SubmitRequestBodyTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/SubmitRequestBodyTest.scala
@@ -1,0 +1,47 @@
+package hydrozoa.multisig.server
+
+import hydrozoa.multisig.consensus.{UserRequest, UserRequestBody}
+import io.circe.parser.decode
+import org.scalatest.funsuite.AnyFunSuite
+import scalus.uplc.builtin.ByteString
+
+/** The submit-body wire contract: the internally-tagged JSON the [[SubmissionClient]] posts must
+  * decode as [[ApiDto.SubmitRequestView]] and [[ApiDto.toUserRequest]] must recover the request.
+  * (Guards the CLI ⇄ `POST /head/requests` round-trip, which has no HTTP-level test.)
+  */
+class SubmitRequestBodyTest extends AnyFunSuite:
+
+    private val l1Hex = "deadbeef"
+    private val l2Hex = "cafe00"
+
+    test("a `type: transaction` body decodes to a TransactionRequest") {
+        val body = s"""{ "type": "transaction", "l2Payload": "$l2Hex" }"""
+        val request = decode[ApiDto.SubmitRequestView](body).flatMap(ApiDto.toUserRequest)
+        assert(
+          request == Right(
+            UserRequest.TransactionRequest(
+              UserRequestBody.TransactionRequestBody(ByteString.fromHex(l2Hex))
+            )
+          )
+        )
+    }
+
+    test("a `type: deposit` body decodes to a DepositRequest") {
+        val body = s"""{ "type": "deposit", "l1Payload": "$l1Hex", "l2Payload": "$l2Hex" }"""
+        val request = decode[ApiDto.SubmitRequestView](body).flatMap(ApiDto.toUserRequest)
+        assert(
+          request == Right(
+            UserRequest.DepositRequest(
+              UserRequestBody.DepositRequestBody(
+                ByteString.fromHex(l1Hex),
+                ByteString.fromHex(l2Hex)
+              )
+            )
+          )
+        )
+    }
+
+    test("an unknown `type` is a client error") {
+        val body = """{ "type": "nonsense", "l2Payload": "cafe00" }"""
+        assert(decode[ApiDto.SubmitRequestView](body).isLeft)
+    }


### PR DESCRIPTION
Stacked on #553. Closes the two remaining head-API gaps from the api.md audit (block/effect paths were already plural in code).

## `GET /head/blocks/{n}/body`
The block's **content**: its transactions (the request ids woven into the block, each with its validity verdict) and its deposit decisions (the request ids absorbed into the treasury and those rejected). Block 0 (config) has empty content. This is the api.md "Block body" / "block transactions" endpoint.

## `stackId` on block details
`GET /head/blocks/{n}` now includes `stackId` — the number of the stack that hard-confirmed the block (absent until hard-confirmed).

## Removed `GET /head/blocks/{n}/header`
It exposed a raw block-header dump, which isn't in api.md and isn't what we want to present — **block details** is the details endpoint (drawing from the header where needed). Dropped it rather than keep a misnamed near-duplicate.

---
Compile + server unit tests green under `-Werror`; `docs/openapi.yaml` regenerated. Integration tests not run.