### PR TITLE
build: enable fmt + lint for integration and benchmark modules

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -245,15 +245,22 @@ ThisBuild / scalacOptions ++= Seq(
 addCompilerPlugin("org.scalus" % "scalus-plugin" % scalusVersion cross CrossVersion.full)
 
 // Custom commands to format and lint all subprojects
-// TODO: Restore integration module to fmt and lint
-//addCommandAlias("fmtAll", ";core/scalafmtAll ;integration/scalafmtAll ;benchmark/scalafmtAll")
-//addCommandAlias("fmtCheckAll", ";core/scalafmtCheckAll ;integration/scalafmtCheckAll ;benchmark/scalafmtCheckAll")
-//addCommandAlias("lintAll", ";core/scalafixAll ;integration/scalafixAll ;benchmark/scalafixAll")
-//addCommandAlias("lintCheckAll", ";core/scalafixAll --check ;integration/scalafixAll --check ;benchmark/scalafixAll --check")
-addCommandAlias("fmtAll", ";core/scalafmtAll")
-addCommandAlias("fmtCheckAll", ";core/scalafmtCheckAll")
-addCommandAlias("lintAll", ";core/scalafixAll")
-addCommandAlias("lintCheckAll", ";core/scalafixAll --check")
+addCommandAlias(
+  "fmtAll",
+  ";core/scalafmtAll ;integration/scalafmtAll ;benchmark/scalafmtAll"
+)
+addCommandAlias(
+  "fmtCheckAll",
+  ";core/scalafmtCheckAll ;integration/scalafmtCheckAll ;benchmark/scalafmtCheckAll"
+)
+addCommandAlias(
+  "lintAll",
+  ";core/scalafixAll ;integration/scalafixAll ;benchmark/scalafixAll"
+)
+addCommandAlias(
+  "lintCheckAll",
+  ";core/scalafixAll --check ;integration/scalafixAll --check ;benchmark/scalafixAll --check"
+)
 
 // Test dependencies
 ThisBuild / testFrameworks += new TestFramework("org.scalatest.tools.Framework")

--- a/integration/src/test/scala/hydrozoa/integration/fallbackhandoff/VoteVersionMismatchTest.scala
+++ b/integration/src/test/scala/hydrozoa/integration/fallbackhandoff/VoteVersionMismatchTest.scala
@@ -4,8 +4,8 @@ import cats.effect.*
 import cats.effect.unsafe.implicits.global
 import cats.syntax.all.*
 import hydrozoa.config.node.MultiNodeConfig
-import hydrozoa.integration.harness.{MultiPeerDisputeProperties, MultiPeerHeadHarness}
 import hydrozoa.integration.harness.MultiPeerHeadHarness.Transport.Mode as TransportMode
+import hydrozoa.integration.harness.{MultiPeerDisputeProperties, MultiPeerHeadHarness}
 import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.backend.cardano.{CardanoBackend as L1Backend, FirewalledCardanoBackend, FirewalledCardanoBackendEvent, yaciTestSauceGenesis}
 import hydrozoa.multisig.consensus.peer.{HeadPeerNumber, PeerId}
@@ -18,23 +18,22 @@ import org.scalacheck.Prop
 import scala.concurrent.duration.*
 import test.{SeedPhrase, TestPeers}
 
-/** Regression test for [[hydrozoa.rulebased.RuleBasedActor.loadAction]]: when the on-chain
-  * treasury lags behind the latest hard-confirmed stack, the RBA must vote with the SEC whose
-  * `versionMajor` matches the on-chain treasury (not the newest SEC in persistence), so the
-  * built Vote passes the Plutus dispute-script's `versionMajor field must match` check.
+/** Regression test for [[hydrozoa.rulebased.RuleBasedActor.loadAction]]: when the on-chain treasury
+  * lags behind the latest hard-confirmed stack, the RBA must vote with the SEC whose `versionMajor`
+  * matches the on-chain treasury (not the newest SEC in persistence), so the built Vote passes the
+  * Plutus dispute-script's `versionMajor field must match` check.
   *
   * Scenario:
   *   1. 2-peer head. Per-peer [[FirewalledCardanoBackend]] drops any [[SettlementTx]] whose
   *      `majorVersionProduced == 2` so the on-chain treasury stays pinned at major-1 while the
   *      off-chain view advances.
   *   2. Both peers hard-confirm through major-2 off-chain.
-  *   3. CL notices the on-chain treasury is stale and dispatches
-  *      `Action.FallbackToRuleBased`; HMRM auto-spawns
-  *      [[hydrozoa.rulebased.RuleBasedRegimeManager]], which spawns
+  *   3. CL notices the on-chain treasury is stale and dispatches `Action.FallbackToRuleBased`; HMRM
+  *      auto-spawns [[hydrozoa.rulebased.RuleBasedRegimeManager]], which spawns
   *      [[hydrozoa.rulebased.RuleBasedActor]].
-  *   4. `loadAction(treasuryVersionMajor)` walks backward through hard-confirmed stacks and
-  *      picks the last SEC matching `versionMajor = 1` (the on-chain treasury's). The Vote it
-  *      builds and submits passes Plutus and lands on chain.
+  *   4. `loadAction(treasuryVersionMajor)` walks backward through hard-confirmed stacks and picks
+  *      the last SEC matching `versionMajor = 1` (the on-chain treasury's). The Vote it builds and
+  *      submits passes Plutus and lands on chain.
   */
 object VoteVersionMismatchTest extends MultiPeerDisputeProperties("Vote Version Mismatch"):
 
@@ -47,7 +46,7 @@ object VoteVersionMismatchTest extends MultiPeerDisputeProperties("Vote Version 
     // ------------------------------------------------------------------
     // Test properties
     // ------------------------------------------------------------------
-    
+
     val _ = property("ws: RRM votes at latest hard-confirmed major even when on-chain lags") =
         testProperty(TransportMode.WebSocket)
 
@@ -97,8 +96,8 @@ object VoteVersionMismatchTest extends MultiPeerDisputeProperties("Vote Version 
 
             // 4. Every head peer's RBA finds the SEC matching the on-chain treasury's
             // versionMajor and submits a Vote that passes Plutus.
-            _    <- lift(ctx.allHeadsBuildingVote.get.timeout(scenarioTimeout))
-            _    <- lift(ctx.allHeadsVoteSubmittedOk.get.timeout(scenarioTimeout))
+            _ <- lift(ctx.allHeadsBuildingVote.get.timeout(scenarioTimeout))
+            _ <- lift(ctx.allHeadsVoteSubmittedOk.get.timeout(scenarioTimeout))
             errs <- lift(ctx.harness.sutErrors.get)
             _ <- assertWith(
               !errs.exists(_.contains("versionMajor field must match")),
@@ -158,7 +157,7 @@ object VoteVersionMismatchTest extends MultiPeerDisputeProperties("Vote Version 
             fallbackDispatched <- Resource.eval(Deferred[IO, Unit])
             bothPeersConfirmedMajor2 <- Resource.eval(Deferred[IO, Unit])
             allHeadsBuildingVote <- Resource.eval(Deferred[IO, Unit])
-            allHeadsVoteSubmittedOk    <- Resource.eval(Deferred[IO, Unit])
+            allHeadsVoteSubmittedOk <- Resource.eval(Deferred[IO, Unit])
             allCoilsHandledDispute <- Resource.eval(Deferred[IO, Unit])
 
             observer <- Resource.eval(
@@ -224,8 +223,8 @@ object VoteVersionMismatchTest extends MultiPeerDisputeProperties("Vote Version 
           firewallTracer = MultiPeerHeadHarness.firewallSlf4jSink(peerId) |+| capture,
         )
 
-    /** Observer tracer wiring — vote/build signals fire when **every** head peer hits the
-      * milestone (not just the first), so a regression in the CL handoff would surface.
+    /** Observer tracer wiring — vote/build signals fire when **every** head peer hits the milestone
+      * (not just the first), so a regression in the CL handoff would surface.
       */
     private def observerTracer(
         bothPeersConfirmedMajor2: Deferred[IO, Unit],
@@ -247,8 +246,8 @@ object VoteVersionMismatchTest extends MultiPeerDisputeProperties("Vote Version 
             }
 
         for
-            peersAtMajor2       <- Ref[IO].of(Set.empty[HeadPeerNumber])
-            headsBuildingVote   <- Ref[IO].of(Set.empty[HeadPeerNumber])
+            peersAtMajor2 <- Ref[IO].of(Set.empty[HeadPeerNumber])
+            headsBuildingVote <- Ref[IO].of(Set.empty[HeadPeerNumber])
             headsVoteSubmittedOk <- Ref[IO].of(Set.empty[HeadPeerNumber])
             coilsHandledDispute <- Ref[IO].of(Set.empty[Int])
         yield ContraTracer[IO, MultiPeerHeadHarness.Event] {

--- a/integration/src/test/scala/hydrozoa/integration/harness/KickRequest.scala
+++ b/integration/src/test/scala/hydrozoa/integration/harness/KickRequest.scala
@@ -8,9 +8,8 @@ import hydrozoa.multisig.consensus.{UserRequest, UserRequestBody}
 import hydrozoa.multisig.ledger.l1.token.CIP67
 import scalus.cardano.ledger.TransactionOutput.Babbage
 import scalus.cardano.ledger.{AuxiliaryData, Coin, Metadatum, TransactionHash, TransactionInput, Utxo, Value, Word64}
-import scalus.cardano.txbuilder.TransactionBuilder
 import scalus.cardano.txbuilder.TransactionBuilderStep.{Fee, ModifyAuxiliaryData, Send, Spend}
-import scalus.cardano.txbuilder.PubKeyWitness
+import scalus.cardano.txbuilder.{PubKeyWitness, TransactionBuilder}
 import scalus.uplc.builtin.Builtins.blake2b_256
 import scalus.uplc.builtin.ByteString
 

--- a/integration/src/test/scala/hydrozoa/integration/harness/MultiPeerDisputeProperties.scala
+++ b/integration/src/test/scala/hydrozoa/integration/harness/MultiPeerDisputeProperties.scala
@@ -4,8 +4,8 @@ import hydrozoa.config.head.network.CardanoNetwork
 import org.scalacheck.Properties
 
 /** Base for the multi-peer dispute-flow property suites driving [[MultiPeerHeadHarness]]. Each
-  * scenario is a single slow end-to-end run, so cap ScalaCheck at one successful evaluation
-  * rather than the default 100.
+  * scenario is a single slow end-to-end run, so cap ScalaCheck at one successful evaluation rather
+  * than the default 100.
   */
 abstract class MultiPeerDisputeProperties(name: String) extends Properties(name):
     override def overrideParameters(

--- a/integration/src/test/scala/hydrozoa/integration/harness/MultiPeerHeadHarness.scala
+++ b/integration/src/test/scala/hydrozoa/integration/harness/MultiPeerHeadHarness.scala
@@ -21,9 +21,9 @@ import hydrozoa.config.node.{MultiNodeConfig, NodeConfig}
 import hydrozoa.lib.cardano.scalus.QuantizedTime.{QuantizedFiniteDuration, quantize}
 import hydrozoa.lib.logging.{ContraTracer, LogEvent, Slf4jMsg, Slf4jMsgFormat, Slf4jTracer, info}
 import hydrozoa.multisig.backend.cardano.{CardanoBackend as L1Backend, CardanoBackendMock, FirewalledCardanoBackendEvent, MockState, yaciTestSauceGenesis}
-import hydrozoa.multisig.consensus.{CardanoLiaison, RequestSequencer}
 import hydrozoa.multisig.consensus.peer.{CoilPeerNumber, HeadPeerId, HeadPeerNumber, PeerId}
 import hydrozoa.multisig.consensus.transport.*
+import hydrozoa.multisig.consensus.{CardanoLiaison, RequestSequencer}
 import hydrozoa.multisig.ledger.block.BlockVersion.Major.given_Conversion_Major_Int
 import hydrozoa.multisig.ledger.eutxol2.EutxoL2Ledger
 import hydrozoa.multisig.ledger.l1.tx.{EnrichedTx, SettlementTx}
@@ -46,13 +46,13 @@ import scalus.cardano.ledger.rules.{Context, UtxoEnv}
 import scalus.cardano.ledger.{CardanoInfo, CertState, Utxos}
 import test.{GenWithTestPeers, TestPeerName, TestPeers, given}
 
-/** Scaffold for a multi-peer head (+ optional coil followers) [[Resource]] backed by a shared
-  * mock L1.
- *
+/** Scaffold for a multi-peer head (+ optional coil followers) [[Resource]] backed by a shared mock
+  * L1.
+  *
   * Test-side concerns (capture observers, signal `Deferred`s, custom per-peer handle types like
   * stage4's `Stage4PeerHandle`) are injected via [[Hooks]] — the harness threads test-provided
-  * tracers into each MRM and runs a test-provided `(num, connections) => IO[H]` finalizer once
-  * each peer's connections are available.
+  * tracers into each MRM and runs a test-provided `(num, connections) => IO[H]` finalizer once each
+  * peer's connections are available.
   */
 object MultiPeerHeadHarness:
 
@@ -63,13 +63,13 @@ object MultiPeerHeadHarness:
     /** Wall-clock alignment for the head's initial-block end-time.
       *
       *   - `useTestControl = true`: return `None`. The head-config generator falls back to the
-      *     deterministic Jan-1-2026 + 100-day random anchor (see [[generateHeadStartTime]]),
-      *     which is stable across TestControl seeds; reading `IO.realTimeInstant` there would
-      *     defeat reproducibility.
+      *     deterministic Jan-1-2026 + 100-day random anchor (see [[generateHeadStartTime]]), which
+      *     is stable across TestControl seeds; reading `IO.realTimeInstant` there would defeat
+      *     reproducibility.
       *   - `useTestControl = false`: return `Some(now + offset)`, materialised via
       *     [[IO.realTimeInstant]] so no wall-clock read happens at property-construction time.
-      *     `offset` gives the scenario room to spawn actors before the initial block's
-      *     validity window opens; each test tunes it against its actor-spawn budget.
+      *     `offset` gives the scenario room to spawn actors before the initial block's validity
+      *     window opens; each test tunes it against its actor-spawn budget.
       */
     def mkTakeoffTime(
         useTestControl: Boolean,
@@ -78,11 +78,11 @@ object MultiPeerHeadHarness:
         if useTestControl then IO.pure(None)
         else IO.realTimeInstant.map(t => Some(t.plusSeconds(offset.toSeconds)))
 
-    /** Head initial-block-end-time generator anchored on [[mkTakeoffTime]]. When `takeoffTime`
-      * is `Some`, quantize it to the peer's slot config. When `None`, generate a random
-      * Jan-1-2026 + 100-day offset — deterministic per ScalaCheck seed, safe under TestControl.
-      * Feed to `hydrozoa.config.head.initialization.generateInitialBlock`'s
-      * `generateBlockCreationEndTime` parameter.
+    /** Head initial-block-end-time generator anchored on [[mkTakeoffTime]]. When `takeoffTime` is
+      * `Some`, quantize it to the peer's slot config. When `None`, generate a random Jan-1-2026 +
+      * 100-day offset — deterministic per ScalaCheck seed, safe under TestControl. Feed to
+      * `hydrozoa.config.head.initialization.generateInitialBlock`'s `generateBlockCreationEndTime`
+      * parameter.
       */
     def generateHeadStartTime(
         takeoffTime: Option[Instant]
@@ -90,9 +90,9 @@ object MultiPeerHeadHarness:
         ReaderT { (tp: TestPeers) =>
             takeoffTime match {
                 case Some(t) => Gen.const(BlockCreationEndTime(t.quantize(tp.slotConfig)))
-                case None    =>
+                case None =>
                     val anchorTime = 1767225600L // Jan 1 2026 00:00:00 UTC
-                    val range      = 86_400 * 100L // 100 days in seconds
+                    val range = 86_400 * 100L // 100 days in seconds
                     for offset <- Gen.choose(0L, range)
                     yield BlockCreationEndTime(
                       java.time.Instant
@@ -102,9 +102,9 @@ object MultiPeerHeadHarness:
             }
         }
 
-    /** Static fast [[TxTiming]] so `Action.FallbackToRuleBased` fires within a wall-clock
-      * scenario budget (settlement/fallback windows are seconds, not hours). Shared by the
-      * dispute-flow tests via [[mkResource]]'s default.
+    /** Static fast [[TxTiming]] so `Action.FallbackToRuleBased` fires within a wall-clock scenario
+      * budget (settlement/fallback windows are seconds, not hours). Shared by the dispute-flow
+      * tests via [[mkResource]]'s default.
       */
     val fastTxTiming: GenWithTestPeers[TxTiming] = ReaderT { (network: TestPeers) =>
         Gen.const(
@@ -181,13 +181,13 @@ object MultiPeerHeadHarness:
         extension (self: DropRule)
             def ||(other: DropRule): DropRule = etx => self(etx) || other(etx)
             def &&(other: DropRule): DropRule = etx => self(etx) && other(etx)
-            def unary_! : DropRule            = etx => !self(etx)
+            def unary_! : DropRule = etx => !self(etx)
 
             /** Lift into the backend's effectful gate. Rules are pure, so this never suspends. */
             def toGate: EnrichedTx[?] => IO[Boolean] = etx => IO.pure(self(etx))
 
-    /** Shared slf4j sink for a peer's [[FirewalledCardanoBackend]] — logs each drop (warn) and
-      * pass (info) tagged with the peer. Compose extra capture tracers onto it with `|+|`.
+    /** Shared slf4j sink for a peer's [[FirewalledCardanoBackend]] — logs each drop (warn) and pass
+      * (info) tagged with the peer. Compose extra capture tracers onto it with `|+|`.
       */
     def firewallSlf4jSink(peerId: PeerId): ContraTracer[IO, FirewalledCardanoBackendEvent] =
         val peerLabel = peerId match
@@ -256,8 +256,8 @@ object MultiPeerHeadHarness:
         // Under TestControl the harness jumps virtual time to `startEpochMs` before any actor
         // exists (see PreSystem.testControlPresleep). Anchor to the head's configured initial block
         // end-time so the model clock is coherent with the head config.
-        val startEpochMs = multiNodeConfig.headConfig.initialBlock.blockBrief.endTime
-            .convert.instant.toEpochMilli
+        val startEpochMs =
+            multiNodeConfig.headConfig.initialBlock.blockBrief.endTime.convert.instant.toEpochMilli
         val coilNodeConfigs = multiNodeConfig.mkCoilNodeConfigs(testPeers.coilWallets)
         resource[Option[RequestSequencer.Handle]](
           Inputs(
@@ -324,10 +324,14 @@ object MultiPeerHeadHarness:
                       generateInitialBlock = (bootstrap, funding) =>
                           generateInitialBlock(
                             genHeadConfigBootstrap = ReaderT
-                                .pure[Gen, TestPeers, (
-                                    HeadConfig.Bootstrap,
-                                    hydrozoa.bootstrap.InitializationFunding
-                                )]((bootstrap, funding)),
+                                .pure[
+                                  Gen,
+                                  TestPeers,
+                                  (
+                                      HeadConfig.Bootstrap,
+                                      hydrozoa.bootstrap.InitializationFunding
+                                  )
+                                ]((bootstrap, funding)),
                             generateBlockCreationEndTime = generateHeadStartTime(takeoffTime),
                           ),
                     ),
@@ -372,14 +376,14 @@ object MultiPeerHeadHarness:
         case Head(peerNum: HeadPeerNumber, event: HeadRegimeManagerEvent)
         case Coil(coilNum: CoilPeerNumber, event: CoilRegimeManagerEvent)
 
-    /** Test-side wiring injected into each MRM. The [[Event]]-typed projects down to Head/Coil-specific tracers
-     * and gets contramapped with the regime managers' tracers. `peerHandle` / `coilHandle` run once each MRM's
-      * `connectionsDeferred` resolves.
+    /** Test-side wiring injected into each MRM. The [[Event]]-typed projects down to
+      * Head/Coil-specific tracers and gets contramapped with the regime managers' tracers.
+      * `peerHandle` / `coilHandle` run once each MRM's `connectionsDeferred` resolves.
       */
     /** Test-side wiring — one `PeerId`-keyed hook per concern. Callers that only need a head-side
       * handle can use `H = Option[HeadHandle]` and return `None` from the coil branch; likewise
-      * `wrapBackend` can pattern-match on `PeerId.Head` / `PeerId.Coil` when the wrap differs
-      * (e.g. only head peers get firewalled).
+      * `wrapBackend` can pattern-match on `PeerId.Head` / `PeerId.Coil` when the wrap differs (e.g.
+      * only head peers get firewalled).
       */
     case class Hooks[H](
         tracer: ContraTracer[IO, Event],
@@ -419,8 +423,8 @@ object MultiPeerHeadHarness:
         sutErrors: Ref[IO, List[String]],
     )
 
-    /** Build a fully-wired multi-peer head + coil followers. The returned resource owns
-      * everything; release cancels the CL tick fibers and the error drainer.
+    /** Build a fully-wired multi-peer head + coil followers. The returned resource owns everything;
+      * release cancels the CL tick fibers and the error drainer.
       */
     def resource[H](
         inputs: Inputs,
@@ -434,55 +438,55 @@ object MultiPeerHeadHarness:
         for
             // Handle websocket "take off" timing alignment
             _ <- Resource.eval(
-                     PreSystem.align(transportMode.useTestControl, startEpochMs, takeoffTime, log)
-                 )
+              PreSystem.align(transportMode.useTestControl, startEpochMs, takeoffTime, log)
+            )
 
-            system                     <- ActorSystem[IO](label)
-            backendAndSnapshot         <- Resource.eval(
-                                              CardanoBackend.mkMock(
-                                                preinitPeerUtxosL1,
-                                                multiNodeConfig.headConfig.scriptReferenceUtxos,
-                                                multiNodeConfig.headConfig.cardanoInfo,
-                                              )
-                                          )
+            system <- ActorSystem[IO](label)
+            backendAndSnapshot <- Resource.eval(
+              CardanoBackend.mkMock(
+                preinitPeerUtxosL1,
+                multiNodeConfig.headConfig.scriptReferenceUtxos,
+                multiNodeConfig.headConfig.cardanoInfo,
+              )
+            )
             (cardanoBackend, l1Snapshot) = backendAndSnapshot
             transports <- Transport.setup(
-                              transportMode,
-                              multiNodeConfig,
-                              peers,
-                              coilNodeConfigs,
-                          )
+              transportMode,
+              multiNodeConfig,
+              peers,
+              coilNodeConfigs,
+            )
             peerMrms <- peers.toList
-                            .traverse(peerNum =>
-                                Mrm
-                                    .buildPeer(
-                                      peerNum,
-                                      system,
-                                      hooks.wrapBackend(PeerId.Head(peerNum), cardanoBackend),
-                                      multiNodeConfig,
-                                      backendMode,
-                                      transports.headNetworks(peerNum),
-                                      hooks.tracer.contramap(Event.Head(peerNum, _)),
-                                    )
-                                    .map(peerNum -> _)
-                            )
-                            .map(_.toMap)
+                .traverse(peerNum =>
+                    Mrm
+                        .buildPeer(
+                          peerNum,
+                          system,
+                          hooks.wrapBackend(PeerId.Head(peerNum), cardanoBackend),
+                          multiNodeConfig,
+                          backendMode,
+                          transports.headNetworks(peerNum),
+                          hooks.tracer.contramap(Event.Head(peerNum, _)),
+                        )
+                        .map(peerNum -> _)
+                )
+                .map(_.toMap)
             coilMrms <- coilNodeConfigs
-                            .traverse { coilConfig =>
-                                val coilNum = Transport.coilNumOf(coilConfig)
-                                Mrm
-                                    .buildCoil(
-                                      coilConfig,
-                                      coilNum,
-                                      system,
-                                      hooks.wrapBackend(PeerId.Coil(coilNum), cardanoBackend),
-                                      multiNodeConfig,
-                                      transports.coilUplinks(coilNum),
-                                      hooks.tracer.contramap(Event.Coil(coilNum, _)),
-                                    )
-                                    .map(coilNum -> _)
-                            }
-                            .map(_.toMap)
+                .traverse { coilConfig =>
+                    val coilNum = Transport.coilNumOf(coilConfig)
+                    Mrm
+                        .buildCoil(
+                          coilConfig,
+                          coilNum,
+                          system,
+                          hooks.wrapBackend(PeerId.Coil(coilNum), cardanoBackend),
+                          multiNodeConfig,
+                          transports.coilUplinks(coilNum),
+                          hooks.tracer.contramap(Event.Coil(coilNum, _)),
+                        )
+                        .map(coilNum -> _)
+                }
+                .map(_.toMap)
             // WS Phase 2 — bind NodeWsServers and start mesh + coil dialers. Acquired *after*
             // peerMrms/coilMrms so its finalizer (server stop + dialer cancel) runs *before*
             // the MRMs stop their actors and close RocksDB. Otherwise an inbound WS frame can
@@ -490,63 +494,62 @@ object MultiPeerHeadHarness:
             // were freed → use-after-free SIGSEGV in `FailIfCfHasTs`. Direct mode: no-op.
             _ <- transports.bringUpNetwork
             peerConnections <- Resource.eval(
-                                   peerMrms.toList
-                                       .traverse { case (peerNum, peerMrm) =>
-                                           peerMrm.mrm.connectionsDeferred.get.map(peerNum -> _)
-                                       }
-                                       .map(_.toMap)
-                               )
+              peerMrms.toList
+                  .traverse { case (peerNum, peerMrm) =>
+                      peerMrm.mrm.connectionsDeferred.get.map(peerNum -> _)
+                  }
+                  .map(_.toMap)
+            )
             coilConnections <- Resource.eval(
-                                   coilMrms.toList
-                                       .traverse { case (coilNum, coilMrm) =>
-                                           coilMrm.mrm.connectionsDeferred.get.map(coilNum -> _)
-                                       }
-                                       .map(_.toMap)
-                               )
+              coilMrms.toList
+                  .traverse { case (coilNum, coilMrm) =>
+                      coilMrm.mrm.connectionsDeferred.get.map(coilNum -> _)
+                  }
+                  .map(_.toMap)
+            )
             sutErrors <- Resource.eval(Ref[IO].of(List.empty[String]))
-            _         <- ErrorDrainer.start(system, sutErrors)
+            _ <- ErrorDrainer.start(system, sutErrors)
             _ <- Ticks.startForHeads(
-                     peerConnections,
-                     peerNum =>
-                         multiNodeConfig
-                             .nodeConfigs(peerNum)
-                             .nodeOperationMultisigConfig
-                             .cardanoLiaisonPollingPeriod,
-                 )
+              peerConnections,
+              peerNum =>
+                  multiNodeConfig
+                      .nodeConfigs(peerNum)
+                      .nodeOperationMultisigConfig
+                      .cardanoLiaisonPollingPeriod,
+            )
             _ <- Ticks.startForCoils(
-                     coilConnections,
-                     coilNum =>
-                         coilMrms(coilNum).config.nodeOperationMultisigConfig
-                             .cardanoLiaisonPollingPeriod,
-                 )
+              coilConnections,
+              coilNum =>
+                  coilMrms(coilNum).config.nodeOperationMultisigConfig.cardanoLiaisonPollingPeriod,
+            )
             peerEntries <- Resource.eval(
-                               peerConnections.toList.traverse { case (peerNum, conns) =>
-                                   for
-                                       submissionClient <- Http.mkPeerSubmissionClient(
-                                                               peerNum,
-                                                               conns,
-                                                               multiNodeConfig,
-                                                           )
-                                       h <- hooks.handle(PeerId.Head(peerNum), conns)
-                                   yield peerNum -> Peer(
-                                     connections = conns,
-                                     backendStore = peerMrms(peerNum).backendStore,
-                                     submissionClient = submissionClient,
-                                     handle = h,
-                                   )
-                               }
-                           )
+              peerConnections.toList.traverse { case (peerNum, conns) =>
+                  for
+                      submissionClient <- Http.mkPeerSubmissionClient(
+                        peerNum,
+                        conns,
+                        multiNodeConfig,
+                      )
+                      h <- hooks.handle(PeerId.Head(peerNum), conns)
+                  yield peerNum -> Peer(
+                    connections = conns,
+                    backendStore = peerMrms(peerNum).backendStore,
+                    submissionClient = submissionClient,
+                    handle = h,
+                  )
+              }
+            )
             coilEntries <- Resource.eval(
-                               coilConnections.toList.traverse { case (coilNum, conns) =>
-                                   hooks.handle(PeerId.Coil(coilNum), conns).map { h =>
-                                       coilNum -> Coil(
-                                         connections = conns,
-                                         backendStore = coilMrms(coilNum).backendStore,
-                                         handle = h,
-                                       )
-                                   }
-                               }
-                           )
+              coilConnections.toList.traverse { case (coilNum, conns) =>
+                  hooks.handle(PeerId.Coil(coilNum), conns).map { h =>
+                      coilNum -> Coil(
+                        connections = conns,
+                        backendStore = coilMrms(coilNum).backendStore,
+                        handle = h,
+                      )
+                  }
+              }
+            )
         yield Harness(
           transportMode = transportMode,
           multiNodeConfig = multiNodeConfig,
@@ -582,15 +585,15 @@ object MultiPeerHeadHarness:
         private def testControlPresleep(useTC: Boolean, startEpochMs: Long): IO[Unit] =
             IO.whenA(useTC)(IO.sleep(FiniteDuration(startEpochMs, TimeUnit.MILLISECONDS)))
 
-        /** Under WS (real-clock) runs, wait until the wall clock reaches `takeoffTime` so the
-          * model clock and the SUT wall clock coincide at command 1. Abort if setup overran the
-          * budget. Same shape as stage 1. No-op when `takeoffTime` is `None` (TestControl runs).
+        /** Under WS (real-clock) runs, wait until the wall clock reaches `takeoffTime` so the model
+          * clock and the SUT wall clock coincide at command 1. Abort if setup overran the budget.
+          * Same shape as stage 1. No-op when `takeoffTime` is `None` (TestControl runs).
           */
         private def websocketTakeoff(
             takeoffTime: Option[Instant],
             log: ContraTracer[IO, Slf4jMsg],
         ): IO[Unit] = takeoffTime match
-            case None    => IO.unit
+            case None => IO.unit
             case Some(t) =>
                 IO.realTimeInstant.flatMap { now =>
                     if now.isAfter(t) then
@@ -602,9 +605,9 @@ object MultiPeerHeadHarness:
                         )
                     else
                         val sleepMs = t.toEpochMilli - now.toEpochMilli
-                        val tickMs  = 5_000L
-                        val ticks   = sleepMs / tickMs
-                        val remMs   = sleepMs % tickMs
+                        val tickMs = 5_000L
+                        val ticks = sleepMs / tickMs
+                        val remMs = sleepMs % tickMs
                         log.info(s"WS mode: sleeping ${sleepMs / 1000}s until takeoff") >>
                             (0L until ticks).toList.traverse_ { i =>
                                 IO.sleep(tickMs.millis) >>
@@ -690,15 +693,15 @@ object MultiPeerHeadHarness:
                 case Mode.Direct    => true
                 case Mode.WebSocket => false
 
-        /** Transport-layer state needed to build Regime Managers. Produced by
-          * exactly one of [[setupDirect]] / [[setupWebSocket]]; the consumer doesn't need to know
-          * which mode it's in.
+        /** Transport-layer state needed to build Regime Managers. Produced by exactly one of
+          * [[setupDirect]] / [[setupWebSocket]]; the consumer doesn't need to know which mode it's
+          * in.
           *
           * `bringUpNetwork` is a second-phase resource the caller must acquire *after* the MRMs
           * (and their RocksDB backends) are built. Under WS it binds sockets and starts dialers;
-         *  under Direct it is a no-op. Acquiring it last makes its finalizer run *before* the MRM
-          * finalizers stop their actors and close RocksDB — so no inbound WS message can cause a use-after-free
-         * segfault.
+          * under Direct it is a no-op. Acquiring it last makes its finalizer run *before* the MRM
+          * finalizers stop their actors and close RocksDB — so no inbound WS message can cause a
+          * use-after-free segfault.
           */
         case class Setup(
             headNetworks: Map[HeadPeerNumber, HeadNetwork],
@@ -714,7 +717,7 @@ object MultiPeerHeadHarness:
             hubTransport: Option[HubTransport],
         )
 
-        type ContextArg  = ActorContext[IO, HeadMultisigRegimeManager.Request, Any]
+        type ContextArg = ActorContext[IO, HeadMultisigRegimeManager.Request, Any]
         type ContextFn[T] = ContextArg => T
 
         def setup(
@@ -758,32 +761,32 @@ object MultiPeerHeadHarness:
                             .eval(InProcessHubCoilTransport.emptyRegistry)
                             .map(Some(_))
                 headNetworks <- peers.toList
-                                    .traverse(peerNum =>
-                                        directHeadNetwork(
-                                          peerNum,
-                                          multiNodeConfig,
-                                          inProcessRegistry,
-                                          hubCoilRegistry,
-                                        ).map(peerNum -> _)
-                                    )
-                                    .map(_.toMap)
+                    .traverse(peerNum =>
+                        directHeadNetwork(
+                          peerNum,
+                          multiNodeConfig,
+                          inProcessRegistry,
+                          hubCoilRegistry,
+                        ).map(peerNum -> _)
+                    )
+                    .map(_.toMap)
                 coilUplinks <- coilNodeConfigs
-                                   .traverse { coilConfig =>
-                                       val coilNum = coilNumOf(coilConfig)
-                                       val registry = hubCoilRegistry.getOrElse(
-                                         throw new IllegalStateException(
-                                           "coilNodeConfigs is non-empty but " +
-                                               "hubCoilRegistry was not allocated"
-                                         )
-                                       )
-                                       Resource
-                                           .eval(InProcessHubCoilTransport.Coil
-                                               .create(coilNum, registry))
-                                           .map(t =>
-                                               coilNum -> ((_: ContextArg) => t: CoilTransport)
-                                           )
-                                   }
-                                   .map(_.toMap)
+                    .traverse { coilConfig =>
+                        val coilNum = coilNumOf(coilConfig)
+                        val registry = hubCoilRegistry.getOrElse(
+                          throw new IllegalStateException(
+                            "coilNodeConfigs is non-empty but " +
+                                "hubCoilRegistry was not allocated"
+                          )
+                        )
+                        Resource
+                            .eval(
+                              InProcessHubCoilTransport.Coil
+                                  .create(coilNum, registry)
+                            )
+                            .map(t => coilNum -> ((_: ContextArg) => t: CoilTransport))
+                    }
+                    .map(_.toMap)
             yield Setup(headNetworks, coilUplinks, Resource.unit)
 
         /** WebSocket (real-clock) bring-up: split into a creation phase (this method) and a
@@ -792,9 +795,8 @@ object MultiPeerHeadHarness:
           * `CoilPeerWsTransport` — handles the MRMs need. The bring-up phase, acquired by the
           * harness *after* the MRMs are built, binds every peer's `NodeWsServer` on port 0
           * (OS-assigned ephemeral), then builds the `HeadPeerId -> Uri` map from the bound ports
-          * and starts every mesh + coil dialer. Acquiring bring-up last guarantees its
-          * finalizers (server stop + dialer cancel) run before the MRMs stop their actors and
-          * close RocksDB.
+          * and starts every mesh + coil dialer. Acquiring bring-up last guarantees its finalizers
+          * (server stop + dialer cancel) run before the MRMs stop their actors and close RocksDB.
           */
         private def setupWebSocket(
             multiNodeConfig: MultiNodeConfig,
@@ -805,41 +807,41 @@ object MultiPeerHeadHarness:
             for
                 wsClient <- Resource.eval(JdkWSClient.simple[IO])
                 headParts <- peers.toList
-                                 .traverse(peerNum =>
-                                     wsHeadParts(peerNum, multiNodeConfig, peers)
-                                         .map(peerNum -> _)
-                                 )
-                                 .map(_.toMap)
+                    .traverse(peerNum =>
+                        wsHeadParts(peerNum, multiNodeConfig, peers)
+                            .map(peerNum -> _)
+                    )
+                    .map(_.toMap)
                 coilTransports <- coilNodeConfigs
-                                      .traverse { coilConfig =>
-                                          val coilNum = coilNumOf(coilConfig)
-                                          val cpwtTracer = Slf4jTracer.sink.contramap(
-                                            CoilPeerWsTransportEventFormat.humanFormat(coilNum)
-                                          )
-                                          Resource
-                                              .eval(
-                                                CoilPeerWsTransport.create(coilNum, cpwtTracer)
-                                              )
-                                              .map(coilNum -> _)
-                                      }
-                                      .map(_.toMap)
+                    .traverse { coilConfig =>
+                        val coilNum = coilNumOf(coilConfig)
+                        val cpwtTracer = Slf4jTracer.sink.contramap(
+                          CoilPeerWsTransportEventFormat.humanFormat(coilNum)
+                        )
+                        Resource
+                            .eval(
+                              CoilPeerWsTransport.create(coilNum, cpwtTracer)
+                            )
+                            .map(coilNum -> _)
+                    }
+                    .map(_.toMap)
                 headNetworks = headParts.view.mapValues(_.network).toMap
-                coilUplinks  = coilTransports.view
-                                   .mapValues(t => (_: ContextArg) => t: CoilTransport)
-                                   .toMap
+                coilUplinks = coilTransports.view
+                    .mapValues(t => (_: ContextArg) => t: CoilTransport)
+                    .toMap
                 bringUp = wsBringUpNetwork(
-                              multiNodeConfig,
-                              peers,
-                              coilNodeConfigs,
-                              wsClient,
-                              headParts,
-                              coilTransports,
-                          )
+                  multiNodeConfig,
+                  peers,
+                  coilNodeConfigs,
+                  wsClient,
+                  headParts,
+                  coilTransports,
+                )
             yield Setup(headNetworks, coilUplinks, bringUp)
 
         /** Per-peer parts produced in WS Phase 1: the transport bundle exposed to the MRM, the
-          * concrete mesh transport needed by Phase 2's dialer starter, and the route builders
-          * Phase 2 binds into a `NodeWsServer`.
+          * concrete mesh transport needed by Phase 2's dialer starter, and the route builders Phase
+          * 2 binds into a `NodeWsServer`.
           */
         private case class WsHeadParts(
             network: HeadNetwork,
@@ -848,10 +850,9 @@ object MultiPeerHeadHarness:
             nwsTracer: ContraTracer[IO, NodeWsServerEvent],
         )
 
-        /** WS Phase 2: bind each peer's `NodeWsServer`, derive its `Uri`, then start every mesh
-          * and coil dialer. Returned as a `Resource` so the harness can acquire it *after* the
-          * MRMs and ensure LIFO release: dialers + servers stop, then actors stop, then
-          * RocksDB closes.
+        /** WS Phase 2: bind each peer's `NodeWsServer`, derive its `Uri`, then start every mesh and
+          * coil dialer. Returned as a `Resource` so the harness can acquire it *after* the MRMs and
+          * ensure LIFO release: dialers + servers stop, then actors stop, then RocksDB closes.
           */
         private def wsBringUpNetwork(
             multiNodeConfig: MultiNodeConfig,
@@ -864,42 +865,42 @@ object MultiPeerHeadHarness:
             val bindHost = host"127.0.0.1"
             for
                 boundPorts <- peers.toList
-                                  .traverse { peerNum =>
-                                      val parts = headParts(peerNum)
-                                      NodeWsServer
-                                          .resource(
-                                            bindHost,
-                                            Port.fromInt(0).get,
-                                            parts.routes,
-                                            parts.nwsTracer,
-                                          )
-                                          .map(server => peerNum -> server.address.getPort)
-                                  }
-                                  .map(_.toMap)
+                    .traverse { peerNum =>
+                        val parts = headParts(peerNum)
+                        NodeWsServer
+                            .resource(
+                              bindHost,
+                              Port.fromInt(0).get,
+                              parts.routes,
+                              parts.nwsTracer,
+                            )
+                            .map(server => peerNum -> server.address.getPort)
+                    }
+                    .map(_.toMap)
                 peerHeadUris = peers.map { p =>
-                                   headPeerId(multiNodeConfig, p) -> Uri.unsafeFromString(
-                                     s"ws://127.0.0.1:${boundPorts(p)}/head"
-                                   )
-                               }.toMap
+                    headPeerId(multiNodeConfig, p) -> Uri.unsafeFromString(
+                      s"ws://127.0.0.1:${boundPorts(p)}/head"
+                    )
+                }.toMap
                 _ <- peers.toList.traverse_ { peerNum =>
-                         val ownId = headPeerId(multiNodeConfig, peerNum)
-                         headParts(peerNum).wsPeerTransport
-                             .startDialers(wsClient, peerHeadUris - ownId)
-                     }
+                    val ownId = headPeerId(multiNodeConfig, peerNum)
+                    headParts(peerNum).wsPeerTransport
+                        .startDialers(wsClient, peerHeadUris - ownId)
+                }
                 _ <- coilNodeConfigs.traverse_ { coilConfig =>
-                         val coilNum = coilNumOf(coilConfig)
-                         val hubNum = coilConfig
-                             .coilPeerHub(coilNum)
-                             .getOrElse(
-                               throw new IllegalStateException(
-                                 s"no hub configured for coil peer $coilNum"
-                               )
-                             )
-                         val hubUri = Uri.unsafeFromString(
-                           s"ws://127.0.0.1:${boundPorts(hubNum)}/hub"
-                         )
-                         coilTransports(coilNum).startDialer(wsClient, hubUri)
-                     }
+                    val coilNum = coilNumOf(coilConfig)
+                    val hubNum = coilConfig
+                        .coilPeerHub(coilNum)
+                        .getOrElse(
+                          throw new IllegalStateException(
+                            s"no hub configured for coil peer $coilNum"
+                          )
+                        )
+                    val hubUri = Uri.unsafeFromString(
+                      s"ws://127.0.0.1:${boundPorts(hubNum)}/hub"
+                    )
+                    coilTransports(coilNum).startDialer(wsClient, hubUri)
+                }
             yield ()
 
         private def directHeadNetwork(
@@ -909,11 +910,11 @@ object MultiPeerHeadHarness:
             hubCoilRegistry: Option[InProcessHubCoilTransport.Registry],
         ): Resource[IO, HeadNetwork] =
             val ownHeadPeerId = headPeerId(multiNodeConfig, peerNum)
-            val hubbedCoils   = multiNodeConfig.headConfig.hubbedCoilPeerNums(peerNum)
+            val hubbedCoils = multiNodeConfig.headConfig.hubbedCoilPeerNums(peerNum)
             for
                 peerT <- Resource.eval(
-                             InProcessPeerTransport.create(ownHeadPeerId, inProcessRegistry)
-                         )
+                  InProcessPeerTransport.create(ownHeadPeerId, inProcessRegistry)
+                )
                 hubT <-
                     if hubbedCoils.isEmpty then Resource.pure[IO, Option[HubTransport]](None)
                     else
@@ -933,9 +934,8 @@ object MultiPeerHeadHarness:
                                     .map(h => Some(h: HubTransport))
             yield HeadNetwork(peerT, hubT)
 
-        /** WS Phase 1: allocate the concrete `WsPeerTransport` (+ optional `HubWsTransport`)
-          * and the route builders that Phase 2 binds into a `NodeWsServer`. No bind, no dialer
-          * start.
+        /** WS Phase 1: allocate the concrete `WsPeerTransport` (+ optional `HubWsTransport`) and
+          * the route builders that Phase 2 binds into a `NodeWsServer`. No bind, no dialer start.
           */
         private def wsHeadParts(
             peerNum: HeadPeerNumber,
@@ -943,7 +943,7 @@ object MultiPeerHeadHarness:
             peers: Seq[HeadPeerNumber],
         )(using CardanoNetwork.Section): Resource[IO, WsHeadParts] =
             val ownHeadPeerId = headPeerId(multiNodeConfig, peerNum)
-            val hubbedCoils   = multiNodeConfig.headConfig.hubbedCoilPeerNums(peerNum)
+            val hubbedCoils = multiNodeConfig.headConfig.hubbedCoilPeerNums(peerNum)
             val remoteIds: List[HeadPeerId] =
                 peers.filterNot(_ == peerNum).map(headPeerId(multiNodeConfig, _)).toList
             val ptTracer =
@@ -954,19 +954,18 @@ object MultiPeerHeadHarness:
                 Slf4jTracer.sink.contramap(HubWsTransportEventFormat.humanFormat(peerNum))
             for
                 peerT <- Resource.eval(
-                             WsPeerTransport.create(ownHeadPeerId, remoteIds, ptTracer)
-                         )
+                  WsPeerTransport.create(ownHeadPeerId, remoteIds, ptTracer)
+                )
                 hubTConcrete: Option[HubWsTransport] <-
-                    if hubbedCoils.isEmpty then
-                        Resource.pure[IO, Option[HubWsTransport]](None)
+                    if hubbedCoils.isEmpty then Resource.pure[IO, Option[HubWsTransport]](None)
                     else
                         Resource
                             .eval(HubWsTransport.create(hubbedCoils, hubTracer))
                             .map(Some(_))
                 meshRoute = (wsb: WebSocketBuilder2[IO]) => peerT.routes(wsb)
                 hubRoutes = hubTConcrete.toList.map(h =>
-                                (wsb: WebSocketBuilder2[IO]) => h.routes(wsb)
-                            )
+                    (wsb: WebSocketBuilder2[IO]) => h.routes(wsb)
+                )
             yield WsHeadParts(
               network = HeadNetwork(peerT, hubTConcrete.map(h => h: HubTransport)),
               wsPeerTransport = peerT,
@@ -1004,14 +1003,12 @@ object MultiPeerHeadHarness:
                 Slf4jTracer.sink.contramap(
                   HeadMultisigRegimeManagerEventFormat.humanFormat(peerNum)
                 )
-            val mrmTracer         = slf4jMrm |+| callerTracer
+            val mrmTracer = slf4jMrm |+| callerTracer
             val persistenceTracer = Slf4jTracer.sink.contramap(PersistenceEventFormat.humanFormat)
             val peerFactory: Resource[IO, Transport.ContextFn[PeerTransport]] =
                 Resource.pure((_: Transport.ContextArg) => network.peerTransport)
             val hubFactory: Option[Resource[IO, Transport.ContextFn[HubTransport]]] =
-                network.hubTransport.map(h =>
-                    Resource.pure((_: Transport.ContextArg) => h)
-                )
+                network.hubTransport.map(h => Resource.pure((_: Transport.ContextArg) => h))
             StorageBackend
                 .openPerPeer(
                   peerNum,
@@ -1026,19 +1023,19 @@ object MultiPeerHeadHarness:
                 .flatMap { backendStore =>
                     for
                         persistence <- Resource.eval {
-                                           given CardanoNetwork.Section = nodeConfig
-                                           Persistence.fromBackend(backendStore, persistenceTracer)
-                                       }
+                            given CardanoNetwork.Section = nodeConfig
+                            Persistence.fromBackend(backendStore, persistenceTracer)
+                        }
                         l2Ledger <- Resource.eval(EutxoL2Ledger(nodeConfig))
                         mrm <- HeadMultisigRegimeManager.resource(
-                                   nodeConfig,
-                                   cardanoBackend,
-                                   l2Ledger,
-                                   persistence,
-                                   mrmTracer,
-                                   peerFactory,
-                                   hubFactory,
-                               )
+                          nodeConfig,
+                          cardanoBackend,
+                          l2Ledger,
+                          persistence,
+                          mrmTracer,
+                          peerFactory,
+                          hubFactory,
+                        )
                         _ <- Resource.eval(system.actorOf(mrm, s"hmrm-$peerNum"))
                     yield Peer(mrm, backendStore)
                 }
@@ -1061,25 +1058,25 @@ object MultiPeerHeadHarness:
                 Slf4jTracer.sink.contramap(
                   CoilMultisigRegimeManagerEventFormat.humanFormat(labelNum, coilNum)
                 )
-            val mrmTracer         = slf4jMrm |+| callerTracer
+            val mrmTracer = slf4jMrm |+| callerTracer
             val persistenceTracer = Slf4jTracer.sink.contramap(PersistenceEventFormat.humanFormat)
             val uplinkFactory: Resource[IO, Transport.ContextFn[CoilTransport]] =
                 Resource.pure(uplink)
             InMemoryBackendStore.open(persistenceTracer).flatMap { backendStore =>
                 for
                     persistence <- Resource.eval {
-                                       given CardanoNetwork.Section = coilConfig
-                                       Persistence.fromBackend(backendStore, persistenceTracer)
-                                   }
+                        given CardanoNetwork.Section = coilConfig
+                        Persistence.fromBackend(backendStore, persistenceTracer)
+                    }
                     l2Ledger <- Resource.eval(EutxoL2Ledger(coilConfig))
                     mrm <- CoilMultisigRegimeManager.resource(
-                               coilConfig,
-                               cardanoBackend,
-                               l2Ledger,
-                               persistence,
-                               mrmTracer,
-                               uplinkFactory,
-                           )
+                      coilConfig,
+                      cardanoBackend,
+                      l2Ledger,
+                      persistence,
+                      mrmTracer,
+                      uplinkFactory,
+                    )
                     _ <- Resource.eval(system.actorOf(mrm, s"cmrm-${coilNum.convert}"))
                 yield Coil(mrm, backendStore, coilConfig)
             }
@@ -1089,8 +1086,8 @@ object MultiPeerHeadHarness:
     // ===================================
 
     object Http:
-        /** Placeholder authority for the in-process HTTP client. `Client.fromHttpApp` dispatches
-          * by path against the wrapped `HttpApp`, so the authority never hits a socket.
+        /** Placeholder authority for the in-process HTTP client. `Client.fromHttpApp` dispatches by
+          * path against the wrapped `HttpApp`, so the authority never hits a socket.
           */
         private val InProcBaseUri: Uri = uri"http://harness"
 
@@ -1146,13 +1143,11 @@ object MultiPeerHeadHarness:
             sutErrors: Ref[IO, List[String]],
         ): Resource[IO, Unit] =
             startedFiber(
-              system.eventStream.take
-                  .flatMap {
-                      case e: ActorError if e.cause != ActorError.NoCause =>
-                          sutErrors.update(_ :+ s"[${e.logSource}] ${e.cause.getMessage}")
-                      case _ => IO.unit
-                  }
-                  .foreverM
+              system.eventStream.take.flatMap {
+                  case e: ActorError if e.cause != ActorError.NoCause =>
+                      sutErrors.update(_ :+ s"[${e.logSource}] ${e.cause.getMessage}")
+                  case _ => IO.unit
+              }.foreverM
             )
 
     // ===================================

--- a/integration/src/test/scala/hydrozoa/integration/harness/Plugin.scala
+++ b/integration/src/test/scala/hydrozoa/integration/harness/Plugin.scala
@@ -41,8 +41,8 @@ final class Signal[T] private (
     def await: IO[T] = signal.get
 
     /** Manually fire the signal once. Used when the test detects the condition outside the
-      * predicate path (e.g. at arming time the condition is already met and no future event
-      * would re-trigger the predicate).
+      * predicate path (e.g. at arming time the condition is already met and no future event would
+      * re-trigger the predicate).
       */
     def complete(value: T): IO[Unit] = signal.complete(value).void
 

--- a/integration/src/test/scala/hydrozoa/integration/rbr/property/Abstraction.scala
+++ b/integration/src/test/scala/hydrozoa/integration/rbr/property/Abstraction.scala
@@ -14,8 +14,8 @@ import scalus.uplc.builtin.{ByteString, Data}
 
 /** Histogram of every UTxO in the shared mock backend, bucketed by [[RBRPlaceId]].
   *
-  * A type alias for [[Histogram]]`[RBRPlaceId, Utxo]`. Produced by running
-  * [[RBRClassifier]] over a UTxO snapshot.
+  * A type alias for [[Histogram]]`[RBRPlaceId, Utxo]`. Produced by running [[RBRClassifier]] over a
+  * UTxO snapshot.
   */
 type RBRHistogram = Histogram[RBRPlaceId, Utxo]
 
@@ -25,18 +25,18 @@ type RBRHistogram = Histogram[RBRPlaceId, Utxo]
   *   - Treasury and vote UTxOs carry a distinctive policy token
   *   - Collateral UTxOs carry the datum sentinel `"collateral"`
   *   - Evacuation outputs carry the datum sentinel `"evacuation"`
-  *   - Script reference UTxOs are identified by their known [[scalus.cardano.ledger.TransactionInput]] keys
+  *   - Script reference UTxOs are identified by their known
+  *     [[scalus.cardano.ledger.TransactionInput]] keys
   *   - Everything else falls into the [[AmbientPlaceId]] default bucket
   *
-  * TODO: the `"collateral"` sentinel only exists in the synthetic `InitialDisputeUtxos`
-  * fixture — the real rule-based tx builders (`VoteTx`, `TallyTx`, `ResolutionTx`,
-  * `AbstainTx`, `RatchetVoteTx`, `EvacuationTx`) draw collateral from plain Ada wallet
-  * UTxOs whose `datumOption` is `None`, so content-based detection fails in end-to-end
-  * scenarios and collateral outputs land in [[AmbientPlaceId]]. The right fix is to bucket
-  * collateral by role in the tx graph — mark any output that is later consumed as a
-  * `collateral_input` of some downstream tx — rather than by a content sentinel. That
-  * requires shifting the classifier from `Utxo => Option[Bucket]` to a form that has
-  * access to the surrounding tx history.
+  * TODO: the `"collateral"` sentinel only exists in the synthetic `InitialDisputeUtxos` fixture —
+  * the real rule-based tx builders (`VoteTx`, `TallyTx`, `ResolutionTx`, `AbstainTx`,
+  * `RatchetVoteTx`, `EvacuationTx`) draw collateral from plain Ada wallet UTxOs whose `datumOption`
+  * is `None`, so content-based detection fails in end-to-end scenarios and collateral outputs land
+  * in [[AmbientPlaceId]]. The right fix is to bucket collateral by role in the tx graph — mark any
+  * output that is later consumed as a `collateral_input` of some downstream tx — rather than by a
+  * content sentinel. That requires shifting the classifier from `Utxo => Option[Bucket]` to a form
+  * that has access to the surrounding tx history.
   *
   * Usage: `Histogram.empty(RBRClassifier(using env)).addAll(utxos.map(Utxo(_, _)))`
   */
@@ -44,13 +44,13 @@ class RBRClassifier(using env: MultiNodeConfig)
     extends Classifier[RBRPlaceId, Utxo](AmbientPlaceId):
 
     def classifierFns: List[Utxo => Option[RBRPlaceId]] =
-        val policyId              = env.headConfig.headMultisigScript.policyId
-        val treasuryToken         = env.headConfig.headTokenNames.treasuryTokenName
-        val voteToken             = env.headConfig.headTokenNames.voteTokenName
-        val treasuryScriptInput   = env.headConfig.rulebasedTreasuryScriptInput
-        val disputeScriptInput    = env.headConfig.disputeResolutionScriptInput
-        val setupLadderInputs     = env.headConfig.setupLadderInputs.toSet
-        val regimeWitnessToken    = env.headConfig.headTokenNames.regimeWitnessTokenName
+        val policyId = env.headConfig.headMultisigScript.policyId
+        val treasuryToken = env.headConfig.headTokenNames.treasuryTokenName
+        val voteToken = env.headConfig.headTokenNames.voteTokenName
+        val treasuryScriptInput = env.headConfig.rulebasedTreasuryScriptInput
+        val disputeScriptInput = env.headConfig.disputeResolutionScriptInput
+        val setupLadderInputs = env.headConfig.setupLadderInputs.toSet
+        val regimeWitnessToken = env.headConfig.headTokenNames.regimeWitnessTokenName
         val collateralDatumMarker = toData(ByteString.fromString("collateral"))
         val evacuationDatumMarker = toData(ByteString.fromString("evacuation"))
 
@@ -67,33 +67,35 @@ class RBRClassifier(using env: MultiNodeConfig)
             out.value.assets.assets.get(policyId).exists(_.contains(regimeWitnessToken))
 
         List(
-            (u: Utxo) => Option.when(u.input == treasuryScriptInput)(TreasuryRefPlaceId),
-            (u: Utxo) => Option.when(u.input == disputeScriptInput)(DisputeRefPlaceId),
-            (u: Utxo) => Option.when(setupLadderInputs.contains(u.input))(SetupLadderRefPlaceId),
-            (u: Utxo) => Option.when(hasRegimeToken(u.output))(RegimeRefPlaceId),
-            // ResolvedTreasuryPlaceId / UnresolvedTreasuryPlaceId: carries treasury token; parse datum to distinguish
-            (u: Utxo) =>
-                Option
-                    .when(hasTreasuryToken(u.output))(u)
-                    .flatMap(RuleBasedTreasuryUtxo.parse(_)(using env.nodeConfigs.values.head).toOption)
-                    .map(tu =>
-                        if tu.treasuryOutput.datum.isInstanceOf[RuleBasedTreasuryDatum.Resolved] then
-                            ResolvedTreasuryPlaceId
-                        else UnresolvedTreasuryPlaceId
-                    ),
-            // VotedPlaceId / UnvotedPlaceId: carries vote token; parse datum to distinguish
-            (u: Utxo) =>
-                Option
-                    .when(hasVoteToken(u.output) && !hasTreasuryToken(u.output))(u)
-                    .flatMap(BallotBox.parse(_)(using env.nodeConfigs.values.head).toOption)
-                    .map(vu =>
-                        if vu.ballotBoxOutput.status.isInstanceOf[VoteStatus.Voted] then VotedPlaceId
-                        else UnvotedPlaceId
-                    ),
-            (u: Utxo) =>
-                Option.when(hasInlineDatum(collateralDatumMarker)(u.output))(CollateralPlaceId),
-            (u: Utxo) =>
-                Option.when(hasInlineDatum(evacuationDatumMarker)(u.output))(
-                    EvacuationOutputPlaceId
-                ),
+          (u: Utxo) => Option.when(u.input == treasuryScriptInput)(TreasuryRefPlaceId),
+          (u: Utxo) => Option.when(u.input == disputeScriptInput)(DisputeRefPlaceId),
+          (u: Utxo) => Option.when(setupLadderInputs.contains(u.input))(SetupLadderRefPlaceId),
+          (u: Utxo) => Option.when(hasRegimeToken(u.output))(RegimeRefPlaceId),
+          // ResolvedTreasuryPlaceId / UnresolvedTreasuryPlaceId: carries treasury token; parse datum to distinguish
+          (u: Utxo) =>
+              Option
+                  .when(hasTreasuryToken(u.output))(u)
+                  .flatMap(
+                    RuleBasedTreasuryUtxo.parse(_)(using env.nodeConfigs.values.head).toOption
+                  )
+                  .map(tu =>
+                      if tu.treasuryOutput.datum.isInstanceOf[RuleBasedTreasuryDatum.Resolved] then
+                          ResolvedTreasuryPlaceId
+                      else UnresolvedTreasuryPlaceId
+                  ),
+          // VotedPlaceId / UnvotedPlaceId: carries vote token; parse datum to distinguish
+          (u: Utxo) =>
+              Option
+                  .when(hasVoteToken(u.output) && !hasTreasuryToken(u.output))(u)
+                  .flatMap(BallotBox.parse(_)(using env.nodeConfigs.values.head).toOption)
+                  .map(vu =>
+                      if vu.ballotBoxOutput.status.isInstanceOf[VoteStatus.Voted] then VotedPlaceId
+                      else UnvotedPlaceId
+                  ),
+          (u: Utxo) =>
+              Option.when(hasInlineDatum(collateralDatumMarker)(u.output))(CollateralPlaceId),
+          (u: Utxo) =>
+              Option.when(hasInlineDatum(evacuationDatumMarker)(u.output))(
+                EvacuationOutputPlaceId
+              ),
         )

--- a/integration/src/test/scala/hydrozoa/integration/rbr/property/CommitmentSelectionPropertyTest.scala
+++ b/integration/src/test/scala/hydrozoa/integration/rbr/property/CommitmentSelectionPropertyTest.scala
@@ -7,8 +7,8 @@ import cats.syntax.all.*
 import hydrozoa.config.head.network.CardanoNetwork
 import hydrozoa.config.head.rulebased.dispute.DisputeResolutionConfig
 import hydrozoa.config.node.MultiNodeConfig
-import hydrozoa.integration.harness.{KickRequest, MultiPeerHeadHarness}
 import hydrozoa.integration.harness.MultiPeerHeadHarness.Transport.Mode as TransportMode
+import hydrozoa.integration.harness.{KickRequest, MultiPeerHeadHarness}
 import hydrozoa.integration.rbr.model.petri.net.RBRPlaceId
 import hydrozoa.integration.rbr.model.petri.net.RBRPlaceId.*
 import hydrozoa.lib.cardano.scalus.QuantizedTime.QuantizedFiniteDuration
@@ -28,17 +28,17 @@ import scala.concurrent.duration.*
 import scalus.cardano.ledger.{Utxo, Utxos}
 import test.{SeedPhrase, TestPeers}
 
-/** Rule-based regime dispute flow through the [[MultiPeerHeadHarness]], with the vote path
-  * disabled at the tx layer to exercise how tally selects a commitment when peers cannot vote.
+/** Rule-based regime dispute flow through the [[MultiPeerHeadHarness]], with the vote path disabled
+  * at the tx layer to exercise how tally selects a commitment when peers cannot vote.
   *
   *   - **Test 1** — firewall every [[VoteTx]] head + coil. No vote lands, tally's max-by-
-  *     versionMinor reduction preserves the public/default ballot box, resolves to `major1`
-  *     (the FallbackTx-produced treasury's kzg = on-chain Major-1 commitment). Peers evacuate
-  *     against `initialEvacuationMap`.
+  *     versionMinor reduction preserves the public/default ballot box, resolves to `major1` (the
+  *     FallbackTx-produced treasury's kzg = on-chain Major-1 commitment). Peers evacuate against
+  *     `initialEvacuationMap`.
   *   - **Test 2** — same firewall, plus an exogenously-built [[VoteTx]] for `sec2` (the SEC at
-  *     hard-confirmed stack 2) submitted directly to the shared L1. Tally's max-by-
-  *     versionMinor picks our vote (default is `versionMinor = 0`; ours is > 0). Peers
-  *     evacuate against `sec2`'s map.
+  *     hard-confirmed stack 2) submitted directly to the shared L1. Tally's max-by- versionMinor
+  *     picks our vote (default is `versionMinor = 0`; ours is > 0). Peers evacuate against `sec2`'s
+  *     map.
   *
   * Setup mirrors [[EvacuationPropertyTest]] (3 head + 2 coil, firewalled v2 settlement, widened
   * init window).
@@ -49,10 +49,10 @@ object CommitmentSelectionPropertyTest extends Properties("RBR Commitment Select
         p: org.scalacheck.Test.Parameters
     ): org.scalacheck.Test.Parameters = p.withMinSuccessfulTests(1)
 
-    private val nHeadPeers: Int                 = 3
-    private val nCoilPeers: Int                 = 2
+    private val nHeadPeers: Int = 3
+    private val nCoilPeers: Int = 2
     private val scenarioTimeout: FiniteDuration = 5.minutes
-    private val cardanoNetwork: CardanoNetwork  = CardanoNetwork.Preprod
+    private val cardanoNetwork: CardanoNetwork = CardanoNetwork.Preprod
 
     /** The commitment we expect the resolved treasury to end up with. Drives both what (if
       * anything) the scenario submits between fallback and resolution, and the expected
@@ -71,9 +71,9 @@ object CommitmentSelectionPropertyTest extends Properties("RBR Commitment Select
         transportMode: TransportMode,
         expected: ExpectedCommitment
     ): Prop =
-        val testPeers   = TestPeers.apply(SeedPhrase.Yaci, cardanoNetwork, nHeadPeers, nCoilPeers)
+        val testPeers = TestPeers.apply(SeedPhrase.Yaci, cardanoNetwork, nHeadPeers, nCoilPeers)
         val coilWallets = testPeers.coilWallets
-        val coilPeers   = testPeers.coilPeersConfig(hub = HeadPeerNumber(0))
+        val coilPeers = testPeers.coilPeersConfig(hub = HeadPeerNumber(0))
 
         val fastDisputeResolutionConfig: test.GenWithTestPeers[DisputeResolutionConfig] =
             ReaderT { network =>
@@ -137,20 +137,20 @@ object CommitmentSelectionPropertyTest extends Properties("RBR Commitment Select
     private def step1a_submitBootstrapRequest: test.TestM[Ctx, Unit] =
         for
             ctx <- ask
-            _   <- lift(submitOneUserRequest(ctx))
+            _ <- lift(submitOneUserRequest(ctx))
         yield ()
 
     private def step1b_startPeriodicRequestLoop: test.TestM[Ctx, Unit] =
         for
-            ctx   <- ask
+            ctx <- ask
             fiber <- lift((IO.sleep(1.second) >> submitOneUserRequest(ctx)).foreverM.start)
-            _     <- lift(ctx.periodicRequestFiber.set(Some(fiber)))
+            _ <- lift(ctx.periodicRequestFiber.set(Some(fiber)))
         yield ()
 
     private def step2_awaitFallbackToRuleBasedHandoff: test.TestM[Ctx, Unit] =
         for
             ctx <- ask
-            _   <- lift(ctx.fallbackDispatched.get.timeout(scenarioTimeout))
+            _ <- lift(ctx.fallbackDispatched.get.timeout(scenarioTimeout))
         yield ()
 
     /** For [[ExpectedCommitment.DefaultMajor1]] this is a no-op. */
@@ -158,43 +158,42 @@ object CommitmentSelectionPropertyTest extends Properties("RBR Commitment Select
         for
             ctx <- ask
             _ <- lift(ctx.expected match
-                case ExpectedCommitment.DefaultMajor1 => IO.unit
-            )
+                case ExpectedCommitment.DefaultMajor1 => IO.unit)
         yield ()
 
     private def step3_awaitResolutionSubmitted: test.TestM[Ctx, Unit] =
         for
             ctx <- ask
-            _   <- lift(ctx.resolutionSubmitted.get.timeout(scenarioTimeout))
+            _ <- lift(ctx.resolutionSubmitted.get.timeout(scenarioTimeout))
         yield ()
 
     private def step4_awaitEvacuationDone: test.TestM[Ctx, Unit] =
         for
             ctx <- ask
-            _   <- lift(ctx.evacuationDone.get.timeout(scenarioTimeout))
+            _ <- lift(ctx.evacuationDone.get.timeout(scenarioTimeout))
         yield ()
 
     private def step5_assertTerminalHistogram: test.TestM[Ctx, Unit] =
         for
-            ctx    <- ask
-            _      <- lift(ctx.periodicRequestFiber.get.flatMap(_.traverse_(_.cancel)))
-            _      <- lift(IO.sleep(quiescenceDelay))
-            utxos  <- lift(ctx.harness.l1Snapshot)
+            ctx <- ask
+            _ <- lift(ctx.periodicRequestFiber.get.flatMap(_.traverse_(_.cancel)))
+            _ <- lift(IO.sleep(quiescenceDelay))
+            utxos <- lift(ctx.harness.l1Snapshot)
             actual <- lift(runClassifier(utxos)(using ctx.multiNodeConfig))
             expectedEvacCount <- lift(
-                                     ctx.firstPayoutsLeft.get.flatMap(
-                                       IO.fromOption(_)(
-                                         new IllegalStateException(
-                                           "no `Evacuation.PayoutsLeft` observed; RBA never entered the drain loop"
-                                         )
-                                       )
-                                     )
-                                 )
+              ctx.firstPayoutsLeft.get.flatMap(
+                IO.fromOption(_)(
+                  new IllegalStateException(
+                    "no `Evacuation.PayoutsLeft` observed; RBA never entered the drain loop"
+                  )
+                )
+              )
+            )
             expected = expectedCardinalities(expectedEvacCount)
             _ <- assertWith(
-                     actual == expected,
-                     s"Cardinality mismatch:\n  expected: $expected\n  actual:   $actual"
-                 )
+              actual == expected,
+              s"Cardinality mismatch:\n  expected: $expected\n  actual:   $actual"
+            )
         yield ()
 
     private val quiescenceDelay: FiniteDuration = 2.seconds
@@ -212,11 +211,11 @@ object CommitmentSelectionPropertyTest extends Properties("RBR Commitment Select
         takeoffTime: Option[java.time.Instant]
     ): Resource[IO, Ctx] =
         for
-            fallbackDispatched   <- Resource.eval(Deferred[IO, Unit])
-            resolutionSubmitted  <- Resource.eval(Deferred[IO, Unit])
-            peersEvacuationDone  <- Resource.eval(Ref[IO].of(Set.empty[PeerId]))
-            evacuationDone       <- Resource.eval(Deferred[IO, Unit])
-            firstPayoutsLeft     <- Resource.eval(Ref[IO].of(Option.empty[Int]))
+            fallbackDispatched <- Resource.eval(Deferred[IO, Unit])
+            resolutionSubmitted <- Resource.eval(Deferred[IO, Unit])
+            peersEvacuationDone <- Resource.eval(Ref[IO].of(Set.empty[PeerId]))
+            evacuationDone <- Resource.eval(Deferred[IO, Unit])
+            firstPayoutsLeft <- Resource.eval(Ref[IO].of(Option.empty[Int]))
             periodicRequestFiber <- Resource.eval(Ref[IO].of(Option.empty[FiberIO[Nothing]]))
 
             preinitPeerUtxosL1 = yaciTestSauceGenesis(cardanoNetwork.network)(testPeers)
@@ -224,7 +223,8 @@ object CommitmentSelectionPropertyTest extends Properties("RBR Commitment Select
 
             coilNodeConfigs = multiNodeConfig.mkCoilNodeConfigs(coilWallets)
 
-            startEpochMs = multiNodeConfig.headConfig.initialBlock.blockBrief.endTime.convert.instant.toEpochMilli
+            startEpochMs =
+                multiNodeConfig.headConfig.initialBlock.blockBrief.endTime.convert.instant.toEpochMilli
 
             hooks = MultiPeerHeadHarness.Hooks[Option[RequestSequencer.Handle]](
               tracer = humanFormatTracer |+| observerTracer(
@@ -281,7 +281,7 @@ object CommitmentSelectionPropertyTest extends Properties("RBR Commitment Select
     // ------------------------------------------------------------------
 
     private def submitOneUserRequest(ctx: Ctx): IO[Unit] =
-        val peerNum     = HeadPeerNumber(0)
+        val peerNum = HeadPeerNumber(0)
         val userRequest = KickRequest.mkKickTransactionRequest(ctx.multiNodeConfig, peerNum)
         for
             sequencer <- IO.fromOption(ctx.harness.peers.get(peerNum).flatMap(_.handle))(
@@ -303,10 +303,10 @@ object CommitmentSelectionPropertyTest extends Properties("RBR Commitment Select
                 )
         }
 
-    /** Same as [[EvacuationPropertyTest.wrapPeerBackend]] plus a blanket drop on every
-      * vote-related tx: head-side [[VoteTx]], coil-side [[RatchetVoteTx]] (structurally the same
-      * as [[VoteTx]] but ratchets an already-`Voted` box forward — can move the resolved kzg),
-      * and [[AbstainTx]] for symmetry. Applies to both head and coil backends.
+    /** Same as [[EvacuationPropertyTest.wrapPeerBackend]] plus a blanket drop on every vote-related
+      * tx: head-side [[VoteTx]], coil-side [[RatchetVoteTx]] (structurally the same as [[VoteTx]]
+      * but ratchets an already-`Voted` box forward — can move the resolved kzg), and [[AbstainTx]]
+      * for symmetry. Applies to both head and coil backends.
       */
     private def wrapPeerBackend(
         peerId: PeerId,
@@ -391,7 +391,7 @@ object CommitmentSelectionPropertyTest extends Properties("RBR Commitment Select
         utxos: Utxos
     )(using MultiNodeConfig): IO[Map[RBRPlaceId, Int]] =
         val classifier = new RBRClassifier
-        val allUtxos   = utxos.toList.map { case (i, o) => Utxo(i, o) }
+        val allUtxos = utxos.toList.map { case (i, o) => Utxo(i, o) }
         Histogram.empty(classifier).addAll(allUtxos).toEither match
             case Left(errs) =>
                 IO.raiseError(
@@ -403,9 +403,11 @@ object CommitmentSelectionPropertyTest extends Properties("RBR Commitment Select
     @unused
     private def logAmbientUtxos(classifier: RBRClassifier, utxos: List[Utxo]): IO[Unit] =
         val ambient = utxos.filter(u => classifier.classify(u).contains(AmbientPlaceId))
-        val lines = ambient.zipWithIndex.map { case (u, idx) =>
-            s"  [$idx] input=${u.input} addr=${u.output.address} value=${u.output.value} datum=${u.output.datumOption}"
-        }.mkString("\n")
+        val lines = ambient.zipWithIndex
+            .map { case (u, idx) =>
+                s"  [$idx] input=${u.input} addr=${u.output.address} value=${u.output.value} datum=${u.output.datumOption}"
+            }
+            .mkString("\n")
         Slf4jTracer.sink.traceWith(
           hydrozoa.lib.logging.LogEvent
               .From(Map.empty, "AmbientDiagnostic")
@@ -414,21 +416,21 @@ object CommitmentSelectionPropertyTest extends Properties("RBR Commitment Select
 
     /** Shape identical to [[EvacuationPropertyTest.expectedCardinalities]]. Only
       * `EvacuationOutputPlaceId` varies with the winning commitment; the count comes from
-      * `PayoutsLeft(n)` observed by the RBA at drain start, which equals the resolved
-      * commitment's evacuation-map size.
+      * `PayoutsLeft(n)` observed by the RBA at drain start, which equals the resolved commitment's
+      * evacuation-map size.
       */
     private def expectedCardinalities(evacuationCount: Int): Map[RBRPlaceId, Int] =
         Map(
-          TreasuryRefPlaceId        -> 1,
-          DisputeRefPlaceId         -> 1,
-          RegimeRefPlaceId          -> 1,
-          SetupLadderRefPlaceId     -> 7,
-          ResolvedTreasuryPlaceId   -> 1,
+          TreasuryRefPlaceId -> 1,
+          DisputeRefPlaceId -> 1,
+          RegimeRefPlaceId -> 1,
+          SetupLadderRefPlaceId -> 7,
+          ResolvedTreasuryPlaceId -> 1,
           UnresolvedTreasuryPlaceId -> 0,
-          VotedPlaceId              -> 0,
-          UnvotedPlaceId            -> 0,
-          CollateralPlaceId         -> 0,
-          EvacuationOutputPlaceId   -> evacuationCount,
-          PayoutObligationsPlaceId  -> 0,
-          AmbientPlaceId            -> (nHeadPeers * 2 + nCoilPeers)
+          VotedPlaceId -> 0,
+          UnvotedPlaceId -> 0,
+          CollateralPlaceId -> 0,
+          EvacuationOutputPlaceId -> evacuationCount,
+          PayoutObligationsPlaceId -> 0,
+          AmbientPlaceId -> (nHeadPeers * 2 + nCoilPeers)
         )

--- a/integration/src/test/scala/hydrozoa/integration/rbr/property/EvacuationPropertyTest.scala
+++ b/integration/src/test/scala/hydrozoa/integration/rbr/property/EvacuationPropertyTest.scala
@@ -4,35 +4,35 @@ import cats.effect.*
 import cats.effect.unsafe.implicits.global
 import cats.syntax.all.*
 import hydrozoa.config.node.MultiNodeConfig
-import hydrozoa.integration.harness.{MultiPeerDisputeProperties, MultiPeerHeadHarness}
 import hydrozoa.integration.harness.MultiPeerHeadHarness.Transport.Mode as TransportMode
-import hydrozoa.lib.logging.{ContraTracer, Slf4jTracer}
-import scala.annotation.unused
-import hydrozoa.multisig.backend.cardano.{FirewalledCardanoBackend, yaciTestSauceGenesis}
-import hydrozoa.multisig.consensus.peer.{HeadPeerNumber, PeerId}
-import hydrozoa.multisig.consensus.{CardanoLiaisonEvent, RequestSequencer}
+import hydrozoa.integration.harness.{MultiPeerDisputeProperties, MultiPeerHeadHarness}
 import hydrozoa.integration.rbr.model.petri.net.RBRPlaceId
 import hydrozoa.integration.rbr.model.petri.net.RBRPlaceId.*
 import hydrozoa.lib.classification.Histogram
+import hydrozoa.lib.logging.{ContraTracer, Slf4jTracer}
+import hydrozoa.multisig.backend.cardano.{FirewalledCardanoBackend, yaciTestSauceGenesis}
+import hydrozoa.multisig.consensus.peer.{HeadPeerNumber, PeerId}
+import hydrozoa.multisig.consensus.{CardanoLiaisonEvent, RequestSequencer}
 import hydrozoa.multisig.{CommonChildEvent, RuleBasedOnlyChildEvent}
 import hydrozoa.rulebased.RuleBasedActorEvent
 import org.scalacheck.Prop
+import scala.annotation.unused
 import scala.concurrent.duration.*
 import scalus.cardano.ledger.{Utxo, Utxos}
 import test.{SeedPhrase, TestPeers}
 
-/** Rule-based regime dispute flow through the [[MultiPeerHeadHarness]] — real MRM + persistence
-  * + RBA against a mock L1, exercising the fallback → vote → tally → resolve sequence.
+/** Rule-based regime dispute flow through the [[MultiPeerHeadHarness]] — real MRM + persistence +
+  * RBA against a mock L1, exercising the fallback → vote → tally → resolve sequence.
   *
   * Scenario:
   *   1. 3-peer head + 2 coil followers; per-head-peer [[FirewalledCardanoBackend]] drops any
-  *      [[SettlementTx]] with
-  *      `versionMajor == 2`, so on-chain lags at v1 while peers hard-confirm through v2 off-chain.
+  *      [[SettlementTx]] with `versionMajor == 2`, so on-chain lags at v1 while peers hard-confirm
+  *      through v2 off-chain.
   *   2. Bootstrap L2 request + periodic requests give each Major stack a trailing Minor with SEC.
   *   3. When CL dispatches `Action.FallbackToRuleBased` for major-2, HMRM spawns
   *      [[RuleBasedRegimeManager]] which spawns [[RuleBasedActor]].
-  *   4. RBA's persistence-backed `loadAction` walks backward, finds the SEC matching the
-  *      on-chain treasury's `versionMajor = 1`, and submits a Vote that Plutus accepts.
+  *   4. RBA's persistence-backed `loadAction` walks backward, finds the SEC matching the on-chain
+  *      treasury's `versionMajor = 1`, and submits a Vote that Plutus accepts.
   *   5. Voting deadline elapses → TallyTx → ResolutionTx.
   *   6. Every peer's RBA builds and submits an [[EvacuationTx]] until its `Evacuation.NoMore`
   *      terminal event fires.
@@ -40,12 +40,13 @@ import test.{SeedPhrase, TestPeers}
   */
 object EvacuationPropertyTest extends MultiPeerDisputeProperties("RBR Evacuation Property"):
 
-    private val nHeadPeers: Int              = 3
-    private val nCoilPeers: Int              = 2
+    private val nHeadPeers: Int = 3
+    private val nCoilPeers: Int = 2
     private val scenarioTimeout: FiniteDuration = 5.minutes
 
-    val _ = property("ws: fallback→RRM→vote→tally→resolve→evacuate happy path") =
-        testProperty(TransportMode.WebSocket)
+    val _ = property("ws: fallback→RRM→vote→tally→resolve→evacuate happy path") = testProperty(
+      TransportMode.WebSocket
+    )
 
     private def testProperty(transportMode: TransportMode): Prop =
         val testPeers = TestPeers.apply(SeedPhrase.Yaci, cardanoNetwork, nHeadPeers, nCoilPeers)
@@ -124,39 +125,41 @@ object EvacuationPropertyTest extends MultiPeerDisputeProperties("RBR Evacuation
     private def step2_awaitFallbackToRuleBasedHandoff: test.TestM[Ctx, Unit] =
         for
             ctx <- ask
-            _   <- lift(ctx.fallbackDispatched.get.timeout(scenarioTimeout))
+            _ <- lift(ctx.fallbackDispatched.get.timeout(scenarioTimeout))
         yield ()
 
     private def step3_awaitResolutionSubmitted: test.TestM[Ctx, Unit] =
         for
             ctx <- ask
-            _   <- lift(ctx.resolutionSubmitted.get.timeout(scenarioTimeout))
+            _ <- lift(ctx.resolutionSubmitted.get.timeout(scenarioTimeout))
         yield ()
 
     private def step4_awaitEvacuationDone: test.TestM[Ctx, Unit] =
         for
             ctx <- ask
-            _   <- lift(ctx.evacuationDone.get.timeout(scenarioTimeout))
+            _ <- lift(ctx.evacuationDone.get.timeout(scenarioTimeout))
         yield ()
 
-    /** After evacuation completes, cancel the periodic-request loop, wait a beat for any
-      * in-flight tx to settle, snapshot the shared mock L1, and check the UTxO distribution
-      * matches the expected terminal buckets.
+    /** After evacuation completes, cancel the periodic-request loop, wait a beat for any in-flight
+      * tx to settle, snapshot the shared mock L1, and check the UTxO distribution matches the
+      * expected terminal buckets.
       */
     private def step5_assertTerminalHistogram: test.TestM[Ctx, Unit] =
         for
-            ctx    <- ask
-            _      <- lift(ctx.periodicRequestFiber.get.flatMap(_.traverse_(_.cancel)))
-            _      <- lift(IO.sleep(quiescenceDelay))
-            utxos  <- lift(ctx.harness.l1Snapshot)
+            ctx <- ask
+            _ <- lift(ctx.periodicRequestFiber.get.flatMap(_.traverse_(_.cancel)))
+            _ <- lift(IO.sleep(quiescenceDelay))
+            utxos <- lift(ctx.harness.l1Snapshot)
             actual <- lift(runClassifier(utxos)(using ctx.harness.multiNodeConfig))
-            expectedEvacCount <- lift(ctx.firstPayoutsLeft.get.flatMap(
-              IO.fromOption(_)(
-                new IllegalStateException(
-                  "no `Evacuation.PayoutsLeft` observed; RBA never entered the drain loop"
+            expectedEvacCount <- lift(
+              ctx.firstPayoutsLeft.get.flatMap(
+                IO.fromOption(_)(
+                  new IllegalStateException(
+                    "no `Evacuation.PayoutsLeft` observed; RBA never entered the drain loop"
+                  )
                 )
               )
-            ))
+            )
             expected = expectedCardinalities(expectedEvacCount)
             _ <- assertWith(
               actual == expected,
@@ -179,11 +182,11 @@ object EvacuationPropertyTest extends MultiPeerDisputeProperties("RBR Evacuation
         takeoffTime: Option[java.time.Instant],
     ): Resource[IO, Ctx] =
         for
-            fallbackDispatched   <- Resource.eval(Deferred[IO, Unit])
-            resolutionSubmitted  <- Resource.eval(Deferred[IO, Unit])
-            peersEvacuationDone  <- Resource.eval(Ref[IO].of(Set.empty[PeerId]))
-            evacuationDone       <- Resource.eval(Deferred[IO, Unit])
-            firstPayoutsLeft     <- Resource.eval(Ref[IO].of(Option.empty[Int]))
+            fallbackDispatched <- Resource.eval(Deferred[IO, Unit])
+            resolutionSubmitted <- Resource.eval(Deferred[IO, Unit])
+            peersEvacuationDone <- Resource.eval(Ref[IO].of(Set.empty[PeerId]))
+            evacuationDone <- Resource.eval(Deferred[IO, Unit])
+            firstPayoutsLeft <- Resource.eval(Ref[IO].of(Option.empty[Int]))
             periodicRequestFiber <- Resource.eval(Ref[IO].of(Option.empty[FiberIO[Nothing]]))
 
             harness <- MultiPeerHeadHarness.disputeHarnessResource(
@@ -278,7 +281,7 @@ object EvacuationPropertyTest extends MultiPeerDisputeProperties("RBR Evacuation
         utxos: Utxos
     )(using MultiNodeConfig): IO[Map[RBRPlaceId, Int]] =
         val classifier = new RBRClassifier
-        val allUtxos   = utxos.toList.map { case (i, o) => Utxo(i, o) }
+        val allUtxos = utxos.toList.map { case (i, o) => Utxo(i, o) }
         Histogram.empty(classifier).addAll(allUtxos).toEither match
             case Left(errs) =>
                 IO.raiseError(
@@ -288,17 +291,19 @@ object EvacuationPropertyTest extends MultiPeerDisputeProperties("RBR Evacuation
                 // logAmbientUtxos(classifier, allUtxos) *>
                 IO.pure(RBRPlaceId.values.toList.map(k => k -> hist(k)).toMap)
 
-    /** Diagnostic helper: emit each ambient-bucket UTxO (input / address / value / datum) via
-      * Slf4j so the composition of [[AmbientPlaceId]] can be identified when the terminal
-      * cardinality shifts. Toggle by uncommenting the `logAmbientUtxos(...)` call site in
-      * [[runClassifier]]. Not on the happy path so callers pay nothing when commented out.
+    /** Diagnostic helper: emit each ambient-bucket UTxO (input / address / value / datum) via Slf4j
+      * so the composition of [[AmbientPlaceId]] can be identified when the terminal cardinality
+      * shifts. Toggle by uncommenting the `logAmbientUtxos(...)` call site in [[runClassifier]].
+      * Not on the happy path so callers pay nothing when commented out.
       */
     @unused
     private def logAmbientUtxos(classifier: RBRClassifier, utxos: List[Utxo]): IO[Unit] =
         val ambient = utxos.filter(u => classifier.classify(u).contains(AmbientPlaceId))
-        val lines = ambient.zipWithIndex.map { case (u, idx) =>
-            s"  [$idx] input=${u.input} addr=${u.output.address} value=${u.output.value} datum=${u.output.datumOption}"
-        }.mkString("\n")
+        val lines = ambient.zipWithIndex
+            .map { case (u, idx) =>
+                s"  [$idx] input=${u.input} addr=${u.output.address} value=${u.output.value} datum=${u.output.datumOption}"
+            }
+            .mkString("\n")
         Slf4jTracer.sink.traceWith(
           hydrozoa.lib.logging.LogEvent
               .From(Map.empty, "AmbientDiagnostic")
@@ -306,42 +311,41 @@ object EvacuationPropertyTest extends MultiPeerDisputeProperties("RBR Evacuation
         )
 
     /** Expected terminal cardinalities: init → settle-v1 → fallback → vote → tally → resolve →
-      * evacuate on the happy path. `evacuationCount` is the first `PayoutsLeft(n)` observed
-      * from any peer's RBA — exactly the size of the resolved treasury's evacuation map before
-      * drain begins (see `RuleBasedActor.Evacuation.handle`).
-      *   - `EvacuationOutputPlaceId -> evacuationCount`: every L2 output was drained to L1 via
-      *     the RBA's `EvacuationTx` loop; each output carries the `"evacuation"` inline-datum
-      *     sentinel stamped by [[InitializationParametersGen.generatePeerContribution]], which
-      *     survives the KZG membership hash and so appears on the L1 evacuation outputs.
-      *   - `PayoutObligationsPlaceId -> 0`: no in-flight payout obligations remain on the
-      *     resolved treasury.
+      * evacuate on the happy path. `evacuationCount` is the first `PayoutsLeft(n)` observed from
+      * any peer's RBA — exactly the size of the resolved treasury's evacuation map before drain
+      * begins (see `RuleBasedActor.Evacuation.handle`).
+      *   - `EvacuationOutputPlaceId -> evacuationCount`: every L2 output was drained to L1 via the
+      *     RBA's `EvacuationTx` loop; each output carries the `"evacuation"` inline-datum sentinel
+      *     stamped by [[InitializationParametersGen.generatePeerContribution]], which survives the
+      *     KZG membership hash and so appears on the L1 evacuation outputs.
+      *   - `PayoutObligationsPlaceId -> 0`: no in-flight payout obligations remain on the resolved
+      *     treasury.
       *   - `CollateralPlaceId -> 0`: the [[RBRClassifier]] identifies collateral by the
       *     `"collateral"` datum sentinel, which only exists in the synthetic
-      *     [[InitialDisputeUtxos]] fixture — the real tx builders draw collateral from plain
-      *     Ada wallet UTxOs (no datum). Preserved collateral therefore lands in
-      *     [[AmbientPlaceId]] here. TODO: the right way to bucket collateral in an end-to-end
-      *     scenario is to walk the tx graph and mark any output that is later consumed as a
-      *     `collateral_input` of some downstream tx — i.e. classify by role in tx history
-      *     rather than by content sentinel.
-      *   - `AmbientPlaceId -> nHeadPeers * 2 + nCoilPeers`: head peers keep two wallet-ADA
-      *     streams at their shelley address — an [[InitializationTx]] change output and a
-      *     [[FallbackTx]] equity payout. Coil peers keep only the init-change stream (no
-      *     fallback equity). Every RBR-side script tx that pays its fee from collateral
-      *     (Vote/Resolution/Evacuation) picks one of these as its collateral input and returns
-      *     it (fee-subtracted) at the same address, so no utxo is destroyed.
+      *     [[InitialDisputeUtxos]] fixture — the real tx builders draw collateral from plain Ada
+      *     wallet UTxOs (no datum). Preserved collateral therefore lands in [[AmbientPlaceId]]
+      *     here. TODO: the right way to bucket collateral in an end-to-end scenario is to walk the
+      *     tx graph and mark any output that is later consumed as a `collateral_input` of some
+      *     downstream tx — i.e. classify by role in tx history rather than by content sentinel.
+      *   - `AmbientPlaceId -> nHeadPeers * 2 + nCoilPeers`: head peers keep two wallet-ADA streams
+      *     at their shelley address — an [[InitializationTx]] change output and a [[FallbackTx]]
+      *     equity payout. Coil peers keep only the init-change stream (no fallback equity). Every
+      *     RBR-side script tx that pays its fee from collateral (Vote/Resolution/Evacuation) picks
+      *     one of these as its collateral input and returns it (fee-subtracted) at the same
+      *     address, so no utxo is destroyed.
       */
     private def expectedCardinalities(evacuationCount: Int): Map[RBRPlaceId, Int] =
         Map(
-          TreasuryRefPlaceId        -> 1,
-          DisputeRefPlaceId         -> 1,
-          RegimeRefPlaceId          -> 1,
-          SetupLadderRefPlaceId     -> 7,
-          ResolvedTreasuryPlaceId   -> 1,
+          TreasuryRefPlaceId -> 1,
+          DisputeRefPlaceId -> 1,
+          RegimeRefPlaceId -> 1,
+          SetupLadderRefPlaceId -> 7,
+          ResolvedTreasuryPlaceId -> 1,
           UnresolvedTreasuryPlaceId -> 0,
-          VotedPlaceId              -> 0,
-          UnvotedPlaceId            -> 0,
-          CollateralPlaceId         -> 0,
-          EvacuationOutputPlaceId   -> evacuationCount,
-          PayoutObligationsPlaceId  -> 0,
-          AmbientPlaceId            -> (nHeadPeers * 2 + nCoilPeers),
+          VotedPlaceId -> 0,
+          UnvotedPlaceId -> 0,
+          CollateralPlaceId -> 0,
+          EvacuationOutputPlaceId -> evacuationCount,
+          PayoutObligationsPlaceId -> 0,
+          AmbientPlaceId -> (nHeadPeers * 2 + nCoilPeers),
         )

--- a/integration/src/test/scala/hydrozoa/integration/stage1/Generator.scala
+++ b/integration/src/test/scala/hydrozoa/integration/stage1/Generator.scala
@@ -156,8 +156,11 @@ object CommandGenerators:
 
         Gen
             .frequency(
-               5 -> Gen.const(1_000L),
-               5 -> Gen.choose(0L, (availableDuration.finiteDuration - reservedSubmissionDuration).toMillis)
+              5 -> Gen.const(1_000L),
+              5 -> Gen.choose(
+                0L,
+                (availableDuration.finiteDuration - reservedSubmissionDuration).toMillis
+              )
             )
             .map(blockDurationMs =>
                 QuantizedFiniteDuration(
@@ -357,15 +360,17 @@ object CommandGenerators:
             )
 
         for {
-            inputs       <- pick(genInputs(ownedUtxos, txStrategy))
-            totalValue   = Value.combine(inputs.map(ownedUtxos(_).value))
-            _            <- run(log.trace(s"totalValue: $totalValue"))
+            inputs <- pick(genInputs(ownedUtxos, txStrategy))
+            totalValue = Value.combine(inputs.map(ownedUtxos(_).value))
+            _ <- run(log.trace(s"totalValue: $totalValue"))
             outputValues <- pick(genOutputValues(totalValue, txStrategy, generateCappedValueC))
-            _            <- run(log.trace(s"outputValues: $outputValues"))
-            outputs      <- pick(Gen.sequence[List[TransactionOutput], TransactionOutput](
-                                outputValues
-                                    .map(v => Gen.oneOf(l2AddressesInUse).map(a => Babbage(a, v)))
-                            ))
+            _ <- run(log.trace(s"outputValues: $outputValues"))
+            outputs <- pick(
+              Gen.sequence[List[TransactionOutput], TransactionOutput](
+                outputValues
+                    .map(v => Gen.oneOf(l2AddressesInUse).map(a => Babbage(a, v)))
+              )
+            )
             auxiliaryData <- pick(genAuxiliaryData(outputs, txStrategy).map(Some.apply))
 
             txUnsigned = TransactionBuilder
@@ -392,7 +397,7 @@ object CommandGenerators:
                 )
 
             txSigned = config.multisignTx(txUnsigned)
-            _        <- run(log.trace(s"signed l2Tx: ${HexUtil.encodeHexString(txSigned.toCbor)}"))
+            _ <- run(log.trace(s"signed l2Tx: ${HexUtil.encodeHexString(txSigned.toCbor)}"))
 
             body = TransactionRequestBody(
               l2Payload = ByteString.fromArray(txSigned.toCbor)
@@ -416,7 +421,9 @@ object CommandGenerators:
 
     /** May fail if there is no enough funds in peer's utxos.
       */
-    def genRegisterDepositCommand(state: Model.State): PropertyM[IO, Option[RegisterDepositCommand]] = {
+    def genRegisterDepositCommand(
+        state: Model.State
+    ): PropertyM[IO, Option[RegisterDepositCommand]] = {
         import PropertyM.run
         import state.multiNodeConfig
 
@@ -438,9 +445,9 @@ object CommandGenerators:
         else
             for {
                 fundingUtxos <- pick(Gen.atLeastOne(l1UtxoAvailable).map(_.toMap))
-                totalValue   = Value.combine(fundingUtxos.map(_._2.value))
-                _            <- run(log.trace(s"fundingUtxos: $fundingUtxos"))
-                _            <- run(log.trace(s"totalValue: $totalValue"))
+                totalValue = Value.combine(fundingUtxos.map(_._2.value))
+                _ <- run(log.trace(s"fundingUtxos: $fundingUtxos"))
+                _ <- run(log.trace(s"totalValue: $totalValue"))
 
                 // Change should be big enough to make balancing of the DEPOSIT tx always possible
                 minimalChangeCoins = 1_500_000L
@@ -459,12 +466,14 @@ object CommandGenerators:
                         val reserved = Value.lovelace(minimalDepositValueCoins)
                         val totalValueAvailable = totalValue - reserved
                         for {
-                            change       <- pick(generateCappedValueC(
-                                                totalValueAvailable,
-                                                Some(minimalChangeCoins),
-                                                None,
-                                                None
-                                            ))
+                            change <- pick(
+                              generateCappedValueC(
+                                totalValueAvailable,
+                                Some(minimalChangeCoins),
+                                None,
+                                None
+                              )
+                            )
                             depositValue = totalValue - change
 
                             ret <-
@@ -472,18 +481,22 @@ object CommandGenerators:
                                 then pick(Gen.const(None))
                                 else
                                     for {
-                                        outputValues <- pick(genOutputValues(
-                                                          depositValue,
-                                                          TxStrategy.Regular,
-                                                          generateCappedValueC
-                                                        ))
+                                        outputValues <- pick(
+                                          genOutputValues(
+                                            depositValue,
+                                            TxStrategy.Regular,
+                                            generateCappedValueC
+                                          )
+                                        )
 
-                                        outputs <- pick(Gen.sequence[List[TransactionOutput], TransactionOutput](
-                                                       outputValues
-                                                           .map(v =>
-                                                               Gen.const(peerAddress).map(a => Babbage(a, v))
-                                                           )
-                                                   ))
+                                        outputs <- pick(
+                                          Gen.sequence[List[TransactionOutput], TransactionOutput](
+                                            outputValues
+                                                .map(v =>
+                                                    Gen.const(peerAddress).map(a => Babbage(a, v))
+                                                )
+                                          )
+                                        )
 
                                         l2Outputs = NonEmptyList.fromListUnsafe(
                                           outputs.map(
@@ -493,7 +506,9 @@ object CommandGenerators:
                                           )
                                         )
 
-                                        l2Value   = Value.combine(l2Outputs.toList.map(_.l2OutputValue))
+                                        l2Value = Value.combine(
+                                          l2Outputs.toList.map(_.l2OutputValue)
+                                        )
                                         requestId = state.nextRequestId
 
                                         // This should be bigger than the longest possible block duration, see [[genCompleteBlock]].
@@ -529,9 +544,11 @@ object CommandGenerators:
                                               depositRefundSeq.depositTx.tx
                                             )
 
-                                        _ <- run(log.trace(
-                                               s"deposit tx signed: ${HexUtil.encodeHexString(depositTxSigned.toCbor)}"
-                                             ))
+                                        _ <- run(
+                                          log.trace(
+                                            s"deposit tx signed: ${HexUtil.encodeHexString(depositTxSigned.toCbor)}"
+                                          )
+                                        )
 
                                         body = DepositRequestBody(
                                           l1Payload = ByteString
@@ -571,23 +588,27 @@ object CommandGenerators:
 
         // Prefix is easier to think about, though we can pick up arbitrary elements
         for {
-            n         <- pick(Gen.choose(1, registeredDeposits.size))
-            _         <- run(log.trace(
-                              s"genSubmitDepositsCommand registered deposits: $registeredDeposits, n=$n"
-                          ))
-            selected  = registeredDeposits.take(n)
+            n <- pick(Gen.choose(1, registeredDeposits.size))
+            _ <- run(
+              log.trace(
+                s"genSubmitDepositsCommand registered deposits: $registeredDeposits, n=$n"
+              )
+            )
+            selected = registeredDeposits.take(n)
             partition = selected.partition { registered =>
-                            val submissionDeadline =
-                                registered.cmd.depositRefundTxSeq.depositTx.depositProduced.requestValidityEndTime
-                            val submissionRunway = state.getCurrentTime.instant + 20.seconds
-                            submissionDeadline.convert > submissionRunway
-                        }
-            _         <- run(log.trace(
-                              s"genSubmitDepositsCommand: forSubmission=${partition._1.size} toDecline=${partition._2.size}"
-                          ))
+                val submissionDeadline =
+                    registered.cmd.depositRefundTxSeq.depositTx.depositProduced.requestValidityEndTime
+                val submissionRunway = state.getCurrentTime.instant + 20.seconds
+                submissionDeadline.convert > submissionRunway
+            }
+            _ <- run(
+              log.trace(
+                s"genSubmitDepositsCommand: forSubmission=${partition._1.size} toDecline=${partition._2.size}"
+              )
+            )
         } yield SubmitDepositsCommand(
-            depositsForSubmission = partition._1,
-            depositsToDecline = partition._2
+          depositsForSubmission = partition._1,
+          depositsToDecline = partition._2
         )
     }
 
@@ -633,7 +654,6 @@ object ScenarioGenerators:
             import hydrozoa.integration.stage1.Model.BlockCycle.*
             import hydrozoa.integration.stage1.Model.CurrentTime.BeforeHappyPathExpiration
 
-
             state.getCurrentTime match {
                 case BeforeHappyPathExpiration(_) =>
                     state.blockCycle match {
@@ -642,51 +662,59 @@ object ScenarioGenerators:
                                 state.multiNodeConfig.headConfig.txTiming.newSettlementEndTime(
                                   state.competingFallbackStartTime
                                 )
-                            pick(CommandGenerators
-                                .genRandomDelay(
-                                  currentTime = state.getCurrentTime.instant,
-                                  settlementExpirationTime = settlementExpirationTime,
-                                  competingFallbackStartTime = state.competingFallbackStartTime,
-                                  slotConfig = state.multiNodeConfig.headConfig.slotConfig,
-                                  blockNumber = blockNumber
-                                )
-                                .map(AnyCommand.apply))
+                            pick(
+                              CommandGenerators
+                                  .genRandomDelay(
+                                    currentTime = state.getCurrentTime.instant,
+                                    settlementExpirationTime = settlementExpirationTime,
+                                    competingFallbackStartTime = state.competingFallbackStartTime,
+                                    slotConfig = state.multiNodeConfig.headConfig.slotConfig,
+                                    blockNumber = blockNumber
+                                  )
+                                  .map(AnyCommand.apply)
+                            )
 
                         case Ready(blockNumber, _) =>
-                            pick(CommandGenerators
-                                .genStartBlock(blockNumber, state.getCurrentTime.instant)
-                                .map(AnyCommand.apply))
+                            pick(
+                              CommandGenerators
+                                  .genStartBlock(blockNumber, state.getCurrentTime.instant)
+                                  .map(AnyCommand.apply)
+                            )
 
                         case InProgress(blockNumber, _, _, _) if blockNumber == BlockNumber.zero =>
-                            pick(CommandGenerators
-                                .genCompleteBlock(
-                                  blockNumber,
-                                  state.multiNodeConfig.initialBlock.blockBrief.endTime,
-                                  state.competingFallbackStartTime,
-                                  state.multiNodeConfig,
-                                  state.reservedSubmissionDuration
-                                )
-                                .map(AnyCommand(_)))
+                            pick(
+                              CommandGenerators
+                                  .genCompleteBlock(
+                                    blockNumber,
+                                    state.multiNodeConfig.initialBlock.blockBrief.endTime,
+                                    state.competingFallbackStartTime,
+                                    state.multiNodeConfig,
+                                    state.reservedSubmissionDuration
+                                  )
+                                  .map(AnyCommand(_))
+                            )
 
                         case InProgress(blockNumber, _, _, _) =>
                             for {
                                 branch <- pick(Gen.frequency(1 -> 0, 10 -> 1))
-                                cmd    <- branch match {
-                                              case 0 =>
-                                                  pick(CommandGenerators
-                                                      .genCompleteBlock(
-                                                        blockNumber,
-                                                        state.getCurrentTime.instant,
-                                                        state.competingFallbackStartTime,
-                                                        state.multiNodeConfig,
-                                                        state.reservedSubmissionDuration
-                                                      )
-                                                      .map(AnyCommand.apply))
-                                              case _ =>
-                                                  if state.utxosL2Active.isEmpty
-                                                  then pick(Gen.const(noOp))
-                                                  else generateL2Tx(state).map(AnyCommand.apply)
-                                          }
+                                cmd <- branch match {
+                                    case 0 =>
+                                        pick(
+                                          CommandGenerators
+                                              .genCompleteBlock(
+                                                blockNumber,
+                                                state.getCurrentTime.instant,
+                                                state.competingFallbackStartTime,
+                                                state.multiNodeConfig,
+                                                state.reservedSubmissionDuration
+                                              )
+                                              .map(AnyCommand.apply)
+                                        )
+                                    case _ =>
+                                        if state.utxosL2Active.isEmpty
+                                        then pick(Gen.const(noOp))
+                                        else generateL2Tx(state).map(AnyCommand.apply)
+                                }
                             } yield cmd
 
                         case HeadFinalized => pick(Gen.const(noOp))
@@ -703,7 +731,6 @@ object ScenarioGenerators:
             import hydrozoa.integration.stage1.Model.BlockCycle.*
             import hydrozoa.integration.stage1.Model.CurrentTime.BeforeHappyPathExpiration
 
-
             state.getCurrentTime match {
                 case BeforeHappyPathExpiration(_) =>
                     state.blockCycle match {
@@ -713,56 +740,67 @@ object ScenarioGenerators:
                                   state.competingFallbackStartTime
                                 )
                             // We need to avoid fallbacks to finalize the head
-                            pick(CommandGenerators
-                                .genStayOnHappyPathDelay(
-                                  currentTime = state.getCurrentTime.instant,
-                                  settlementExpirationTime = settlementExpirationTime
-                                )
-                                .map(AnyCommand.apply))
+                            pick(
+                              CommandGenerators
+                                  .genStayOnHappyPathDelay(
+                                    currentTime = state.getCurrentTime.instant,
+                                    settlementExpirationTime = settlementExpirationTime
+                                  )
+                                  .map(AnyCommand.apply)
+                            )
 
                         case Ready(blockNumber, _) =>
-                            pick(CommandGenerators
-                                .genStartBlock(blockNumber, state.getCurrentTime.instant)
-                                .map(AnyCommand.apply))
+                            pick(
+                              CommandGenerators
+                                  .genStartBlock(blockNumber, state.getCurrentTime.instant)
+                                  .map(AnyCommand.apply)
+                            )
 
                         case InProgress(blockNumber, _, _, _) if blockNumber == BlockNumber.zero =>
-                            pick(CommandGenerators
-                                .genCompleteBlock(
-                                  blockNumber,
-                                  state.multiNodeConfig.initialBlock.blockBrief.endTime,
-                                  state.competingFallbackStartTime,
-                                  state.multiNodeConfig,
-                                  state.reservedSubmissionDuration
-                                )
-                                .map(AnyCommand(_)))
+                            pick(
+                              CommandGenerators
+                                  .genCompleteBlock(
+                                    blockNumber,
+                                    state.multiNodeConfig.initialBlock.blockBrief.endTime,
+                                    state.competingFallbackStartTime,
+                                    state.multiNodeConfig,
+                                    state.reservedSubmissionDuration
+                                  )
+                                  .map(AnyCommand(_))
+                            )
                         case InProgress(blockNumber, _, _, _) =>
                             for {
                                 branch <- pick(Gen.frequency(1 -> 0, 10 -> 1))
-                                cmd    <- branch match {
-                                              case 0 =>
-                                                  pick((if state.utxosL2Active.size >= minL2Utxos
-                                                        then CommandGenerators.genCompleteBlockFinal(
-                                                            blockNumber,
-                                                            state.getCurrentTime.instant,
-                                                            state.competingFallbackStartTime,
-                                                            state.multiNodeConfig,
-                                                            state.reservedSubmissionDuration
-                                                        )
-                                                        else CommandGenerators.genCompleteBlockRegular(
-                                                            blockNumber,
-                                                            state.getCurrentTime.instant,
-                                                            state.competingFallbackStartTime,
-                                                            state.multiNodeConfig,
-                                                            state.reservedSubmissionDuration
-                                                        )).map(AnyCommand.apply))
-                                              case _ =>
-                                                  CommandGenerators
-                                                      .genValidNonPlutusL2Tx(
-                                                        txStrategy = Dust(),
-                                                        txMutator = Identity
-                                                      )(state)
-                                                      .map(AnyCommand.apply)
-                                          }
+                                cmd <- branch match {
+                                    case 0 =>
+                                        pick(
+                                          (if state.utxosL2Active.size >= minL2Utxos
+                                           then
+                                               CommandGenerators.genCompleteBlockFinal(
+                                                 blockNumber,
+                                                 state.getCurrentTime.instant,
+                                                 state.competingFallbackStartTime,
+                                                 state.multiNodeConfig,
+                                                 state.reservedSubmissionDuration
+                                               )
+                                           else
+                                               CommandGenerators.genCompleteBlockRegular(
+                                                 blockNumber,
+                                                 state.getCurrentTime.instant,
+                                                 state.competingFallbackStartTime,
+                                                 state.multiNodeConfig,
+                                                 state.reservedSubmissionDuration
+                                               )
+                                          ).map(AnyCommand.apply)
+                                        )
+                                    case _ =>
+                                        CommandGenerators
+                                            .genValidNonPlutusL2Tx(
+                                              txStrategy = Dust(),
+                                              txMutator = Identity
+                                            )(state)
+                                            .map(AnyCommand.apply)
+                                }
                             } yield cmd
 
                         case HeadFinalized => pick(Gen.const(noOp))
@@ -784,7 +822,6 @@ object ScenarioGenerators:
             import hydrozoa.integration.stage1.Model.BlockCycle.*
             import hydrozoa.integration.stage1.Model.CurrentTime.BeforeHappyPathExpiration
 
-
             state.getCurrentTime match {
                 case BeforeHappyPathExpiration(_) =>
                     state.blockCycle match {
@@ -793,65 +830,75 @@ object ScenarioGenerators:
                                 state.multiNodeConfig.headConfig.txTiming.newSettlementEndTime(
                                   state.competingFallbackStartTime
                                 )
-                            pick(CommandGenerators
-                                .genRandomDelay(
-                                  currentTime = state.getCurrentTime.instant,
-                                  settlementExpirationTime = settlementExpirationTime,
-                                  competingFallbackStartTime = state.competingFallbackStartTime,
-                                  slotConfig = state.multiNodeConfig.headConfig.slotConfig,
-                                  blockNumber = blockNumber
-                                )
-                                .map(AnyCommand.apply))
+                            pick(
+                              CommandGenerators
+                                  .genRandomDelay(
+                                    currentTime = state.getCurrentTime.instant,
+                                    settlementExpirationTime = settlementExpirationTime,
+                                    competingFallbackStartTime = state.competingFallbackStartTime,
+                                    slotConfig = state.multiNodeConfig.headConfig.slotConfig,
+                                    blockNumber = blockNumber
+                                  )
+                                  .map(AnyCommand.apply)
+                            )
 
                         case Ready(blockNumber, _) =>
-                            pick(CommandGenerators
-                                .genStartBlock(blockNumber, state.getCurrentTime.instant)
-                                .map(AnyCommand.apply))
+                            pick(
+                              CommandGenerators
+                                  .genStartBlock(blockNumber, state.getCurrentTime.instant)
+                                  .map(AnyCommand.apply)
+                            )
 
                         case InProgress(blockNumber, _, _, _) if blockNumber == BlockNumber.zero =>
-                            pick(CommandGenerators
-                                .genCompleteBlock(
-                                  blockNumber,
-                                  state.multiNodeConfig.initialBlock.blockBrief.endTime,
-                                  state.competingFallbackStartTime,
-                                  state.multiNodeConfig,
-                                  state.reservedSubmissionDuration
-                                )
-                                .map(AnyCommand(_)))
+                            pick(
+                              CommandGenerators
+                                  .genCompleteBlock(
+                                    blockNumber,
+                                    state.multiNodeConfig.initialBlock.blockBrief.endTime,
+                                    state.competingFallbackStartTime,
+                                    state.multiNodeConfig,
+                                    state.reservedSubmissionDuration
+                                  )
+                                  .map(AnyCommand(_))
+                            )
                         case InProgress(blockNumber, _, _, _) =>
                             for {
                                 branch <- pick(Gen.frequency(3 -> 0, 5 -> 1, 1 -> 2, 3 -> 3))
-                                cmd    <- branch match {
-                                              case 0 =>
-                                                  CommandGenerators
-                                                      .genRegisterDepositCommand(state)
-                                                      .map(_.fold(noOp)(AnyCommand.apply))
-                                              case 1 =>
-                                                  if state.deposits.depositsRegistered.nonEmpty
-                                                  then CommandGenerators
-                                                      .genSubmitDepositsCommand(state)
-                                                      .map(AnyCommand.apply)
-                                                  else pick(Gen.const(noOp))
-                                              case 2 =>
-                                                  pick(CommandGenerators
-                                                      .genCompleteBlock(
-                                                        blockNumber,
-                                                        state.getCurrentTime.instant,
-                                                        state.competingFallbackStartTime,
-                                                        state.multiNodeConfig,
-                                                        state.reservedSubmissionDuration
-                                                      )
-                                                      .map(AnyCommand.apply))
-                                              case _ =>
-                                                  if state.utxosL2Active.nonEmpty
-                                                  then CommandGenerators
-                                                      .genValidNonPlutusL2Tx(
-                                                        txStrategy = RandomWithdrawals,
-                                                        txMutator = Identity
-                                                      )(state)
-                                                      .map(AnyCommand.apply)
-                                                  else pick(Gen.const(noOp))
-                                          }
+                                cmd <- branch match {
+                                    case 0 =>
+                                        CommandGenerators
+                                            .genRegisterDepositCommand(state)
+                                            .map(_.fold(noOp)(AnyCommand.apply))
+                                    case 1 =>
+                                        if state.deposits.depositsRegistered.nonEmpty
+                                        then
+                                            CommandGenerators
+                                                .genSubmitDepositsCommand(state)
+                                                .map(AnyCommand.apply)
+                                        else pick(Gen.const(noOp))
+                                    case 2 =>
+                                        pick(
+                                          CommandGenerators
+                                              .genCompleteBlock(
+                                                blockNumber,
+                                                state.getCurrentTime.instant,
+                                                state.competingFallbackStartTime,
+                                                state.multiNodeConfig,
+                                                state.reservedSubmissionDuration
+                                              )
+                                              .map(AnyCommand.apply)
+                                        )
+                                    case _ =>
+                                        if state.utxosL2Active.nonEmpty
+                                        then
+                                            CommandGenerators
+                                                .genValidNonPlutusL2Tx(
+                                                  txStrategy = RandomWithdrawals,
+                                                  txMutator = Identity
+                                                )(state)
+                                                .map(AnyCommand.apply)
+                                        else pick(Gen.const(noOp))
+                                }
                             } yield cmd
 
                         case HeadFinalized => pick(Gen.const(noOp))

--- a/integration/src/test/scala/hydrozoa/integration/stage1/Model.scala
+++ b/integration/src/test/scala/hydrozoa/integration/stage1/Model.scala
@@ -125,7 +125,7 @@ object Model:
         /** Calculate the current major block wakeup time according to the current state of the
           * deposits. This is the earliest DepositAbsorptionStateTime of any deposit that hydrozoa
           * will check for absorption
-         * */
+          */
         def mAbsorptionStartTime: Option[DepositAbsorptionStartTime] = {
             val absorptionBounds: Queue[(DepositAbsorptionStartTime, DepositAbsorptionEndTime)] =
                 deposits.hydrozoaKnownRegisteredDeposits.map(cmd =>
@@ -248,7 +248,9 @@ object Model:
             StateT.modifyF[M, State] { state =>
                 val newBlockM = state.blockCycle match {
                     case BlockCycle.Done(blockNumber, version) =>
-                        MonadThrow[M].pure(BlockCycle.Ready(blockNumber = blockNumber, prevVersion = version))
+                        MonadThrow[M].pure(
+                          BlockCycle.Ready(blockNumber = blockNumber, prevVersion = version)
+                        )
                     case _ =>
                         MonadThrow[M].raiseError(
                           Error.UnexpectedState("DelayCommand requires BlockCycle.Done")
@@ -262,7 +264,9 @@ object Model:
                     _ <- newState.getCurrentTime match {
                         case CurrentTime.InSilencePeriod(_) |
                             CurrentTime.AfterCompetingFallbackStartTime(_) =>
-                            log.warn("MODEL>> DelayCommand: model time entering silence/fallback zone")
+                            log.warn(
+                              "MODEL>> DelayCommand: model time entering silence/fallback zone"
+                            )
                         case _ => MonadThrow[M].pure(())
                     }
                 yield newState
@@ -332,34 +336,34 @@ object Model:
                         val events: List[(RequestId, ValidityFlag)] =
                             accumulator.map((le, _, flag) => le.requestId -> flag)
                         for
-                            _                   <- StateT.liftF(
-                                                     log.debug(
-                                                       s"MODEL>> CompleteBlockCommand for block number: ${cmd.blockNumber}"
-                                                     )
-                                                   )
-                            _                   <- registerOrReject[M](events)
-                            absorbedThisBlock   <- absorb[M](cmd.blockCreationEndTime)
-                            refundedThisBlock   <- refund[M](cmd.isFinal, cmd.blockCreationEndTime)
-                            blockBrief          <- mkBlockBrief[M](
-                                                     cmd.isFinal,
-                                                     cmd.blockCreationEndTime,
-                                                     cmd.blockNumber,
-                                                     prevVersion,
-                                                     accumulator,
-                                                     absorbedThisBlock,
-                                                     refundedThisBlock
-                                                   )
+                            _ <- StateT.liftF(
+                              log.debug(
+                                s"MODEL>> CompleteBlockCommand for block number: ${cmd.blockNumber}"
+                              )
+                            )
+                            _ <- registerOrReject[M](events)
+                            absorbedThisBlock <- absorb[M](cmd.blockCreationEndTime)
+                            refundedThisBlock <- refund[M](cmd.isFinal, cmd.blockCreationEndTime)
+                            blockBrief <- mkBlockBrief[M](
+                              cmd.isFinal,
+                              cmd.blockCreationEndTime,
+                              cmd.blockNumber,
+                              prevVersion,
+                              accumulator,
+                              absorbedThisBlock,
+                              refundedThisBlock
+                            )
                             // tick time
-                            _                   <- StateT.modify[M, State](
-                                                     _.advanceCurrentTime(cmd.blockCreationEndTime.convert)
-                                                   )
+                            _ <- StateT.modify[M, State](
+                              _.advanceCurrentTime(cmd.blockCreationEndTime.convert)
+                            )
                             // update block cycle
-                            _                   <- StateT.modify[M, State] { state =>
-                                                     val nextBlockCycle =
-                                                         if cmd.isFinal then BlockCycle.HeadFinalized
-                                                         else BlockCycle.Done(cmd.blockNumber, blockBrief.blockVersion)
-                                                     state.copy(blockCycle = nextBlockCycle)
-                                                   }
+                            _ <- StateT.modify[M, State] { state =>
+                                val nextBlockCycle =
+                                    if cmd.isFinal then BlockCycle.HeadFinalized
+                                    else BlockCycle.Done(cmd.blockNumber, blockBrief.blockVersion)
+                                state.copy(blockCycle = nextBlockCycle)
+                            }
                         yield blockBrief
                     case _ =>
                         StateT.liftF(
@@ -370,12 +374,16 @@ object Model:
                 }
             yield brief
 
-        private def getBlockCreationStartTime[M[_]: Applicative]: StateT[M, State, BlockCreationStartTime] =
+        private def getBlockCreationStartTime[M[_]: Applicative]
+            : StateT[M, State, BlockCreationStartTime] =
             StateT.inspect(state => BlockCreationStartTime(state.getCurrentTime.instant))
 
-        private def getNewSettlementValidityEnd[M[_]: Applicative]: StateT[M, State, SettlementTxEndTime] =
+        private def getNewSettlementValidityEnd[M[_]: Applicative]
+            : StateT[M, State, SettlementTxEndTime] =
             StateT.inspect(state =>
-                state.multiNodeConfig.txTiming.newSettlementEndTime(state.competingFallbackStartTime)
+                state.multiNodeConfig.txTiming.newSettlementEndTime(
+                  state.competingFallbackStartTime
+                )
             )
 
         /** Register or reject [[Enqueued]] deposits depending on their [[ValidityFlag]], as derived
@@ -484,11 +492,11 @@ object Model:
                         refundable.depositAbsorptionEnd.convert < settlementValidityEnd.convert
                         || refundable.depositAbsorptionStart.convert <= blockCreationEndTime
                     )
-                    // Previous predicate (restore when the slow cycle wires absorption back in):
-                    //
-                    // refundable.depositAbsorptionEnd.convert < settlementValidityEnd.convert
-                    // || (refundable.depositAbsorptionStart.convert <= blockCreationEndTime && !refundable
-                    //     .isInstanceOf[Submitted])
+            // Previous predicate (restore when the slow cycle wires absorption back in):
+            //
+            // refundable.depositAbsorptionEnd.convert < settlementValidityEnd.convert
+            // || (refundable.depositAbsorptionStart.convert <= blockCreationEndTime && !refundable
+            //     .isInstanceOf[Submitted])
             refunded <- liftS(DepositStatus.Refunded.refund(depositsToRefund))
         } yield refunded
 
@@ -755,11 +763,11 @@ object Model:
                         config.headConfig.txTiming.depositAbsorptionEndTime(requestValidityEndTime)
                     // For now, all deposits request should be valid by construction
                     _ <- MonadThrow[M].raiseUnless(
-                           blockStartTime < seq.depositTx.submissionDeadline
-                         )(RuntimeException("deposit past submissionDeadline"))
+                      blockStartTime < seq.depositTx.submissionDeadline
+                    )(RuntimeException("deposit past submissionDeadline"))
                     _ <- MonadThrow[M].raiseUnless(blockStartTime < depositAbsorptionEndTime)(
-                           RuntimeException("deposit past absorptionEndTime")
-                         )
+                      RuntimeException("deposit past absorptionEndTime")
+                    )
                     depositUtxo = seq.depositTx.depositProduced
                     newState = state
                         .pipe(
@@ -791,11 +799,11 @@ object Model:
                 _ <- liftS(DepositStatus.Submitted.submit(cmd.depositsForSubmission))
                 _ <- liftS(DepositStatus.Declined.decline(cmd.depositsToDecline))
                 _ <- StateT.liftF(
-                       log.debug(
-                         s"MODEL>> SubmitDepositCommand, for submission: ${cmd.depositsForSubmission.size}, " +
-                             s"for rejection: ${cmd.depositsToDecline.size}"
-                       )
-                     )
+                  log.debug(
+                    s"MODEL>> SubmitDepositCommand, for submission: ${cmd.depositsForSubmission.size}, " +
+                        s"for rejection: ${cmd.depositsToDecline.size}"
+                  )
+                )
             yield ()
     }
 

--- a/integration/src/test/scala/hydrozoa/integration/stage1/Runner.scala
+++ b/integration/src/test/scala/hydrozoa/integration/stage1/Runner.scala
@@ -15,13 +15,13 @@ object Stage1PropertiesL1Mock extends YetAnotherProperties("Integration Stage 1 
         p: org.scalacheck.Test.Parameters
     ): org.scalacheck.Test.Parameters = {
         p.withWorkers(1)
-            //.withPropFilter(Some("Block promotion with real L2 txs"))
-            //.withPropFilter(Some("Dusty head finalization"))
-            //.withPropFilter(Some("Ongoing withdrawals"))
-            //.withPropFilter(Some("Deposits"))
-            //.withInitialSeed(
-            //  Some(Seed.fromBase64("lr7yvfMC6Qxtovs5UjWZSfTcqzr7pHrzQ4_mcWApnUP=").get)
-            //)
+        // .withPropFilter(Some("Block promotion with real L2 txs"))
+        // .withPropFilter(Some("Dusty head finalization"))
+        // .withPropFilter(Some("Ongoing withdrawals"))
+        // .withPropFilter(Some("Deposits"))
+        // .withInitialSeed(
+        //  Some(Seed.fromBase64("lr7yvfMC6Qxtovs5UjWZSfTcqzr7pHrzQ4_mcWApnUP=").get)
+        // )
         // NB: careful, this will override -s from the command line
         // .withMinSuccessfulTests(100) // 10000
         // .withMaxSize(100) // 500

--- a/integration/src/test/scala/hydrozoa/integration/stage1/Suite.scala
+++ b/integration/src/test/scala/hydrozoa/integration/stage1/Suite.scala
@@ -182,10 +182,10 @@ case class Suite(
                     mixSplitTx <- mkMixSplitTx(cardanoNetwork, backend, aliceAddress)
                     mixSplitTxSigned = testPeers.walletFor(Alice).signTx(mixSplitTx)
                     _ <- run(
-                           log.trace(
-                             s"mixSplitTxSigned = ${HexUtil.encodeHexString(mixSplitTxSigned.toCbor)}"
-                           )
-                         )
+                      log.trace(
+                        s"mixSplitTxSigned = ${HexUtil.encodeHexString(mixSplitTxSigned.toCbor)}"
+                      )
+                    )
                     ret <- run(backend.submitTx(RawTx(mixSplitTxSigned)))
                     _ <- run(log.trace(s"submission response: $ret"))
 
@@ -193,15 +193,15 @@ case class Suite(
                     _ <- run(IO.sleep(5.seconds))
 
                     splitUpUtxos <- run(
-                                      backend
-                                          .utxosAt(aliceAddress)
-                                          .flatMap(_.fold(IO.raiseError, IO.pure))
-                                    )
+                      backend
+                          .utxosAt(aliceAddress)
+                          .flatMap(_.fold(IO.raiseError, IO.pure))
+                    )
                 } yield Stage1Env(
-                    startTime = startTime,
-                    cardanoNetwork = cardanoNetwork,
-                    genesisUtxo = _ => Map(Alice -> splitUpUtxos),
-                    testPeers = testPeers
+                  startTime = startTime,
+                  cardanoNetwork = cardanoNetwork,
+                  genesisUtxo = _ => Map(Alice -> splitUpUtxos),
+                  testPeers = testPeers
                 )
 
             case SuiteCardano.Public(seedPhrase, cardanoNetwork, blockfrostKey) =>
@@ -214,17 +214,17 @@ case class Suite(
                 )
                 for {
                     _ <- run(
-                           log.info(
-                             s"Splitting up utxos at Alice's address ${aliceAddress.toBech32.get}"
-                           )
-                         )
+                      log.info(
+                        s"Splitting up utxos at Alice's address ${aliceAddress.toBech32.get}"
+                      )
+                    )
                     mixSplitTx <- mkMixSplitTx(cardanoNetwork, backend, aliceAddress)
                     splitTxSigned = testPeers.walletFor(Alice).signTx(mixSplitTx)
                     _ <- run(
-                           log.trace(
-                             s"splitTxSigned = ${HexUtil.encodeHexString(splitTxSigned.toCbor)}"
-                           )
-                         )
+                      log.trace(
+                        s"splitTxSigned = ${HexUtil.encodeHexString(splitTxSigned.toCbor)}"
+                      )
+                    )
                     ret <- run(backend.submitTx(RawTx(splitTxSigned)))
                     _ <- run(log.trace(s"submission response: $ret"))
 
@@ -233,15 +233,15 @@ case class Suite(
 
                     startTime <- run(IO.realTimeInstant)
                     splitUpUtxos <- run(
-                                      backend
-                                          .utxosAt(aliceAddress)
-                                          .flatMap(_.fold(IO.raiseError, IO.pure))
-                                    )
+                      backend
+                          .utxosAt(aliceAddress)
+                          .flatMap(_.fold(IO.raiseError, IO.pure))
+                    )
                 } yield Stage1Env(
-                    startTime = startTime,
-                    cardanoNetwork = cardanoNetwork,
-                    genesisUtxo = _ => Map(Alice -> splitUpUtxos),
-                    testPeers = testPeers
+                  startTime = startTime,
+                  cardanoNetwork = cardanoNetwork,
+                  genesisUtxo = _ => Map(Alice -> splitUpUtxos),
+                  testPeers = testPeers
                 )
         }
     }
@@ -255,48 +255,48 @@ case class Suite(
         for {
             peerUtxos <- run(backend.utxosAt(address).flatMap(_.fold(IO.raiseError, IO.pure)))
             outputValues <- {
-                                val totalValue = Value.combine(peerUtxos.map((_, o) => o.value))
-                                val gen = CappedValueGen.generateCappedValue(cardanoNetwork)
-                                pick(
-                                  Gen.tailRecM((totalValue, List.empty: List[Value]))((rest, acc) =>
-                                      gen(rest, Some(20_000_000L), Some(1000_000_000), None).map(
-                                        next =>
-                                            if next == rest
-                                            then Right(acc :+ next)
-                                            else Left((rest - next, acc :+ next))
-                                      )
-                                  )
-                                )
-                            }
-            tx <- run(
-                    IO.fromEither(
-                      (for {
-                          unbalanced <- TransactionBuilder
-                              .build(
-                                cardanoNetwork.cardanoInfo.network,
-                                peerUtxos.map { case (utxoId, output) =>
-                                    Spend(Utxo(utxoId, output))
-                                }.toList ++ outputValues.map(value =>
-                                    Send(
-                                      TransactionOutput.Babbage(address = address, value = value)
-                                    )
-                                )
-                              )
-                          balanced <- unbalanced.balanceContext(
-                            diffHandler = Change.changeOutputDiffHandler(
-                              _, _,
-                              protocolParams = cardanoNetwork.cardanoProtocolParams,
-                              changeOutputIdx = 0
-                            ),
-                            protocolParams = cardanoNetwork.cardanoProtocolParams,
-                            evaluator = PlutusScriptEvaluator(
-                              cardanoNetwork.cardanoInfo,
-                              EvaluatorMode.EvaluateAndComputeCost
-                            )
-                          )
-                      } yield balanced.transaction).left.map(err => RuntimeException(err.toString))
-                    )
+                val totalValue = Value.combine(peerUtxos.map((_, o) => o.value))
+                val gen = CappedValueGen.generateCappedValue(cardanoNetwork)
+                pick(
+                  Gen.tailRecM((totalValue, List.empty: List[Value]))((rest, acc) =>
+                      gen(rest, Some(20_000_000L), Some(1000_000_000), None).map(next =>
+                          if next == rest
+                          then Right(acc :+ next)
+                          else Left((rest - next, acc :+ next))
+                      )
                   )
+                )
+            }
+            tx <- run(
+              IO.fromEither(
+                (for {
+                    unbalanced <- TransactionBuilder
+                        .build(
+                          cardanoNetwork.cardanoInfo.network,
+                          peerUtxos.map { case (utxoId, output) =>
+                              Spend(Utxo(utxoId, output))
+                          }.toList ++ outputValues.map(value =>
+                              Send(
+                                TransactionOutput.Babbage(address = address, value = value)
+                              )
+                          )
+                        )
+                    balanced <- unbalanced.balanceContext(
+                      diffHandler = Change.changeOutputDiffHandler(
+                        _,
+                        _,
+                        protocolParams = cardanoNetwork.cardanoProtocolParams,
+                        changeOutputIdx = 0
+                      ),
+                      protocolParams = cardanoNetwork.cardanoProtocolParams,
+                      evaluator = PlutusScriptEvaluator(
+                        cardanoNetwork.cardanoInfo,
+                        EvaluatorMode.EvaluateAndComputeCost
+                      )
+                    )
+                } yield balanced.transaction).left.map(err => RuntimeException(err.toString))
+              )
+            )
         } yield tx
     }
 
@@ -316,11 +316,11 @@ case class Suite(
             // For real-blockchain modes: anchor all block times 1 minute in the future so the SUT
             // can sleep until that moment and be perfectly synchronized with the model clock.
             takeoffTime <- suiteCardano match {
-                               case _: SuiteCardano.Mock =>
-                                   pick(Gen.const(None: Option[java.time.Instant]))
-                               case _ =>
-                                   run(IO.realTimeInstant.map(t => Some(t.plusSeconds(60))))
-                           }
+                case _: SuiteCardano.Mock =>
+                    pick(Gen.const(None: Option[java.time.Instant]))
+                case _ =>
+                    run(IO.realTimeInstant.map(t => Some(t.plusSeconds(60))))
+            }
 
             _ <- run(log.debug(s"takeoff time: $takeoffTime"))
 
@@ -354,19 +354,23 @@ case class Suite(
               generateInitialBlock = (bootstrap, funding) =>
                   hydrozoa.config.head.initialization.generateInitialBlock(
                     genHeadConfigBootstrap = ReaderT
-                        .pure[Gen, TestPeers, (
-                            hydrozoa.config.head.HeadConfig.Bootstrap,
-                            hydrozoa.bootstrap.InitializationFunding
-                        )]((bootstrap, funding)),
+                        .pure[
+                          Gen,
+                          TestPeers,
+                          (
+                              hydrozoa.config.head.HeadConfig.Bootstrap,
+                              hydrozoa.bootstrap.InitializationFunding
+                          )
+                        ]((bootstrap, funding)),
                     generateBlockCreationEndTime = generateHeadStartTime
                   )
             )
 
             config <- pick(
-                        MultiNodeConfig.generateWith(testPeers)(
-                          generateHeadConfig = generateHeadConfig
-                        )
-                      )
+              MultiNodeConfig.generateWith(testPeers)(
+                generateHeadConfig = generateHeadConfig
+              )
+            )
 
             _ <- run(log.debug(s"total contingency: ${config.headConfig.fallbackContingency}"))
             _ <- run(log.debug(s"l2 utxos: ${config.headConfig.initialEvacuationMap.size}"))
@@ -377,15 +381,15 @@ case class Suite(
             _ <- run(log.debug(s"peerL1GenesisUtxos: ${peerL1GenesisUtxos}"))
 
             _ <- pick(
-                   generateNodeOperationMultisigConfig(
-                     config.headConfig.maxCardanoLiaisonPollingPeriod
-                   )
-                 )
+              generateNodeOperationMultisigConfig(
+                config.headConfig.maxCardanoLiaisonPollingPeriod
+              )
+            )
             _ <- pick(
-                   generateNodeOperationEvacuationConfig(
-                     testPeers.walletFor(Alice)
-                   )
-                 )
+              generateNodeOperationEvacuationConfig(
+                testPeers.walletFor(Alice)
+              )
+            )
         } yield Model
             .State(
               multiNodeConfig = config,
@@ -495,98 +499,102 @@ case class Suite(
             // system was not terminated in the [[beforeFinalize]] action.
             // In-memory persistence — released when the Resource is finalized.
             persistenceBackend <- InMemoryBackendStore.open(persistenceTracer)
-            sut <- Resource.eval(for {
-                cardanoBackend <- mkCardanoBackend(cardanoBackendConfig)
-                fcaTracer: ContraTracer[IO, FastConsensusActorEvent] =
-                    Slf4jTracer.sink.contramap(FastConsensusActorEventFormat.humanFormat(headPeerNum))
-                clTracer: ContraTracer[IO, CardanoLiaisonEvent] =
-                    Slf4jTracer.sink.contramap(CardanoLiaisonEventFormat.humanFormat(headPeerNum))
-                // In-memory persistence for the SUT — stage1 doesn't assert on it, but the actors
-                // need a handle.
-                persistence <- {
-                    given CardanoNetwork.Section = nodeConfig
-                    Persistence.fromBackend(persistenceBackend, persistenceTracer)
-                }
-                // Weaver stub — emits leader_started for tracing
-                blockWeaver <- system.actorOf(
-                  new BlockWeaverMock(
-                    fcaTracer,
-                    headPeerNum,
-                    nodeConfig.headPeers.nHeadPeers: Int
-                  )
-                )
-                // No HMRM in stage1 — provide a stub actor that swallows any HandoffToRuleBased
-                // signal. Stage 1 doesn't exercise fallback-to-rule-based (single-peer / happy
-                // path only), so the ref is a required-but-inert construction parameter.
-                mrmSelfStub <- system.actorOf(
-                  new Actor[IO, HeadMultisigRegimeManager.HandoffToRuleBased] {
-                      override def receive
-                          : Receive[IO, HeadMultisigRegimeManager.HandoffToRuleBased] =
-                          _ => IO.unit
+            sut <- Resource.eval(
+              for {
+                  cardanoBackend <- mkCardanoBackend(cardanoBackendConfig)
+                  fcaTracer: ContraTracer[IO, FastConsensusActorEvent] =
+                      Slf4jTracer.sink.contramap(
+                        FastConsensusActorEventFormat.humanFormat(headPeerNum)
+                      )
+                  clTracer: ContraTracer[IO, CardanoLiaisonEvent] =
+                      Slf4jTracer.sink.contramap(CardanoLiaisonEventFormat.humanFormat(headPeerNum))
+                  // In-memory persistence for the SUT — stage1 doesn't assert on it, but the actors
+                  // need a handle.
+                  persistence <- {
+                      given CardanoNetwork.Section = nodeConfig
+                      Persistence.fromBackend(persistenceBackend, persistenceTracer)
                   }
-                )
-                // Cardano liaison
-                cardanoLiaison <- system.actorOf(
-                  CardanoLiaison(
-                    nodeConfig,
-                    cardanoBackend,
-                    CardanoLiaison.Connections(blockWeaver),
-                    clTracer,
-                    persistence,
-                    mrmSelf = mrmSelfStub,
-                    // Stage1 runs no user-facing HTTP server, so the readiness status has
-                    // no reader.
-                    advanceNodeStatus = _ => IO.unit,
+                  // Weaver stub — emits leader_started for tracing
+                  blockWeaver <- system.actorOf(
+                    new BlockWeaverMock(
+                      fcaTracer,
+                      headPeerNum,
+                      nodeConfig.headPeers.nHeadPeers: Int
+                    )
                   )
-                )
-                // Request sequencer stub
-                requestSequencerStub <- system.actorOf(new Actor[IO, RequestSequencer.Request] {
-                    override def receive: Receive[IO, RequestSequencer.Request] = _ => IO.pure(())
-                })
-                // Agent actor
-                jointLedgerD <- IO.deferred[JointLedger.Handle]
-                consensusActorD <- IO.deferred[FastConsensusActor.Handle]
-                agent <- system.actorOf(AgentActor(jointLedgerD, consensusActorD, cardanoLiaison))
-                // StackComposer stub — stage1 does not exercise slow consensus.
-                stackComposerStub <- system.actorOf(new Actor[IO, StackComposer.Request] {
-                    override def receive: Receive[IO, StackComposer.Request] = _ => IO.pure(())
-                })
-                jointLedgerConnections = JointLedger.Connections(
-                  fastConsensusActor = agent,
-                  stackComposer = stackComposerStub,
-                  headPeerLiaisons = List(),
-                )
-                l2Ledger <- EutxoL2Ledger(nodeConfig)
-                jointLedger <- system.actorOf(
-                  JointLedger(
-                    nodeConfig,
-                    jointLedgerConnections,
-                    l2Ledger,
-                    Slf4jTracer.sink.contramap(JointLedgerEventFormat.humanFormat(headPeerNum)),
-                    persistence
+                  // No HMRM in stage1 — provide a stub actor that swallows any HandoffToRuleBased
+                  // signal. Stage 1 doesn't exercise fallback-to-rule-based (single-peer / happy
+                  // path only), so the ref is a required-but-inert construction parameter.
+                  mrmSelfStub <- system.actorOf(
+                    new Actor[IO, HeadMultisigRegimeManager.HandoffToRuleBased] {
+                        override def receive
+                            : Receive[IO, HeadMultisigRegimeManager.HandoffToRuleBased] =
+                            _ => IO.unit
+                    }
                   )
-                )
-                _ <- jointLedgerD.complete(jointLedger)
-                // Consensus actor
-                consensusConnections = FastConsensusActor.Connections(
-                  blockWeaver = blockWeaver,
-                  cardanoLiaison = cardanoLiaison,
-                  requestSequencer = Some(requestSequencerStub),
-                  headPeerLiaisons = List.empty,
-                  stackComposer = stackComposerStub,
-                )
-                consensusActor <- system.actorOf(
-                  FastConsensusActor(nodeConfig, consensusConnections, fcaTracer, persistence)
-                )
-                _ <- consensusActorD.complete(consensusActor)
-            } yield Stage1Sut(
-              headAddress = multiNodeConfig.headConfig.headMultisigAddress,
-              system = system,
-              cardanoBackend = cardanoBackend,
-              agent = agent,
-              log = Slf4jTracer.sink.contramap(Slf4jMsgFormat.humanFormat("Stage1.Sut")),
-              runId = runId,
-            ))
+                  // Cardano liaison
+                  cardanoLiaison <- system.actorOf(
+                    CardanoLiaison(
+                      nodeConfig,
+                      cardanoBackend,
+                      CardanoLiaison.Connections(blockWeaver),
+                      clTracer,
+                      persistence,
+                      mrmSelf = mrmSelfStub,
+                      // Stage1 runs no user-facing HTTP server, so the readiness status has
+                      // no reader.
+                      advanceNodeStatus = _ => IO.unit,
+                    )
+                  )
+                  // Request sequencer stub
+                  requestSequencerStub <- system.actorOf(new Actor[IO, RequestSequencer.Request] {
+                      override def receive: Receive[IO, RequestSequencer.Request] = _ => IO.pure(())
+                  })
+                  // Agent actor
+                  jointLedgerD <- IO.deferred[JointLedger.Handle]
+                  consensusActorD <- IO.deferred[FastConsensusActor.Handle]
+                  agent <- system.actorOf(AgentActor(jointLedgerD, consensusActorD, cardanoLiaison))
+                  // StackComposer stub — stage1 does not exercise slow consensus.
+                  stackComposerStub <- system.actorOf(new Actor[IO, StackComposer.Request] {
+                      override def receive: Receive[IO, StackComposer.Request] = _ => IO.pure(())
+                  })
+                  jointLedgerConnections = JointLedger.Connections(
+                    fastConsensusActor = agent,
+                    stackComposer = stackComposerStub,
+                    headPeerLiaisons = List(),
+                  )
+                  l2Ledger <- EutxoL2Ledger(nodeConfig)
+                  jointLedger <- system.actorOf(
+                    JointLedger(
+                      nodeConfig,
+                      jointLedgerConnections,
+                      l2Ledger,
+                      Slf4jTracer.sink.contramap(JointLedgerEventFormat.humanFormat(headPeerNum)),
+                      persistence
+                    )
+                  )
+                  _ <- jointLedgerD.complete(jointLedger)
+                  // Consensus actor
+                  consensusConnections = FastConsensusActor.Connections(
+                    blockWeaver = blockWeaver,
+                    cardanoLiaison = cardanoLiaison,
+                    requestSequencer = Some(requestSequencerStub),
+                    headPeerLiaisons = List.empty,
+                    stackComposer = stackComposerStub,
+                  )
+                  consensusActor <- system.actorOf(
+                    FastConsensusActor(nodeConfig, consensusConnections, fcaTracer, persistence)
+                  )
+                  _ <- consensusActorD.complete(consensusActor)
+              } yield Stage1Sut(
+                headAddress = multiNodeConfig.headConfig.headMultisigAddress,
+                system = system,
+                cardanoBackend = cardanoBackend,
+                agent = agent,
+                log = Slf4jTracer.sink.contramap(Slf4jMsgFormat.humanFormat("Stage1.Sut")),
+                runId = runId,
+              )
+            )
         } yield sut
     }
 

--- a/integration/src/test/scala/hydrozoa/integration/stage1/Sut.scala
+++ b/integration/src/test/scala/hydrozoa/integration/stage1/Sut.scala
@@ -228,9 +228,7 @@ object SutCommands:
                     val id = cmd.request.requestId
                     val tx = cmd.depositTxBytesSigned
 
-                    sut.cardanoBackend.submitTx(RawTx(tx)) >>= (ret =>
-                        IO.pure((id, tx) -> ret)
-                    )
+                    sut.cardanoBackend.submitTx(RawTx(tx)) >>= (ret => IO.pure((id, tx) -> ret))
                 })
 
                 submissionErrors = ret.filter(_._2.isLeft)

--- a/integration/src/test/scala/hydrozoa/integration/stage4/EffectsLanded.scala
+++ b/integration/src/test/scala/hydrozoa/integration/stage4/EffectsLanded.scala
@@ -12,16 +12,15 @@ import scalus.cardano.ledger.TransactionHash
 /** Stage4 "effects landed" assertion: every backbone tx the slow cycle produced (settlement /
   * finalization / init plus dependent rollouts) lands on L1.
   *
-  * Backend-agnostic via [[CardanoBackend.isTxKnown]]. Rule-based fallback is out of scope — see
-  * the package docstring; the suite-level fallback signal fails the test before this property
-  * runs.
+  * Backend-agnostic via [[CardanoBackend.isTxKnown]]. Rule-based fallback is out of scope — see the
+  * package docstring; the suite-level fallback signal fails the test before this property runs.
   *
-  * == Out of scope ==
+  * ==Out of scope==
   *
   *   - Refunds: user-submitted, not produced by `CardanoLiaison`.
   *   - Standalone evac commitments: header signatures, not L1 txs.
-  *   - Strong (model-predicted) backbone: this only verifies what the slow cycle produced
-  *     landed; it cannot catch "the slow side never produced an expected settlement".
+  *   - Strong (model-predicted) backbone: this only verifies what the slow cycle produced landed;
+  *     it cannot catch "the slow side never produced an expected settlement".
   */
 object EffectsLanded {
 
@@ -174,8 +173,8 @@ object EffectsLanded {
     ): IO[Unit] =
         log.info(renderEffectsTable(results))
 
-    /** Build the property directly from observed stacks + backend. Vacuous when the observed
-      * stack list is empty — [[Stage4Suite.propStackCoverage]] catches that case, not this one.
+    /** Build the property directly from observed stacks + backend. Vacuous when the observed stack
+      * list is empty — [[Stage4Suite.propStackCoverage]] catches that case, not this one.
       */
     def propEffectsLanded(
         stacks: Seq[Stack.HardConfirmed],

--- a/integration/src/test/scala/hydrozoa/integration/stage4/Generator.scala
+++ b/integration/src/test/scala/hydrozoa/integration/stage4/Generator.scala
@@ -390,12 +390,12 @@ object Stage4ScenarioGen extends ScenarioGen[ModelState, Stage4Sut]:
         // marginal stream is exactly Poisson at its configured rate, so peers with smaller mean
         // inter-arrival are picked proportionally more often and the global rate is Σλ_p.
         pick(
-            for {
-                (peerNum, interArrivalDelay) <- CommandGenerators.genSuperposedNextEvent(
-                  state.params.meanInterArrivalTimes
-                )
-                cmd <- genCommandForPeer(peerNum, interArrivalDelay, state)
-            } yield cmd
+          for {
+              (peerNum, interArrivalDelay) <- CommandGenerators.genSuperposedNextEvent(
+                state.params.meanInterArrivalTimes
+              )
+              cmd <- genCommandForPeer(peerNum, interArrivalDelay, state)
+          } yield cmd
         )
 
     private def genCommandForPeer(

--- a/integration/src/test/scala/hydrozoa/integration/stage4/Model.scala
+++ b/integration/src/test/scala/hydrozoa/integration/stage4/Model.scala
@@ -163,50 +163,53 @@ object Model {
         )(using log: ContraTracer[M, Slf4jMsg]): StateT[M, ModelState, ValidityFlag] =
             import cmd.peerNum
             for
-                state         <- StateT.get[M, ModelState]
-                newTime        = state.currentModelTime + cmd.interArrivalDelay
-                stateAT        = absorbDeposits(newTime, state).copy(currentModelTime = newTime)
-                nodeConfig     = stateAT.nodeConfigFor(peerNum)
-                l2Tx          <- StateT.liftF(
-                                   L2Tx
-                                       .parse(
-                                         cmd.request.request.body.l2Payload.bytes,
-                                         nodeConfig.headConfig.cardanoNetwork
-                                       )
-                                       .fold(
-                                         err =>
-                                             MonadThrow[M].raiseError(
-                                               RuntimeException(s"Failed to parse L2Tx: $err")
-                                             ),
-                                         MonadThrow[M].pure(_)
-                                       )
-                                 )
-                mutatorResult  = HydrozoaTransactionMutator.transit(
-                                   config = nodeConfig.headConfig,
-                                   time = stateAT.currentModelTime,
-                                   state = stateAT.utxosL2Active,
-                                   l2Tx = l2Tx
-                                 )
+                state <- StateT.get[M, ModelState]
+                newTime = state.currentModelTime + cmd.interArrivalDelay
+                stateAT = absorbDeposits(newTime, state).copy(currentModelTime = newTime)
+                nodeConfig = stateAT.nodeConfigFor(peerNum)
+                l2Tx <- StateT.liftF(
+                  L2Tx
+                      .parse(
+                        cmd.request.request.body.l2Payload.bytes,
+                        nodeConfig.headConfig.cardanoNetwork
+                      )
+                      .fold(
+                        err =>
+                            MonadThrow[M].raiseError(
+                              RuntimeException(s"Failed to parse L2Tx: $err")
+                            ),
+                        MonadThrow[M].pure(_)
+                      )
+                )
+                mutatorResult = HydrozoaTransactionMutator.transit(
+                  config = nodeConfig.headConfig,
+                  time = stateAT.currentModelTime,
+                  state = stateAT.utxosL2Active,
+                  l2Tx = l2Tx
+                )
                 (flag, newL2Utxos, mInvalidMsg) = mutatorResult match {
                     case Left(err) =>
-                        (ValidityFlag.Invalid, stateAT.utxosL2Active,
-                            Some(s"L2 tx ${cmd.request.requestId} invalid in model: $err"))
+                        (
+                          ValidityFlag.Invalid,
+                          stateAT.utxosL2Active,
+                          Some(s"L2 tx ${cmd.request.requestId} invalid in model: $err")
+                        )
                     case Right(newUtxos) =>
                         (ValidityFlag.Valid, newUtxos, None)
                 }
-                newState       = stateAT.copy(
-                                   utxosL2Active = newL2Utxos,
-                                   nextRequestNumbers = stateAT.nextRequestNumbers +
-                                       (peerNum -> stateAT.nextRequestNumbers(peerNum).increment),
-                                   modelFlags = stateAT.modelFlags + (cmd.request.requestId -> flag),
-                                 )
-                _             <- StateT.liftF(
-                                   log.debug(
-                                     s"MODEL>> L2TxCommand(peer=$peerNum, requestId=${cmd.request.requestId})"
-                                   )
-                                 )
-                _             <- StateT.liftF(mInvalidMsg.fold(MonadThrow[M].pure(()))(log.debug(_)))
-                _             <- StateT.set[M, ModelState](newState)
+                newState = stateAT.copy(
+                  utxosL2Active = newL2Utxos,
+                  nextRequestNumbers = stateAT.nextRequestNumbers +
+                      (peerNum -> stateAT.nextRequestNumbers(peerNum).increment),
+                  modelFlags = stateAT.modelFlags + (cmd.request.requestId -> flag),
+                )
+                _ <- StateT.liftF(
+                  log.debug(
+                    s"MODEL>> L2TxCommand(peer=$peerNum, requestId=${cmd.request.requestId})"
+                  )
+                )
+                _ <- StateT.liftF(mInvalidMsg.fold(MonadThrow[M].pure(()))(log.debug(_)))
+                _ <- StateT.set[M, ModelState](newState)
             yield flag
     }
 
@@ -219,35 +222,35 @@ object Model {
         )(using log: ContraTracer[M, Slf4jMsg]): StateT[M, ModelState, ValidityFlag] =
             import cmd.peerNum
             for
-                state           <- StateT.get[M, ModelState]
-                newTime          = state.currentModelTime + cmd.interArrivalDelay
-                stateAfterTime   = absorbDeposits(newTime, state).copy(currentModelTime = newTime)
-                pending          = PendingDeposit(
-                                     requestId = cmd.request.requestId,
-                                     absorptionStartTime = cmd.absorptionStartTime,
-                                     expectedAbsorptionTime = cmd.expectedAbsorptionTime,
-                                     l2Payload = cmd.l2Payload,
-                                     depositProduced = cmd.depositProduced
-                                   )
-                spentL1Inputs    = cmd.depositTxBytesSigned.body.value.inputs.toSet
-                updatedPeerL1    = stateAfterTime.peerUtxosL1(peerNum) -- spentL1Inputs
-                newState         = stateAfterTime.copy(
-                                     pendingDeposits = stateAfterTime.pendingDeposits +
-                                         (peerNum -> (stateAfterTime.pendingDeposits(peerNum) :+ pending)),
-                                     nextRequestNumbers = stateAfterTime.nextRequestNumbers +
-                                         (peerNum -> stateAfterTime.nextRequestNumbers(peerNum).increment),
-                                     peerUtxosL1 = stateAfterTime.peerUtxosL1 + (peerNum -> updatedPeerL1),
-                                     modelFlags =
-                                         stateAfterTime.modelFlags + (cmd.request.requestId -> ValidityFlag.Valid),
-                                     registeredDeposits =
-                                         stateAfterTime.registeredDeposits + (cmd.request.requestId -> pending),
-                                   )
-                _               <- StateT.set[M, ModelState](newState)
-                _               <- StateT.liftF(
-                                     log.debug(
-                                       s"MODEL>> RegisterAndSubmitDepositCommand(peer=$peerNum, requestId=${cmd.request.requestId})"
-                                     )
-                                   )
+                state <- StateT.get[M, ModelState]
+                newTime = state.currentModelTime + cmd.interArrivalDelay
+                stateAfterTime = absorbDeposits(newTime, state).copy(currentModelTime = newTime)
+                pending = PendingDeposit(
+                  requestId = cmd.request.requestId,
+                  absorptionStartTime = cmd.absorptionStartTime,
+                  expectedAbsorptionTime = cmd.expectedAbsorptionTime,
+                  l2Payload = cmd.l2Payload,
+                  depositProduced = cmd.depositProduced
+                )
+                spentL1Inputs = cmd.depositTxBytesSigned.body.value.inputs.toSet
+                updatedPeerL1 = stateAfterTime.peerUtxosL1(peerNum) -- spentL1Inputs
+                newState = stateAfterTime.copy(
+                  pendingDeposits = stateAfterTime.pendingDeposits +
+                      (peerNum -> (stateAfterTime.pendingDeposits(peerNum) :+ pending)),
+                  nextRequestNumbers = stateAfterTime.nextRequestNumbers +
+                      (peerNum -> stateAfterTime.nextRequestNumbers(peerNum).increment),
+                  peerUtxosL1 = stateAfterTime.peerUtxosL1 + (peerNum -> updatedPeerL1),
+                  modelFlags =
+                      stateAfterTime.modelFlags + (cmd.request.requestId -> ValidityFlag.Valid),
+                  registeredDeposits =
+                      stateAfterTime.registeredDeposits + (cmd.request.requestId -> pending),
+                )
+                _ <- StateT.set[M, ModelState](newState)
+                _ <- StateT.liftF(
+                  log.debug(
+                    s"MODEL>> RegisterAndSubmitDepositCommand(peer=$peerNum, requestId=${cmd.request.requestId})"
+                  )
+                )
             yield ValidityFlag.Valid
     }
 

--- a/integration/src/test/scala/hydrozoa/integration/stage4/Plugins.scala
+++ b/integration/src/test/scala/hydrozoa/integration/stage4/Plugins.scala
@@ -21,8 +21,8 @@ import scalus.cardano.ledger.TransactionHash
   */
 private[stage4] object Stage4Plugins {
 
-    /** Capture briefs (`JL.BriefProduced`) and hard-confirmed stacks (`SCA.StackHardConfirmed`)
-      * per head peer.
+    /** Capture briefs (`JL.BriefProduced`) and hard-confirmed stacks (`SCA.StackHardConfirmed`) per
+      * head peer.
       */
     def perPeerCaptures(
         peers: Seq[HeadPeerNumber]
@@ -68,8 +68,8 @@ private[stage4] object Stage4Plugins {
             }
         }
 
-    /** Capture L1 tx hashes from `CardanoLiaisonEvent.TxSubmitting` across head and coil sides.
-      * All head peers submit the same backbone txs in parallel; the `Set` collapses duplicates.
+    /** Capture L1 tx hashes from `CardanoLiaisonEvent.TxSubmitting` across head and coil sides. All
+      * head peers submit the same backbone txs in parallel; the `Set` collapses duplicates.
       */
     def effectsLandedCapture: IO[Capture[Ref[IO, Set[TransactionHash]]]] =
         Ref[IO].of(Set.empty[TransactionHash]).map { ref =>
@@ -104,7 +104,7 @@ private[stage4] object Stage4Plugins {
                   CommonChildEvent.JointLedger(JointLedgerEvent.BriefProduced(_)),
                 ) =>
                 target.tryGet.flatMap {
-                    case None            => IO.pure(None)
+                    case None => IO.pure(None)
                     case Some(submitted) =>
                         perPeer.state(p).blockBriefs.get.map { briefs =>
                             val seen = briefs
@@ -120,9 +120,9 @@ private[stage4] object Stage4Plugins {
             case _ => IO.pure(None)
         }
 
-    /** Slow-cycle coverage signal: armed externally with the block-number set that must be
-      * covered; fires once every head peer's hard-confirmed stacks span every block num. No coil
-      * arm — followers participate only via the head set (see [[propCoilParticipation]]).
+    /** Slow-cycle coverage signal: armed externally with the block-number set that must be covered;
+      * fires once every head peer's hard-confirmed stacks span every block num. No coil arm —
+      * followers participate only via the head set (see [[propCoilParticipation]]).
       */
     def slowCoverageSignal(
         perPeer: Capture[Map[HeadPeerNumber, PerPeerCaptures]],
@@ -136,7 +136,7 @@ private[stage4] object Stage4Plugins {
                   ),
                 ) =>
                 target.tryGet.flatMap {
-                    case None             => IO.pure(None)
+                    case None => IO.pure(None)
                     case Some(targetNums) =>
                         perPeer.state.values.toList.traverse(_.stacks.get).map { allPeersStacks =>
                             val allCovered = targetNums.isEmpty ||
@@ -171,7 +171,7 @@ private[stage4] object Stage4Plugins {
                   CommonChildEvent.CardanoLiaison(CardanoLiaisonEvent.TxSubmitting(_)),
                 ) =>
                 target.tryGet.flatMap {
-                    case None       => IO.pure(None)
+                    case None => IO.pure(None)
                     case Some(exps) =>
                         landed.state.get.map { l =>
                             Option.when(EffectsLanded.isComplete(l, exps))(())

--- a/integration/src/test/scala/hydrozoa/integration/stage4/Runner.scala
+++ b/integration/src/test/scala/hydrozoa/integration/stage4/Runner.scala
@@ -18,13 +18,15 @@ object Stage4Runner:
     def generateCommands(
         initialState: ModelState,
         n: Int
-    )(using ContraTracer[IO, Slf4jMsg]): PropertyM[IO, (ModelState, List[AnyCommand[ModelState, Stage4Sut]])] =
+    )(using
+        ContraTracer[IO, Slf4jMsg]
+    ): PropertyM[IO, (ModelState, List[AnyCommand[ModelState, Stage4Sut]])] =
         val step: StateT[[x] =>> PropertyM[IO, x], ModelState, AnyCommand[ModelState, Stage4Sut]] =
             for
-                state    <- StateT.get[[x] =>> PropertyM[IO, x], ModelState]
-                cmd      <- StateT.liftF(Stage4ScenarioGen.genNextCommand(state))
+                state <- StateT.get[[x] =>> PropertyM[IO, x], ModelState]
+                cmd <- StateT.liftF(Stage4ScenarioGen.genNextCommand(state))
                 newState <- StateT.liftF(PropertyM.run(cmd.advanceState[IO](state)))
-                _        <- StateT.set[[x] =>> PropertyM[IO, x], ModelState](newState)
+                _ <- StateT.set[[x] =>> PropertyM[IO, x], ModelState](newState)
             yield cmd
         step.replicateA(n).run(initialState)
 
@@ -67,9 +69,11 @@ object Stage4Runner:
 
         // Collect (genSeqNum, cmd, nextState) for all non-NoOp commands
         commands.zipWithIndex
-            .foldLeft(IO.pure(
-              (initialState, List.empty[(Int, AnyCommand[ModelState, Stage4Sut], ModelState)])
-            )) { case (ioAcc, (cmd, idx)) =>
+            .foldLeft(
+              IO.pure(
+                (initialState, List.empty[(Int, AnyCommand[ModelState, Stage4Sut], ModelState)])
+              )
+            ) { case (ioAcc, (cmd, idx)) =>
                 ioAcc.flatMap { case (state, acc) =>
                     cmd.advanceState[IO](state).map { nextState =>
                         val entry =
@@ -86,20 +90,23 @@ object Stage4Runner:
                     (nextState.currentModelTime.getEpochSecond, genSeq)
                 }
 
-                val rowLines = sorted.zipWithIndex.map { case ((genSeq, cmd, nextState), displayIdx) =>
-                    val actingPeer =
-                        peerRegex.findFirstMatchIn(cmd.label).map(m => HeadPeerNumber(m.group(1).toInt))
-                    s"| ${(displayIdx + 1).toString.padTo(stepWidth, ' ')} |" + peers.map { p =>
-                        val cell =
-                            if actingPeer.contains(p) then
-                                val t = nextState.currentModelTime.getEpochSecond - startEpoch
-                                val d = cmd.delay.toSeconds
-                                s"#$genSeq ${compactLabel(cmd.label)} +${t}s Δ${d}s"
-                                    .take(colWidth)
-                                    .padTo(colWidth, ' ')
-                            else " " * colWidth
-                        s" $cell |"
-                    }.mkString
+                val rowLines = sorted.zipWithIndex.map {
+                    case ((genSeq, cmd, nextState), displayIdx) =>
+                        val actingPeer =
+                            peerRegex
+                                .findFirstMatchIn(cmd.label)
+                                .map(m => HeadPeerNumber(m.group(1).toInt))
+                        s"| ${(displayIdx + 1).toString.padTo(stepWidth, ' ')} |" + peers.map { p =>
+                            val cell =
+                                if actingPeer.contains(p) then
+                                    val t = nextState.currentModelTime.getEpochSecond - startEpoch
+                                    val d = cmd.delay.toSeconds
+                                    s"#$genSeq ${compactLabel(cmd.label)} +${t}s Δ${d}s"
+                                        .take(colWidth)
+                                        .padTo(colWidth, ' ')
+                                else " " * colWidth
+                            s" $cell |"
+                        }.mkString
                 }
 
                 (List(divider, header, divider) ++ rowLines ++ List(divider, legend)).mkString("\n")
@@ -116,17 +123,19 @@ object Stage4Runner:
         Slf4jTracer.sink.contramap(Slf4jMsgFormat.humanFormat("Stage4.Runner"))
     val prop = PropertyM.monadicIO {
         for
-            initialState <- PropertyM.pick[IO, ModelState](Stage4Suite.genInitialState(
+            initialState <- PropertyM.pick[IO, ModelState](
+              Stage4Suite.genInitialState(
                 nPeers = 3,
                 meanInterArrivalTime = p =>
                     (p: Int) match
                         case 0 => 30.seconds
                         case 1 => 8.seconds
                         case _ => 15.seconds
-            ))
+              )
+            )
             commandsResult <- Stage4Runner.generateCommands(initialState, 300)
-            (_, commands)   = commandsResult
-            _              <- PropertyM.run(Stage4Runner.printTable(initialState, commands))
+            (_, commands) = commandsResult
+            _ <- PropertyM.run(Stage4Runner.printTable(initialState, commands))
         yield Prop.passed
     }
     val _ = Test.check(Test.Parameters.default.withMinSuccessfulTests(1), prop)
@@ -175,13 +184,12 @@ object Stage4Properties extends YetAnotherProperties("Integration Stage 4"):
     val _ = property("Two-peers head works (extended)") =
         Stage4Suite(label = "stage4-two-peers-extended", nPeers = 2, nCommands = 500).property()
 
-    val _ = property("Two-heads-one-coil works (extended)") =
-        Stage4Suite(
-          label = "stage4-2h1c-extended",
-          nPeers = 2,
-          nCoilPeers = 1,
-          nCommands = 500,
-        ).property()
+    val _ = property("Two-heads-one-coil works (extended)") = Stage4Suite(
+      label = "stage4-2h1c-extended",
+      nPeers = 2,
+      nCoilPeers = 1,
+      nCommands = 500,
+    ).property()
 
     val _ = property("Three-peers head works (extended)") =
         Stage4Suite(label = "stage4-three-peers-extended", nPeers = 3, nCommands = 500).property()
@@ -208,13 +216,12 @@ object Stage4Properties extends YetAnotherProperties("Integration Stage 4"):
     // WebSocket transport variant of the two-heads-one-coil run: the hub↔coil link runs over the
     // shared per-peer WS server (`/hub` route) instead of in-process handles, exercising the
     // HubWsTransport / CoilPeerWsTransport / CoilFrame path end-to-end.
-    val _ = property("Two-heads-one-coil works WS") =
-        Stage4Suite(
-          label = "stage4-ws-2h1c",
-          nPeers = 2,
-          nCoilPeers = 1,
-          transportMode = TransportMode.WebSocket,
-        ).property()
+    val _ = property("Two-heads-one-coil works WS") = Stage4Suite(
+      label = "stage4-ws-2h1c",
+      nPeers = 2,
+      nCoilPeers = 1,
+      transportMode = TransportMode.WebSocket,
+    ).property()
 
 // ===================================
 // Diagnostic: termination check
@@ -224,7 +231,6 @@ object Stage4Diagnostics extends YetAnotherProperties("Integration Stage 4 Diagn
 
     override def overrideParameters(p: Test.Parameters): Test.Parameters =
         p.withWorkers(1).withMinSuccessfulTests(1)
-
 
     val _ = property("Two-peers 1 command") =
         Stage4Suite(label = "diag-1", nPeers = 2, nCommands = 1).property()

--- a/integration/src/test/scala/hydrozoa/integration/stage4/Suite.scala
+++ b/integration/src/test/scala/hydrozoa/integration/stage4/Suite.scala
@@ -12,10 +12,7 @@ import hydrozoa.config.head.{InitParamsType, generateHeadConfig, generateHeadCon
 import hydrozoa.config.node.{MultiNodeConfig, NodeConfig}
 import hydrozoa.integration.harness.MultiPeerHeadHarness.StorageBackend.Mode as BackendMode
 import hydrozoa.integration.harness.MultiPeerHeadHarness.Transport.Mode as TransportMode
-import hydrozoa.integration.harness.{
-  MultiPeerHeadHarness,
-  Plugin
-}
+import hydrozoa.integration.harness.{MultiPeerHeadHarness, Plugin}
 import hydrozoa.integration.stage4.EffectsLanded.BlockExpectation
 import hydrozoa.integration.stage4.Model.*
 import hydrozoa.lib.cardano.scalus.QuantizedTime.given_Ordering_QuantizedInstant.mkOrderingOps
@@ -98,35 +95,35 @@ case class Stage4Suite(
     // into each MRM.
     override def sutResource(state: ModelState): Resource[IO, Stage4Sut] =
         val multiNodeConfig = state.params.multiNodeConfig
-        val peers           = multiNodeConfig.nodeConfigs.keys.toSeq.sortBy(p => p: Int)
-        val coilConfigs     = state.params.coilNodeConfigs
-        val startEpochMs    = state.currentModelTime.getEpochSecond * 1000L
-        val coilNums        = coilConfigs.map(MultiPeerHeadHarness.Transport.coilNumOf)
+        val peers = multiNodeConfig.nodeConfigs.keys.toSeq.sortBy(p => p: Int)
+        val coilConfigs = state.params.coilNodeConfigs
+        val startEpochMs = state.currentModelTime.getEpochSecond * 1000L
+        val coilNums = coilConfigs.map(MultiPeerHeadHarness.Transport.coilNumOf)
 
         for
             // Captures (writer arms over Refs)
-            perPeer   <- Resource.eval(Stage4Plugins.perPeerCaptures(peers))
-            perCoil   <- Resource.eval(Stage4Plugins.perCoilCaptures(coilNums))
+            perPeer <- Resource.eval(Stage4Plugins.perPeerCaptures(peers))
+            perCoil <- Resource.eval(Stage4Plugins.perCoilCaptures(coilNums))
             landedTxs <- Resource.eval(Stage4Plugins.effectsLandedCapture)
 
             // Target Deferreds — armed in beforeFinalize to gate the signal predicates below.
             fastSettlementTarget <- Resource.eval(IO.deferred[Set[RequestId]])
-            slowCoverageTarget   <- Resource.eval(IO.deferred[Set[Int]])
-            effectsLandedTarget  <- Resource.eval(IO.deferred[List[BlockExpectation]])
+            slowCoverageTarget <- Resource.eval(IO.deferred[Set[Int]])
+            effectsLandedTarget <- Resource.eval(IO.deferred[List[BlockExpectation]])
 
             // Signals (predicate arms over Deferred[T])
-            fastSettlementSignal  <- Resource.eval(
-                                       Stage4Plugins
-                                           .fastSettlementSignal(perPeer, fastSettlementTarget)
-                                     )
-            slowCoverageSignal    <- Resource.eval(
-                                       Stage4Plugins
-                                           .slowCoverageSignal(perPeer, slowCoverageTarget)
-                                     )
-            effectsLandedSignal   <- Resource.eval(
-                                       Stage4Plugins
-                                           .effectsLandedSignal(landedTxs, effectsLandedTarget)
-                                     )
+            fastSettlementSignal <- Resource.eval(
+              Stage4Plugins
+                  .fastSettlementSignal(perPeer, fastSettlementTarget)
+            )
+            slowCoverageSignal <- Resource.eval(
+              Stage4Plugins
+                  .slowCoverageSignal(perPeer, slowCoverageTarget)
+            )
+            effectsLandedSignal <- Resource.eval(
+              Stage4Plugins
+                  .effectsLandedSignal(landedTxs, effectsLandedTarget)
+            )
             fallbackEnteredSignal <- Resource.eval(Stage4Plugins.fallbackEnteredSignal)
 
             // SUT-command-fed Ref (not a plugin — written by commands, not tracer arms)
@@ -135,29 +132,29 @@ case class Stage4Suite(
             // Hooks.handle is unused now — each head peer's SubmissionClient is built by the
             // harness against its in-process HydrozoaRoutes and exposed on Peer[H].submissionClient.
             hooks = MultiPeerHeadHarness.Hooks[Unit](
-                      tracer = Plugin.tracerOf(
-                        perPeer,
-                        perCoil,
-                        landedTxs,
-                        fastSettlementSignal,
-                        slowCoverageSignal,
-                        effectsLandedSignal,
-                        fallbackEnteredSignal,
-                      ),
-                      handle = (_, _) => IO.unit,
-                    )
+              tracer = Plugin.tracerOf(
+                perPeer,
+                perCoil,
+                landedTxs,
+                fastSettlementSignal,
+                slowCoverageSignal,
+                effectsLandedSignal,
+                fallbackEnteredSignal,
+              ),
+              handle = (_, _) => IO.unit,
+            )
             harness <- MultiPeerHeadHarness.resource(
-                           MultiPeerHeadHarness.Inputs(
-                             config = MultiPeerHeadHarness
-                                 .Config(label, backendMode, transportMode),
-                             multiNodeConfig = multiNodeConfig,
-                             coilNodeConfigs = coilConfigs,
-                             preinitPeerUtxosL1 = state.preinitPeerUtxosL1,
-                             takeoffTime = state.takeoffTime,
-                             startEpochMs = startEpochMs,
-                           ),
-                           hooks,
-                       )
+              MultiPeerHeadHarness.Inputs(
+                config = MultiPeerHeadHarness
+                    .Config(label, backendMode, transportMode),
+                multiNodeConfig = multiNodeConfig,
+                coilNodeConfigs = coilConfigs,
+                preinitPeerUtxosL1 = state.preinitPeerUtxosL1,
+                takeoffTime = state.takeoffTime,
+                startEpochMs = startEpochMs,
+              ),
+              hooks,
+            )
         yield Stage4Sut(
           static = Stage4SutStatic(
             system = harness.system,
@@ -182,7 +179,6 @@ case class Stage4Suite(
           ),
         )
 
-
     override def beforeFinalize(lastState: ModelState, sut: Stage4Sut): IO[Prop] = {
         // Race the happy-path drain against the fallback-entered signal. If any peer's CL
         // successfully submits a `FallbackToRuleBased`, abandon the analysis and fail with
@@ -199,35 +195,33 @@ case class Stage4Suite(
             // One-time coverage check: if all IDs already landed before we armed the target,
             // fire the signal ourselves (no new brief will arrive to trigger the predicate).
             allBriefs <- sut.mutable.perPeer.state.values.toList
-                             .traverse(_.blockBriefs.get)
-                             .map(_.flatten)
-            seen       = allBriefs
-                             .flatMap(br =>
-                                 br.requests.map(_._1) ++ br.depositsAbsorbed ++ br.depositsRejected
-                             )
-                             .toSet
+                .traverse(_.blockBriefs.get)
+                .map(_.flatten)
+            seen = allBriefs
+                .flatMap(br => br.requests.map(_._1) ++ br.depositsAbsorbed ++ br.depositsRejected)
+                .toSet
             _ <- IO.whenA(submitted.forall(seen.contains))(
-                     sut.mutable.fastSettlementSignal.complete(())
-                 )
+              sut.mutable.fastSettlementSignal.complete(())
+            )
             _ <- IO.whenA(submitted.nonEmpty)(sut.mutable.fastSettlementSignal.await)
             // Arm the slow-cycle drain: freeze the block nums that must be covered. Done after
             // the fast drain so any blocks produced during that wait are included in the target.
             blockNums <- sut.mutable.perPeer.state.values.toList
-                             .traverse(_.blockBriefs.get)
-                             .map(_.flatten.map(b => (b.blockNum: Int)).toSet)
+                .traverse(_.blockBriefs.get)
+                .map(_.flatten.map(b => b.blockNum: Int).toSet)
             _ <- sut.mutable.slowCoverageTarget.complete(blockNums)
             // One-time coverage check across ALL peers — matching the predicate condition so a
             // spurious signal fire can't race ahead of any peer's stacks update.
             allPeersStacks <- sut.mutable.perPeer.state.values.toList.traverse(_.stacks.get)
-            allCovered      = blockNums.isEmpty ||
-                                  allPeersStacks.forall { peerStacks =>
-                                      blockNums.forall { bn =>
-                                          peerStacks.exists { s =>
-                                              (s.brief.firstBlockNum: Int) <= bn &&
-                                              bn <= (s.brief.lastBlockNum: Int)
-                                          }
-                                      }
-                                  }
+            allCovered = blockNums.isEmpty ||
+                allPeersStacks.forall { peerStacks =>
+                    blockNums.forall { bn =>
+                        peerStacks.exists { s =>
+                            (s.brief.firstBlockNum: Int) <= bn &&
+                            bn <= (s.brief.lastBlockNum: Int)
+                        }
+                    }
+                }
             _ <- IO.whenA(allCovered)(sut.mutable.slowCoverageSignal.complete(()))
             _ <- IO.whenA(blockNums.nonEmpty)(sut.mutable.slowCoverageSignal.await)
             // Arm the effects-landed drain: now that the slow cycle has reached agreement on
@@ -235,19 +229,19 @@ case class Stage4Suite(
             // wait for the TxSubmitting predicate to observe enough hashes to satisfy them. Gap
             // between slow signal and this one = the StackComposer rate-limit delay.
             canonicalStacksForTarget <- sut.mutable.perPeer.state.toList
-                                            .traverse { case (p, c) => c.stacks.get.map(p -> _) }
-                                            .map { byPeer =>
-                                                val sorted = byPeer.toMap.toSeq.sortBy(_._1: Int)
-                                                sorted.headOption.map(_._2).getOrElse(Vector.empty)
-                                            }
+                .traverse { case (p, c) => c.stacks.get.map(p -> _) }
+                .map { byPeer =>
+                    val sorted = byPeer.toMap.toSeq.sortBy(_._1: Int)
+                    sorted.headOption.map(_._2).getOrElse(Vector.empty)
+                }
             expectations = EffectsLanded.expectations(canonicalStacksForTarget)
             _ <- sut.mutable.effectsLandedTarget.complete(expectations)
             // One-time check: if every relevant expectation is already satisfied by the hashes
             // we've observed so far, fire the signal ourselves (no new TxSubmitting will arrive).
             landedNow <- sut.mutable.landedTxs.state.get
             _ <- IO.whenA(EffectsLanded.isComplete(landedNow, expectations))(
-                     sut.mutable.effectsLandedSignal.complete(())
-                 )
+              sut.mutable.effectsLandedSignal.complete(())
+            )
             _ <- IO.whenA(expectations.nonEmpty)(sut.mutable.effectsLandedSignal.await)
             errors <- sut.mutable.sutErrors.get
             // Snapshot every capture-written Ref ONCE here, after all drain signals have fired,
@@ -257,28 +251,28 @@ case class Stage4Suite(
             // derived from inconsistent snapshots. Freezing once removes that window by
             // construction.
             briefsByPeer <- sut.mutable.perPeer.state.toList
-                                .traverse { case (p, c) => c.blockBriefs.get.map(p -> _) }
-                                .map(_.toMap)
+                .traverse { case (p, c) => c.blockBriefs.get.map(p -> _) }
+                .map(_.toMap)
             stacksByPeer <- sut.mutable.perPeer.state.toList
-                                .traverse { case (p, c) => c.stacks.get.map(p -> _) }
-                                .map(_.toMap)
+                .traverse { case (p, c) => c.stacks.get.map(p -> _) }
+                .map(_.toMap)
             coilStacksByCoil <- sut.mutable.perCoil.state.toList
-                                    .traverse { case (c, cap) => cap.stacks.get.map(c -> _) }
-                                    .map(_.toMap)
+                .traverse { case (c, cap) => cap.stacks.get.map(c -> _) }
+                .map(_.toMap)
             submittedIds <- sut.mutable.submittedRequestIds.get
             sortedPeers = stacksByPeer.keys.toSeq.sortBy(p => p: Int)
             // propEffectsLanded must check exactly what effectsLandedSignal confirmed landed, so it
             // uses the stacks frozen when effectsLandedTarget was armed (above), not the post-signal
             // snapshot — which could include a trailing stack whose txs have not landed yet.
             analysisProp <- analyzeBlockBriefs(
-                              lastState,
-                              sut,
-                              briefsByPeer,
-                              stacksByPeer,
-                              coilStacksByCoil,
-                              submittedIds,
-                              canonicalStacksForTarget,
-                            )
+              lastState,
+              sut,
+              briefsByPeer,
+              stacksByPeer,
+              coilStacksByCoil,
+              submittedIds,
+              canonicalStacksForTarget,
+            )
             persistenceProp <- analyzePersistence(sut, stacksByPeer, sortedPeers)
             props = analysisProp && persistenceProp
         yield
@@ -354,7 +348,6 @@ case class Stage4Suite(
             )
 
             targetBlockNums <- sut.mutable.slowCoverageTarget.get
-
         yield propLiveness(submittedIds, canonicalBriefs) &&
             propDepositTiming(lastState.registeredDeposits, canonicalBriefs) &&
             propValidRatio(lastState, canonicalBriefs) &&
@@ -593,8 +586,8 @@ case class Stage4Suite(
       *
       * Both sides are restricted to L2-tx reqIds (excluding any deposit reqId — deposits go into
       * `depositsAbsorbed` / `depositsRejected` on the SUT side, but a rejected deposit registration
-      * ends up in `requests` via `JointLedger.invalidateRequest` and would otherwise inflate the SUT total
-      * relative to the model.
+      * ends up in `requests` via `JointLedger.invalidateRequest` and would otherwise inflate the
+      * SUT total relative to the model.
       */
     private def propValidRatio(
         lastState: ModelState,
@@ -651,128 +644,130 @@ case class Stage4Suite(
       * the suite's `log` tracer so emit lines for free.
       */
     private object PrettyPrinters:
-      def traceBlockTable(
-        canonicalBriefs: Vector[BlockBrief.Intermediate],
-        sortedPeers: Seq[HeadPeerNumber],
-        briefsByPeer: Map[HeadPeerNumber, Vector[BlockBrief.Intermediate]],
-        nPeers: Int,
-        submittedIds: Vector[RequestId],
-        lastState: ModelState,
-    ): IO[Unit] = {
-        val colWidth = 72
-        val divider = s"+${"-" * (colWidth + 2)}+"
-        val header = s"| ${"Block".padTo(colWidth, ' ')} |"
+        def traceBlockTable(
+            canonicalBriefs: Vector[BlockBrief.Intermediate],
+            sortedPeers: Seq[HeadPeerNumber],
+            briefsByPeer: Map[HeadPeerNumber, Vector[BlockBrief.Intermediate]],
+            nPeers: Int,
+            submittedIds: Vector[RequestId],
+            lastState: ModelState,
+        ): IO[Unit] = {
+            val colWidth = 72
+            val divider = s"+${"-" * (colWidth + 2)}+"
+            val header = s"| ${"Block".padTo(colWidth, ' ')} |"
 
-        val rows = canonicalBriefs.map { brief =>
-            val blockType = brief match {
-                case _: BlockBrief.Minor => "Min"; case _: BlockBrief.Major => "Maj"
+            val rows = canonicalBriefs.map { brief =>
+                val blockType = brief match {
+                    case _: BlockBrief.Minor => "Min"; case _: BlockBrief.Major => "Maj"
+                }
+                val vMaj = brief.blockVersion.major.convert
+                val vMin = brief.blockVersion.minor.convert
+                val leader = (brief.blockNum: Int) % nPeers
+                val evs = brief.requests.map { case (reqId, flag) =>
+                    val f = if flag == ValidityFlag.Valid then "V" else "I"
+                    s"p${reqId.peerNum.convert}:r${reqId.requestNum.convert}=$f"
+                }
+                val abs = brief.depositsAbsorbed.map(r =>
+                    s"abs:p${r.peerNum.convert}:r${r.requestNum.convert}"
+                )
+                val ref = brief.depositsRejected.map(r =>
+                    s"ref:p${r.peerNum.convert}:r${r.requestNum.convert}"
+                )
+                val events = (evs ++ abs ++ ref).mkString(" ")
+                val label =
+                    s"#${brief.blockNum: Int} $blockType v$vMaj.$vMin lead=p$leader | $events"
+                s"| ${label.take(colWidth).padTo(colWidth, ' ')} |"
             }
-            val vMaj = brief.blockVersion.major.convert
-            val vMin = brief.blockVersion.minor.convert
-            val leader = (brief.blockNum: Int) % nPeers
-            val evs = brief.requests.map { case (reqId, flag) =>
-                val f = if flag == ValidityFlag.Valid then "V" else "I"
-                s"p${reqId.peerNum.convert}:r${reqId.requestNum.convert}=$f"
-            }
-            val abs = brief.depositsAbsorbed.map(r =>
-                s"abs:p${r.peerNum.convert}:r${r.requestNum.convert}"
-            )
-            val ref = brief.depositsRejected.map(r =>
-                s"ref:p${r.peerNum.convert}:r${r.requestNum.convert}"
-            )
-            val events = (evs ++ abs ++ ref).mkString(" ")
-            val label =
-                s"#${brief.blockNum: Int} $blockType v$vMaj.$vMin lead=p$leader | $events"
-            s"| ${label.take(colWidth).padTo(colWidth, ' ')} |"
+
+            // SUT processing order — each block contributes its absorbed deposits, then its events.
+            val sutOrder: Vector[RequestId] =
+                canonicalBriefs.flatMap(b => b.depositsAbsorbed ++ b.requests.map(_._1)).toVector
+            val commonPrefixLen =
+                submittedIds.zip(sutOrder).takeWhile { case (a, b) => a == b }.length
+
+            val depositIds = lastState.registeredDeposits.keySet
+            val l2TxReqIds = lastState.modelFlags.keySet -- depositIds
+            val modelValid = l2TxReqIds.count(lastState.modelFlags(_) == ValidityFlag.Valid)
+            val modelTotal = l2TxReqIds.size
+            val sutL2Events =
+                canonicalBriefs.flatMap(_.requests).filterNot { case (r, _) =>
+                    depositIds.contains(r)
+                }
+            val sutValid = sutL2Events.count(_._2 == ValidityFlag.Valid)
+            val sutTotal = sutL2Events.size
+
+            val peersLine =
+                s"Peers: ${sortedPeers.map(p => s"p${p: Int}=${briefsByPeer(p).length}blks").mkString("  ")}"
+            val prefixLine =
+                s"Common prefix: $commonPrefixLen / ${submittedIds.length} (submission order vs SUT block order)"
+            val ratioLine =
+                s"Valid/total (L2 txs) — model: $modelValid/$modelTotal  SUT: $sutValid/$sutTotal"
+            val legend =
+                "Legend: Min=Minor Maj=Major v=version lead=leader p=peer r=requestNum V=valid I=invalid abs=deposit-absorbed ref=refunded"
+
+            val text = (divider :: header :: divider :: rows.toList ++
+                (divider :: peersLine :: prefixLine :: ratioLine :: legend :: Nil))
+                .mkString("\n", "\n", "")
+            log.info(text)
         }
 
-        // SUT processing order — each block contributes its absorbed deposits, then its events.
-        val sutOrder: Vector[RequestId] =
-            canonicalBriefs.flatMap(b => b.depositsAbsorbed ++ b.requests.map(_._1)).toVector
-        val commonPrefixLen =
-            submittedIds.zip(sutOrder).takeWhile { case (a, b) => a == b }.length
+        /** Mirror of [[traceBlockTable]] for the slow cycle: one row per hard-confirmed stack on
+          * the canonical peer, showing the stack number, covered block range, partition spine
+          * (Min/Maj/Fin kinds, in stack order), and the round-2 unlock selection (settlement-at-i,
+          * finalization-at-i, or sole-acknowledgment / no unlock). Stack-0 renders as `Init`.
+          * Followed by a per-peer stack-count line for cross-peer convergence at a glance.
+          */
+        def traceStackTable(
+            canonicalStacks: Vector[Stack.HardConfirmed],
+            sortedPeers: Seq[HeadPeerNumber],
+            stacksByPeer: Map[HeadPeerNumber, Vector[Stack.HardConfirmed]],
+            nPeers: Int,
+        ): IO[Unit] = {
+            val colWidth = 72
+            val divider = s"+${"-" * (colWidth + 2)}+"
+            val header = s"| ${"Stack".padTo(colWidth, ' ')} |"
 
-        val depositIds = lastState.registeredDeposits.keySet
-        val l2TxReqIds = lastState.modelFlags.keySet -- depositIds
-        val modelValid = l2TxReqIds.count(lastState.modelFlags(_) == ValidityFlag.Valid)
-        val modelTotal = l2TxReqIds.size
-        val sutL2Events =
-            canonicalBriefs.flatMap(_.requests).filterNot { case (r, _) => depositIds.contains(r) }
-        val sutValid = sutL2Events.count(_._2 == ValidityFlag.Valid)
-        val sutTotal = sutL2Events.size
-
-        val peersLine =
-            s"Peers: ${sortedPeers.map(p => s"p${p: Int}=${briefsByPeer(p).length}blks").mkString("  ")}"
-        val prefixLine =
-            s"Common prefix: $commonPrefixLen / ${submittedIds.length} (submission order vs SUT block order)"
-        val ratioLine =
-            s"Valid/total (L2 txs) — model: $modelValid/$modelTotal  SUT: $sutValid/$sutTotal"
-        val legend =
-            "Legend: Min=Minor Maj=Major v=version lead=leader p=peer r=requestNum V=valid I=invalid abs=deposit-absorbed ref=refunded"
-
-        val text = (divider :: header :: divider :: rows.toList ++
-            (divider :: peersLine :: prefixLine :: ratioLine :: legend :: Nil))
-            .mkString("\n", "\n", "")
-        log.info(text)
-    }
-
-      /** Mirror of [[traceBlockTable]] for the slow cycle: one row per hard-confirmed stack on
-        * the canonical peer, showing the stack number, covered block range, partition spine
-        * (Min/Maj/Fin kinds, in stack order), and the round-2 unlock selection (settlement-at-i,
-        * finalization-at-i, or sole-acknowledgment / no unlock). Stack-0 renders as `Init`.
-        * Followed by a per-peer stack-count line for cross-peer convergence at a glance.
-        */
-      def traceStackTable(
-        canonicalStacks: Vector[Stack.HardConfirmed],
-        sortedPeers: Seq[HeadPeerNumber],
-        stacksByPeer: Map[HeadPeerNumber, Vector[Stack.HardConfirmed]],
-        nPeers: Int,
-    ): IO[Unit] = {
-        val colWidth = 72
-        val divider = s"+${"-" * (colWidth + 2)}+"
-        val header = s"| ${"Stack".padTo(colWidth, ' ')} |"
-
-        val rows = canonicalStacks.map { stack =>
-            val brief = stack.brief
-            val sNum = brief.stackNum: Int
-            val first = brief.firstBlockNum: Int
-            val last = brief.lastBlockNum: Int
-            val nBlks = last - first + 1
-            // Slow-consensus leadership schedule is round-robin by stack number, mirroring
-            // fast-consensus block-number round-robin.
-            val leader = sNum % nPeers
-            val label = stack.effects match {
-                case _: StackEffects.HardConfirmed.Initial =>
-                    s"#$sNum Init lead=p$leader | init+fallback"
-                case r: StackEffects.HardConfirmed.Regular =>
-                    val blkLabel = if nBlks == 1 then "blk" else "blks"
-                    val parts = r.partitions.toList.map {
-                        case _: PartitionEffects.Minor[?] => "Min"
-                        case _: PartitionEffects.Major[?] => "Maj"
-                        case _: PartitionEffects.Final    => "Fin"
-                    }
-                    val unlockStr = PartitionEffects.unlock(r.partitions) match {
-                        case Some(PartitionEffects.Unlock.Settlement(i))   => s"sttlmnt@$i"
-                        case Some(PartitionEffects.Unlock.Finalization(i)) => s"fin@$i"
-                        case None                                          => "sole"
-                    }
-                    s"#$sNum [$first..$last] ($nBlks $blkLabel) Reg lead=p$leader | " +
-                        s"[${parts.mkString(",")}] u=$unlockStr"
+            val rows = canonicalStacks.map { stack =>
+                val brief = stack.brief
+                val sNum = brief.stackNum: Int
+                val first = brief.firstBlockNum: Int
+                val last = brief.lastBlockNum: Int
+                val nBlks = last - first + 1
+                // Slow-consensus leadership schedule is round-robin by stack number, mirroring
+                // fast-consensus block-number round-robin.
+                val leader = sNum % nPeers
+                val label = stack.effects match {
+                    case _: StackEffects.HardConfirmed.Initial =>
+                        s"#$sNum Init lead=p$leader | init+fallback"
+                    case r: StackEffects.HardConfirmed.Regular =>
+                        val blkLabel = if nBlks == 1 then "blk" else "blks"
+                        val parts = r.partitions.toList.map {
+                            case _: PartitionEffects.Minor[?] => "Min"
+                            case _: PartitionEffects.Major[?] => "Maj"
+                            case _: PartitionEffects.Final    => "Fin"
+                        }
+                        val unlockStr = PartitionEffects.unlock(r.partitions) match {
+                            case Some(PartitionEffects.Unlock.Settlement(i))   => s"sttlmnt@$i"
+                            case Some(PartitionEffects.Unlock.Finalization(i)) => s"fin@$i"
+                            case None                                          => "sole"
+                        }
+                        s"#$sNum [$first..$last] ($nBlks $blkLabel) Reg lead=p$leader | " +
+                            s"[${parts.mkString(",")}] u=$unlockStr"
+                }
+                s"| ${label.take(colWidth).padTo(colWidth, ' ')} |"
             }
-            s"| ${label.take(colWidth).padTo(colWidth, ' ')} |"
+
+            val peersLine =
+                s"Peers: ${sortedPeers.map(p => s"p${p: Int}=${stacksByPeer(p).length}stk").mkString("  ")}"
+            val legend =
+                "Legend: Init=initial stack Reg=regular Min/Maj/Fin=partition kinds " +
+                    "u=unlock (set=settlement, fin=finalization, sole=no unlock) @i=partition index"
+
+            val text = (divider :: header :: divider :: rows.toList ++
+                (divider :: peersLine :: legend :: Nil))
+                .mkString("\n", "\n", "")
+            log.info(text)
         }
-
-        val peersLine =
-            s"Peers: ${sortedPeers.map(p => s"p${p: Int}=${stacksByPeer(p).length}stk").mkString("  ")}"
-        val legend =
-            "Legend: Init=initial stack Reg=regular Min/Maj/Fin=partition kinds " +
-                "u=unlock (set=settlement, fin=finalization, sole=no unlock) @i=partition index"
-
-        val text = (divider :: header :: divider :: rows.toList ++
-            (divider :: peersLine :: legend :: Nil))
-            .mkString("\n", "\n", "")
-        log.info(text)
-    }
 
 // ===================================
 // Initial state generator (canonical location; Runner delegates here for @main)
@@ -832,10 +827,14 @@ object Stage4Suite:
           generateInitialBlock = (bootstrap, funding) =>
               generateInitialBlock(
                 genHeadConfigBootstrap = ReaderT
-                    .pure[Gen, TestPeers, (
-                        hydrozoa.config.head.HeadConfig.Bootstrap,
-                        hydrozoa.bootstrap.InitializationFunding
-                    )]((bootstrap, funding)),
+                    .pure[
+                      Gen,
+                      TestPeers,
+                      (
+                          hydrozoa.config.head.HeadConfig.Bootstrap,
+                          hydrozoa.bootstrap.InitializationFunding
+                      )
+                    ]((bootstrap, funding)),
                 generateBlockCreationEndTime = generateHeadStartTime
               )
         )

--- a/integration/src/test/scala/hydrozoa/integration/stage4/Sut.scala
+++ b/integration/src/test/scala/hydrozoa/integration/stage4/Sut.scala
@@ -35,8 +35,8 @@ case class Stage4SutStatic(
     system: ActorSystem[IO],
     cardanoBackend: CardanoBackend[IO],
     peers: Map[HeadPeerNumber, SubmissionClient],
-    /** Per-peer persistence backend store — used by `analyzePersistence` to assert SC + SCA
-      * writes (Treasury + EvacuationMap + HardConfirmation) landed during the scenario.
+    /** Per-peer persistence backend store — used by `analyzePersistence` to assert SC + SCA writes
+      * (Treasury + EvacuationMap + HardConfirmation) landed during the scenario.
       */
     backendStores: Map[HeadPeerNumber, BackendStore[IO]],
     log: ContraTracer[IO, Slf4jMsg],
@@ -62,10 +62,10 @@ object PerPeerCaptures:
     def makeMap(peers: Seq[HeadPeerNumber]): IO[Map[HeadPeerNumber, PerPeerCaptures]] =
         peers.toList.traverse(p => make.map(p -> _)).map(_.toMap)
 
-/** Per-coil-peer mutable Refs populated by the [[Stage4Plugins.perCoilCaptures]] writer arm.
-  * Today only the hard-confirmed stacks stream is captured; bundled here so a future coil-side
-  * signal (e.g. coil `TxSubmitting`) lands alongside it without churning the
-  * [[Stage4SutMutable]] field set.
+/** Per-coil-peer mutable Refs populated by the [[Stage4Plugins.perCoilCaptures]] writer arm. Today
+  * only the hard-confirmed stacks stream is captured; bundled here so a future coil-side signal
+  * (e.g. coil `TxSubmitting`) lands alongside it without churning the [[Stage4SutMutable]] field
+  * set.
   */
 case class PerCoilCaptures(
     stacks: Ref[IO, Vector[Stack.HardConfirmed]],
@@ -79,47 +79,44 @@ object PerCoilCaptures:
         coils.toList.traverse(c => make.map(c -> _)).map(_.toMap)
 
 /** Mutable state of a running stage4 SUT. [[Capture]]s wrap Refs populated by writer arms;
-  * [[Signal]]s wrap one-shot Deferreds completed by predicate arms; `*Target` Deferreds are
-  * armed by [[beforeFinalize]] to gate when the matching signal predicate may fire.
+  * [[Signal]]s wrap one-shot Deferreds completed by predicate arms; `*Target` Deferreds are armed
+  * by [[beforeFinalize]] to gate when the matching signal predicate may fire.
   */
 case class Stage4SutMutable(
     sutErrors: Ref[IO, List[String]],
     submittedRequestIds: Ref[IO, Vector[RequestId]],
-
     perPeer: Capture[Map[HeadPeerNumber, PerPeerCaptures]],
     // Per-coil hard-confirmed stacks, captured by each coil peer follower's SCA arm
     // (same mechanism as `perPeer.state(_).stacks` on the head side). Empty for a pure-head run.
     // Used to assert the coil peer participates in the slow cycle.
     perCoil: Capture[Map[CoilPeerNumber, PerCoilCaptures]],
     /** Cross-peer set of L1 tx hashes observed via `CardanoLiaisonEvent.TxSubmitting`. All head
-     * peers submit the same backbone txs in parallel; the `Set` collapses duplicates.
-     */
+      * peers submit the same backbone txs in parallel; the `Set` collapses duplicates.
+      */
     landedTxs: Capture[Ref[IO, Set[TransactionHash]]],
-
     fastSettlementSignal: Signal[Unit],
-    /** Set by [[beforeFinalize]] with the final submitted ID set; the JL predicate arm reads it
-     * via `tryGet` and only fires [[fastSettlementSignal]] once the target is populated.
-     * Prevents the signal from firing mid-run against a partial [[submittedRequestIds]] snapshot.
-     */
+    /** Set by [[beforeFinalize]] with the final submitted ID set; the JL predicate arm reads it via
+      * `tryGet` and only fires [[fastSettlementSignal]] once the target is populated. Prevents the
+      * signal from firing mid-run against a partial [[submittedRequestIds]] snapshot.
+      */
     fastSettlementTarget: Deferred[IO, Set[RequestId]],
-
     slowCoverageSignal: Signal[Unit],
     /** Set by [[beforeFinalize]] (after fast drain) with the block numbers that must be covered;
       * the SCA predicate arm reads it via `tryGet` and only fires [[slowCoverageSignal]] once set.
       */
     slowCoverageTarget: Deferred[IO, Set[Int]],
 
-    /** Fires when the same condit2ion `EffectsLanded.propEffectsLanded` checks is satisfied —
-      * i.e. every backbone expectation completed via happy path or competing fallback. Anchored
-      * on `CardanoLiaisonEvent.TxSubmitting` (the enactment event), distinct from
+    /** Fires when the same condit2ion `EffectsLanded.propEffectsLanded` checks is satisfied — i.e.
+      * every backbone expectation completed via happy path or competing fallback. Anchored on
+      * `CardanoLiaisonEvent.TxSubmitting` (the enactment event), distinct from
       * [[slowCoverageSignal]] which fires on consensus reach. The gap between the two is the
-      * `StackComposer` rate-limit delay; observing both lets us distinguish "stalled at
-      * consensus" from "stalled before enactment".
+      * `StackComposer` rate-limit delay; observing both lets us distinguish "stalled at consensus"
+      * from "stalled before enactment".
       */
     effectsLandedSignal: Signal[Unit],
-    /** Set by [[beforeFinalize]] (after slow drain) with the backbone expectations derived from
-      * the canonical hard-confirmed stacks. The TxSubmitting predicate arm reads via `tryGet`
-      * and only fires [[effectsLandedSignal]] once this is populated.
+    /** Set by [[beforeFinalize]] (after slow drain) with the backbone expectations derived from the
+      * canonical hard-confirmed stacks. The TxSubmitting predicate arm reads via `tryGet` and only
+      * fires [[effectsLandedSignal]] once this is populated.
       */
     effectsLandedTarget: Deferred[IO, List[BlockExpectation]],
 
@@ -154,7 +151,9 @@ object Stage4SutCommands:
         override def run(cmd: L2TxCommand, sut: Stage4Sut): IO[ValidityFlag] = {
             for {
                 reqId <- sut.static.peers(cmd.peerNum).submit(cmd.request.asUserRequest)
-                _ <- sut.static.log.trace(s"reqId=$reqId, cmd.request.requestId=${cmd.request.requestId}")
+                _ <- sut.static.log.trace(
+                  s"reqId=$reqId, cmd.request.requestId=${cmd.request.requestId}"
+                )
                 _ <- sut.mutable.submittedRequestIds.update(_ :+ cmd.request.requestId)
             } yield ValidityFlag.Valid
         }
@@ -167,7 +166,9 @@ object Stage4SutCommands:
         override def run(cmd: RegisterAndSubmitDepositCommand, sut: Stage4Sut): IO[ValidityFlag] = {
             for {
                 reqId <- sut.static.peers(cmd.peerNum).submit(cmd.request.asUserRequest)
-                _ <- sut.static.log.trace(s"reqId=$reqId, cmd.request.requestId=${cmd.request.requestId}")
+                _ <- sut.static.log.trace(
+                  s"reqId=$reqId, cmd.request.requestId=${cmd.request.requestId}"
+                )
                 _ <- sut.mutable.submittedRequestIds.update(_ :+ cmd.request.requestId)
                 _ <- sut.static.cardanoBackend.submitTx(RawTx(cmd.depositTxBytesSigned))
             } yield ValidityFlag.Valid

--- a/integration/src/test/scala/hydrozoa/integration/stage4/package.scala
+++ b/integration/src/test/scala/hydrozoa/integration/stage4/package.scala
@@ -4,34 +4,34 @@ package hydrozoa.integration
   *
   * ==What stage 4 tests==
   *
-  * Runs N≥2 peers' full multisig actor stack (`BlockWeaver`, `JointLedger`,
-  * `FastConsensusActor`, `StackComposer`, `SlowConsensusActor`, `CardanoLiaison`,
-  * `RequestSequencer`, plus inter-peer liaisons; optional coil followers) in one JVM against a
-  * shared [[hydrozoa.multisig.backend.cardano.CardanoBackendMock]] L1. A ScalaCheck-driven
-  * scenario submits randomized L2 transactions, deposits, and delays at the per-peer
-  * `RequestSequencer`s; the suite asserts the protocol behaves correctly on the happy path.
+  * Runs N≥2 peers' full multisig actor stack (`BlockWeaver`, `JointLedger`, `FastConsensusActor`,
+  * `StackComposer`, `SlowConsensusActor`, `CardanoLiaison`, `RequestSequencer`, plus inter-peer
+  * liaisons; optional coil followers) in one JVM against a shared
+  * [[hydrozoa.multisig.backend.cardano.CardanoBackendMock]] L1. A ScalaCheck-driven scenario
+  * submits randomized L2 transactions, deposits, and delays at the per-peer `RequestSequencer`s;
+  * the suite asserts the protocol behaves correctly on the happy path.
   *
   * ==Scenario==
   *
-  * Commands ([[Commands]]) sampled by [[Generator.Stage4ScenarioGen]] from a Poisson
-  * superposition of N per-peer processes: each `(peer, delay)` dispatches to that peer's
-  * `L2TxCommand`, `RegisterAndSubmitDepositCommand`, or `DelayCommand`. A single global model
-  * clock advances by `cmd.interArrivalDelay` and the harness sleeps the same amount before
-  * submission, so the model clock and the SUT clock coincide at every command boundary.
+  * Commands ([[Commands]]) sampled by [[Generator.Stage4ScenarioGen]] from a Poisson superposition
+  * of N per-peer processes: each `(peer, delay)` dispatches to that peer's `L2TxCommand`,
+  * `RegisterAndSubmitDepositCommand`, or `DelayCommand`. A single global model clock advances by
+  * `cmd.interArrivalDelay` and the harness sleeps the same amount before submission, so the model
+  * clock and the SUT clock coincide at every command boundary.
   *
   * ==Properties (asserted in `Suite.beforeFinalize`)==
   *
   *   - '''propLiveness''' — every submitted `RequestId` appears in some block brief.
-  *   - '''propDepositTiming''' — no deposit absorbed before its protocol maturity
-  *     (`brief.endTime >= deposit.absorptionStartTime`).
-  *   - '''propValidRatio''' — SUT L2 valid/total ratio ≤ model's (SUT no more permissive than
-  *     the mutator).
+  *   - '''propDepositTiming''' — no deposit absorbed before its protocol maturity (`brief.endTime
+  *     >= deposit.absorptionStartTime`).
+  *   - '''propValidRatio''' — SUT L2 valid/total ratio ≤ model's (SUT no more permissive than the
+  *     mutator).
   *   - '''propStackCoverage''' — every observed block lies in some hard-confirmed stack on the
   *     canonical peer.
-  *   - '''propEffectsLanded''' — every backbone tx (settlement / finalization / init plus
-  *     dependent rollouts) the slow cycle produced lands on L1.
-  *   - '''propCoilParticipation''' — coil followers hard-confirm the same stacks the head
-  *     does (no-op for pure-head runs).
+  *   - '''propEffectsLanded''' — every backbone tx (settlement / finalization / init plus dependent
+  *     rollouts) the slow cycle produced lands on L1.
+  *   - '''propCoilParticipation''' — coil followers hard-confirm the same stacks the head does
+  *     (no-op for pure-head runs).
   *   - '''analyzePersistence''' — §6/§7 producer-side writes (Treasury, EvacuationMap,
   *     HardConfirmation, BlockResult, SoftConfirmation, DepositMap, SoftAck/HardAck, Request)
   *     landed in each peer's backend store.
@@ -39,15 +39,15 @@ package hydrozoa.integration
   *
   * ==Contract: happy-path only==
   *
-  * Stage 4 has no semantics in the rule-based regime. Any peer's `CardanoLiaison` dispatching
-  * a `FallbackToRuleBased` short-circuits the scenario with `Prop.exception` via
+  * Stage 4 has no semantics in the rule-based regime. Any peer's `CardanoLiaison` dispatching a
+  * `FallbackToRuleBased` short-circuits the scenario with `Prop.exception` via
   * `Stage4Sut.fallbackEnteredSignal`. Fallback firing is a generator / timing regression.
   *
   * ==TestControl==
   *
-  * Direct-transport runs default to `useTestControl = true`: command delays advance virtual
-  * time, and the scenario simulates minutes-to-hours of head lifetime in seconds. WebSocket
-  * runs are real-clock (TestControl can't drive real sockets).
+  * Direct-transport runs default to `useTestControl = true`: command delays advance virtual time,
+  * and the scenario simulates minutes-to-hours of head lifetime in seconds. WebSocket runs are
+  * real-clock (TestControl can't drive real sockets).
   *
   * ==Files==
   *

--- a/integration/src/test/scala/org/scalacheck/commands/ModelBasedSuite.scala
+++ b/integration/src/test/scala/org/scalacheck/commands/ModelBasedSuite.scala
@@ -30,7 +30,9 @@ trait ModelCommand[Cmd, Result, State] {
     /** Returns the result and the new [[State]] after this command has run. The effect monad [[M]]
       * and tracer are supplied by the caller.
       */
-    def runState[M[_]: MonadThrow](cmd: Cmd)(using ContraTracer[M, Slf4jMsg]): StateT[M, State, Result]
+    def runState[M[_]: MonadThrow](cmd: Cmd)(using
+        ContraTracer[M, Slf4jMsg]
+    ): StateT[M, State, Result]
 
     /** Precondition that decides if this command is allowed to run when the model is in the
       * provided state.
@@ -110,8 +112,8 @@ trait CommandLabel[Cmd]:
 // AdvanceState — rank-2 state-advance function
 // ===================================
 
-/** Rank-2 advance-state function: the caller supplies the effect monad [[M]] and a matching
-  * tracer at use time.
+/** Rank-2 advance-state function: the caller supplies the effect monad [[M]] and a matching tracer
+  * at use time.
   */
 trait AdvanceState[State]:
     def apply[M[_]: MonadThrow](state: State)(using ContraTracer[M, Slf4jMsg]): M[State]
@@ -158,14 +160,16 @@ object AnyCommand {
           preCondition = state => mc.preCondition(cmd, state),
           advanceState = new AdvanceState[State]:
               def apply[M[_]: MonadThrow](s: State)(using ContraTracer[M, Slf4jMsg]): M[State] =
-                  mc.runState[M](cmd).runS(s),
+                  mc.runState[M](cmd).runS(s)
+          ,
           delay = mc.delay(cmd),
           runPC = (sut, tracer) =>
               given ContraTracer[IO, Slf4jMsg] = tracer
               sc.run(cmd, sut).attempt.map { r => (s: State) =>
                   if mc.preCondition(cmd, s) then cp.postCondition[IO](cmd, s, r)
                   else IO.pure(Prop.passed)
-              },
+              }
+          ,
           repr = cmd.toString,
           label = cl.label(cmd)
         )
@@ -181,7 +185,8 @@ def noOp[State, Sut]: AnyCommand[State, Sut] =
       preCondition = _ => true,
       advanceState = new AdvanceState[State]:
           def apply[M[_]: MonadThrow](s: State)(using ContraTracer[M, Slf4jMsg]): M[State] =
-              MonadThrow[M].pure(s),
+              MonadThrow[M].pure(s)
+      ,
       delay = Duration.Zero,
       runPC = (_, _) => IO.pure(_ => IO.pure(Prop.passed)),
       repr = "NoOp",
@@ -350,37 +355,37 @@ trait ModelBasedSuite {
         PropertyM.monadicIO {
             for {
                 testCase <- genTestCase
-                prop     <- PropertyM.run {
+                prop <- PropertyM.run {
                     for {
                         _ <- log.info(
-                               "\n\n\n\n\n\n\n\n ---------------------------------------------- " +
-                                   "Executing the next test case..."
-                             )
+                          "\n\n\n\n\n\n\n\n ---------------------------------------------- " +
+                              "Executing the next test case..."
+                        )
                         sutId <- IO {
-                                     suts.synchronized {
-                                         if canStartupNewSut() then {
-                                             val sutId = new AnyRef
-                                             suts += (sutId -> None)
-                                             Some(sutId)
-                                         } else None
-                                     }
-                                 }
+                            suts.synchronized {
+                                if canStartupNewSut() then {
+                                    val sutId = new AnyRef
+                                    suts += (sutId -> None)
+                                    Some(sutId)
+                                } else None
+                            }
+                        }
                         prop <- sutId match {
-                                    case Some(id) =>
-                                        if suts.contains(id) then {
-                                            val _ = suts.put(id, Some(sutResource))
-                                            runTestCase(testCase, sutResource)
-                                                .handleErrorWith { e =>
-                                                    IO(suts.synchronized(suts.clear())) >>
-                                                        IO.raiseError(e)
-                                                }
-                                        } else
-                                            log.error("WARNING: you should never see that")
-                                                .as(Prop.undecided)
-                                    case None =>
-                                        log.error("WARNING: you should never see that")
-                                            .as(Prop.undecided)
-                                }
+                            case Some(id) =>
+                                if suts.contains(id) then {
+                                    val _ = suts.put(id, Some(sutResource))
+                                    runTestCase(testCase, sutResource)
+                                        .handleErrorWith { e =>
+                                            IO(suts.synchronized(suts.clear())) >>
+                                                IO.raiseError(e)
+                                        }
+                                } else
+                                    log.error("WARNING: you should never see that")
+                                        .as(Prop.undecided)
+                            case None =>
+                                log.error("WARNING: you should never see that")
+                                    .as(Prop.undecided)
+                        }
                     } yield prop
                 }
             } yield prop
@@ -409,35 +414,36 @@ trait ModelBasedSuite {
         import Gen.sized
 
         def sizedCmds(initialState: State)(size: Int): PropertyM[IO, (State, Commands)] =
-            List.fill(size)(()).foldLeft[PropertyM[IO, (State, Commands)]](
-              run(IO.pure((initialState, Nil: Commands)))
-            ) { (pm, _) =>
-                for {
-                    sc       <- pm
-                    (s0, cs) = sc
-                    c        <- scenarioGen.genNextCommand(s0)
-                    s1       <- run(c.advanceState[IO](s0))
-                } yield (s1, cs :+ c)
-            }
+            List.fill(size)(())
+                .foldLeft[PropertyM[IO, (State, Commands)]](
+                  run(IO.pure((initialState, Nil: Commands)))
+                ) { (pm, _) =>
+                    for {
+                        sc <- pm
+                        (s0, cs) = sc
+                        c <- scenarioGen.genNextCommand(s0)
+                        s1 <- run(c.advanceState[IO](s0))
+                    } yield (s1, cs :+ c)
+                }
 
         def cmdsPrecond(s: State, cmds: Commands): IO[Boolean] = cmds match {
-            case Nil                          => IO.pure(true)
+            case Nil => IO.pure(true)
             case c :: cs if c.preCondition(s) =>
                 c.advanceState[IO](s).flatMap(s1 => cmdsPrecond(s1, cs))
-            case _                            => IO.pure(false)
+            case _ => IO.pure(false)
         }
 
         for {
-            env             <- initEnv
-            s0              <- genInitialState(env)
-            n               <- pick[IO, Int](commandGenTweaker[Int](sized(n => Gen.const(n))))
-            sc              <- sizedCmds(s0)(n)
-            (s, seqCmds)    = sc
-            tc               = TestCase(s0, seqCmds)
-            _               <- pre[IO](initialStatePreCondition(tc.initialState))
-            precondMet      <- run(cmdsPrecond(tc.initialState, tc.commands))
-            _               <- pre[IO](precondMet)
-            _               <- pre[IO](scenarioGen.targetStatePrecondition(s))
+            env <- initEnv
+            s0 <- genInitialState(env)
+            n <- pick[IO, Int](commandGenTweaker[Int](sized(n => Gen.const(n))))
+            sc <- sizedCmds(s0)(n)
+            (s, seqCmds) = sc
+            tc = TestCase(s0, seqCmds)
+            _ <- pre[IO](initialStatePreCondition(tc.initialState))
+            precondMet <- run(cmdsPrecond(tc.initialState, tc.commands))
+            _ <- pre[IO](precondMet)
+            _ <- pre[IO](scenarioGen.targetStatePrecondition(s))
         } yield tc
     }
 
@@ -456,15 +462,16 @@ trait ModelBasedSuite {
             else runCommandsPlain(testCase, sutResource)
         (_, prop, s, lastCmd, _) = result
         r = prop.apply(Gen.Parameters.default)
-        _ <- if r.failure then
-                 log.warn(
-                   "Property is falsified (see the labels down below). Additional information: \n" +
-                       s"Initial state:\n  ${testCase.initialState}\n" +
-                       s"Last state:\n  ${s}\n" +
-                       s"Sequential Commands:\n${prettyCmdsRes(testCase.commands, lastCmd)}\n" +
-                       s"Last executed command: $lastCmd"
-                 )
-             else IO(ModelBasedSuite.recordTestCase(testCase.commands.map(_.label)))
+        _ <-
+            if r.failure then
+                log.warn(
+                  "Property is falsified (see the labels down below). Additional information: \n" +
+                      s"Initial state:\n  ${testCase.initialState}\n" +
+                      s"Last state:\n  ${s}\n" +
+                      s"Sequential Commands:\n${prettyCmdsRes(testCase.commands, lastCmd)}\n" +
+                      s"Last executed command: $lastCmd"
+                )
+            else IO(ModelBasedSuite.recordTestCase(testCase.commands.map(_.label)))
     } yield prop :| "Property failed, see the log above for details"
 
     private def prettyCmdsRes(rs: List[AnyCommand[State, Sut]], lastCmd: Int) = {
@@ -501,34 +508,35 @@ trait ModelBasedSuite {
         testCase: TestCase,
         sutResource: State => Resource[IO, Sut]
     ): IO[(Sut, Prop, State, Int, TestCase)] = for {
-        _      <- log.debug("Using plain IO to run the test case...")
+        _ <- log.debug("Using plain IO to run the test case...")
         result <- sutResource(testCase.initialState).use { sut =>
-                      val initial = (sut, Prop.proved: Prop, testCase.initialState, 0, false)
-                      for {
-                          result <- testCase.commands.foldLeft(IO.pure(initial)) { case (acc, c) =>
-                                        acc.flatMap { case (sut, p, s, lastCmd, hasFailed) =>
-                                            if hasFailed then IO.pure((sut, p, s, lastCmd, true))
-                                            else for {
-                                                _        <- IO.sleep(c.delay)
-                                                // Predicate evaluation re-runs the model-side
-                                                // runState internally; advanceState walks the
-                                                // model forward. Silence model-side logs from
-                                                // both — they would duplicate the per-command
-                                                // logs already emitted by the SUT side.
-                                                pred     <- c.runPC(sut, ContraTracer.nullTracer)
-                                                pp       <- pred(s)
-                                                newState <- c.advanceState[IO](s)(using
-                                                                MonadThrow[IO],
-                                                                ContraTracer.nullTracer
-                                                            )
-                                                predResult = pp.apply(Gen.Parameters.default)
-                                            } yield (sut, p && pp, newState, lastCmd + 1, predResult.failure)
-                                        }
-                                    }
-                          (sut, prop, s, lastCmd, _) = result
-                          beforeFinalizeProp <- beforeFinalize(s, sut)
-                      } yield (sut, prop && beforeFinalizeProp, s, lastCmd, testCase)
-                  }
+            val initial = (sut, Prop.proved: Prop, testCase.initialState, 0, false)
+            for {
+                result <- testCase.commands.foldLeft(IO.pure(initial)) { case (acc, c) =>
+                    acc.flatMap { case (sut, p, s, lastCmd, hasFailed) =>
+                        if hasFailed then IO.pure((sut, p, s, lastCmd, true))
+                        else
+                            for {
+                                _ <- IO.sleep(c.delay)
+                                // Predicate evaluation re-runs the model-side
+                                // runState internally; advanceState walks the
+                                // model forward. Silence model-side logs from
+                                // both — they would duplicate the per-command
+                                // logs already emitted by the SUT side.
+                                pred <- c.runPC(sut, ContraTracer.nullTracer)
+                                pp <- pred(s)
+                                newState <- c.advanceState[IO](s)(using
+                                  MonadThrow[IO],
+                                  ContraTracer.nullTracer
+                                )
+                                predResult = pp.apply(Gen.Parameters.default)
+                            } yield (sut, p && pp, newState, lastCmd + 1, predResult.failure)
+                    }
+                }
+                (sut, prop, s, lastCmd, _) = result
+                beforeFinalizeProp <- beforeFinalize(s, sut)
+            } yield (sut, prop && beforeFinalizeProp, s, lastCmd, testCase)
+        }
     } yield result
 
     /** [[TestControl]]-based execution. Command delays are advanced via the virtual clock, allowing
@@ -577,34 +585,35 @@ trait ModelBasedSuite {
                 val initial = (sut, Prop.proved: Prop, testCase.initialState, 0, false)
                 for {
                     result <- testCase.commands.foldLeft(IO.pure(initial)) { case (acc, c) =>
-                                  acc.flatMap { case (sut, p, s, lastCmd, hasFailed) =>
-                                      if hasFailed then IO.pure((sut, p, s, lastCmd, true))
-                                      else for {
-                                          gate     <- Deferred[IO, Unit]
-                                          _        <- IO(pendingDelay.set(Some((c.delay, gate))))
-                                          _        <- log.info("Suspend on the gate...")
-                                          _        <- gate.get
-                                          _        <- log.info("Running the command...")
-                                          // Silence model-side logs from predicate evaluation +
-                                          // state advancement — see runCommandsPlain for the
-                                          // rationale.
-                                          predFn   <- c.runPC(sut, ContraTracer.nullTracer)
-                                          pp       <- predFn(s)
-                                          newState <- c.advanceState[IO](s)(using
-                                                          MonadThrow[IO],
-                                                          ContraTracer.nullTracer
-                                                      )
-                                          predResult = pp.apply(Gen.Parameters.default)
-                                      } yield (sut, p && pp, newState, lastCmd + 1, predResult.failure)
-                                  }
-                              }
+                        acc.flatMap { case (sut, p, s, lastCmd, hasFailed) =>
+                            if hasFailed then IO.pure((sut, p, s, lastCmd, true))
+                            else
+                                for {
+                                    gate <- Deferred[IO, Unit]
+                                    _ <- IO(pendingDelay.set(Some((c.delay, gate))))
+                                    _ <- log.info("Suspend on the gate...")
+                                    _ <- gate.get
+                                    _ <- log.info("Running the command...")
+                                    // Silence model-side logs from predicate evaluation +
+                                    // state advancement — see runCommandsPlain for the
+                                    // rationale.
+                                    predFn <- c.runPC(sut, ContraTracer.nullTracer)
+                                    pp <- predFn(s)
+                                    newState <- c.advanceState[IO](s)(using
+                                      MonadThrow[IO],
+                                      ContraTracer.nullTracer
+                                    )
+                                    predResult = pp.apply(Gen.Parameters.default)
+                                } yield (sut, p && pp, newState, lastCmd + 1, predResult.failure)
+                        }
+                    }
                     (sut, prop, s, lastCmd, _) = result
                     // Sentinel: signal outer that all commands are done before entering shutdownSut.
                     // shutdownSut calls waitForIdle → IO.sleep, which needs nextInterval advances.
                     // The sentinel lets the outer switch from tickUntil (strict) to tickUntilAdvancing.
                     shutdownGate <- Deferred[IO, Unit]
-                    _            <- IO(pendingDelay.set(Some((Duration.Zero, shutdownGate))))
-                    _            <- shutdownGate.get
+                    _ <- IO(pendingDelay.set(Some((Duration.Zero, shutdownGate))))
+                    _ <- shutdownGate.get
                     beforeFinalizeProp <- beforeFinalize(s, sut)
                 } yield (sut, prop && beforeFinalizeProp, s, lastCmd, testCase)
             }
@@ -686,12 +695,12 @@ trait ModelBasedSuite {
 
             // 10. Extract the result
             result <- tc.results
-            days   <- IO {
-                          val nanos = totalAdvanced.get
-                          ModelBasedSuite.addSimulatedNanos(nanos)
-                          nanos / 86_400_000_000_000L
-                      }
-            _      <- log.info(s"---- TC ---- seed: ${tc.seed}  simulated: ${days} days")
+            days <- IO {
+                val nanos = totalAdvanced.get
+                ModelBasedSuite.addSimulatedNanos(nanos)
+                nanos / 86_400_000_000_000L
+            }
+            _ <- log.info(s"---- TC ---- seed: ${tc.seed}  simulated: ${days} days")
         } yield result match {
             case Some(cats.effect.Outcome.Succeeded(value)) => value
             case Some(cats.effect.Outcome.Errored(e))       => throw e


### PR DESCRIPTION
The `integration` and `benchmark` modules had been carved out of the fmt/lint aliases with a `// TODO: Restore integration module to fmt and lint`. This restores them, so `just fmt-check` / `just lint-check` (and CI's `just precommit`) now cover all modules — no module can drift again.

Includes the one-time scalafmt + scalafix catch-up pass across both modules (22 integration files + benchmark). Purely mechanical: formatting, import organization, explicit result types — **no behavioural changes**.

Verified: `fmtCheckAll` + `lintCheckAll` clean, `integration/Test/compile` + `benchmark/Test/compile` green under `-Werror`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)