### PR TITLE
fix(config): encode CardanoNetwork.Custom protocolMagic correctly

### DIFF
--- a/src/main/scala/hydrozoa/config/head/network/CardanoNetwork.scala
+++ b/src/main/scala/hydrozoa/config/head/network/CardanoNetwork.scala
@@ -86,7 +86,7 @@ object CardanoNetwork {
             case CardanoNetwork.Custom(cardanoInfo, protocolMagic) =>
                 Json.obj(
                   "custom" -> cardanoInfo.asJson,
-                  "protocolMagic" -> cardanoInfo.protocolParams.asJson
+                  "protocolMagic" -> protocolMagic.asJson
                 )
         }
     }

--- a/src/main/scala/hydrozoa/lib/cardano/scalus/codecs/json/Codecs.scala
+++ b/src/main/scala/hydrozoa/lib/cardano/scalus/codecs/json/Codecs.scala
@@ -5,7 +5,7 @@ import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import io.circe.{Decoder, DecodingFailure, Encoder, Json, KeyDecoder, KeyEncoder, parser}
 import scala.util.Try
 import scalus.cardano.address.Network
-import scalus.cardano.ledger.{CardanoInfo, KeepRaw, ProtocolParams, SlotConfig, Transaction, TransactionHash, TransactionInput, TransactionOutput, Utxo}
+import scalus.cardano.ledger.{CardanoInfo, CostModels, DRepVotingThresholds, ExUnitPrices, ExUnits, KeepRaw, NonNegativeInterval, PoolVotingThresholds, ProtocolParams, ProtocolVersion, SlotConfig, Transaction, TransactionHash, TransactionInput, TransactionOutput, UnitInterval, Utxo}
 import scalus.crypto.ed25519.SigningKey
 import scalus.uplc.builtin.ByteString
 
@@ -13,21 +13,101 @@ import scalus.uplc.builtin.ByteString
   */
 object Codecs {
 
-    given protocolParamsDecoder: Decoder[ProtocolParams] = Decoder.decodeString.emap(rawString =>
-        Try(ProtocolParams.fromBlockfrostJson(rawString)).toEither.left.map(e =>
-            "ProtocolParams decoding failed. NOTE: we wrap the scalus blockfrost codec," +
-                s"which uses the upickle JSON library instead of circe. The message from upickle is: $e"
+    /** Symmetric, human-observable JSON codec for [[ProtocolParams]] and its nested field types.
+      *
+      * scalus provides only upickle codecs for `ProtocolParams`, and neither round-trips exactly:
+      * `blockfrostParamsReadWriter` is write/read asymmetric (its `cost_models` writer emits arrays
+      * while the reader expects objects), and `cardanoCliParamsReadWriter` routes the
+      * `UnitInterval`/`NonNegativeInterval` fields through `Double`, which is lossy (a mainnet
+      * `priceSteps` of `0.0000721` decodes back as `0.000072`). We instead derive circe codecs
+      * field-by-field from the record structure and serialize the two fraction types as exact
+      * `{ "numerator": <Long>, "denominator": <Long> }` objects, so a `Custom` head-config's
+      * `CardanoInfo` stays readable and survives a serialize/deserialize cycle unchanged.
+      *
+      * The leaf codecs are defined before the derived aggregates that summon them.
+      */
+
+    /** Shared `{ "numerator": <Long>, "denominator": <Long> }` shape for the two scalus fraction
+      * types. The decoder wraps construction in `Try` because both `require` a positive
+      * denominator, which keeps it total — a malformed fraction yields a `Left`, never a thrown
+      * exception.
+      */
+    private def fractionEncoder[A](numerator: A => Long, denominator: A => Long): Encoder[A] =
+        Encoder.instance(fraction =>
+            Json.obj(
+              "numerator" -> Json.fromLong(numerator(fraction)),
+              "denominator" -> Json.fromLong(denominator(fraction))
+            )
+        )
+
+    private def fractionDecoder[A](name: String)(build: (Long, Long) => A): Decoder[A] =
+        Decoder.instance(c =>
+            for {
+                numerator <- c.downField("numerator").as[Long]
+                denominator <- c.downField("denominator").as[Long]
+                fraction <- Try(build(numerator, denominator)).toEither.left.map(e =>
+                    DecodingFailure(s"Invalid $name: ${e.getMessage}", c.history)
+                )
+            } yield fraction
+        )
+
+    given nonNegativeIntervalEncoder: Encoder[NonNegativeInterval] =
+        fractionEncoder[NonNegativeInterval](_.numerator, _.denominator)
+    given nonNegativeIntervalDecoder: Decoder[NonNegativeInterval] =
+        fractionDecoder("NonNegativeInterval")((numerator, denominator) =>
+            NonNegativeInterval(numerator, denominator)
+        )
+
+    given unitIntervalEncoder: Encoder[UnitInterval] =
+        fractionEncoder[UnitInterval](_.numerator, _.denominator)
+    given unitIntervalDecoder: Decoder[UnitInterval] =
+        fractionDecoder("UnitInterval")((numerator, denominator) =>
+            UnitInterval(numerator, denominator)
+        )
+
+    /** `cost_models` serialize as a JSON object keyed by language id (`"0"`, `"1"`, `"2"`), each
+      * mapped to its cost list. Keys are emitted in id order for a deterministic encoding.
+      */
+    given costModelsEncoder: Encoder[CostModels] = Encoder.instance(costModels =>
+        Json.obj(
+          costModels.models.toSeq.sortBy(_._1).map { case (languageId, costs) =>
+              languageId.toString -> Json.arr(costs.map(Json.fromLong)*)
+          }*
         )
     )
 
-    given protocolParamsEncoder: Encoder[ProtocolParams] with {
-        override def apply(pp: ProtocolParams): Json = {
-            val scalusSerialization =
-                upickle.write(pp)(using ProtocolParams.blockfrostParamsReadWriter)
-            val Right(json) = parser.parse(scalusSerialization): @unchecked
-            json
-        }
-    }
+    given costModelsDecoder: Decoder[CostModels] = Decoder.instance(c =>
+        for {
+            raw <- c.as[Map[String, List[Long]]]
+            models <- Try(
+              raw.map { case (languageId, costs) => languageId.toInt -> costs.toIndexedSeq }
+            ).toEither.left.map(e =>
+                DecodingFailure(s"Invalid CostModels: ${e.getMessage}", c.history)
+            )
+        } yield CostModels(models)
+    )
+
+    given protocolVersionEncoder: Encoder[ProtocolVersion] = deriveEncoder[ProtocolVersion]
+    given protocolVersionDecoder: Decoder[ProtocolVersion] = deriveDecoder[ProtocolVersion]
+
+    given exUnitsEncoder: Encoder[ExUnits] = deriveEncoder[ExUnits]
+    given exUnitsDecoder: Decoder[ExUnits] = deriveDecoder[ExUnits]
+
+    given exUnitPricesEncoder: Encoder[ExUnitPrices] = deriveEncoder[ExUnitPrices]
+    given exUnitPricesDecoder: Decoder[ExUnitPrices] = deriveDecoder[ExUnitPrices]
+
+    given drepVotingThresholdsEncoder: Encoder[DRepVotingThresholds] =
+        deriveEncoder[DRepVotingThresholds]
+    given drepVotingThresholdsDecoder: Decoder[DRepVotingThresholds] =
+        deriveDecoder[DRepVotingThresholds]
+
+    given poolVotingThresholdsEncoder: Encoder[PoolVotingThresholds] =
+        deriveEncoder[PoolVotingThresholds]
+    given poolVotingThresholdsDecoder: Decoder[PoolVotingThresholds] =
+        deriveDecoder[PoolVotingThresholds]
+
+    given protocolParamsEncoder: Encoder[ProtocolParams] = deriveEncoder[ProtocolParams]
+    given protocolParamsDecoder: Decoder[ProtocolParams] = deriveDecoder[ProtocolParams]
 
     given cardanoInfoEncoder: Encoder[CardanoInfo] = deriveEncoder[CardanoInfo]
 

--- a/src/main/scala/hydrozoa/lib/cardano/scalus/codecs/json/Codecs.scala
+++ b/src/main/scala/hydrozoa/lib/cardano/scalus/codecs/json/Codecs.scala
@@ -24,33 +24,9 @@ object Codecs {
       * `{ "numerator": <Long>, "denominator": <Long> }` objects, so a `Custom` head-config's
       * `CardanoInfo` stays readable and survives a serialize/deserialize cycle unchanged.
       *
-      * The leaf codecs are defined before the derived aggregates that summon them.
+      * The leaf codecs are defined before the derived aggregates that summon them; the two private
+      * fraction helpers they share sit at the foot of the object, per the file's ordering rule.
       */
-
-    /** Shared `{ "numerator": <Long>, "denominator": <Long> }` shape for the two scalus fraction
-      * types. The decoder wraps construction in `Try` because both `require` a positive
-      * denominator, which keeps it total — a malformed fraction yields a `Left`, never a thrown
-      * exception.
-      */
-    private def fractionEncoder[A](numerator: A => Long, denominator: A => Long): Encoder[A] =
-        Encoder.instance(fraction =>
-            Json.obj(
-              "numerator" -> Json.fromLong(numerator(fraction)),
-              "denominator" -> Json.fromLong(denominator(fraction))
-            )
-        )
-
-    private def fractionDecoder[A](name: String)(build: (Long, Long) => A): Decoder[A] =
-        Decoder.instance(c =>
-            for {
-                numerator <- c.downField("numerator").as[Long]
-                denominator <- c.downField("denominator").as[Long]
-                fraction <- Try(build(numerator, denominator)).toEither.left.map(e =>
-                    DecodingFailure(s"Invalid $name: ${e.getMessage}", c.history)
-                )
-            } yield fraction
-        )
-
     given nonNegativeIntervalEncoder: Encoder[NonNegativeInterval] =
         fractionEncoder[NonNegativeInterval](_.numerator, _.denominator)
     given nonNegativeIntervalDecoder: Decoder[NonNegativeInterval] =
@@ -88,7 +64,20 @@ object Codecs {
     )
 
     given protocolVersionEncoder: Encoder[ProtocolVersion] = deriveEncoder[ProtocolVersion]
-    given protocolVersionDecoder: Decoder[ProtocolVersion] = deriveDecoder[ProtocolVersion]
+
+    /** `ProtocolVersion` `require`s `major >= 1` and `minor >= 0`, so — like the fraction decoders
+      * — construction is wrapped in `Try` to keep the decoder total instead of letting circe's
+      * derivation throw the constructor `require` on malformed input.
+      */
+    given protocolVersionDecoder: Decoder[ProtocolVersion] = Decoder.instance(c =>
+        for {
+            major <- c.downField("major").as[Int]
+            minor <- c.downField("minor").as[Int]
+            version <- Try(ProtocolVersion(major, minor)).toEither.left.map(e =>
+                DecodingFailure(s"Invalid ProtocolVersion: ${e.getMessage}", c.history)
+            )
+        } yield version
+    )
 
     given exUnitsEncoder: Encoder[ExUnits] = deriveEncoder[ExUnits]
     given exUnitsDecoder: Decoder[ExUnits] = deriveDecoder[ExUnits]
@@ -109,10 +98,6 @@ object Codecs {
     given protocolParamsEncoder: Encoder[ProtocolParams] = deriveEncoder[ProtocolParams]
     given protocolParamsDecoder: Decoder[ProtocolParams] = deriveDecoder[ProtocolParams]
 
-    given cardanoInfoEncoder: Encoder[CardanoInfo] = deriveEncoder[CardanoInfo]
-
-    given cardanoInfoDecoder: Decoder[CardanoInfo] = deriveDecoder[CardanoInfo]
-
     given networkEncoder: Encoder[Network] = deriveEncoder[Network]
 
     given networkDecoder: Decoder[Network] = deriveDecoder[Network]
@@ -120,6 +105,11 @@ object Codecs {
     given slotConfigEncoder: Encoder[SlotConfig] = deriveEncoder[SlotConfig]
 
     given slotConfigDecoder: Decoder[SlotConfig] = deriveDecoder[SlotConfig]
+
+    // CardanoInfo aggregates ProtocolParams, Network, and SlotConfig, so its codecs follow theirs.
+    given cardanoInfoEncoder: Encoder[CardanoInfo] = deriveEncoder[CardanoInfo]
+
+    given cardanoInfoDecoder: Decoder[CardanoInfo] = deriveDecoder[CardanoInfo]
 
     given utxoEncoder: Encoder[Utxo] = deriveEncoder[Utxo]
 
@@ -250,5 +240,29 @@ object Codecs {
                 case _ => None
             }
     }
+
+    /** Shared `{ "numerator": <Long>, "denominator": <Long> }` shape for the two scalus fraction
+      * types ([[NonNegativeInterval]], [[UnitInterval]]). The decoder wraps construction in `Try`
+      * because both `require` a positive denominator, which keeps it total — a malformed fraction
+      * yields a `Left`, never a thrown exception.
+      */
+    private def fractionEncoder[A](numerator: A => Long, denominator: A => Long): Encoder[A] =
+        Encoder.instance(fraction =>
+            Json.obj(
+              "numerator" -> Json.fromLong(numerator(fraction)),
+              "denominator" -> Json.fromLong(denominator(fraction))
+            )
+        )
+
+    private def fractionDecoder[A](name: String)(build: (Long, Long) => A): Decoder[A] =
+        Decoder.instance(c =>
+            for {
+                numerator <- c.downField("numerator").as[Long]
+                denominator <- c.downField("denominator").as[Long]
+                fraction <- Try(build(numerator, denominator)).toEither.left.map(e =>
+                    DecodingFailure(s"Invalid $name: ${e.getMessage}", c.history)
+                )
+            } yield fraction
+        )
 
 }

--- a/src/test/scala/hydrozoa/config/head/network/CardanoNetworkCodecTest.scala
+++ b/src/test/scala/hydrozoa/config/head/network/CardanoNetworkCodecTest.scala
@@ -1,9 +1,10 @@
 package hydrozoa.config.head.network
 
 import hydrozoa.lib.cardano.scalus.codecs.json.Codecs.given
+import io.circe.Json
 import io.circe.syntax.*
 import org.scalatest.funsuite.AnyFunSuite
-import scalus.cardano.ledger.{CardanoInfo, ProtocolParams}
+import scalus.cardano.ledger.{CardanoInfo, ProtocolParams, ProtocolVersion}
 
 /** Shape and round-trip coverage for the [[CardanoNetwork]] JSON codec.
   *
@@ -53,6 +54,16 @@ class CardanoNetworkCodecTest extends AnyFunSuite:
               s"Custom round-trip failed for ${info.network}"
             )
         }
+    }
+
+    test("a malformed ProtocolVersion decodes to a Left, not a thrown exception") {
+        // ProtocolVersion requires major >= 1; a derived decoder would let that require throw. The
+        // total decoder must surface it as a DecodingFailure (a Left) instead.
+        val badVersion = Json.obj("major" -> Json.fromInt(0), "minor" -> Json.fromInt(0))
+        assert(
+          badVersion.as[ProtocolVersion].isLeft,
+          s"expected a Left for major=0, got ${badVersion.as[ProtocolVersion]}"
+        )
     }
 
 end CardanoNetworkCodecTest

--- a/src/test/scala/hydrozoa/config/head/network/CardanoNetworkCodecTest.scala
+++ b/src/test/scala/hydrozoa/config/head/network/CardanoNetworkCodecTest.scala
@@ -1,0 +1,37 @@
+package hydrozoa.config.head.network
+
+import io.circe.syntax.*
+import org.scalatest.funsuite.AnyFunSuite
+import scalus.cardano.ledger.CardanoInfo
+
+/** Shape coverage for the [[CardanoNetwork]] JSON codec.
+  *
+  * The three standard networks encode as bare strings and round-trip. A `Custom` network encodes as
+  * `{ "custom": <CardanoInfo>, "protocolMagic": <Long> }`; this pins that `protocolMagic` is
+  * written as the magic (a number). A prior encoder bug wrote the protocol-params object under that
+  * key instead, dropping the magic entirely.
+  *
+  * Note: a full `Custom` decode is not asserted here because it additionally requires the
+  * `CardanoInfo` / `ProtocolParams` codec to round-trip, which is a separate open issue (the scalus
+  * blockfrost ReadWriter is write/read asymmetric) — see docs/local/integration/phases.md.
+  */
+class CardanoNetworkCodecTest extends AnyFunSuite:
+
+    test("standard networks round-trip through JSON") {
+        List(CardanoNetwork.Mainnet, CardanoNetwork.Preprod, CardanoNetwork.Preview).foreach { n =>
+            assert(n.asJson.as[CardanoNetwork] == Right(n), s"round-trip failed for $n")
+        }
+    }
+
+    test("a Custom network encodes protocolMagic as the magic number") {
+        val magic =
+            42L // distinct from every standard magic (mainnet 764824073, preprod 1, preview 2)
+        val custom: CardanoNetwork = CardanoNetwork.Custom(CardanoInfo.preview, magic)
+        val encoded = custom.asJson
+        assert(
+          encoded.hcursor.downField("protocolMagic").as[Long] == Right(magic),
+          s"protocolMagic must encode as the Long magic, not the params object; got ${encoded.noSpaces}"
+        )
+    }
+
+end CardanoNetworkCodecTest

--- a/src/test/scala/hydrozoa/config/head/network/CardanoNetworkCodecTest.scala
+++ b/src/test/scala/hydrozoa/config/head/network/CardanoNetworkCodecTest.scala
@@ -1,21 +1,22 @@
 package hydrozoa.config.head.network
 
+import hydrozoa.lib.cardano.scalus.codecs.json.Codecs.given
 import io.circe.syntax.*
 import org.scalatest.funsuite.AnyFunSuite
-import scalus.cardano.ledger.CardanoInfo
+import scalus.cardano.ledger.{CardanoInfo, ProtocolParams}
 
-/** Shape coverage for the [[CardanoNetwork]] JSON codec.
+/** Shape and round-trip coverage for the [[CardanoNetwork]] JSON codec.
   *
-  * The three standard networks encode as bare strings and round-trip. A `Custom` network encodes as
-  * `{ "custom": <CardanoInfo>, "protocolMagic": <Long> }`; this pins that `protocolMagic` is
-  * written as the magic (a number). A prior encoder bug wrote the protocol-params object under that
-  * key instead, dropping the magic entirely.
-  *
-  * Note: a full `Custom` decode is not asserted here because it additionally requires the
-  * `CardanoInfo` / `ProtocolParams` codec to round-trip, which is a separate open issue (the scalus
-  * blockfrost ReadWriter is write/read asymmetric) — see docs/local/integration/phases.md.
+  * The three standard networks encode as bare strings. A `Custom` network encodes as
+  * `{ "custom": <CardanoInfo>, "protocolMagic": <Long> }` and must round-trip in full, which relies
+  * on the structural `ProtocolParams` / `CardanoInfo` codec in
+  * [[hydrozoa.lib.cardano.scalus.codecs.json.Codecs]] preserving every field exactly.
   */
 class CardanoNetworkCodecTest extends AnyFunSuite:
+
+    // Real protocol params (with tiny ExUnitPrices) make these strong round-trip fixtures: they
+    // catch any precision loss a Double-routed codec would introduce.
+    private val infos = List(CardanoInfo.mainnet, CardanoInfo.preprod, CardanoInfo.preview)
 
     test("standard networks round-trip through JSON") {
         List(CardanoNetwork.Mainnet, CardanoNetwork.Preprod, CardanoNetwork.Preview).foreach { n =>
@@ -32,6 +33,26 @@ class CardanoNetworkCodecTest extends AnyFunSuite:
           encoded.hcursor.downField("protocolMagic").as[Long] == Right(magic),
           s"protocolMagic must encode as the Long magic, not the params object; got ${encoded.noSpaces}"
         )
+    }
+
+    test("ProtocolParams round-trips through JSON") {
+        infos.foreach { info =>
+            val pp = info.protocolParams
+            assert(
+              pp.asJson.as[ProtocolParams] == Right(pp),
+              s"ProtocolParams round-trip failed for ${info.network}"
+            )
+        }
+    }
+
+    test("a Custom network round-trips through JSON in full") {
+        infos.foreach { info =>
+            val custom: CardanoNetwork = CardanoNetwork.Custom(info, 42L)
+            assert(
+              custom.asJson.as[CardanoNetwork] == Right(custom),
+              s"Custom round-trip failed for ${info.network}"
+            )
+        }
     }
 
 end CardanoNetworkCodecTest


### PR DESCRIPTION
## What

The `Custom`-network JSON encoder wrote `cardanoInfo.protocolParams` under the `protocolMagic` key,
while the decoder reads a `Long` there — so a `Custom` network never round-tripped and the magic was
silently dropped. This emits the actual `protocolMagic`.

## Test

Adds `CardanoNetworkCodecTest`:

- the three standard networks round-trip through JSON;
- a `Custom` network encodes `protocolMagic` as the magic number (the exact regression).

## Impact / scope

Latent today — no `Custom` network is constructed anywhere yet — so there is no runtime impact; this
unblocks upcoming custom/devnet support.

Note: a *full* `Custom` decode additionally requires the `ProtocolParams` / `CardanoInfo` codec to
round-trip, which is a separate, deeper issue (the scalus blockfrost `ReadWriter` is write/read
asymmetric). This PR is the `CardanoNetwork`-level half.

Generated by Claude Opus 4.8 (1M context)
