### PR TITLE
chore: gitignore the leftover config/ directory, which holds real signing keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,17 @@ target/
 # private configs + signing keys, head-config — all per-deployment, never commit.
 /head/*
 !/head/.gitkeep
+
+# The same working directory under its pre-rename name. `config/` became `head/`, but a leftover
+# `config/` still exists on working copies that predate the rename — and it holds generated private
+# configs with real signing keys, so an unqualified `git add -A` would commit them.
+/config/
+
+# Local notes and tool output (not for commit)
+/docs/local/
+/log
+/.scalex/
+
+# Editor leftovers
+*.swp
+*.swo


### PR DESCRIPTION
## What & why

`.gitignore` already protects the head working directory:

```
# The head working directory: scaffolded template.local (real Blockfrost key), generated rosters,
# private configs + signing keys, head-config — all per-deployment, never commit.
/head/*
```

But only under that name. `config/` was renamed to `head/` in `8bf00b73`, and working copies predating the rename still carry a `config/` — holding generated private configs with **real `signingKey` values**. Nothing ignores it, so an unqualified `git add -A` / `git add .` commits them.

That is not hypothetical: I hit it while staging a `git mv`, and caught it only because I checked the file list before pushing. The commit itself succeeded and the pre-commit hook passed it.

**No keys are in history.** The `signingKey` hits in `git log -S` are all `peer-private.template.json`, the placeholder template.

## What's in it

- `/config/` — the actual fix.
- `/docs/local/` — local notes, mirroring the existing `.scratch/` entry.
- `/log` — the existing `**/*.log` does not match an extensionless `log`.
- `/.scalex/` — a ~1 MB binary index.
- `*.swp` / `*.swo`.

`config/` is left on disk: it is a working directory, and deleting a directory of keys is not this commit's business.

Not included: `anthill-todo/`. It holds no secrets and a teammate might reasonably want it tracked, so that is a call for whoever owns it rather than something to silently hide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B21A9azBmPNgQjRrxGnN1r