### PR TITLE
refactor(deploy): root the head workspace at HYDROZOA_HOME

### DIFF
--- a/docs/user-guide/DEPLOYMENT.md
+++ b/docs/user-guide/DEPLOYMENT.md
@@ -100,8 +100,8 @@ to Blockfrost (`blockfrostApiKey` in `peer-private.json`).
 ## 2. Getting Hydrozoa
 
 > Assumes **rootless Docker** (the tested setup): the alias runs the container as root, which under
-> rootless maps to *your* host user, so it can write the mounted `head/`. On rootful Docker, add
-> `-u "$(id -u):$(id -g)"` to the alias instead.
+> rootless maps to *your* host user, so it can write the mounted head directory. On rootful Docker,
+> add `-u "$(id -u):$(id -g)"` to the alias instead.
 
 **You do not need to clone this repo.** The published image carries the whole CLI plus the workspace
 files (`docker-compose.yml`, `hydrozoa.sh`, config template), so pull it and scaffold a head
@@ -112,13 +112,14 @@ mkdir myhead && cd myhead
 docker pull ghcr.io/cardano-hydrozoa/hydrozoa:0.1.1
 docker run --rm -v "$PWD:/work" -w /work --user root \
   ghcr.io/cardano-hydrozoa/hydrozoa:0.1.1 scaffold .
-# writes docker-compose.yml, hydrozoa.sh, head/template/peer-private.template.json.local
+# writes docker-compose.yml, hydrozoa.sh, template/peer-private.template.json.local
 ```
 
-Then load the CLI alias and check you are on the version you expect:
+The scaffold dir is itself the head directory — everything the CLI reads and writes lives directly
+under it. Then load the CLI alias and check you are on the version you expect:
 
 ```bash
-source ./hydrozoa.sh   # sets the `hydrozoa` alias + HYDROZOA_HOME=./head/demo
+source ./hydrozoa.sh   # sets the `hydrozoa` alias + HYDROZOA_HOME (this folder, an absolute path)
 
 hydrozoa version       # verify the image you are running
 #   hydrozoa 0.1.1
@@ -222,8 +223,9 @@ pipeline turns operator-authored files into the two runtime files each node need
 
 ### Step 1 — Edit the template
 
-Set `blockfrostApiKey` in `head/template/peer-private.template.json.local` (scaffolded in §2;
-Nix users create it with `just scaffold`).
+Set `blockfrostApiKey` in `$HYDROZOA_HOME/template/peer-private.template.json.local` — i.e.
+`template/peer-private.template.json.local` in the Docker workspace, or `head/demo/template/…` for a
+local `just` run (scaffolded in §2; Nix users create it with `just scaffold`).
 
 - **Blockfrost key** — keygen-fleet reads only the `.local` file and refuses to run without it,
   so the real key never lands in a committed file. The build steps that query the chain
@@ -238,8 +240,8 @@ The template is read at generation time — regenerating means fresh keys, so re
 ### Step 2 — Generate keys, roster, and defaults
 
 ```bash
-hydrozoa keygen-fleet 2 4 2        # Docker; HEADS COILS QUORUM, → head/demo/
-just keygen-fleet 2 4 2            # local; custom dir: just keygen-fleet 2 4 2 head/mydir
+hydrozoa keygen-fleet 2 4 2        # Docker; HEADS COILS QUORUM, → $HYDROZOA_HOME/ (the workspace)
+just keygen-fleet 2 4 2            # local; → head/demo/ (custom dir: just keygen-fleet 2 4 2 head/mydir)
 ```
 
 One command generates a key pair per peer (registered in the roster, with a filled private config),
@@ -247,7 +249,7 @@ then the shared `defaults.json` + `l2-cardano-eutxo.json`; the network comes fro
 Blockfrost-key prefix. Output layout:
 
 ```
-head/demo/
+$HYDROZOA_HOME/                    # Docker: your scaffold dir; local just: head/demo/
 ├── bootstrap/                     # the operator-facing bootstrap directory (build-head-config input)
 │   ├── roster.json                #   peer topology
 │   ├── defaults.json              #   network + head params (coilQuorum, timing…) + per-peer equity
@@ -309,7 +311,7 @@ tx fee; step 5 logs the exact lovelace required and fails with the shortfall if 
 ```bash
 hydrozoa deploy-scripts-and-g2-setup   # Docker
 just deploy-scripts-and-g2-setup        # local
-# -> head/demo/bootstrap/ref-utxos.json (funded by head-0's wallet under the head dir)
+# -> $HYDROZOA_HOME/bootstrap/ref-utxos.json (funded by head-0's wallet under the head dir)
 ```
 
 The rule-based regime (evacuation/dispute) txs resolve the treasury + dispute validators — and
@@ -326,7 +328,7 @@ the ladder never changes.
 ### Step 5 — Build the shared head config
 
 ```bash
-hydrozoa build-head-config   # Docker; reads head/demo/bootstrap/, writes head/demo/head-config/head-config.json
+hydrozoa build-head-config   # Docker; reads $HYDROZOA_HOME/bootstrap/, writes $HYDROZOA_HOME/head-config/head-config.json
 just build-head-config       # local
 ```
 
@@ -369,7 +371,8 @@ Caveats:
 
 ### Bringing up the head
 
-Default — pull the published image and run `head/demo`:
+Default — pull the published image and run the scaffolded head (`hydrozoa.sh` exports
+`HYDROZOA_HOME`, so `docker compose` mounts the same workspace the CLI generated into):
 
 ```bash
 docker compose up -d           # pulls ghcr.io/cardano-hydrozoa/hydrozoa:0.1.1 on first run
@@ -382,12 +385,13 @@ locally built one (§3):
 HYDROZOA_IMAGE=cardano-hydrozoa/hydrozoa:0.1.1 docker compose up -d
 ```
 
-**Another configuration** — `HYDROZOA_HOME` (default `./head/demo`) selects the directory each
-container mounts `head-config.json` + its `private.json` from. It's the same variable the CLI
-generates into, so one value drives both the build and the run:
+**Another configuration** — `HYDROZOA_HOME` selects the directory each container mounts
+`head-config.json` + its `private.json` from (`hydrozoa.sh` sets it to your scaffolded workspace; the
+compose file itself falls back to `./head/demo`, the local `just` default). It's the same variable
+the CLI generates into, so one value drives both the build and the run:
 
 ```bash
-HYDROZOA_HOME=./head/other docker compose up -d
+HYDROZOA_HOME=/abs/path/to/other-head docker compose up -d
 ```
 
 Stack 0 initializes once both head peers + any `coilQuorum` coil peers are signing.
@@ -440,8 +444,8 @@ just build-head-config
 docker compose up -d           # right after the build — the config is freshest now
 ```
 
-**Reusable across restarts:** the whole `head/demo/bootstrap/` directory and every
-`head/demo/private/` config — identities and keys are not time- or UTxO-bound, and the
+**Reusable across restarts:** the whole `$HYDROZOA_HOME/bootstrap/` directory and every
+`$HYDROZOA_HOME/private/` config — identities and keys are not time- or UTxO-bound, and the
 reference-script UTxOs sit at an unspendable burn address. Only `head-config/head-config.json` is
 single-use. Regenerate the fleet (`just keygen-fleet`) only for fresh identities; that changes head
 peer 0's address, so re-fund it. The hydrozoa docker image only needs rebuilding after hydrozoa

--- a/hydrozoa.sh
+++ b/hydrozoa.sh
@@ -4,18 +4,24 @@
 #     hydrozoa keygen-fleet 2 4 2
 #     hydrozoa build-head-config
 #
-# The Blockfrost key comes from head/template/peer-private.template.json.local (`blockfrostApiKey`);
-# `export BLOCKFROST_API_KEY=preview…` before sourcing overrides it for the chain-querying commands.
+# The Blockfrost key comes from $HYDROZOA_HOME/template/peer-private.template.json.local
+# (`blockfrostApiKey`); `export BLOCKFROST_API_KEY=preview…` before sourcing overrides it for the
+# chain-querying commands.
 #
-# Override the version or head directory before sourcing (or edit the defaults below). HYDROZOA_HOME
-# is the one head directory the CLI and `docker compose` (docs/user-guide/DEPLOYMENT.md §4) both read.
-: "${HYDROZOA_VERSION:=0.1.1}"      # published image tag (ghcr.io/cardano-hydrozoa/hydrozoa)
-: "${HYDROZOA_HOME:=./head/demo}"  # head directory
+# HYDROZOA_HOME is the one head directory the CLI and `docker compose`
+# (docs/user-guide/DEPLOYMENT.md §4) both read. It defaults to this file's own directory — the
+# scaffolded workspace — resolved to an absolute path, so the alias mounts correctly no matter which
+# directory you run it from. Override HYDROZOA_HOME (to an absolute path) or HYDROZOA_VERSION before
+# sourcing, or edit the defaults below.
+: "${HYDROZOA_VERSION:=0.1.1}"   # published image tag (ghcr.io/cardano-hydrozoa/hydrozoa)
+: "${HYDROZOA_HOME:=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)}"   # head directory (absolute)
 export HYDROZOA_VERSION HYDROZOA_HOME
 
-# Runs the image's `hydrozoa` CLI: passes the Blockfrost key + HYDROZOA_HOME through, enables host
+# Runs the image's `hydrozoa` CLI: mounts HYDROZOA_HOME as the in-container workdir /work — every
+# file the CLI reads or writes (template, bootstrap, private configs, head-config) lives under that
+# one head directory, so nothing else needs mounting. Passes the Blockfrost key through, enables host
 # networking + a TTY (for the interactive submit-* commands), and runs as container-root so it can
-# write the mounted head/ dir (see the rootless-Docker note in docs/user-guide/DEPLOYMENT.md §2).
-alias hydrozoa='docker run --rm -it --network host -e BLOCKFROST_API_KEY -e HYDROZOA_HOME \
-  --user root -v "$PWD/head:/work/head" -w /work \
+# write the mounted dir (see the rootless-Docker note in docs/user-guide/DEPLOYMENT.md §2).
+alias hydrozoa='docker run --rm -it --network host -e BLOCKFROST_API_KEY -e HYDROZOA_HOME=/work \
+  --user root -v "$HYDROZOA_HOME:/work" -w /work \
   ghcr.io/cardano-hydrozoa/hydrozoa:"$HYDROZOA_VERSION"'

--- a/justfile
+++ b/justfile
@@ -80,8 +80,9 @@ docker-stage:
   trap 'just notify "docker-stage"' EXIT
   sbt Docker/stage
 
-# Scaffold the head workspace files: head/template/peer-private.template.json.local (fill in the
-# Blockfrost key), plus docker-compose.yml + hydrozoa.sh in a fresh dir. Existing files are skipped.
+# Scaffold the head workspace files: head/demo/template/peer-private.template.json.local (fill in
+# the Blockfrost key), plus docker-compose.yml + hydrozoa.sh in a fresh dir. Existing files are
+# skipped.
 scaffold DIR=".": _require-launcher
   {{hydrozoa}} scaffold {{DIR}}
 
@@ -112,7 +113,7 @@ deploy-scripts-and-g2-setup HOME="head/demo" LADDER_REFS="": _require-launcher
   #!/usr/bin/env bash
   set -euo pipefail
   trap 'just notify "deploy-scripts-and-g2-setup"' EXIT
-  template="head/template/peer-private.template.json.local"
+  template="{{HOME}}/template/peer-private.template.json.local"
   key="${BLOCKFROST_API_KEY:-}"
   if [ -f "$template" ]; then key=$(sed -n 's/.*"blockfrostApiKey"[^"]*"\([^"]*\)".*/\1/p' "$template"); fi
   if [ -z "$key" ]; then echo "error: no Blockfrost key — create $template (deployment guide step 1) or export BLOCKFROST_API_KEY" >&2; exit 1; fi
@@ -128,7 +129,7 @@ build-head-config HOME="head/demo": _require-launcher
   #!/usr/bin/env bash
   set -euo pipefail
   trap 'just notify "build-head-config"' EXIT
-  template="head/template/peer-private.template.json.local"
+  template="{{HOME}}/template/peer-private.template.json.local"
   key="${BLOCKFROST_API_KEY:-}"
   if [ -f "$template" ]; then key=$(sed -n 's/.*"blockfrostApiKey"[^"]*"\([^"]*\)".*/\1/p' "$template"); fi
   if [ -z "$key" ]; then echo "error: no Blockfrost key — create $template (deployment guide step 1) or export BLOCKFROST_API_KEY" >&2; exit 1; fi

--- a/src/main/scala/hydrozoa/app/DeployScriptsAndG2Setup.scala
+++ b/src/main/scala/hydrozoa/app/DeployScriptsAndG2Setup.scala
@@ -94,6 +94,7 @@ object DeployScriptsAndG2Setup:
               deployScriptsAndG2Setup(
                 walletOverride.getOrElse(Bootstrap.HomeLayout.privateConfig(home, "head-0")),
                 mbKey,
+                Bootstrap.defaultPrivateTemplate(home),
                 ladder,
                 Bootstrap.HomeLayout.refUtxos(home)
               )
@@ -102,6 +103,7 @@ object DeployScriptsAndG2Setup:
     private def deployScriptsAndG2Setup(
         walletPath: Path,
         mbBlockfrostKey: Option[String],
+        template: Path,
         ladderRefsPath: Option[Path],
         outPath: Path
     ): IO[ExitCode] =
@@ -110,8 +112,8 @@ object DeployScriptsAndG2Setup:
             blockfrostKey <- mbBlockfrostKey.fold(
               log.info(
                 "no --blockfrost-key / $BLOCKFROST_API_KEY; using blockfrostApiKey from " +
-                    s"${Bootstrap.defaultPrivateTemplate}"
-              ) *> Bootstrap.blockfrostKeyFrom(Bootstrap.defaultPrivateTemplate)
+                    s"$template"
+              ) *> Bootstrap.blockfrostKeyFrom(template)
             )(IO.pure)
             cardanoNetwork <- IO.fromEither[StandardCardanoNetwork](
               networkOfBlockfrostKey(blockfrostKey)

--- a/src/main/scala/hydrozoa/app/cli/Scaffold.scala
+++ b/src/main/scala/hydrozoa/app/cli/Scaffold.scala
@@ -8,8 +8,10 @@ import java.nio.file.{Files, Path}
 /** The `scaffold` subcommand: materialize the operator-facing workspace files that are baked into
   * the image, so a Docker-only user never has to clone the repo. Into `<dir>` (default `.`) it
   * writes `docker-compose.yml`, `hydrozoa.sh` (the CLI alias — `source` it), and
-  * `head/template/peer-private.template.json.local` (fill in `blockfrostApiKey`) — the layout every
-  * later command expects, so they run with no path flags. Refuses to overwrite existing files.
+  * `template/peer-private.template.json.local` (fill in `blockfrostApiKey`) — the layout every
+  * later command expects, so they run with no path flags. The scaffold dir itself is the head
+  * directory (the default `$HYDROZOA_HOME` that `hydrozoa.sh` sets), so the whole workspace is
+  * self-contained. Refuses to overwrite existing files.
   */
 object Scaffold:
 
@@ -17,7 +19,7 @@ object Scaffold:
     private val resources: List[(String, String)] = List(
       "/scaffold/docker-compose.yml" -> "docker-compose.yml",
       "/scaffold/hydrozoa.sh" -> "hydrozoa.sh",
-      "/scaffold/peer-private.template.json" -> "head/template/peer-private.template.json.local"
+      "/scaffold/peer-private.template.json" -> "template/peer-private.template.json.local"
     )
 
     private val dirArg: Opts[Path] =
@@ -52,7 +54,7 @@ object Scaffold:
             }
             _ <- IO.println(
               s"Scaffolded into $dir. Next: set blockfrostApiKey in " +
-                  "head/template/peer-private.template.json.local, then `source ./hydrozoa.sh`."
+                  "template/peer-private.template.json.local, then `source ./hydrozoa.sh`."
             )
         } yield ExitCode.Success
 

--- a/src/main/scala/hydrozoa/bootstrap/Bootstrap.scala
+++ b/src/main/scala/hydrozoa/bootstrap/Bootstrap.scala
@@ -100,14 +100,15 @@ object Bootstrap:
             home.resolve("head-config").resolve("head-config.json")
     }
 
-    /** The scaffolded private-config template. `keygen-fleet` reads its `blockfrostApiKey` (to
-      * derive the network and to fill each peer's `private.json`); the build commands
-      * (`build-head-config`, `deploy-scripts-and-g2-setup`) fall back to it for the Cardano backend
-      * key when neither `--blockfrost-key` nor `$BLOCKFROST_API_KEY` is given — so the key set once
-      * in the template is the single source.
+    /** The scaffolded private-config template, under the head directory ([[homeOpt]]) so the whole
+      * workspace is self-contained. `keygen-fleet` reads its `blockfrostApiKey` (to derive the
+      * network and to fill each peer's `private.json`); the build commands (`build-head-config`,
+      * `deploy-scripts-and-g2-setup`) fall back to it for the Cardano backend key when neither
+      * `--blockfrost-key` nor `$BLOCKFROST_API_KEY` is given — so the key set once in the template
+      * is the single source.
       */
-    val defaultPrivateTemplate: Path =
-        Path.of("head/template/peer-private.template.json.local")
+    def defaultPrivateTemplate(home: Path): Path =
+        home.resolve("template").resolve("peer-private.template.json.local")
 
     private val blockfrostKeyRe = """"blockfrostApiKey"\s*:\s*"([^"]*)"""".r
 
@@ -577,7 +578,7 @@ end Bootstrap
   * Usage:
   * {{{
   *   hydrozoa keygen --roster nodes/roster.json --role head --ws-address ws://head-0:4001 \
-  *     --template head/template/peer-private.template.json.local --out nodes/head-0/private.json
+  *     --template head/demo/template/peer-private.template.json.local --out nodes/head-0/private.json
   * }}}
   */
 object GenerateKeyPair:
@@ -1078,6 +1079,7 @@ object BuildHeadConfig:
             buildHeadConfig(
               Bootstrap.HomeLayout.bootstrapDir(home),
               mbKey,
+              Bootstrap.defaultPrivateTemplate(home),
               Bootstrap.HomeLayout.headConfig(home)
             )
         )
@@ -1085,6 +1087,7 @@ object BuildHeadConfig:
     private def buildHeadConfig(
         bootstrapDir: Path,
         mbBlockfrostKey: Option[String],
+        template: Path,
         outPath: Path
     ): IO[ExitCode] =
         for {
@@ -1092,8 +1095,8 @@ object BuildHeadConfig:
             blockfrostKey <- mbBlockfrostKey.fold(
               logger.info(
                 "no --blockfrost-key / $BLOCKFROST_API_KEY; using blockfrostApiKey from " +
-                    s"${Bootstrap.defaultPrivateTemplate}"
-              ) *> Bootstrap.blockfrostKeyFrom(Bootstrap.defaultPrivateTemplate)
+                    s"$template"
+              ) *> Bootstrap.blockfrostKeyFrom(template)
             )(IO.pure)
             bootstrapConfig <- Bootstrap.readBootstrapDir(bootstrapDir)
             cardanoNetwork = bootstrapConfig.cardanoNetwork
@@ -1278,17 +1281,16 @@ end InitBootstrapFiles
 object KeygenFleet:
     import GenerateKeyPair.Role
 
-    private val defaultTemplate = Bootstrap.defaultPrivateTemplate.toString
-
     private val headsArg: Opts[Int] = Opts.argument[Int]("heads")
     private val coilsArg: Opts[Int] = Opts.argument[Int]("coils")
     private val quorumArg: Opts[Int] = Opts.argument[Int]("coil-quorum")
-    private val templateOpt: Opts[Path] =
+    private val templateOpt: Opts[Option[Path]] =
         Opts.option[String](
           "template",
-          s"Private-config template to fill with each peer's keys (default $defaultTemplate)"
+          "Private-config template to fill with each peer's keys " +
+              "(default $HYDROZOA_HOME/template/peer-private.template.json.local)"
         ).map(Path.of(_))
-            .withDefault(Path.of(defaultTemplate))
+            .orNone
 
     /** The `keygen-fleet` subcommand. */
     lazy val command: Command[IO[ExitCode]] =
@@ -1303,10 +1305,11 @@ object KeygenFleet:
         coils: Int,
         coilQuorum: Int,
         home: Path,
-        template: Path
+        mbTemplate: Option[Path]
     ): IO[ExitCode] = {
         val bootstrapDir = Bootstrap.HomeLayout.bootstrapDir(home)
         val rosterPath = Bootstrap.HomeLayout.roster(home)
+        val template = mbTemplate.getOrElse(Bootstrap.defaultPrivateTemplate(home))
         def privatePath(label: String): Path = Bootstrap.HomeLayout.privateConfig(home, label)
         for {
             _ <- IO.raiseWhen(heads < 1)(


### PR DESCRIPTION
Make `$HYDROZOA_HOME` the single root every CLI command reads and writes, so the Docker alias mounts only that one directory and runs from any working directory.

## Changes
- **Template moved inside the head dir**: `defaultPrivateTemplate` is now home-derived (`$HYDROZOA_HOME/template/…`) instead of a sibling `head/template`. `keygen-fleet` `--template` defaults to it; `build-head-config` and `deploy-scripts-and-g2-setup` thread it through.
- **`scaffold` writes a flat workspace**: the scaffold dir itself is the head dir (`docker-compose.yml`, `hydrozoa.sh`, `template/peer-private.template.json.local`) — no `head/demo` nesting.
- **`hydrozoa.sh`**: `HYDROZOA_HOME` defaults to the script's own directory as an absolute path; the alias mounts `$HYDROZOA_HOME` at `/work` (drops `$PWD`/`realpath`), so it works from any cwd.
- **justfile + DEPLOYMENT.md**: head-relative paths expressed as `$HYDROZOA_HOME/…`; the local `just` flow keeps `head/demo` as its home.

Passes `just fmt`, `just lint`, and the full `-Werror` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)