### PR TITLE
test(e2e): 4-head propagation, on a topology of its own

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -242,7 +242,8 @@ lazy val integration: Project = (project in file("integration"))
                  Tests.Exclude(
                    Seq(
                      "hydrozoa.integration.stage1.Stage1PropertiesYaci",
-                     "hydrozoa.integration.e2e.DockerSmokeTest"
+                     "hydrozoa.integration.e2e.DockerSmokeTest",
+                     "hydrozoa.integration.e2e.Docker400PropagationTest"
                    )
                  )
                )),

--- a/integration/src/test/resources/e2e/docker-compose.4-0-0.yml
+++ b/integration/src/test/resources/e2e/docker-compose.4-0-0.yml
@@ -1,0 +1,75 @@
+# A 4-head-peer, 0-coil-peer head — the `keygen-fleet 4 0 0` topology, hence the file name
+# (HEADS-COILS-QUORUM, matching the argument order). Used only by Docker400PropagationTest.
+#
+# This is deliberately *not* what we ship. `docker-compose.yml` at the repo root describes the
+# deployment DEPLOYMENT.md walks through (2 head peers + 4 coil peers) and DockerSmokeTest exercises
+# that one. This file exists to test a property the shipped topology cannot: propagation across four
+# peers that are all HTTP-observable, since only head peers publish the user API. Keep the two
+# apart — a test-shaped topology masquerading as the shipped one is what this split fixes.
+#
+# The quorum is 0 because there are no coil peers to reach one: the head multisig is all head peers
+# plus MOf(coilQuorum, coilPeerVKeys), and HeadConfig refuses a coilQuorum above the coil count.
+#
+# Compose it with the devnet overlay, from the repo root:
+#
+#   docker compose -p hydrozoa-e2e-400 \
+#     -f integration/src/test/resources/e2e/docker-compose.4-0-0.yml \
+#     -f docker-compose.yaci.yml up -d
+#
+# HYDROZOA_HOME points at the generated configs; HYDROZOA_IMAGE overrides the image.
+
+name: hydrozoa-4-0-0
+
+networks:
+  mesh:
+    driver_opts:
+      # Rootless docker (slirp4netns) can drop outbound TLS at the default MTU.
+      com.docker.network.driver.mtu: 1400
+
+x-hydrozoa: &hydrozoa
+  image: ${HYDROZOA_IMAGE:-ghcr.io/cardano-hydrozoa/hydrozoa:0.1.1}
+  # root: the image's non-root user cannot write the RocksDB stores / logs under the /opt/docker
+  # workdir. State is ephemeral here (no volumes) — restarting re-initializes a fresh head.
+  user: root
+  environment:
+    JAVA_OPTS: -Xmx1g -Xms256m
+  command: ["serve", "/configs/head-config.json", "/configs/private.json"]
+  networks: [mesh]
+  dns:
+    - 8.8.8.8
+    - 8.8.4.4
+  stop_grace_period: 120s
+  restart: on-failure
+
+services:
+  head-0:
+    <<: *hydrozoa
+    ports:
+      - "8080:8080"
+    volumes:
+      - ${HYDROZOA_HOME:-./head/demo}/head-config/head-config.json:/configs/head-config.json:ro
+      - ${HYDROZOA_HOME:-./head/demo}/private/head-0/private.json:/configs/private.json:ro
+
+  head-1:
+    <<: *hydrozoa
+    ports:
+      - "8081:8080"
+    volumes:
+      - ${HYDROZOA_HOME:-./head/demo}/head-config/head-config.json:/configs/head-config.json:ro
+      - ${HYDROZOA_HOME:-./head/demo}/private/head-1/private.json:/configs/private.json:ro
+
+  head-2:
+    <<: *hydrozoa
+    ports:
+      - "8082:8080"
+    volumes:
+      - ${HYDROZOA_HOME:-./head/demo}/head-config/head-config.json:/configs/head-config.json:ro
+      - ${HYDROZOA_HOME:-./head/demo}/private/head-2/private.json:/configs/private.json:ro
+
+  head-3:
+    <<: *hydrozoa
+    ports:
+      - "8083:8080"
+    volumes:
+      - ${HYDROZOA_HOME:-./head/demo}/head-config/head-config.json:/configs/head-config.json:ro
+      - ${HYDROZOA_HOME:-./head/demo}/private/head-3/private.json:/configs/private.json:ro

--- a/integration/src/test/scala/hydrozoa/integration/e2e/Docker400PropagationTest.scala
+++ b/integration/src/test/scala/hydrozoa/integration/e2e/Docker400PropagationTest.scala
@@ -1,0 +1,49 @@
+package hydrozoa.integration.e2e
+
+/** [[DockerHeadSuite]] on a 4-head-peer, no-coil head — `keygen-fleet 4 0 0`, hence the name and
+  * that of its compose file (HEADS-COILS-QUORUM, the argument order).
+  *
+  * '''Why a second Docker suite.''' [[DockerSmokeTest]] runs what we ship, and must keep doing so —
+  * its value is that a failure implicates DEPLOYMENT.md. But the shipped head has two head peers,
+  * and only head peers publish the HTTP API, so it can only ever assert propagation across two. A
+  * bug that needs three or four peers to show — a fan-out that drops the last recipient, a quorum
+  * off-by-one — is invisible to it. This suite trades away the "same as production" property to buy
+  * four HTTP-observable peers, and says so in its name rather than quietly reshaping the smoke
+  * test's topology.
+  *
+  * The quorum is 0 because there is nothing to reach one with: the head multisig is all head peers
+  * plus `MOf(coilQuorum, coilPeerVKeys)`, and head peers sign unanimously — so with no coil peers,
+  * 0 is the only value `HeadConfig` accepts. Coil fan-out is therefore *not* covered here; that is
+  * the smoke test's job.
+  *
+  * Heavy and CI-excluded by FQN in `build.sbt`, like every [[DockerHeadSuite]]. Run it with:
+  * {{{
+  *   HYDROZOA_INCLUDE_HEAVY_TESTS=1 sbt Docker/publishLocal stage \
+  *     "integration/testOnly hydrozoa.integration.e2e.Docker400PropagationTest"
+  * }}}
+  */
+class Docker400PropagationTest extends DockerHeadSuite(Docker400PropagationTest.topology)
+
+object Docker400PropagationTest:
+
+    /** Four head peers on their own compose file, under a project name of their own so containers
+      * and networks stay clear of a [[DockerSmokeTest]] run — or of an operator's own project.
+      *
+      * Host ports are shared, though: the suite reaches peer `i` at `localhost:${8080 + i}`, and
+      * the devnet overlay always publishes 18080 and 10000. So the two suites cannot run at the
+      * same time. Both are minutes-long and run one at a time anyway.
+      */
+    private val topology: DockerTopology = DockerTopology(
+      name = "4 head + 0 coil",
+      heads = 4,
+      coils = 0,
+      coilQuorum = 0,
+      project = "hydrozoa-e2e-400",
+      tag = "[e2e-400]",
+      composeFileNames = List(
+        "integration/src/test/resources/e2e/docker-compose.4-0-0.yml",
+        "docker-compose.yaci.yml"
+      )
+    )
+
+end Docker400PropagationTest

--- a/justfile
+++ b/justfile
@@ -211,6 +211,14 @@ integration-e2e-docker:
   trap 'just notify "integration-e2e-docker"' EXIT
   HYDROZOA_INCLUDE_HEAVY_TESTS=1 sbt Docker/publishLocal stage "integration/testOnly hydrozoa.integration.e2e.DockerSmokeTest"
 
+# Heavy Docker propagation test on a 4-head, 0-coil head — a topology we do NOT ship, run to assert
+# propagation across four HTTP-observable peers (the shipped one has only two). Same prerequisites
+# as integration-e2e-docker; the two cannot run at the same time (shared host ports).
+integration-e2e-docker-400:
+  #!/usr/bin/env bash
+  trap 'just notify "integration-e2e-docker-400"' EXIT
+  HYDROZOA_INCLUDE_HEAVY_TESTS=1 sbt Docker/publishLocal stage "integration/testOnly hydrozoa.integration.e2e.Docker400PropagationTest"
+
 precommit: lint-check fmt-check nixfmt-check
   just notify "precommit"
 


### PR DESCRIPTION
Stacked on #570 — it needs `EutxoL2QueryClient` and `scripts/yaci-devnet.sh` from there. Based on `feat/custom-network-serve` so the diff shows only this change; GitHub will retarget to `main` when #570 merges.

## Why a second Docker suite

`DockerSmokeTest` (in #570) runs the head we ship — 2 head peers, 4 coils — and has to keep doing so: its value is that a failure implicates DEPLOYMENT.md. But only head peers publish the HTTP API (`runCoilNode` starts no `HydrozoaServer`), so it can assert propagation across **two** peers and no more. A fan-out that drops the last recipient, or a quorum off-by-one, would not show up.

This suite buys four HTTP-observable peers by giving up the "same as production" property — and says so in its name rather than quietly reshaping the smoke test's topology. Until #570, this 4-head shape *was* the only Docker test, wearing the shipped topology's clothes and carrying its own compose fork to make that work. Separating them is the point.

## What's here

- `Docker400PropagationTest` — `DockerHeadSuite` bound to a 4-head, 0-coil topology, under its own compose project.
- `integration/src/test/resources/e2e/docker-compose.4-0-0.yml` — named HEADS-COILS-QUORUM, matching `keygen-fleet`'s argument order.
- CI exclusion by FQN in `build.sbt`, plus `just integration-e2e-docker-400`.

## Why quorum 0

Nothing can reach a higher one. The head multisig is *all* head peers plus `MOf(coilQuorum, coilPeerVKeys)` (`HeadConfig.scala:530-539`) — head peers sign unanimously, there is no m-of-n over them — and `HeadConfig` refuses a quorum above the coil count. With no coil peers, 0 is the only accepted value. So coil fan-out is **not** covered here; that is the smoke test's job. The two are complementary, not redundant.

## Caveats

- **Not yet run.** It compiles and the devnet script beneath it is verified end to end, but no head has formed in containers on this topology yet.
- **Cannot run concurrently with `DockerSmokeTest`** — both reach peer *i* at `localhost:${8080 + i}` and both publish the devnet's 18080/10000. Different project names isolate containers and networks, not host ports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)