### PR TITLE
refactor(liaison): detect rule-based handoff via the treasury beacon

### DIFF
--- a/integration/src/test/scala/hydrozoa/integration/stage1/Suite.scala
+++ b/integration/src/test/scala/hydrozoa/integration/stage1/Suite.scala
@@ -526,9 +526,9 @@ case class Suite(
                   // signal. Stage 1 doesn't exercise fallback-to-rule-based (single-peer / happy
                   // path only), so the ref is a required-but-inert construction parameter.
                   mrmSelfStub <- system.actorOf(
-                    new Actor[IO, HeadMultisigRegimeManager.HandoffToRuleBased] {
+                    new Actor[IO, HeadMultisigRegimeManager.HandoffToRuleBased.type] {
                         override def receive
-                            : Receive[IO, HeadMultisigRegimeManager.HandoffToRuleBased] =
+                            : Receive[IO, HeadMultisigRegimeManager.HandoffToRuleBased.type] =
                             _ => IO.unit
                     }
                   )

--- a/src/main/scala/hydrozoa/multisig/CoilMultisigRegimeManager.scala
+++ b/src/main/scala/hydrozoa/multisig/CoilMultisigRegimeManager.scala
@@ -13,7 +13,6 @@ import hydrozoa.multisig.consensus.*
 import hydrozoa.multisig.consensus.peer.PeerId
 import hydrozoa.multisig.consensus.peer.PeerId.{Coil, Head}
 import hydrozoa.multisig.consensus.transport.{CoilTransport, RemoteHubProxy}
-import hydrozoa.multisig.ledger.l1.tx.FallbackTx
 import hydrozoa.multisig.ledger.l2.L2Ledger
 import hydrozoa.multisig.persistence.Persistence
 import hydrozoa.rulebased.RuleBasedRegimeManager
@@ -159,7 +158,7 @@ trait CoilMultisigRegimeManager(
       * `RuleBasedActor.Dispute.handleCoil`).
       */
     // Idempotent — mirrors HMRM.onHandoffToRuleBased.
-    override protected def onHandoffToRuleBased(fallback: FallbackTx): IO[Unit] =
+    override protected def onHandoffToRuleBased: IO[Unit] =
         nonClChildren.getAndSet(Nil).flatMap {
             case Nil => IO.unit
             case refs =>

--- a/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManager.scala
+++ b/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManager.scala
@@ -15,7 +15,6 @@ import hydrozoa.multisig.consensus.limiter.Limiter
 import hydrozoa.multisig.consensus.peer.{CoilPeerNumber, HeadPeerNumber, PeerId}
 import hydrozoa.multisig.consensus.transport.{HubTransport, PeerTransport, RemoteCoilProxy, RemotePeerProxy}
 import hydrozoa.multisig.ledger.joint.JointLedger
-import hydrozoa.multisig.ledger.l1.tx.FallbackTx
 import hydrozoa.multisig.ledger.l2.L2Ledger
 import hydrozoa.multisig.persistence.Persistence
 import hydrozoa.rulebased.RuleBasedRegimeManager
@@ -271,7 +270,7 @@ trait HeadMultisigRegimeManager(
         } yield ()
 
     // Idempotent: `Nil` from `getAndSet` means we've already handed off.
-    override protected def onHandoffToRuleBased(fallback: FallbackTx): IO[Unit] =
+    override protected def onHandoffToRuleBased: IO[Unit] =
         nonClChildren.getAndSet(Nil).flatMap {
             case Nil => IO.unit
             case refs =>
@@ -375,7 +374,8 @@ object HeadMultisigRegimeManager {
             StackComposer, SlowConsensus
 
     /** Requests received by the multisig regime manager. */
-    type Request = PreStart.type | TerminatedChild | TerminatedDependency | HandoffToRuleBased
+    type Request =
+        PreStart.type | TerminatedChild | TerminatedDependency | HandoffToRuleBased.type
 
     type Children = Actors
 
@@ -392,9 +392,11 @@ object HeadMultisigRegimeManager {
 
     final case class TerminatedDependency(dependencyType: Dependencies, ref: NoSendActorRef[IO])
 
-    /** Sent by [[CardanoLiaison]] once a `FallbackToRuleBased` action has been dispatched. HMRM
-      * responds by gracefully stopping every multisig child except CL (which stays up to process
-      * refunds and finish rollouts) and spawning [[hydrozoa.rulebased.RuleBasedRegimeManager]].
+    /** Sent by [[CardanoLiaison]] once it observes the rule-based treasury on L1 (the head has
+      * fallen into the rule-based regime). A pure trigger — the rule-based side reads its version
+      * and status from the on-chain treasury utxo, not from any tx carried here. HMRM responds by
+      * gracefully stopping every multisig child except CL (which stays up to process refunds and
+      * finish rollouts) and spawning [[hydrozoa.rulebased.RuleBasedRegimeManager]].
       */
-    final case class HandoffToRuleBased(fallback: FallbackTx)
+    case object HandoffToRuleBased
 }

--- a/src/main/scala/hydrozoa/multisig/MultisigRegimeManagerBase.scala
+++ b/src/main/scala/hydrozoa/multisig/MultisigRegimeManagerBase.scala
@@ -14,7 +14,6 @@ import hydrozoa.multisig.MultisigRegimeManagerBase.CoreActors
 import hydrozoa.multisig.backend.cardano.CardanoBackend
 import hydrozoa.multisig.consensus.*
 import hydrozoa.multisig.ledger.joint.JointLedger
-import hydrozoa.multisig.ledger.l1.tx.FallbackTx
 import hydrozoa.multisig.ledger.l2.L2Ledger
 import hydrozoa.multisig.persistence.Persistence
 import scala.concurrent.duration.DurationInt
@@ -76,9 +75,9 @@ trait MultisigRegimeManagerBase[E >: LifecycleEvent <: RegimeManagerEvent]
             tracer.traceWith(LifecycleEvent.TerminatedActor(childType))
         case TerminatedDependency(dependencyType, _) =>
             tracer.traceWith(LifecycleEvent.TerminatedDependency(dependencyType))
-        case HandoffToRuleBased(fallback) =>
+        case HandoffToRuleBased =>
             nodeStatus.update(_.advanceTo(NodeStatus.HandedOffToRuleBased)) *>
-                onHandoffToRuleBased(fallback)
+                onHandoffToRuleBased
         // TODO: Implement a way to receive a remote comm actor and connect it to its corresponding local comm actor
     }
 
@@ -92,7 +91,7 @@ trait MultisigRegimeManagerBase[E >: LifecycleEvent <: RegimeManagerEvent]
       * HMRM spawns [[hydrozoa.rulebased.RuleBasedRegimeManager]]; CMRM will spawn the coil-side
       * equivalent. Abstract on purpose — a silent default would swallow the handoff.
       */
-    protected def onHandoffToRuleBased(fallback: FallbackTx): IO[Unit]
+    protected def onHandoffToRuleBased: IO[Unit]
 
     /** Fan a list of (actorRef, actor-kind) pairs into per-child death watches that fire
       * `TerminatedChild` back to this manager.

--- a/src/main/scala/hydrozoa/multisig/consensus/CardanoLiaison.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/CardanoLiaison.scala
@@ -4,6 +4,8 @@ import cats.effect.{IO, Ref}
 import cats.implicits.*
 import com.suprnation.actor.Actor.{Actor, Receive}
 import com.suprnation.actor.ActorRef.ActorRef
+import hydrozoa.config.HydrozoaBlueprint
+import hydrozoa.config.head.initialization.InitializationParameters
 import hydrozoa.config.head.multisig.timing.TxTiming.BlockTimes.FallbackTxStartTime
 import hydrozoa.config.head.network.CardanoNetwork
 import hydrozoa.config.head.peers.HeadPeers
@@ -32,6 +34,39 @@ import scalus.cardano.ledger.{Block as _, BlockHeader as _, Transaction, Transac
   *   - Submits whichever L1 effects are not yet reflected in the Cardano blockchain.
   *   - Keeps track of confirmed L1 effects of L2 blocks that are immutable on L1 (TODO F14)
   *
+  * ==Decision schema (one pass of `runEffects`, per poll/timeout)==
+  *
+  * Every pass first polls the head multisig address for its utxo set, forwards it to BlockWeaver,
+  * then walks the following ladder, taking the first branch that applies. All L1 reads beyond the
+  * one address poll (steps 2–4) are made lazily — only on the branch that needs them — so a head
+  * that is in sync makes exactly one Cardano query per pass.
+  *
+  *   1. '''Due effects at the multisig address.''' If any polled utxo is a known effect input
+  *      (`state.effectInputs`), submit those direct actions — push the backbone forward
+  *      (`PushForwardMultisig` / `Rollout`), enter the silence period (`SilencePeriodNoop`), or
+  *      submit the now-valid competing fallback (`FallbackToRuleBased` action). A tip settlement
+  *      whose fallback has just become valid but has no competing next backbone is caught by the
+  *      `lastFallback` fallthrough and submitted the same way. This is the multisig-regime path —
+  *      the happy path plus the timing-driven fallback submission (not purely happy-path).
+  *   2. '''Finalization reached''' (only when the target is `Finalized`). If the finalization tx is
+  *      on L1, the head is settled for good — nothing to do.
+  *   3. '''Rule-based treasury present.''' If the target anchor (treasury utxo / finalization tx)
+  *      is gone, probe the rule-based treasury beacon at its script address. Its presence means the
+  *      head has fallen into the rule-based regime — send
+  *      [[HeadMultisigRegimeManager.HandoffToRuleBased]] (idempotent; every peer that observes it
+  *      hands off) and submit nothing. The rule-based side reads its version and status from this
+  *      on-chain treasury utxo, so no tx needs to be carried.
+  *   4. '''Resubmit the skeleton.''' No rule-based treasury either ⇒ a genuine L1 rollback. If the
+  *      init tx is no longer on L1 the head must be re-established: resubmit the whole skeleton
+  *      (`InitializeHead`), but only while inside the init tx's validity window (else
+  *      `InitWindowElapsed`). If the init tx still stands, the head is up and step 1 alone repairs
+  *      it as inputs reappear — nothing is resubmitted here.
+  *
+  * Submitting a fallback (step 1) and handing off to rule-based (step 3) are deliberately
+  * decoupled: a peer first waits out the silence period and submits a suitable fallback, and only
+  * on a later pass — once that fallback has landed and produced the rule-based treasury — does the
+  * treasury-beacon probe fire the handoff.
+  *
   * Some notes:
   *   - Though this module belongs to the multisig regime, the component's lifespan lasts longer
   *     since once a fallback tx gets submitted unfinished rollouts still may exist.
@@ -56,7 +91,7 @@ object CardanoLiaison:
             CardanoLiaison.Connections,
         tracer: ContraTracer[IO, CardanoLiaisonEvent],
         persistence: Persistence[IO],
-        mrmSelf: ActorRef[IO, HeadMultisigRegimeManager.HandoffToRuleBased],
+        mrmSelf: ActorRef[IO, HeadMultisigRegimeManager.HandoffToRuleBased.type],
         advanceNodeStatus: NodeStatus => IO[Unit],
     ): IO[CardanoLiaison] =
         IO(
@@ -72,7 +107,7 @@ object CardanoLiaison:
         )
 
     type Config = CardanoNetwork.Section & NodeOperationMultisigConfig.Section &
-        OwnPeerPublic.Section & HeadPeers.Section
+        OwnPeerPublic.Section & HeadPeers.Section & InitializationParameters.Section
 
     final case class Connections(
         blockWeaver: BlockWeaver.Handle
@@ -354,7 +389,7 @@ trait CardanoLiaison(
     pendingConnections: HeadMultisigRegimeManager.PendingConnections | CardanoLiaison.Connections,
     tracer: ContraTracer[IO, CardanoLiaisonEvent],
     persistence: Persistence[IO],
-    mrmSelf: ActorRef[IO, HeadMultisigRegimeManager.HandoffToRuleBased],
+    mrmSelf: ActorRef[IO, HeadMultisigRegimeManager.HandoffToRuleBased.type],
     advanceNodeStatus: NodeStatus => IO[Unit],
 ) extends Actor[IO, CardanoLiaison.Request]:
     import CardanoLiaison.*
@@ -595,12 +630,12 @@ trait CardanoLiaison(
                       IO.pure
                     )
 
-                    // 3. Decide what to submit this cycle, in priority order:
-                    //      (a) direct actions — effects whose inputs just appeared on L1;
-                    //      (b) else a fallback tx that has become valid → rule-based regime;
-                    //      (c) else reconcile the L1 target state (init / settlement / finalization).
+                    // 3. Decide what to submit this cycle. See the decision schema in the class
+                    //    doc: (1) due direct actions, else a now-valid tip fallback; otherwise
+                    //    reconcile the target — (2) finalized, (3) rule-based treasury present →
+                    //    handoff, (4) resubmit the skeleton.
                     actionsToSubmit <-
-                        // (a) Effect inputs are on L1 — submit exactly those direct actions.
+                        // (1) Effect inputs are on L1 — submit exactly those direct actions.
                         if dueActions.nonEmpty
                         then IO.pure(dueActions)
                         else
@@ -608,11 +643,10 @@ trait CardanoLiaison(
 
                                 _ <- tracer.traceWith(CardanoLiaisonEvent.NoActionsScheduled)
 
-                                // No direct actions. Fall through to (b) a now-valid fallback, else
-                                // (c) reconciling the target state.
-
-                                // TODO: this is done in a bit a makeshift manner to fix the test, likely we want to do it
-                                //   more systematically
+                                // (1) A tip settlement's fallback that has just become valid (its
+                                // spent treasury is present and its start time has passed) still
+                                // needs submitting: the last settlement has no competing next
+                                // backbone to trigger it via `mkDirectAction`.
                                 lastFallback: Option[FallbackTx] = for {
                                     maxKey <- state.fallbackEffects.keySet.maxOption
                                     fallbackTx = state.fallbackEffects(maxKey)
@@ -622,115 +656,11 @@ trait CardanoLiaison(
                                 } yield fallbackTx
 
                                 ret <- lastFallback match {
-                                    // (b) A fallback tx has become valid on L1 (its spent treasury is
-                                    // present and its start time has passed) — switch to rule-based.
                                     case Some(fallback) =>
                                         IO.pure(Seq(Action.FallbackToRuleBased(fallback)))
-                                    // (c) No fallback due — reconcile the L1 target state below.
-                                    case None => {
-                                        // `initAction` re-submits the full effect sequence to rebuild
-                                        // the head's L1 state when the expected target isn't there
-                                        // (e.g. after an L1 rollback). The init tx — and its validity
-                                        // window — come from the hard-confirmed stack 0 (held in
-                                        // `happyPathEffects`), NOT the unsigned config body; it is
-                                        // present whenever the head is Active/Finalized, i.e. whenever
-                                        // `initAction` runs. Within that window it resubmits
-                                        // everything; once `initializationTxEndTime` passes the init tx
-                                        // can never confirm, so the head cannot be rebuilt and we trace
-                                        // `InitWindowElapsed`.
-                                        val initEndTime =
-                                            state.happyPathEffects
-                                                .get(EffectId.initializationEffectId)
-                                                .collect { case it: InitializationTx =>
-                                                    it.initializationTxEndTime.convert
-                                                }
-                                        val initAction: IO[Seq[Action]] =
-                                            initEndTime match {
-                                                case Some(end) if currentTime < end =>
-                                                    IO.pure(
-                                                      Seq(
-                                                        Action.InitializeHead(
-                                                          state.happyPathEffects.values.toSeq
-                                                        )
-                                                      )
-                                                    )
-                                                case Some(end) =>
-                                                    tracer.traceWith(
-                                                      CardanoLiaisonEvent.InitWindowElapsed(
-                                                        currentTime.toString,
-                                                        end.toString
-                                                      )
-                                                    ) >> IO.pure(Seq.empty)
-                                                case None =>
-                                                    // No hard-confirmed init tx in state yet —
-                                                    // nothing to re-submit.
-                                                    IO.pure(Seq.empty)
-                                            }
-                                        // TODO: check the rule-based treasury, and if it exists, don't try to initialize the head.
-                                        // (c) Reconcile the local target with what is actually on L1:
-                                        state.targetState match {
-                                            case TargetState.Uninitialized =>
-                                                // Pre stack-0: no L1 target to reconcile and nothing
-                                                // submittable — wait for the Initial stack effects.
-                                                IO.pure(List.empty)
-                                            case TargetState.Active(targetTreasuryUtxoId) =>
-                                                // The head's current treasury should be on L1.
-                                                if utxoIds.contains(targetTreasuryUtxoId)
-                                                then
-                                                    // Present — L1 is in sync with the target.
-                                                    tracer.traceWith(
-                                                      CardanoLiaisonEvent.TargetUtxoStatus(
-                                                        targetTreasuryUtxoId.toString,
-                                                        found = true
-                                                      )
-                                                    ) >> IO.pure(List.empty)
-                                                else
-                                                    // Missing — the expected state isn't on L1 (a
-                                                    // possible rollback, or the head moved to the
-                                                    // rule-based regime — see TODO). Re-submit the
-                                                    // full sequence to rebuild.
-                                                    tracer.traceWith(
-                                                      CardanoLiaisonEvent.TargetUtxoStatus(
-                                                        targetTreasuryUtxoId.toString,
-                                                        found = false
-                                                      )
-                                                    ) >> initAction
-
-                                            case TargetState.Finalized(finalizationTxHash) =>
-                                                // Head is finalized: the finalization tx should be on
-                                                // L1. Check whether the backend knows it yet.
-                                                for {
-                                                    txResp <- cardanoBackend.isTxKnown(
-                                                      finalizationTxHash
-                                                    )
-                                                    mbInitAction <- txResp match {
-                                                        // Couldn't query its status — skip this cycle.
-                                                        case Left(err) =>
-                                                            tracer.traceWith(
-                                                              CardanoLiaisonEvent
-                                                                  .FinalizationTxQueryError(
-                                                                    err.toString
-                                                                  )
-                                                            ) >> IO.pure(Seq.empty)
-                                                        case Right(isKnown) =>
-                                                            tracer.traceWith(
-                                                              CardanoLiaisonEvent
-                                                                  .FinalizationTxStatus(
-                                                                    finalizationTxHash.toString,
-                                                                    if isKnown then "known"
-                                                                    else "not known"
-                                                                  )
-                                                            ) >> (
-                                                              // Known → in sync. Not on L1 →
-                                                              // possible rollback; re-submit the full
-                                                              // sequence to recover.
-                                                              if isKnown then IO.pure(Seq.empty)
-                                                              else initAction
-                                                            )
-                                                    }
-                                                } yield mbInitAction
-                                        }
-                                    }
+                                    // Steps (2)/(3)/(4): nothing is due at the multisig address.
+                                    case None =>
+                                        reconcileTargetState(state, utxoIds, currentTime)
                                 }
                             } yield ret
 
@@ -767,28 +697,149 @@ trait CardanoLiaison(
                       tracer.traceWith(CardanoLiaisonEvent.SubmissionErrors(submissionErrors.size))
                     )
 
-                    // Every peer that sees a known fallback tx on L1 hands off — not just the
-                    // submitter. MRM handler is idempotent so re-fires are safe.
-                    _ <- state.fallbackEffects.values.toList
-                        .traverse { ft =>
-                            cardanoBackend.isTxKnown(ft.tx.id).map {
-                                case Right(true) => Some(ft)
-                                case _           => None
-                            }
-                        }
-                        .map(_.flatten.headOption)
-                        .flatMap {
-                            case None => IO.unit
-                            case Some(ft) =>
-                                tracer.traceWith(
-                                  CardanoLiaisonEvent.FallbackToRuleBasedDispatched(ft.tx.id)
-                                ) >>
-                                    (mrmSelf ! HeadMultisigRegimeManager.HandoffToRuleBased(ft))
-                        }
+                    // The handoff to the rule-based regime is driven by the rule-based treasury
+                    // probe in `reconcileTargetState` (step 3), not by an isTxKnown sweep over every
+                    // known fallback tx here.
 
                 } yield ()
         }
     } yield ()
+
+    /** Steps (2)–(4) of the decision schema, reached when no L1 effect is due at the multisig
+      * address this pass. Walks the target state:
+      *   - `Uninitialized`: pre stack-0 — nothing submittable.
+      *   - `Active` with its treasury utxo present, or `Finalized` with its finalization tx on L1:
+      *     the head is in sync — nothing to do.
+      *   - otherwise the target anchor is gone: probe the rule-based treasury and either hand off
+      *     (step 3) or resubmit the skeleton (step 4), via [[handoffOrResubmit]].
+      */
+    private def reconcileTargetState(
+        state: State,
+        utxoIds: Set[TransactionInput],
+        currentTime: QuantizedInstant
+    ): IO[Seq[Action]] =
+        state.targetState match {
+            case TargetState.Uninitialized =>
+                // Pre stack-0: no L1 target to reconcile and nothing submittable — wait for the
+                // Initial stack effects.
+                IO.pure(Seq.empty)
+
+            case TargetState.Active(targetTreasuryUtxoId) =>
+                if utxoIds.contains(targetTreasuryUtxoId) then
+                    // (1) Present — L1 is in sync with the target; anything due was already a direct
+                    // action above.
+                    tracer.traceWith(
+                      CardanoLiaisonEvent
+                          .TargetUtxoStatus(targetTreasuryUtxoId.toString, found = true)
+                    ) >> IO.pure(Seq.empty)
+                else
+                    // The treasury is gone: either we fell into the rule-based regime, or an L1
+                    // rollback took it. Steps (3)/(4) tell those apart.
+                    tracer.traceWith(
+                      CardanoLiaisonEvent
+                          .TargetUtxoStatus(targetTreasuryUtxoId.toString, found = false)
+                    ) >> handoffOrResubmit(state, currentTime)
+
+            case TargetState.Finalized(finalizationTxHash) =>
+                // (2) Finalization is the target: if its tx is on L1 the head is settled for good.
+                cardanoBackend.isTxKnown(finalizationTxHash).flatMap {
+                    // Couldn't query its status — skip this cycle.
+                    case Left(err) =>
+                        tracer.traceWith(
+                          CardanoLiaisonEvent.FinalizationTxQueryError(err.toString)
+                        ) >> IO.pure(Seq.empty)
+                    case Right(true) =>
+                        tracer.traceWith(
+                          CardanoLiaisonEvent
+                              .FinalizationTxStatus(finalizationTxHash.toString, "known")
+                        ) >> IO.pure(Seq.empty)
+                    // Not on L1 — possible rollback of the finalization; fall to steps (3)/(4).
+                    case Right(false) =>
+                        tracer.traceWith(
+                          CardanoLiaisonEvent
+                              .FinalizationTxStatus(finalizationTxHash.toString, "not known")
+                        ) >> handoffOrResubmit(state, currentTime)
+                }
+        }
+
+    /** Steps (3) then (4): the target anchor (treasury utxo / finalization tx) is not on L1. First
+      * probe the rule-based treasury beacon — if it exists the head has fallen into the rule-based
+      * regime, so hand off (idempotent) and submit nothing. Otherwise it is a genuine L1 rollback:
+      * resubmit the skeleton via [[resubmitSkeleton]].
+      */
+    private def handoffOrResubmit(state: State, currentTime: QuantizedInstant): IO[Seq[Action]] =
+        ruleBasedTreasuryPresent.flatMap {
+            // Couldn't probe — skip this cycle, retry on the next tick.
+            case Left(err) =>
+                tracer.traceWith(CardanoLiaisonEvent.RuleBasedTreasuryQueryError(err.toString)) >>
+                    IO.pure(Seq.empty)
+            // (3) The rule-based treasury is on L1 — hand off. Every peer that observes it hands
+            // off, not just the fallback's submitter; the MRM handler is idempotent so re-fires are
+            // safe. The rule-based side reads its version/status from this treasury utxo, so the
+            // trigger carries no tx. `txId` is the tx that produced the observed treasury utxo.
+            case Right(Some(treasuryUtxoId)) =>
+                tracer.traceWith(
+                  CardanoLiaisonEvent.FallbackToRuleBasedDispatched(treasuryUtxoId.transactionId)
+                ) >>
+                    (mrmSelf ! HeadMultisigRegimeManager.HandoffToRuleBased) >>
+                    IO.pure(Seq.empty)
+            // (4) No rule-based treasury — a real rollback.
+            case Right(None) =>
+                resubmitSkeleton(state, currentTime)
+        }
+
+    /** Step (4): the target anchor is gone and there is no rule-based treasury — a genuine L1
+      * rollback. If the init tx is no longer on L1 the head must be re-established from scratch, so
+      * resubmit the whole skeleton (`InitializeHead`) — but only while inside its validity window
+      * (`currentTime < initializationTxEndTime`); once that passes the init tx can never confirm
+      * and the head cannot be re-established (`InitWindowElapsed`). If the init tx still stands the
+      * head is up; nothing is resubmitted here — step (1)'s direct actions push it forward as
+      * inputs reappear. The init tx (and its window) come from the hard-confirmed stack 0 held in
+      * `happyPathEffects`, not the unsigned config body.
+      */
+    private def resubmitSkeleton(state: State, currentTime: QuantizedInstant): IO[Seq[Action]] =
+        state.happyPathEffects.get(EffectId.initializationEffectId) match {
+            case Some(initTx: InitializationTx) =>
+                cardanoBackend.isTxKnown(initTx.tx.id).flatMap {
+                    case Left(err) =>
+                        tracer.traceWith(CardanoLiaisonEvent.InitTxQueryError(err.toString)) >>
+                            IO.pure(Seq.empty)
+                    case Right(true) =>
+                        // Head is established — leave recovery to the direct-action path.
+                        tracer.traceWith(
+                          CardanoLiaisonEvent.InitTxStatus(initTx.tx.id.toString, "known")
+                        ) >> IO.pure(Seq.empty)
+                    case Right(false) =>
+                        val initEnd = initTx.initializationTxEndTime.convert
+                        if currentTime < initEnd then
+                            tracer.traceWith(
+                              CardanoLiaisonEvent.InitTxStatus(initTx.tx.id.toString, "not known")
+                            ) >> IO.pure(
+                              Seq(Action.InitializeHead(state.happyPathEffects.values.toSeq))
+                            )
+                        else
+                            tracer.traceWith(
+                              CardanoLiaisonEvent
+                                  .InitWindowElapsed(currentTime.toString, initEnd.toString)
+                            ) >> IO.pure(Seq.empty)
+                }
+            case _ =>
+                // No hard-confirmed init tx in state yet — nothing to resubmit.
+                IO.pure(Seq.empty)
+        }
+
+    /** Probe L1 for the rule-based treasury: the treasury-token beacon at the rule-based treasury
+      * script address. Its presence means the head has fallen into the rule-based regime. Returns
+      * the treasury utxo's id when found (its `transactionId` names the producing tx, for tracing).
+      */
+    private def ruleBasedTreasuryPresent
+        : IO[Either[CardanoBackend.Error, Option[TransactionInput]]] =
+        cardanoBackend
+            .utxosAt(
+              HydrozoaBlueprint.mkTreasuryAddress(config.network),
+              (config.headMultisigScript.policyId, config.headTokenNames.treasuryTokenName)
+            )
+            .map(_.map(_.keySet.headOption))
 
     // ===================================
     // Actions

--- a/src/main/scala/hydrozoa/multisig/consensus/CardanoLiaisonEvent.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/CardanoLiaisonEvent.scala
@@ -62,16 +62,29 @@ object CardanoLiaisonEvent:
 
     final case class FinalizationTxQueryError(err: String) extends CardanoLiaisonEvent
 
+    /** Whether the init tx is on L1, probed (step 4) when the target anchor is missing and no
+      * rule-based treasury exists. `isKnown == "not known"` triggers a full skeleton re-submission.
+      */
+    final case class InitTxStatus(hash: String, isKnown: String) extends CardanoLiaisonEvent
+
+    final case class InitTxQueryError(err: String) extends CardanoLiaisonEvent
+
+    /** The rule-based treasury beacon probe (step 3) failed — skipped this cycle, retried next
+      * tick.
+      */
+    final case class RuleBasedTreasuryQueryError(err: String) extends CardanoLiaisonEvent
+
     /** Some actions will be submitted to L1. `hasFallback` true means at least one is a fallback or
       * silence-period noop (logged at warn level).
       */
     final case class ActionsDispatched(msgs: List[String], hasFallback: Boolean)
         extends CardanoLiaisonEvent
 
-    /** A `FallbackToRuleBased` action has been selected for submission: the head is flipping into
-      * rule-based fallback. Distinct from `ActionsDispatched.hasFallback`, which also covers
-      * `SilencePeriodNoop`. Tests can observe this to short-circuit scenarios that drift outside
-      * the modeled happy-path regime.
+    /** The rule-based treasury has been observed on L1 and the handoff to the rule-based regime has
+      * been dispatched (step 3): the head has fallen into rule-based fallback. `txId` is the tx
+      * that produced the observed treasury utxo (the fallback tx, or a later rule-based tx). Tests
+      * can observe this to short-circuit scenarios that drift outside the modeled happy-path
+      * regime.
       */
     final case class FallbackToRuleBasedDispatched(txId: TransactionHash)
         extends CardanoLiaisonEvent

--- a/src/main/scala/hydrozoa/multisig/consensus/CardanoLiaisonEventFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/CardanoLiaisonEventFormat.scala
@@ -40,7 +40,7 @@ object CardanoLiaisonEventFormat:
             case TargetUtxoStatus(targetId, true) =>
                 trace(s"target $targetId found, do nothing")
             case TargetUtxoStatus(targetId, false) =>
-                trace(s"no target $targetId found, submitting init action")
+                trace(s"target $targetId gone; probing rule-based treasury / init tx")
             case InitWindowElapsed(currentTime, endTime) =>
                 warn(
                   s"init tx validity window elapsed (currentTime=$currentTime >=" +
@@ -51,6 +51,12 @@ object CardanoLiaisonEventFormat:
                 trace(s"finalizationTx: hash=$hash known=$isKnown")
             case FinalizationTxQueryError(err) =>
                 error(s"error when getting finalization tx info: $err")
+            case InitTxStatus(hash, isKnown) =>
+                trace(s"initTx: hash=$hash known=$isKnown")
+            case InitTxQueryError(err) =>
+                error(s"error when getting init tx info: $err")
+            case RuleBasedTreasuryQueryError(err) =>
+                error(s"error when probing the rule-based treasury: $err")
             case ActionsDispatched(msgs, hasFallback) =>
                 val text = "Liaison's actions:" + msgs.map(m => s"\n\t- $m").mkString
                 if hasFallback then warn(text) else info(text)


### PR DESCRIPTION
## What

Reworks `CardanoLiaison`'s per-poll decision (`runEffects`) into an explicit 4-step ladder, documented precisely in the class doc. Each pass polls the head multisig address once, forwards the utxo set to BlockWeaver, then takes the first branch that applies:

1. **Due effects at the multisig address** → submit those direct actions (push forward / rollout / silence / submit now-valid fallback). This is the **multisig-regime path** — the happy path plus the timing-driven fallback submission (not purely happy-path).
2. **Finalization reached** (only when target is `Finalized`) → if the finalization tx is on L1, done.
3. **Rule-based treasury present** → hand off to the rule-based regime and submit nothing.
4. **Rebuild from the skeleton** → no rule-based treasury ⇒ genuine rollback; if the init tx is off L1, re-submit the whole skeleton within its TTL.

All L1 reads beyond the one address poll (steps 2–4) are lazy, so a head that is in sync makes exactly **one** Cardano query per pass.

## Why

Step 3 replaces the previous per-poll `isTxKnown` sweep over **every** known fallback tx — a large chunk of the Blockfrost `/txs` burn (~330k/day on a 6-peer head) — with a single treasury-beacon probe, taken only when the target anchor is missing. It also resolves the long-standing false-rollback re-init TODO: treasury gone **+ rule-based treasury present** ⇒ handoff (don't rebuild); treasury gone **+ no rule-based treasury** ⇒ genuine rollback ⇒ rebuild.

## Handoff message trimmed

`HeadMultisigRegimeManager.HandoffToRuleBased` becomes a pure trigger (`case object`, no `FallbackTx`). The rule-based side already reads its version and status from the on-chain treasury utxo (`RuleBasedActor.getTreasury` / `extractTreasuryVersionMajor`), never from the carried tx — `onHandoffToRuleBased` only used it as a signal — so dropping the payload is a no-op for `RuleBasedActor` / `RuleBasedRegimeManager`.

## Decoupling

Submitting a fallback (step 1, timing-driven via `mkDirectAction` / `lastFallback`) and handing off (step 3) stay decoupled: a peer waits out the silence period and submits a suitable fallback, and only on a later poll — once that fallback has landed and produced the rule-based treasury — does the beacon probe fire the handoff. Every peer that observes the treasury hands off (idempotent MRM handler), same as before.

## Notes

- `FallbackToRuleBasedDispatched` (the stage4 / RBR test signal) is retained; its `txId` is now the tx that produced the observed treasury utxo (the fallback, or a later rule-based tx).
- Config widened by one section (`InitializationParameters.Section`) for the treasury token name used in the beacon probe.
- Independent of #564, but complements it: the probe uses the (now script-free) two-arg `utxosAt`.

Compiles clean; `just fmt`, `just lint`, and `just build-werror` all pass.