### PR TITLE
chore(release): bump version to 0.1.1

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -226,7 +226,9 @@ Set `blockfrostApiKey` in `head/template/peer-private.template.json.local` (scaf
 Nix users create it with `just scaffold`).
 
 - **Blockfrost key** — keygen-fleet reads only the `.local` file and refuses to run without it,
-  so the real key never lands in a committed file.
+  so the real key never lands in a committed file. The build steps that query the chain
+  (`build-head-config`, `deploy-scripts-and-g2-setup`) fall back to this same `blockfrostApiKey`
+  unless you pass `--blockfrost-key` / `$BLOCKFROST_API_KEY`, so you set the key once, here.
 - **Cardano network** — the key's prefix (`preview…` / `preprod…` / `mainnet…`) selects the
   network for everything downstream: the `cardanoNetwork` seeded into `defaults.json` and the
   target of `deploy-scripts-and-g2-setup`.

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -115,8 +115,20 @@ docker run --rm -v "$PWD:/work" -w /work --user root \
 # writes docker-compose.yml, hydrozoa.sh, head/template/peer-private.template.json.local
 ```
 
-Set `blockfrostApiKey` in `head/template/peer-private.template.json.local`, then `source
-./hydrozoa.sh` (sets the `hydrozoa` alias + `HYDROZOA_HOME=./head/demo`).
+Then load the CLI alias and check you are on the version you expect:
+
+```bash
+source ./hydrozoa.sh   # sets the `hydrozoa` alias + HYDROZOA_HOME=./head/demo
+
+hydrozoa version       # verify the image you are running
+#   hydrozoa 0.1.1
+#   git:   v0.1.1
+#   built: 2026-07-28 14:00:37.834-0600
+```
+
+(The `git:` line is `git describe` provenance; a published image built from the `v0.1.1` tag reads a
+clean `v0.1.1`. A locally built image between releases shows the distance from the newest tag, e.g.
+`v0.1.0-10-gaa9d7c69`.)
 
 Need a version that isn't in the registry? Build it from this repo — see §3.
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -208,7 +208,7 @@ pipeline turns operator-authored files into the two runtime files each node need
                                       │
    deploy-scripts-and-g2-setup        │
    (head-0 wallet, Blockfrost)        │
-   └─ bootstrap/ref-utxos.json ─────┤  the on-chain reference UTxOs: treasury + dispute
+   └─ bootstrap/ref-utxos.json ───────┤  the on-chain reference UTxOs: treasury + dispute
                                       │  validators and the G2 setup ladder (falls back to the
                                       │  per-network default baked into the image)
                                       │

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -109,9 +109,9 @@ workspace from it:
 
 ```bash
 mkdir myhead && cd myhead
-docker pull ghcr.io/cardano-hydrozoa/hydrozoa:0.1.0
+docker pull ghcr.io/cardano-hydrozoa/hydrozoa:0.1.1
 docker run --rm -v "$PWD:/work" -w /work --user root \
-  ghcr.io/cardano-hydrozoa/hydrozoa:0.1.0 scaffold .
+  ghcr.io/cardano-hydrozoa/hydrozoa:0.1.1 scaffold .
 # writes docker-compose.yml, hydrozoa.sh, head/template/peer-private.template.json.local
 ```
 
@@ -141,8 +141,8 @@ Two ways to use your build:
 `docker compose` (§5) at it with `HYDROZOA_IMAGE`:
 
 ```bash
-just docker-image      # -> cardano-hydrozoa/hydrozoa:0.1.0 (base eclipse-temurin:25-jre, EXPOSE 8080)
-# then: HYDROZOA_IMAGE=cardano-hydrozoa/hydrozoa:0.1.0 docker compose up -d
+just docker-image      # -> cardano-hydrozoa/hydrozoa:0.1.1 (base eclipse-temurin:25-jre, EXPOSE 8080)
+# then: HYDROZOA_IMAGE=cardano-hydrozoa/hydrozoa:0.1.1 docker compose up -d
 ```
 
 **Locally-compiled code (development)** — `just stage` builds the `hydrozoa` launcher from the
@@ -337,8 +337,8 @@ At this point every node has its two files, and the composition (§5) mounts
 
 - Config mounts come from `${HYDROZOA_HOME:-./head/demo}`: the shared `head-config.json` plus
   `head-N/private.json` or `coil-N/private.json` per node. The image defaults to the published
-  `ghcr.io/cardano-hydrozoa/hydrozoa:0.1.0` (pulled on first run); set `${HYDROZOA_IMAGE}` to use
-  another, e.g. a locally built `cardano-hydrozoa/hydrozoa:0.1.0`.
+  `ghcr.io/cardano-hydrozoa/hydrozoa:0.1.1` (pulled on first run); set `${HYDROZOA_IMAGE}` to use
+  another, e.g. a locally built `cardano-hydrozoa/hydrozoa:0.1.1`.
 
 Caveats:
 - **State is ephemeral.** No data volumes are mounted (only read-only config bind mounts), so both
@@ -358,14 +358,14 @@ Caveats:
 Default — pull the published image and run `head/demo`:
 
 ```bash
-docker compose up -d           # pulls ghcr.io/cardano-hydrozoa/hydrozoa:0.1.0 on first run
+docker compose up -d           # pulls ghcr.io/cardano-hydrozoa/hydrozoa:0.1.1 on first run
 ```
 
-**Another image** — `HYDROZOA_IMAGE` (default `ghcr.io/cardano-hydrozoa/hydrozoa:0.1.0`), e.g. a
+**Another image** — `HYDROZOA_IMAGE` (default `ghcr.io/cardano-hydrozoa/hydrozoa:0.1.1`), e.g. a
 locally built one (§3):
 
 ```bash
-HYDROZOA_IMAGE=cardano-hydrozoa/hydrozoa:0.1.0 docker compose up -d
+HYDROZOA_IMAGE=cardano-hydrozoa/hydrozoa:0.1.1 docker compose up -d
 ```
 
 **Another configuration** — `HYDROZOA_HOME` (default `./head/demo`) selects the directory each

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,9 +10,19 @@ the image with `sbt Docker/stage` and pushes it to ghcr. No manual `docker push`
 
 ## Making a release
 
-1. **Pick the version** and set it in `build.sbt` (`inThisBuild { version := "X.Y.Z" }`). This
-   drives the image tag, `hydrozoa.BuildInfo.version`, and `GET /version` — keep it equal to the
-   git tag below. Commit the bump on `main` (via PR; `main` is protected).
+1. **Bump the version** to `X.Y.Z`. The release version lives in `build.sbt`
+   (`inThisBuild { version := "X.Y.Z" }`) and drives the image tag, `hydrozoa.BuildInfo.version`,
+   and `GET /version` — keep it equal to the git tag below. The same image tag is **hard-coded** in
+   a few deployment files that do *not* read `build.sbt`, so bump them in lockstep:
+
+   - `hydrozoa.sh` — `HYDROZOA_VERSION` default
+   - `docker-compose.yml` — the default `${HYDROZOA_IMAGE:-ghcr.io/cardano-hydrozoa/hydrozoa:X.Y.Z}`
+   - `DEPLOYMENT.md` — the `…/hydrozoa:X.Y.Z` pull/run examples
+
+   Catch stragglers with `grep -rn "hydrozoa:<previous-version>"` (and the bare previous version in
+   `hydrozoa.sh`). Not bumped: `HydrozoaRoutes.apiVersion` + `docs/openapi*.yaml` (the API-contract
+   version, separate from the release version). Commit the bump on `main` (via PR; `main` is
+   protected).
 
 2. **Sanity-check the image locally** (optional but recommended):
 

--- a/build.sbt
+++ b/build.sbt
@@ -296,7 +296,7 @@ inThisBuild(
   List(
     // Release version — drives the Docker image tag, `hydrozoa.BuildInfo.version`, and `GET
     // /version`. Bump here for a release (see RELEASE.md), then tag `v<version>`.
-    version := "0.1.0",
+    version := "0.1.1",
     scalaVersion := "3.3.7",
     semanticdbEnabled := true,
     semanticdbVersion := scalafixSemanticdb.revision

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ networks:
       com.docker.network.driver.mtu: 1400
 
 x-hydrozoa: &hydrozoa
-  image: ${HYDROZOA_IMAGE:-ghcr.io/cardano-hydrozoa/hydrozoa:0.1.0}
+  image: ${HYDROZOA_IMAGE:-ghcr.io/cardano-hydrozoa/hydrozoa:0.1.1}
   # root: the image's non-root user cannot write the RocksDB stores / logs under the /opt/docker
   # workdir. State is ephemeral here (no volumes) — restarting re-initializes a fresh head (§5b).
   user: root

--- a/hydrozoa.sh
+++ b/hydrozoa.sh
@@ -7,7 +7,7 @@
 #
 # Override the version or head directory before sourcing (or edit the defaults below). HYDROZOA_HOME
 # is the one head directory the CLI and `docker compose` (DEPLOYMENT.md §4) both read.
-: "${HYDROZOA_VERSION:=0.1.0}"      # published image tag (ghcr.io/cardano-hydrozoa/hydrozoa)
+: "${HYDROZOA_VERSION:=0.1.1}"      # published image tag (ghcr.io/cardano-hydrozoa/hydrozoa)
 : "${HYDROZOA_HOME:=./head/demo}"  # head directory
 export HYDROZOA_VERSION HYDROZOA_HOME
 

--- a/hydrozoa.sh
+++ b/hydrozoa.sh
@@ -1,9 +1,11 @@
 # Source this to get the `hydrozoa` Docker CLI alias, so you don't retype the docker run flags:
 #
-#     export BLOCKFROST_API_KEY=preview…      # your key (a secret — not stored here)
 #     source ./hydrozoa.sh
 #     hydrozoa keygen-fleet 2 4 2
 #     hydrozoa build-head-config
+#
+# The Blockfrost key comes from head/template/peer-private.template.json.local (`blockfrostApiKey`);
+# `export BLOCKFROST_API_KEY=preview…` before sourcing overrides it for the chain-querying commands.
 #
 # Override the version or head directory before sourcing (or edit the defaults below). HYDROZOA_HOME
 # is the one head directory the CLI and `docker compose` (DEPLOYMENT.md §4) both read.

--- a/src/main/resources/scaffold/peer-private.template.json
+++ b/src/main/resources/scaffold/peer-private.template.json
@@ -13,7 +13,7 @@
     }
   },
   "nodeOperationMultisigConfig": {
-    "cardanoLiaisonPollingPeriod": 10000,
+    "cardanoLiaisonPollingPeriod": 20000,
     "peerLiaisonMaxRequestsPerBatch": 42,
     "peerLiaisonResendInterval": 5000,
     "rateLimits": {

--- a/src/main/scala/hydrozoa/app/DeployScriptsAndG2Setup.scala
+++ b/src/main/scala/hydrozoa/app/DeployScriptsAndG2Setup.scala
@@ -63,14 +63,15 @@ object DeployScriptsAndG2Setup:
         ).map(Path.of(_))
             .orNone
 
-    private val blockfrostKeyOpt: Opts[String] =
+    private val blockfrostKeyOpt: Opts[Option[String]] =
         Opts.option[String](
           "blockfrost-key",
-          "Blockfrost API key for the Cardano backend (falls back to $BLOCKFROST_API_KEY)",
+          "Blockfrost API key for the Cardano backend (falls back to $BLOCKFROST_API_KEY, then the " +
+              "template's blockfrostApiKey)",
           short = "k"
         ).orElse(
           Opts.env[String]("BLOCKFROST_API_KEY", "Blockfrost API key for the Cardano backend")
-        )
+        ).orNone
 
     private val ladderRefsOpt: Opts[Option[Path]] =
         Opts.option[String](
@@ -89,10 +90,10 @@ object DeployScriptsAndG2Setup:
 
     private def runOpts: Opts[IO[ExitCode]] =
         (Bootstrap.homeOpt, walletOpt, blockfrostKeyOpt, ladderRefsOpt).mapN(
-          (home, walletOverride, key, ladder) =>
+          (home, walletOverride, mbKey, ladder) =>
               deployScriptsAndG2Setup(
                 walletOverride.getOrElse(Bootstrap.HomeLayout.privateConfig(home, "head-0")),
-                key,
+                mbKey,
                 ladder,
                 Bootstrap.HomeLayout.refUtxos(home)
               )
@@ -100,17 +101,26 @@ object DeployScriptsAndG2Setup:
 
     private def deployScriptsAndG2Setup(
         walletPath: Path,
-        blockfrostKey: String,
+        mbBlockfrostKey: Option[String],
         ladderRefsPath: Option[Path],
         outPath: Path
-    ): IO[ExitCode] = IO
-        .fromEither[StandardCardanoNetwork](
-          networkOfBlockfrostKey(blockfrostKey)
-        )
-        .flatMap { (cardanoNetwork: StandardCardanoNetwork) =>
-            given CardanoNetwork.Section = cardanoNetwork
-            deployOn(cardanoNetwork, walletPath, blockfrostKey, ladderRefsPath, outPath)
-        }
+    ): IO[ExitCode] =
+        for {
+            // No --blockfrost-key / $BLOCKFROST_API_KEY → fall back to the key set in the template.
+            blockfrostKey <- mbBlockfrostKey.fold(
+              log.info(
+                "no --blockfrost-key / $BLOCKFROST_API_KEY; using blockfrostApiKey from " +
+                    s"${Bootstrap.defaultPrivateTemplate}"
+              ) *> Bootstrap.blockfrostKeyFrom(Bootstrap.defaultPrivateTemplate)
+            )(IO.pure)
+            cardanoNetwork <- IO.fromEither[StandardCardanoNetwork](
+              networkOfBlockfrostKey(blockfrostKey)
+            )
+            exit <- {
+                given CardanoNetwork.Section = cardanoNetwork
+                deployOn(cardanoNetwork, walletPath, blockfrostKey, ladderRefsPath, outPath)
+            }
+        } yield exit
 
     private def deployOn(
         cardanoNetwork: StandardCardanoNetwork,

--- a/src/main/scala/hydrozoa/app/cli/SubmitDeposit.scala
+++ b/src/main/scala/hydrozoa/app/cli/SubmitDeposit.scala
@@ -157,17 +157,38 @@ object SubmitDeposit:
                     )
                 _ <- IO.println(s"Submitted deposit tx ${signed.id} to L1; waiting for the utxo…")
                 _ <- awaitUtxo(backend, depositTx.depositProduced.utxoId)
-                _ <- IO.println(
-                  "Deposit is on L1. The head absorbs it after maturity — watch the spawned " +
-                      "outputs:\n" +
-                      outputs.toList
-                          .flatMap((address, _) => address.toBech32.toOption)
-                          .distinct
-                          .map(dest => s"  GET $headUri/l2/cardano-eutxo/utxos/$dest")
-                          .mkString("\n")
-                )
+                _ <- {
+                    val txLine = cexplorerTxUrl(config.cardanoNetwork, signed.id.toHex)
+                        .fold(s"  deposit tx:      ${signed.id.toHex}")(url =>
+                            s"  deposit tx:      $url"
+                        )
+                    val requestLine =
+                        s"  request details: GET $headUri/head/requests/${requestId.asI64}"
+                    val watchLines = outputs.toList
+                        .flatMap((address, _) => address.toBech32.toOption)
+                        .distinct
+                        .map(dest => s"    GET $headUri/l2/cardano-eutxo/utxos/$dest")
+                        .mkString("\n")
+                    IO.println(
+                      "Deposit is on L1. The head absorbs it after maturity.\n" +
+                          s"$txLine\n$requestLine\n" +
+                          "  spawned outputs (watch after absorption):\n" +
+                          watchLines
+                    )
+                }
             } yield ExitCode.Success
         }
+
+    /** cexplorer.io transaction URL for the head's network; `None` for a Custom network, which has
+      * no public explorer.
+      */
+    private def cexplorerTxUrl(network: CardanoNetwork, txHex: String): Option[String] =
+        val subdomain = network match
+            case CardanoNetwork.Mainnet   => Some("")
+            case CardanoNetwork.Preprod   => Some("preprod.")
+            case CardanoNetwork.Preview   => Some("preview.")
+            case _: CardanoNetwork.Custom => None
+        subdomain.map(s => s"https://${s}cexplorer.io/tx/$txHex")
 
     /** Poll L1 until the deposit utxo is visible (5s intervals, 3 minutes). */
     private def awaitUtxo(

--- a/src/main/scala/hydrozoa/app/cli/SubmitDeposit.scala
+++ b/src/main/scala/hydrozoa/app/cli/SubmitDeposit.scala
@@ -158,8 +158,13 @@ object SubmitDeposit:
                 _ <- IO.println(s"Submitted deposit tx ${signed.id} to L1; waiting for the utxo…")
                 _ <- awaitUtxo(backend, depositTx.depositProduced.utxoId)
                 _ <- IO.println(
-                  "Deposit is on L1. The head absorbs it after maturity — watch " +
-                      s"GET $headUri/l2/cardano-eutxo/utxos/{destination} for the spawned outputs."
+                  "Deposit is on L1. The head absorbs it after maturity — watch the spawned " +
+                      "outputs:\n" +
+                      outputs.toList
+                          .flatMap((address, _) => address.toBech32.toOption)
+                          .distinct
+                          .map(dest => s"  GET $headUri/l2/cardano-eutxo/utxos/$dest")
+                          .mkString("\n")
                 )
             } yield ExitCode.Success
         }

--- a/src/main/scala/hydrozoa/bootstrap/Bootstrap.scala
+++ b/src/main/scala/hydrozoa/bootstrap/Bootstrap.scala
@@ -100,6 +100,31 @@ object Bootstrap:
             home.resolve("head-config").resolve("head-config.json")
     }
 
+    /** The scaffolded private-config template. `keygen-fleet` reads its `blockfrostApiKey` (to
+      * derive the network and to fill each peer's `private.json`); the build commands
+      * (`build-head-config`, `deploy-scripts-and-g2-setup`) fall back to it for the Cardano backend
+      * key when neither `--blockfrost-key` nor `$BLOCKFROST_API_KEY` is given — so the key set once
+      * in the template is the single source.
+      */
+    val defaultPrivateTemplate: Path =
+        Path.of("head/template/peer-private.template.json.local")
+
+    private val blockfrostKeyRe = """"blockfrostApiKey"\s*:\s*"([^"]*)"""".r
+
+    /** Extract `blockfrostApiKey` from a private-config JSON (the template, or a peer's filled
+      * `private.json`). Fails if the field is absent.
+      */
+    def blockfrostKeyFrom(privateConfig: Path): IO[String] =
+        for {
+            content <- IO.blocking(Files.readString(privateConfig))
+            key <- IO.fromOption(blockfrostKeyRe.findFirstMatchIn(content).map(_.group(1)))(
+              RuntimeException(
+                s"no blockfrostApiKey found in $privateConfig — pass --blockfrost-key or set " +
+                    "$BLOCKFROST_API_KEY"
+              )
+            )
+        } yield key
+
     // Shared peer-topology decoders, used by both `Membership` (the roster) and `BootstrapConfig`
     // (the full config). Nested in the enclosing object so both companions see them.
     private given Decoder[Uri] =
@@ -1031,14 +1056,15 @@ object BuildHeadConfig:
 
     private val logger = Logging.loggerIO("hydrozoa.bootstrap.BuildHeadConfig")
 
-    private val blockfrostKeyOpt: Opts[String] =
+    private val blockfrostKeyOpt: Opts[Option[String]] =
         Opts.option[String](
           "blockfrost-key",
-          "Blockfrost API key for the Cardano backend (falls back to $BLOCKFROST_API_KEY)",
+          "Blockfrost API key for the Cardano backend (falls back to $BLOCKFROST_API_KEY, then the " +
+              "template's blockfrostApiKey)",
           short = "k"
         ).orElse(
           Opts.env[String]("BLOCKFROST_API_KEY", "Blockfrost API key for the Cardano backend")
-        )
+        ).orNone
 
     /** The `build-head-config` subcommand. */
     lazy val command: Command[IO[ExitCode]] =
@@ -1048,20 +1074,27 @@ object BuildHeadConfig:
         )(runOpts)
 
     private def runOpts: Opts[IO[ExitCode]] =
-        (Bootstrap.homeOpt, blockfrostKeyOpt).mapN((home, key) =>
+        (Bootstrap.homeOpt, blockfrostKeyOpt).mapN((home, mbKey) =>
             buildHeadConfig(
               Bootstrap.HomeLayout.bootstrapDir(home),
-              key,
+              mbKey,
               Bootstrap.HomeLayout.headConfig(home)
             )
         )
 
     private def buildHeadConfig(
         bootstrapDir: Path,
-        blockfrostKey: String,
+        mbBlockfrostKey: Option[String],
         outPath: Path
     ): IO[ExitCode] =
         for {
+            // No --blockfrost-key / $BLOCKFROST_API_KEY → fall back to the key set in the template.
+            blockfrostKey <- mbBlockfrostKey.fold(
+              logger.info(
+                "no --blockfrost-key / $BLOCKFROST_API_KEY; using blockfrostApiKey from " +
+                    s"${Bootstrap.defaultPrivateTemplate}"
+              ) *> Bootstrap.blockfrostKeyFrom(Bootstrap.defaultPrivateTemplate)
+            )(IO.pure)
             bootstrapConfig <- Bootstrap.readBootstrapDir(bootstrapDir)
             cardanoNetwork = bootstrapConfig.cardanoNetwork
             // Fail fast on a key/network mismatch — a Blockfrost key only works on its own
@@ -1245,8 +1278,7 @@ end InitBootstrapFiles
 object KeygenFleet:
     import GenerateKeyPair.Role
 
-    private val defaultTemplate = "head/template/peer-private.template.json.local"
-    private val blockfrostKeyRe = """"blockfrostApiKey"\s*:\s*"([^"]*)"""".r
+    private val defaultTemplate = Bootstrap.defaultPrivateTemplate.toString
 
     private val headsArg: Opts[Int] = Opts.argument[Int]("heads")
     private val coilsArg: Opts[Int] = Opts.argument[Int]("coils")
@@ -1325,23 +1357,18 @@ object KeygenFleet:
       * did) — the key's `preview…` / `preprod…` / `mainnet…` prefix picks the network.
       */
     private def deriveNetwork(template: Path): IO[CardanoNetwork] =
-        for {
-            content <- IO.blocking(Files.readString(template))
-            key <- IO.fromOption(blockfrostKeyRe.findFirstMatchIn(content).map(_.group(1)))(
-              new IllegalArgumentException(s"no blockfrostApiKey found in $template")
-            )
-            network <-
-                if key.startsWith("preview") then IO.pure(CardanoNetwork.Preview)
-                else if key.startsWith("preprod") then IO.pure(CardanoNetwork.Preprod)
-                else if key.startsWith("mainnet") then IO.pure(CardanoNetwork.Mainnet)
-                else
-                    IO.raiseError(
-                      new IllegalArgumentException(
-                        s"cannot derive the network from blockfrostApiKey in $template " +
-                            "(expected a preview…/preprod…/mainnet… key)"
-                      )
-                    )
-        } yield network
+        Bootstrap.blockfrostKeyFrom(template).flatMap { key =>
+            if key.startsWith("preview") then IO.pure(CardanoNetwork.Preview)
+            else if key.startsWith("preprod") then IO.pure(CardanoNetwork.Preprod)
+            else if key.startsWith("mainnet") then IO.pure(CardanoNetwork.Mainnet)
+            else
+                IO.raiseError(
+                  new IllegalArgumentException(
+                    s"cannot derive the network from blockfrostApiKey in $template " +
+                        "(expected a preview…/preprod…/mainnet… key)"
+                  )
+                )
+        }
 
 end KeygenFleet
 

--- a/src/main/scala/hydrozoa/multisig/persistence/PersistenceEventFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/persistence/PersistenceEventFormat.scala
@@ -20,12 +20,12 @@ object PersistenceEventFormat:
             case OpenRocksDbReady(path, cfCount) =>
                 info(s"RocksDB backend at $path ready (CFs=$cfCount)")
             case Get(key, hit) =>
-                info(s"get $key -> ${if hit then "hit" else "miss"}")
+                debug(s"get $key -> ${if hit then "hit" else "miss"}")
             case Put(key) =>
-                info(s"put $key")
+                debug(s"put $key")
             case Delete(key) =>
-                info(s"delete $key")
+                debug(s"delete $key")
             case Write(ops) =>
-                info(s"write batch ($ops ops)")
+                debug(s"write batch ($ops ops)")
         }
     }


### PR DESCRIPTION
Release-prep for **0.1.1**.

## Version bump (0.1.0 → 0.1.1)
The release version lives in `build.sbt` (`inThisBuild { version }`) and drives the image tag, `hydrozoa.BuildInfo.version`, and `GET /version` (confirmed `sbt reload; show version` → `0.1.1`). The same tag is hard-coded in deployment files that don't read `build.sbt`, bumped in lockstep:
- `hydrozoa.sh` — `HYDROZOA_VERSION` default
- `docker-compose.yml` — default `${HYDROZOA_IMAGE:-…:0.1.1}`
- `DEPLOYMENT.md` — pull/run image tags

RELEASE.md step 1 is expanded into a checklist of exactly these files (+ a straggler grep), so the next release doesn't miss one (as `hydrozoa.sh` was here).

**Left as-is** (intentional): `HydrozoaRoutes.apiVersion` + `docs/openapi*.yaml` (API-contract version, separate from the release version), the `petri` module SNAPSHOT, and RELEASE.md's illustrative `git describe` example.

## Also included
- **`cardanoLiaisonPollingPeriod` default → 20s** in the scaffold template (`peer-private.template.json`, `10000` → `20000` ms). Halves the L1 poll rate a scaffolded deployment starts with (a chunk of the Blockfrost free-tier `/addresses` burn); still well inside the safety margin vs `depositMaturityDuration`. Template pin test (`GenerateKeyPairOutputsTest`) green.

## After merge (per RELEASE.md)
`git tag v0.1.1 && git push origin v0.1.1` from the merged commit publishes `ghcr.io/cardano-hydrozoa/hydrozoa:{0.1.1,0.1,latest}`.