### PR TITLE
feat(api): copy-pasteable submit-body examples (with the type discriminator)

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -52,6 +52,18 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/SubmitRequest'
+            examples:
+              transaction:
+                summary: Submit an L2 transaction
+                value:
+                  l2Payload: 84a400d9010281825820…
+                  type: transaction
+              deposit:
+                summary: Register an L1 deposit
+                value:
+                  l1Payload: 84a400d9010281825820…
+                  l2Payload: a1024568656164…
+                  type: deposit
         required: true
       responses:
         '200':

--- a/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
+++ b/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
@@ -80,7 +80,25 @@ class HydrozoaRoutes(
             .in("head" / "requests")
             .name("postHeadRequest")
             .tag("Requests")
-            .in(jsonBody[SubmitRequestView])
+            .in(
+              // Explicit examples so Swagger UI shows a copy-pasteable body *including* the `type`
+              // discriminator — its auto-generated examples omit the discriminator property, which
+              // for this (internally-tagged) input would produce a 400.
+              jsonBody[SubmitRequestView].examples(
+                List(
+                  EndpointIO.Example.of(
+                    SubmitRequestView.SubmitTransactionView("84a400d9010281825820…"),
+                    name = Some("transaction"),
+                    summary = Some("Submit an L2 transaction")
+                  ),
+                  EndpointIO.Example.of(
+                    SubmitRequestView.SubmitDepositView("84a400d9010281825820…", "a1024568656164…"),
+                    name = Some("deposit"),
+                    summary = Some("Register an L1 deposit")
+                  )
+                )
+              )
+            )
             .out(jsonBody[RequestAcceptedResponse])
             .errorOut(errorOut)
             .description(


### PR DESCRIPTION
Swagger UI omits the `discriminator` property from its auto-generated examples, so `POST /head/requests` showed `{ l1Payload, l2Payload }` with **no `type`** — and the submit body is internally tagged, so a copy of that example fails to decode (400).

This attaches explicit `deposit` / `transaction` examples to the request body. tapir renders explicit examples through the DTO codec (which writes the discriminator), so the **Example Value** tab now shows a copy-pasteable body that includes `type`:

```json
{ "type": "deposit", "l1Payload": "…", "l2Payload": "…" }
```

Regenerates `docs/openapi.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)