### PR TITLE
chore(build): fmt/lint the cardanoOnchain and petri modules too

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -266,19 +266,19 @@ addCompilerPlugin("org.scalus" % "scalus-plugin" % scalusVersion cross CrossVers
 // Custom commands to format and lint all subprojects
 addCommandAlias(
   "fmtAll",
-  ";core/scalafmtAll ;integration/scalafmtAll ;benchmark/scalafmtAll"
+  ";cardanoOnchain/scalafmtAll ;petri/scalafmtAll ;core/scalafmtAll ;integration/scalafmtAll ;benchmark/scalafmtAll"
 )
 addCommandAlias(
   "fmtCheckAll",
-  ";core/scalafmtCheckAll ;integration/scalafmtCheckAll ;benchmark/scalafmtCheckAll"
+  ";cardanoOnchain/scalafmtCheckAll ;petri/scalafmtCheckAll ;core/scalafmtCheckAll ;integration/scalafmtCheckAll ;benchmark/scalafmtCheckAll"
 )
 addCommandAlias(
   "lintAll",
-  ";core/scalafixAll ;integration/scalafixAll ;benchmark/scalafixAll"
+  ";cardanoOnchain/scalafixAll ;petri/scalafixAll ;core/scalafixAll ;integration/scalafixAll ;benchmark/scalafixAll"
 )
 addCommandAlias(
   "lintCheckAll",
-  ";core/scalafixAll --check ;integration/scalafixAll --check ;benchmark/scalafixAll --check"
+  ";cardanoOnchain/scalafixAll --check ;petri/scalafixAll --check ;core/scalafixAll --check ;integration/scalafixAll --check ;benchmark/scalafixAll --check"
 )
 
 // Test dependencies

--- a/cardano-onchain/src/main/scala/hydrozoa/rulebased/ledger/l1/script/plutus/DisputeResolutionScript.scala
+++ b/cardano-onchain/src/main/scala/hydrozoa/rulebased/ledger/l1/script/plutus/DisputeResolutionScript.scala
@@ -3,14 +3,13 @@ package hydrozoa.rulebased.ledger.l1.script.plutus
 import hydrozoa.lib.cardano.scalus.cardano.onchain.plutus.ByteStringExtension.take
 import hydrozoa.lib.cardano.scalus.cardano.onchain.plutus.TxOutExtension.inlineDatumOfType
 import hydrozoa.lib.cardano.scalus.cardano.onchain.plutus.ValueExtension.*
-import hydrozoa.rulebased.ledger.l1.state.StandaloneEvacuationCommitmentOnchain
 import hydrozoa.rulebased.ledger.l1.script.plutus.DisputeResolutionValidator.TallyRedeemer.{Continuing, Removed}
 import hydrozoa.rulebased.ledger.l1.script.plutus.RuleBasedTreasuryValidator.{cip67BeaconTokenPrefix, findRegimeReference}
 import hydrozoa.rulebased.ledger.l1.state.TreasuryState.RuleBasedTreasuryDatum
 import hydrozoa.rulebased.ledger.l1.state.TreasuryState.RuleBasedTreasuryDatum.Unresolved
-import hydrozoa.rulebased.ledger.l1.state.VoteState
 import hydrozoa.rulebased.ledger.l1.state.VoteState.VoteStatus.AwaitingVote
 import hydrozoa.rulebased.ledger.l1.state.VoteState.{VoteDatum, VoteStatus, secFromData, secToData}
+import hydrozoa.rulebased.ledger.l1.state.{StandaloneEvacuationCommitmentOnchain, VoteState}
 import scala.annotation.tailrec
 import scalus.*
 import scalus.cardano.address.{Network, ShelleyAddress, ShelleyDelegationPart, ShelleyPaymentPart}

--- a/cardano-onchain/src/main/scala/hydrozoa/rulebased/ledger/l1/script/plutus/RuleBasedTreasuryScript.scala
+++ b/cardano-onchain/src/main/scala/hydrozoa/rulebased/ledger/l1/script/plutus/RuleBasedTreasuryScript.scala
@@ -139,8 +139,8 @@ object RuleBasedTreasuryValidator extends Validator {
 
     /** Finds the rule-based regime reference input — the one holding exactly one `headMp` token
       * with the HRWT CIP-67 prefix — and parses its inline datum. The token policy is the
-      * authentication: only the head multisig script can mint under `headMp`, and it mints
-      * exactly one HRWT.
+      * authentication: only the head multisig script can mint under `headMp`, and it mints exactly
+      * one HRWT.
       */
     def findRegimeReference(tx: TxInfo, headMp: PolicyId): RuleBasedRegimeDatum =
         tx.referenceInputs
@@ -150,8 +150,8 @@ object RuleBasedTreasuryValidator extends Validator {
                         tokens.toList match
                             case List.Cons(tokenNameAndAmount, tail) =>
                                 tail.isEmpty
-                                    && tokenNameAndAmount._2 == BigInt(1)
-                                    && tokenNameAndAmount._1.take(4) == cip67RegimeTokenPrefix
+                                && tokenNameAndAmount._2 == BigInt(1)
+                                && tokenNameAndAmount._1.take(4) == cip67RegimeTokenPrefix
                             case _ => false
                     case None => false
             )
@@ -242,8 +242,8 @@ object RuleBasedTreasuryValidator extends Validator {
                     // and the FallbackTx's default vote utxo is always Voted with the implicit
                     // commitment, so reaching Resolve with a non-Voted status indicates an
                     // upstream tally bug.
-                    case AwaitingVote(_) => fail(ResolveUnexpectedAwaitingVote)
-                    case Abstain         => fail(ResolveUnexpectedAbstain)
+                    case AwaitingVote(_)                 => fail(ResolveUnexpectedAwaitingVote)
+                    case Abstain                         => fail(ResolveUnexpectedAbstain)
                     case Voted(commitment, versionMinor) =>
                         // The only valid Resolve output is the unresolved input transitioned to
                         // this vote's commitment and minor version; check each field of the output

--- a/cardano-onchain/src/main/scala/hydrozoa/rulebased/ledger/l1/state/RegimeState.scala
+++ b/cardano-onchain/src/main/scala/hydrozoa/rulebased/ledger/l1/state/RegimeState.scala
@@ -1,9 +1,9 @@
 package hydrozoa.rulebased.ledger.l1.state
 
 import hydrozoa.rulebased.ledger.l1.state.TreasuryState.VerificationKey
-import scalus.compiler.Compile
 import scalus.cardano.onchain.plutus.prelude.List
 import scalus.cardano.onchain.plutus.v3.*
+import scalus.compiler.Compile
 import scalus.uplc.builtin.{FromData, ToData}
 
 @Compile

--- a/cardano-onchain/src/main/scala/hydrozoa/rulebased/ledger/l1/state/TreasuryState.scala
+++ b/cardano-onchain/src/main/scala/hydrozoa/rulebased/ledger/l1/state/TreasuryState.scala
@@ -1,7 +1,7 @@
 package hydrozoa.rulebased.ledger.l1.state
 
-import scalus.compiler.Compile
 import scalus.cardano.onchain.plutus.v3.*
+import scalus.compiler.Compile
 import scalus.uplc.builtin.{ByteString, FromData, ToData}
 
 @Compile
@@ -11,9 +11,9 @@ object TreasuryState:
     /** Treasury datum, used both on- and off-chain.
       *
       * `headMp` is the induction anchor for reference-input lookups: written by the
-      * all-peers-signed FallbackTx and preserved across Resolve/Evacuate, it lets validators
-      * locate the rule-based regime utxo (HRWT beacon under `headMp`) without trusting tokens in
-      * the treasury's own value, which holds arbitrary L2 assets.
+      * all-peers-signed FallbackTx and preserved across Resolve/Evacuate, it lets validators locate
+      * the rule-based regime utxo (HRWT beacon under `headMp`) without trusting tokens in the
+      * treasury's own value, which holds arbitrary L2 assets.
       *
       * The immutable head-identity fields live in the regime utxo ([[RegimeState]]); the KZG G2
       * setup lives in the deployed setup-ladder utxos.
@@ -40,9 +40,9 @@ object TreasuryState:
 
     given ToData[RuleBasedTreasuryDatum] = ToData.derived
 
-    /** The only valid treasury-datum transitions, single-sourcing which fields advance and which are
-      * carried forward immutably. Validators build the expected next datum from these and check the
-      * output against it; off-chain builders construct the next datum the same way.
+    /** The only valid treasury-datum transitions, single-sourcing which fields advance and which
+      * are carried forward immutably. Validators build the expected next datum from these and check
+      * the output against it; off-chain builders construct the next datum the same way.
       */
     extension (self: RuleBasedTreasuryDatum.Unresolved)
         /** Resolve advances the unresolved treasury to the winning vote's commitment and minor

--- a/petri/src/main/scala/hydrozoa/lib/petri/hlpn/Sort.scala
+++ b/petri/src/main/scala/hydrozoa/lib/petri/hlpn/Sort.scala
@@ -64,10 +64,10 @@ object Sort:
         ): Class[C] =
             new Class(name, carrier, discipline, Map.empty)
 
-        /** A color class with a declared Concept-15 partition: `subclasses` must genuinely partition
-          * the carrier — every block non-empty and within the carrier, pairwise disjoint, and
-          * together covering it — else a [[SortError.MalformedPartition]] naming the first breach.
-          * An empty map is the undivided class (the trivial partition).
+        /** A color class with a declared Concept-15 partition: `subclasses` must genuinely
+          * partition the carrier — every block non-empty and within the carrier, pairwise disjoint,
+          * and together covering it — else a [[SortError.MalformedPartition]] naming the first
+          * breach. An empty map is the undivided class (the trivial partition).
           */
         def apply[C](
             name: String,
@@ -81,9 +81,11 @@ object Sort:
                 Left(SortError.MalformedPartition(name, reason))
             if subclasses.isEmpty then Right(new Class(name, carrier, discipline, subclasses))
             else if blocks.exists(_.isEmpty) then bad("a declared subclass is empty")
-            else if !members.forall(carrier.contains) then bad("a subclass color is outside the carrier")
+            else if !members.forall(carrier.contains) then
+                bad("a subclass color is outside the carrier")
             else if members.size != members.toSet.size then bad("subclasses overlap")
-            else if members.toSet != carrier.toSortedSet.toSet then bad("subclasses do not cover the carrier")
+            else if members.toSet != carrier.toSortedSet.toSet then
+                bad("subclasses do not cover the carrier")
             else Right(new Class(name, carrier, discipline, subclasses))
 
     /** A color domain that is the cartesian product of two sorts (Concept 14). N-ary domains nest

--- a/petri/src/main/scala/hydrozoa/lib/petri/hlpn/SortCheck.scala
+++ b/petri/src/main/scala/hydrozoa/lib/petri/hlpn/SortCheck.scala
@@ -52,19 +52,19 @@ object SortCheck:
     /** Whether an arc inscription of sort `leaf` may target a place of color domain `domain`.
       *
       * Exact equality is the usual case. The relaxation: an enumerated `Sort.Class` domain — whose
-      * carrier is a hand-listed sub-domain — accepts a structurally larger `leaf` (e.g. the `Prod` of
-      * a componentwise inscription) as long as every carrier color is a `leaf` color, i.e. the domain
-      * is a genuine sub-domain of what the arc produces. The arc may still produce a color outside the
-      * carrier, so exact domain membership is a marking invariant ([[ColoredPlace.markingError]]), not
-      * a static guarantee — SortCheck here is type compatibility, not domain containment.
+      * carrier is a hand-listed sub-domain — accepts a structurally larger `leaf` (e.g. the `Prod`
+      * of a componentwise inscription) as long as every carrier color is a `leaf` color, i.e. the
+      * domain is a genuine sub-domain of what the arc produces. The arc may still produce a color
+      * outside the carrier, so exact domain membership is a marking invariant
+      * ([[ColoredPlace.markingError]]), not a static guarantee — SortCheck here is type
+      * compatibility, not domain containment.
       */
     private def domainCompatible(leaf: Sort[?], domain: Sort[?]): Boolean =
         leaf == domain || (domain match
             case cls: Sort.Class[?] =>
                 val leafAny = leaf.asInstanceOf[Sort[Any]]
                 cls.carrier.toSortedSet.forall(c => leafAny.contains(c))
-            case _ => false
-        )
+            case _ => false)
 
     /** The sort of every weighted color in an inscription — both branches of a `Union`, not just
       * the root (whose sort is only the left branch's).

--- a/petri/src/test/scala/hydrozoa/lib/petri/hlpn/SortCheckTest.scala
+++ b/petri/src/test/scala/hydrozoa/lib/petri/hlpn/SortCheckTest.scala
@@ -107,7 +107,8 @@ class SortCheckTest extends AnyFunSuite:
     // the inscription's sort is accepted — exact membership is a marking invariant, not static. (The
     // product-into-class case is exercised by the RBR model; here both sorts are String classes.)
     test("an enumerated sub-domain accepts an inscription of a larger sort") {
-        val evenPeers = Sort.Class("EvenPeer", NonEmptySet.of("p0", "p2"), Sort.Discipline.Unordered)
+        val evenPeers =
+            Sort.Class("EvenPeer", NonEmptySet.of("p0", "p2"), Sort.Discipline.Unordered)
         val net = netWith(List(p), Guard.True, wp, placeDomain = evenPeers)
         assert(!SortCheck.errors(net).exists {
             case _: SortError.ArcDomainMismatch => true


### PR DESCRIPTION
## Problem

The `fmtAll` / `fmtCheckAll` / `lintAll` / `lintCheckAll` aliases only listed `core`, `integration`, and `benchmark`. The other two source modules were silently unchecked:

| Module | Path | .scala files | Was checked? |
|---|---|---|---|
| `cardanoOnchain` | `cardano-onchain` | 10 | ❌ |
| `petri` | `petri` | 27 | ❌ |

Since CI runs `fmtCheckAll`/`lintCheckAll`, **37 files had no formatting or lint enforcement**. The build already enables `-Wunused:all` and `semanticdbEnabled` build-wide, so the machinery was there — only the aliases skipped these modules.

## Change

1. Add `cardanoOnchain` + `petri` to all four aliases.
2. Bring their existing sources into compliance — scalafmt reflow + `OrganizeImports`. **No logic changes.**

`fmtCheckAll` + `lintCheckAll` now pass across all 5 modules.

## Note

`scalafix`'s `OrganizeImports` output isn't always scalafmt-clean, so the correct order is lint-then-fmt (one file needed a second fmt pass). Worth remembering when running these locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)