### PR TITLE
fix(build): git describe --tags so lightweight release tags resolve

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -54,13 +54,14 @@ the image with `sbt Docker/stage` and pushes it to ghcr. No manual `docker push`
 
 - **Version ↔ tag must agree.** `build.sbt`'s `version` is baked into the image; the tag names the
   published image. A mismatch means the image reports a different version than its tag.
-- **The `git:` line in `hydrozoa version`.** It is raw `git describe --always --dirty --abbrev=8`,
-  not the release version — `<nearest-tag>-<commits-since>-g<hash>` (e.g.
-  `pre-george-refactor-2196-g228a83c9` means 2196 commits past the last tag, at `228a83c9`). It
-  looks stale between releases because `git describe` reports the newest tag that *exists*. Building
-  from the freshly-pushed `vX.Y.Z` commit (as the release workflow does) makes it read a clean
-  `vX.Y.Z`; later commits then read `vX.Y.Z-<n>-g<hash>`. The release version proper is the
-  `hydrozoa X.Y.Z` line (from `build.sbt`), so this is provenance detail, not a mismatch.
+- **The `git:` line in `hydrozoa version`.** It is raw `git describe --tags --always --dirty
+  --abbrev=8`, not the release version — `<nearest-tag>-<commits-since>-g<hash>` (e.g.
+  `v0.1.0-3-gabc12345` means 3 commits past `v0.1.0`, at `abc12345`). Building from a tagged commit
+  (as the release workflow does) makes it read a clean `vX.Y.Z`; between releases it shows the
+  distance from the newest tag. `--tags` is required so lightweight tags (`git tag vX.Y.Z`) resolve
+  — without it `git describe` only considers annotated tags and falls back to an older one. The
+  release version proper is the `hydrozoa X.Y.Z` line (from `build.sbt`), so this is provenance
+  detail, not a mismatch.
 - **Architecture.** The image is currently linux/amd64 only. Multi-arch (adding linux/arm64 via
   buildx) is a future improvement — it needs the native deps (blst-java, rocksdbjni) verified on
   arm64 first.

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ Compile / discoveredMainClasses := Seq("hydrozoa.app.Main")
 // The git revision baked into the Docker image labels; matches `hydrozoa.BuildInfo.gitCommit`.
 lazy val gitRevision: String =
     scala.util
-        .Try(scala.sys.process.Process("git describe --always --dirty --abbrev=8").!!.trim)
+        .Try(scala.sys.process.Process("git describe --tags --always --dirty --abbrev=8").!!.trim)
         .getOrElse("unknown")
 
 // Bake the clean-output JVM flags into the generated launcher scripts (both `stage` and the Docker
@@ -171,7 +171,12 @@ lazy val core: Project = (project in file("."))
         version,
         BuildInfoKey.action("gitCommit") {
             scala.util
-                .Try(scala.sys.process.Process("git describe --always --dirty --abbrev=8").!!.trim)
+                .Try(
+                    scala.sys.process
+                        .Process("git describe --tags --always --dirty --abbrev=8")
+                        .!!
+                        .trim
+                )
                 .getOrElse("unknown")
         }
       ),


### PR DESCRIPTION
## Problem

The published `0.1.0` image reports the wrong `git:` provenance line:

```
hydrozoa 0.1.0
git:   pre-george-refactor-2198-g6f381e0f     ← should be v0.1.0
built: 2026-07-25 19:53:45 +0000
```

`BuildInfo.gitCommit` (and the Docker image `org.opencontainers.image.revision` label) shell out to `git describe --always --dirty --abbrev=8`. **Without `--tags`, `git describe` only considers *annotated* tags.** Release tags are created lightweight (`git tag vX.Y.Z`), so it skips `v0.1.0` and falls back to the nearest annotated tag (`pre-george-refactor`).

## Fix

Add `--tags` to both `git describe` invocations in `build.sbt` (the top-level `gitRevision` and the `buildInfoKeys` action). Now:

```
$ git describe --tags --always --dirty --abbrev=8
v0.1.0            # on the tagged commit (clean)
v0.1.0-3-gabc123  # 3 commits later
```

Also corrects the RELEASE.md "git: line" note (it documented the old command and the now-explained `--tags` requirement).

## Scope

- The already-published `0.1.0` image is unaffected and stays as-is — correct version and commit, only a cosmetic provenance string. Every release from `0.1.1` on will show `git: vX.Y.Z`.
- Docs/build-config only; no runtime code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)