### PR TITLE
fix(config): round-trip ProtocolParams/CardanoInfo JSON for Custom networks

### DIFF
--- a/src/main/scala/hydrozoa/lib/cardano/scalus/codecs/json/Codecs.scala
+++ b/src/main/scala/hydrozoa/lib/cardano/scalus/codecs/json/Codecs.scala
@@ -5,7 +5,7 @@ import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import io.circe.{Decoder, DecodingFailure, Encoder, Json, KeyDecoder, KeyEncoder, parser}
 import scala.util.Try
 import scalus.cardano.address.Network
-import scalus.cardano.ledger.{CardanoInfo, KeepRaw, ProtocolParams, SlotConfig, Transaction, TransactionHash, TransactionInput, TransactionOutput, Utxo}
+import scalus.cardano.ledger.{CardanoInfo, CostModels, DRepVotingThresholds, ExUnitPrices, ExUnits, KeepRaw, NonNegativeInterval, PoolVotingThresholds, ProtocolParams, ProtocolVersion, SlotConfig, Transaction, TransactionHash, TransactionInput, TransactionOutput, UnitInterval, Utxo}
 import scalus.crypto.ed25519.SigningKey
 import scalus.uplc.builtin.ByteString
 
@@ -13,21 +13,101 @@ import scalus.uplc.builtin.ByteString
   */
 object Codecs {
 
-    given protocolParamsDecoder: Decoder[ProtocolParams] = Decoder.decodeString.emap(rawString =>
-        Try(ProtocolParams.fromBlockfrostJson(rawString)).toEither.left.map(e =>
-            "ProtocolParams decoding failed. NOTE: we wrap the scalus blockfrost codec," +
-                s"which uses the upickle JSON library instead of circe. The message from upickle is: $e"
+    /** Symmetric, human-observable JSON codec for [[ProtocolParams]] and its nested field types.
+      *
+      * scalus provides only upickle codecs for `ProtocolParams`, and neither round-trips exactly:
+      * `blockfrostParamsReadWriter` is write/read asymmetric (its `cost_models` writer emits arrays
+      * while the reader expects objects), and `cardanoCliParamsReadWriter` routes the
+      * `UnitInterval`/`NonNegativeInterval` fields through `Double`, which is lossy (a mainnet
+      * `priceSteps` of `0.0000721` decodes back as `0.000072`). We instead derive circe codecs
+      * field-by-field from the record structure and serialize the two fraction types as exact
+      * `{ "numerator": <Long>, "denominator": <Long> }` objects, so a `Custom` head-config's
+      * `CardanoInfo` stays readable and survives a serialize/deserialize cycle unchanged.
+      *
+      * The leaf codecs are defined before the derived aggregates that summon them.
+      */
+
+    /** Shared `{ "numerator": <Long>, "denominator": <Long> }` shape for the two scalus fraction
+      * types. The decoder wraps construction in `Try` because both `require` a positive
+      * denominator, which keeps it total — a malformed fraction yields a `Left`, never a thrown
+      * exception.
+      */
+    private def fractionEncoder[A](numerator: A => Long, denominator: A => Long): Encoder[A] =
+        Encoder.instance(fraction =>
+            Json.obj(
+              "numerator" -> Json.fromLong(numerator(fraction)),
+              "denominator" -> Json.fromLong(denominator(fraction))
+            )
+        )
+
+    private def fractionDecoder[A](name: String)(build: (Long, Long) => A): Decoder[A] =
+        Decoder.instance(c =>
+            for {
+                numerator <- c.downField("numerator").as[Long]
+                denominator <- c.downField("denominator").as[Long]
+                fraction <- Try(build(numerator, denominator)).toEither.left.map(e =>
+                    DecodingFailure(s"Invalid $name: ${e.getMessage}", c.history)
+                )
+            } yield fraction
+        )
+
+    given nonNegativeIntervalEncoder: Encoder[NonNegativeInterval] =
+        fractionEncoder[NonNegativeInterval](_.numerator, _.denominator)
+    given nonNegativeIntervalDecoder: Decoder[NonNegativeInterval] =
+        fractionDecoder("NonNegativeInterval")((numerator, denominator) =>
+            NonNegativeInterval(numerator, denominator)
+        )
+
+    given unitIntervalEncoder: Encoder[UnitInterval] =
+        fractionEncoder[UnitInterval](_.numerator, _.denominator)
+    given unitIntervalDecoder: Decoder[UnitInterval] =
+        fractionDecoder("UnitInterval")((numerator, denominator) =>
+            UnitInterval(numerator, denominator)
+        )
+
+    /** `cost_models` serialize as a JSON object keyed by language id (`"0"`, `"1"`, `"2"`), each
+      * mapped to its cost list. Keys are emitted in id order for a deterministic encoding.
+      */
+    given costModelsEncoder: Encoder[CostModels] = Encoder.instance(costModels =>
+        Json.obj(
+          costModels.models.toSeq.sortBy(_._1).map { case (languageId, costs) =>
+              languageId.toString -> Json.arr(costs.map(Json.fromLong)*)
+          }*
         )
     )
 
-    given protocolParamsEncoder: Encoder[ProtocolParams] with {
-        override def apply(pp: ProtocolParams): Json = {
-            val scalusSerialization =
-                upickle.write(pp)(using ProtocolParams.blockfrostParamsReadWriter)
-            val Right(json) = parser.parse(scalusSerialization): @unchecked
-            json
-        }
-    }
+    given costModelsDecoder: Decoder[CostModels] = Decoder.instance(c =>
+        for {
+            raw <- c.as[Map[String, List[Long]]]
+            models <- Try(
+              raw.map { case (languageId, costs) => languageId.toInt -> costs.toIndexedSeq }
+            ).toEither.left.map(e =>
+                DecodingFailure(s"Invalid CostModels: ${e.getMessage}", c.history)
+            )
+        } yield CostModels(models)
+    )
+
+    given protocolVersionEncoder: Encoder[ProtocolVersion] = deriveEncoder[ProtocolVersion]
+    given protocolVersionDecoder: Decoder[ProtocolVersion] = deriveDecoder[ProtocolVersion]
+
+    given exUnitsEncoder: Encoder[ExUnits] = deriveEncoder[ExUnits]
+    given exUnitsDecoder: Decoder[ExUnits] = deriveDecoder[ExUnits]
+
+    given exUnitPricesEncoder: Encoder[ExUnitPrices] = deriveEncoder[ExUnitPrices]
+    given exUnitPricesDecoder: Decoder[ExUnitPrices] = deriveDecoder[ExUnitPrices]
+
+    given drepVotingThresholdsEncoder: Encoder[DRepVotingThresholds] =
+        deriveEncoder[DRepVotingThresholds]
+    given drepVotingThresholdsDecoder: Decoder[DRepVotingThresholds] =
+        deriveDecoder[DRepVotingThresholds]
+
+    given poolVotingThresholdsEncoder: Encoder[PoolVotingThresholds] =
+        deriveEncoder[PoolVotingThresholds]
+    given poolVotingThresholdsDecoder: Decoder[PoolVotingThresholds] =
+        deriveDecoder[PoolVotingThresholds]
+
+    given protocolParamsEncoder: Encoder[ProtocolParams] = deriveEncoder[ProtocolParams]
+    given protocolParamsDecoder: Decoder[ProtocolParams] = deriveDecoder[ProtocolParams]
 
     given cardanoInfoEncoder: Encoder[CardanoInfo] = deriveEncoder[CardanoInfo]
 

--- a/src/main/scala/hydrozoa/lib/cardano/scalus/codecs/json/Codecs.scala
+++ b/src/main/scala/hydrozoa/lib/cardano/scalus/codecs/json/Codecs.scala
@@ -24,33 +24,9 @@ object Codecs {
       * `{ "numerator": <Long>, "denominator": <Long> }` objects, so a `Custom` head-config's
       * `CardanoInfo` stays readable and survives a serialize/deserialize cycle unchanged.
       *
-      * The leaf codecs are defined before the derived aggregates that summon them.
+      * The leaf codecs are defined before the derived aggregates that summon them; the two private
+      * fraction helpers they share sit at the foot of the object, per the file's ordering rule.
       */
-
-    /** Shared `{ "numerator": <Long>, "denominator": <Long> }` shape for the two scalus fraction
-      * types. The decoder wraps construction in `Try` because both `require` a positive
-      * denominator, which keeps it total — a malformed fraction yields a `Left`, never a thrown
-      * exception.
-      */
-    private def fractionEncoder[A](numerator: A => Long, denominator: A => Long): Encoder[A] =
-        Encoder.instance(fraction =>
-            Json.obj(
-              "numerator" -> Json.fromLong(numerator(fraction)),
-              "denominator" -> Json.fromLong(denominator(fraction))
-            )
-        )
-
-    private def fractionDecoder[A](name: String)(build: (Long, Long) => A): Decoder[A] =
-        Decoder.instance(c =>
-            for {
-                numerator <- c.downField("numerator").as[Long]
-                denominator <- c.downField("denominator").as[Long]
-                fraction <- Try(build(numerator, denominator)).toEither.left.map(e =>
-                    DecodingFailure(s"Invalid $name: ${e.getMessage}", c.history)
-                )
-            } yield fraction
-        )
-
     given nonNegativeIntervalEncoder: Encoder[NonNegativeInterval] =
         fractionEncoder[NonNegativeInterval](_.numerator, _.denominator)
     given nonNegativeIntervalDecoder: Decoder[NonNegativeInterval] =
@@ -88,7 +64,20 @@ object Codecs {
     )
 
     given protocolVersionEncoder: Encoder[ProtocolVersion] = deriveEncoder[ProtocolVersion]
-    given protocolVersionDecoder: Decoder[ProtocolVersion] = deriveDecoder[ProtocolVersion]
+
+    /** `ProtocolVersion` `require`s `major >= 1` and `minor >= 0`, so — like the fraction decoders
+      * — construction is wrapped in `Try` to keep the decoder total instead of letting circe's
+      * derivation throw the constructor `require` on malformed input.
+      */
+    given protocolVersionDecoder: Decoder[ProtocolVersion] = Decoder.instance(c =>
+        for {
+            major <- c.downField("major").as[Int]
+            minor <- c.downField("minor").as[Int]
+            version <- Try(ProtocolVersion(major, minor)).toEither.left.map(e =>
+                DecodingFailure(s"Invalid ProtocolVersion: ${e.getMessage}", c.history)
+            )
+        } yield version
+    )
 
     given exUnitsEncoder: Encoder[ExUnits] = deriveEncoder[ExUnits]
     given exUnitsDecoder: Decoder[ExUnits] = deriveDecoder[ExUnits]
@@ -109,10 +98,6 @@ object Codecs {
     given protocolParamsEncoder: Encoder[ProtocolParams] = deriveEncoder[ProtocolParams]
     given protocolParamsDecoder: Decoder[ProtocolParams] = deriveDecoder[ProtocolParams]
 
-    given cardanoInfoEncoder: Encoder[CardanoInfo] = deriveEncoder[CardanoInfo]
-
-    given cardanoInfoDecoder: Decoder[CardanoInfo] = deriveDecoder[CardanoInfo]
-
     given networkEncoder: Encoder[Network] = deriveEncoder[Network]
 
     given networkDecoder: Decoder[Network] = deriveDecoder[Network]
@@ -120,6 +105,11 @@ object Codecs {
     given slotConfigEncoder: Encoder[SlotConfig] = deriveEncoder[SlotConfig]
 
     given slotConfigDecoder: Decoder[SlotConfig] = deriveDecoder[SlotConfig]
+
+    // CardanoInfo aggregates ProtocolParams, Network, and SlotConfig, so its codecs follow theirs.
+    given cardanoInfoEncoder: Encoder[CardanoInfo] = deriveEncoder[CardanoInfo]
+
+    given cardanoInfoDecoder: Decoder[CardanoInfo] = deriveDecoder[CardanoInfo]
 
     given utxoEncoder: Encoder[Utxo] = deriveEncoder[Utxo]
 
@@ -250,5 +240,29 @@ object Codecs {
                 case _ => None
             }
     }
+
+    /** Shared `{ "numerator": <Long>, "denominator": <Long> }` shape for the two scalus fraction
+      * types ([[NonNegativeInterval]], [[UnitInterval]]). The decoder wraps construction in `Try`
+      * because both `require` a positive denominator, which keeps it total — a malformed fraction
+      * yields a `Left`, never a thrown exception.
+      */
+    private def fractionEncoder[A](numerator: A => Long, denominator: A => Long): Encoder[A] =
+        Encoder.instance(fraction =>
+            Json.obj(
+              "numerator" -> Json.fromLong(numerator(fraction)),
+              "denominator" -> Json.fromLong(denominator(fraction))
+            )
+        )
+
+    private def fractionDecoder[A](name: String)(build: (Long, Long) => A): Decoder[A] =
+        Decoder.instance(c =>
+            for {
+                numerator <- c.downField("numerator").as[Long]
+                denominator <- c.downField("denominator").as[Long]
+                fraction <- Try(build(numerator, denominator)).toEither.left.map(e =>
+                    DecodingFailure(s"Invalid $name: ${e.getMessage}", c.history)
+                )
+            } yield fraction
+        )
 
 }

--- a/src/test/scala/hydrozoa/config/head/network/CardanoNetworkCodecTest.scala
+++ b/src/test/scala/hydrozoa/config/head/network/CardanoNetworkCodecTest.scala
@@ -1,9 +1,10 @@
 package hydrozoa.config.head.network
 
 import hydrozoa.lib.cardano.scalus.codecs.json.Codecs.given
+import io.circe.Json
 import io.circe.syntax.*
 import org.scalatest.funsuite.AnyFunSuite
-import scalus.cardano.ledger.{CardanoInfo, ProtocolParams}
+import scalus.cardano.ledger.{CardanoInfo, ProtocolParams, ProtocolVersion}
 
 /** Shape and round-trip coverage for the [[CardanoNetwork]] JSON codec.
   *
@@ -53,6 +54,16 @@ class CardanoNetworkCodecTest extends AnyFunSuite:
               s"Custom round-trip failed for ${info.network}"
             )
         }
+    }
+
+    test("a malformed ProtocolVersion decodes to a Left, not a thrown exception") {
+        // ProtocolVersion requires major >= 1; a derived decoder would let that require throw. The
+        // total decoder must surface it as a DecodingFailure (a Left) instead.
+        val badVersion = Json.obj("major" -> Json.fromInt(0), "minor" -> Json.fromInt(0))
+        assert(
+          badVersion.as[ProtocolVersion].isLeft,
+          s"expected a Left for major=0, got ${badVersion.as[ProtocolVersion]}"
+        )
     }
 
 end CardanoNetworkCodecTest

--- a/src/test/scala/hydrozoa/config/head/network/CardanoNetworkCodecTest.scala
+++ b/src/test/scala/hydrozoa/config/head/network/CardanoNetworkCodecTest.scala
@@ -1,21 +1,22 @@
 package hydrozoa.config.head.network
 
+import hydrozoa.lib.cardano.scalus.codecs.json.Codecs.given
 import io.circe.syntax.*
 import org.scalatest.funsuite.AnyFunSuite
-import scalus.cardano.ledger.CardanoInfo
+import scalus.cardano.ledger.{CardanoInfo, ProtocolParams}
 
-/** Shape coverage for the [[CardanoNetwork]] JSON codec.
+/** Shape and round-trip coverage for the [[CardanoNetwork]] JSON codec.
   *
-  * The three standard networks encode as bare strings and round-trip. A `Custom` network encodes as
-  * `{ "custom": <CardanoInfo>, "protocolMagic": <Long> }`; this pins that `protocolMagic` is
-  * written as the magic (a number). A prior encoder bug wrote the protocol-params object under that
-  * key instead, dropping the magic entirely.
-  *
-  * Note: a full `Custom` decode is not asserted here because it additionally requires the
-  * `CardanoInfo` / `ProtocolParams` codec to round-trip, which is a separate open issue (the scalus
-  * blockfrost ReadWriter is write/read asymmetric) — see docs/local/integration/phases.md.
+  * The three standard networks encode as bare strings. A `Custom` network encodes as
+  * `{ "custom": <CardanoInfo>, "protocolMagic": <Long> }` and must round-trip in full, which relies
+  * on the structural `ProtocolParams` / `CardanoInfo` codec in
+  * [[hydrozoa.lib.cardano.scalus.codecs.json.Codecs]] preserving every field exactly.
   */
 class CardanoNetworkCodecTest extends AnyFunSuite:
+
+    // Real protocol params (with tiny ExUnitPrices) make these strong round-trip fixtures: they
+    // catch any precision loss a Double-routed codec would introduce.
+    private val infos = List(CardanoInfo.mainnet, CardanoInfo.preprod, CardanoInfo.preview)
 
     test("standard networks round-trip through JSON") {
         List(CardanoNetwork.Mainnet, CardanoNetwork.Preprod, CardanoNetwork.Preview).foreach { n =>
@@ -32,6 +33,26 @@ class CardanoNetworkCodecTest extends AnyFunSuite:
           encoded.hcursor.downField("protocolMagic").as[Long] == Right(magic),
           s"protocolMagic must encode as the Long magic, not the params object; got ${encoded.noSpaces}"
         )
+    }
+
+    test("ProtocolParams round-trips through JSON") {
+        infos.foreach { info =>
+            val pp = info.protocolParams
+            assert(
+              pp.asJson.as[ProtocolParams] == Right(pp),
+              s"ProtocolParams round-trip failed for ${info.network}"
+            )
+        }
+    }
+
+    test("a Custom network round-trips through JSON in full") {
+        infos.foreach { info =>
+            val custom: CardanoNetwork = CardanoNetwork.Custom(info, 42L)
+            assert(
+              custom.asJson.as[CardanoNetwork] == Right(custom),
+              s"Custom round-trip failed for ${info.network}"
+            )
+        }
     }
 
 end CardanoNetworkCodecTest


### PR DESCRIPTION
## What & why

A `Custom` (e.g. Yaci devnet) head-config must serialize its `CardanoInfo` and read it back on `serve`, but the `ProtocolParams` / `CardanoInfo` circe codec did not round-trip:

- hydrozoa's wrapper was internally mismatched — the encoder emitted a JSON **object** while the decoder expected a JSON **string**.
- scalus itself exposes no exact round-tripping JSON codec for `ProtocolParams`: `blockfrostParamsReadWriter` is write/read asymmetric (its `cost_models` writer emits arrays, the reader expects objects → upickle `TraceException`), and `cardanoCliParamsReadWriter` routes `UnitInterval` / `NonNegativeInterval` through `Double`, which is lossy (a mainnet `priceSteps` of `0.0000721` decodes back as `0.000072`).

This blocked Phase 0b/1 custom-network work — a `Custom` head-config could not fully deserialize.

## What changed

`Codecs.scala` now derives a **structural, human-observable** circe codec for `ProtocolParams`, preserving every field exactly:

- `UnitInterval` / `NonNegativeInterval` → exact `{ "numerator": <Long>, "denominator": <Long> }` (shared `fraction*` helper; `Try`-wrapped so the decoders stay total, since both constructors `require` a positive denominator)
- `cost_models` → id-keyed object (`"0"`, `"1"`, `"2"`)
- `ProtocolVersion` decoder is likewise `Try`-wrapped (it `require`s `major >= 1`), keeping the whole `ProtocolParams` decode total
- everything else (`ExUnits`, `ExUnitPrices`, both voting-thresholds, `ProtocolParams`) derived from the record structure

This makes `ProtocolParams` consistent with its already-derived container/siblings (`CardanoInfo`, `Network`, `SlotConfig`, `Utxo`) rather than being the lone opaque-string exception.

## Tests

`CardanoNetworkCodecTest` asserts a direct `ProtocolParams` round-trip and a full `Custom`-network round-trip over the real mainnet/preprod/preview params — strong fixtures, since their tiny `ExUnitPrices` expose any precision loss — plus a regression test that a malformed `ProtocolVersion` decodes to a `Left` rather than throwing. All pass; `CI=true sbt Test/compile` (`-Werror`) clean.

## Review notes

Ran `/simplify` (deduped the interval codecs into the shared `fraction*` helper; flattened `costModelsDecoder`) and `/code-review`. The review **refuted the main risk** — the encoding-format change can't break existing consumers, because the old codec was already broken (encoder emitted an object, decoder expected a string), so no working old-format `Custom` config exists, and standard networks encode as bare strings. Its robustness findings are addressed here: total `ProtocolVersion` decoder, leaf-before-aggregate codec ordering, and private-helper placement.

**Known limitation (pre-existing, low severity):** the derived decoders don't honor case-class default parameters, so a hand-authored `Custom` config that *omits* a defaulted `SlotConfig` field (`epochLength`, `zeroEpoch`) fails to decode rather than falling back to the default. Round-trips are unaffected (the encoder always emits all fields); closing this would mean switching to configured decoders file-wide.

---

Delivers anthill **WI-005**. Stacked on #567 (the `Custom` protocolMagic encoder fix it builds on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019kwekvQLBqvm8n9oXaU194
