### PR TITLE
perf(backend): cut Blockfrost /scripts on the utxosAt path

### DIFF
--- a/src/main/scala/hydrozoa/multisig/backend/cardano/CardanoBackendBlockfrost.scala
+++ b/src/main/scala/hydrozoa/multisig/backend/cardano/CardanoBackendBlockfrost.scala
@@ -74,10 +74,7 @@ class CardanoBackendBlockfrost private (
         paginate(page =>
             backendService.getUtxoService
                 .getUtxos(address.toBech32.get, pageSize, page, OrderEnum.asc)
-        ).flatMap {
-            case Left(error)  => IO.pure(Left(error))
-            case Right(utxos) => convertUtxosWithScripts(utxos)
-        }
+        ).map(_.map(convertUtxosWithoutScripts))
 
     override def utxosAt(
         address: ShelleyAddress,
@@ -87,13 +84,26 @@ class CardanoBackendBlockfrost private (
         paginate(page =>
             backendService.getUtxoService
                 .getUtxos(address.toBech32.get, unit, pageSize, page, OrderEnum.asc)
-        ).flatMap {
-            case Left(error)  => IO.pure(Left(error))
-            case Right(utxos) => convertUtxosWithScripts(utxos)
-        }
+        ).map(_.map(convertUtxosWithoutScripts))
     }
 
+    /** Converts UTXOs without fetching their reference scripts: any `scriptRef` on the resulting
+      * outputs is left as `None`.
+      *
+      * Used by [[utxosAt]]. None of its callers read the reference script off the returned UTXOs
+      * (they use only value/datum/input), so fetching scripts here would be pure waste — one extra
+      * Blockfrost /scripts request per ref-script UTXO, on a hot polling path. The one consumer
+      * that genuinely needs the script (the reference-script checker in
+      * `ScriptReferenceUtxos.resolve`) goes through [[resolve]], which keeps
+      * [[convertUtxosWithScripts]].
+      */
+    private def convertUtxosWithoutScripts(utxos: List[Utxo]): Utxos =
+        utxos.map(convert(_, scriptRef = None)).toMap
+
     /** Converts UTXOs with script fetching. Fetches reference scripts if needed before converting.
+      *
+      * Only used by [[resolve]], which backs the reference-script checker; the polling [[utxosAt]]
+      * path deliberately avoids the per-UTXO /scripts request via [[convertUtxosWithoutScripts]].
       */
     private def convertUtxosWithScripts(
         utxos: List[Utxo]


### PR DESCRIPTION
## What

Splits UTXO conversion in `CardanoBackendBlockfrost` so that `utxosAt` no longer fetches reference scripts.

- New script-free `convertUtxosWithoutScripts` backs both `utxosAt` overloads — it leaves `scriptRef = None`.
- `resolve` keeps `convertUtxosWithScripts`, which is what the reference-script checker (`ScriptReferenceUtxos.resolve`) actually needs.

## Why

`utxosAt` unconditionally ran `convertUtxosWithScripts`, firing a Blockfrost `/scripts` request (native-then-plutus) for every returned UTXO carrying a `referenceScriptHash`. But **no caller of `utxosAt` ever reads `scriptRef`** off the result — they use only value/datum/input. The one genuine script consumer, the reference-script checker, resolves inputs one-by-one via `resolve`, not `utxosAt`.

So the per-UTXO script fetch on the `utxosAt` path was pure waste — and it sat on hot polling paths (e.g. `CardanoLiaison`'s ~10s treasury poll across peers), a meaningful chunk of the free-tier `/scripts` burn.

## Notes

Remaining `/scripts` traffic is now just the checker's `resolve` calls. If `/scripts` volume stays high, the next thing to check is how often `ScriptReferenceUtxos.resolve` re-runs (it should be ~once per boot).

Compiles clean; `just fmt` + `just lint` pass.