### PR TITLE
docs(site): left-sidebar navigation for the docs site

### DIFF
--- a/docs/_includes/custom-head.html
+++ b/docs/_includes/custom-head.html
@@ -1,0 +1,97 @@
+<style>
+  /* Two-column docs layout: a sticky left navigation sidebar + the content column.
+     Layered on top of minima (which supplies base typography, code, and tables);
+     this file only adds the sidebar and adjusts the content wrapper. */
+
+  :root {
+    --sidebar-w: 264px;
+    --accent: #0b7a85;
+    --nav-line: #e6ebeb;
+    --nav-bg: #fafcfc;
+  }
+
+  body { margin: 0; }
+
+  .layout {
+    display: flex;
+    align-items: flex-start;
+  }
+
+  .sidebar {
+    flex: 0 0 var(--sidebar-w);
+    position: sticky;
+    top: 0;
+    max-height: 100vh;
+    overflow-y: auto;
+    box-sizing: border-box;
+    padding: 22px 16px 40px;
+    border-right: 1px solid var(--nav-line);
+    background: var(--nav-bg);
+  }
+
+  .sidebar .brand {
+    display: block;
+    font-weight: 600;
+    font-size: 1.02rem;
+    line-height: 1.3;
+    color: #1a1a1a;
+    text-decoration: none;
+    margin-bottom: 16px;
+  }
+  .sidebar .brand:hover { color: var(--accent); }
+
+  .site-nav ul { list-style: none; margin: 0 0 6px; padding: 0; }
+
+  .site-nav .nav-section { margin: 18px 0 4px; }
+  .site-nav .nav-section a {
+    font-size: 0.7rem;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+    font-weight: 700;
+    color: #6b7577;
+    text-decoration: none;
+  }
+  .site-nav .nav-section a:hover { color: var(--accent); }
+
+  .site-nav .nav-item {
+    display: block;
+    padding: 5px 9px;
+    margin: 1px 0;
+    font-size: 0.9rem;
+    line-height: 1.35;
+    color: #333;
+    text-decoration: none;
+    border-radius: 7px;
+  }
+  .site-nav .nav-item:hover { background: #eef3f3; color: #111; }
+  .site-nav .nav-item.active {
+    background: #e2f0f0;
+    color: var(--accent);
+    font-weight: 600;
+  }
+
+  /* Content column: keep a readable measure; let wide code/tables scroll inside. */
+  .content { flex: 1 1 auto; min-width: 0; }
+  .content .wrapper {
+    max-width: 820px;
+    margin: 0;
+    padding: 8px 44px 64px;
+  }
+  .content pre,
+  .content table { overflow-x: auto; }
+
+  /* The site footer (minima) sits full width beneath the two columns. */
+  .site-footer { border-top: 1px solid var(--nav-line); }
+
+  @media (max-width: 900px) {
+    .layout { display: block; }
+    .sidebar {
+      position: static;
+      max-height: none;
+      width: auto;
+      border-right: none;
+      border-bottom: 1px solid var(--nav-line);
+    }
+    .content .wrapper { padding: 8px 24px 48px; }
+  }
+</style>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -10,8 +10,8 @@
       READMEs (their url ends in `/`, not `.html`) are the section landing pages,
       linked from the section headers rather than listed as items.
     {%- endcomment -%}
-    {%- assign guides = site.html_pages | where_exp: "p", "p.url contains '/user-guide/' and p.url contains '.html'" | sort: "title" -%}
-    {%- assign specs = site.html_pages | where_exp: "p", "p.url contains '/spec/' and p.url contains '.html'" | sort: "title" -%}
+    {%- assign guides = site.html_pages | where_exp: "p", "p.url contains '/user-guide/'" | where_exp: "p", "p.url contains '.html'" | sort: "title" -%}
+    {%- assign specs = site.html_pages | where_exp: "p", "p.url contains '/spec/'" | where_exp: "p", "p.url contains '.html'" | sort: "title" -%}
 
     <div class="layout">
       <aside class="sidebar" aria-label="Documentation navigation">

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="{{ page.lang | default: site.lang | default: "en" }}">
+
+  {%- include head.html -%}
+
+  <body>
+
+    {%- comment -%}
+      Group the content pages into the two doc sections for the left sidebar.
+      READMEs (their url ends in `/`, not `.html`) are the section landing pages,
+      linked from the section headers rather than listed as items.
+    {%- endcomment -%}
+    {%- assign guides = site.html_pages | where_exp: "p", "p.url contains '/user-guide/' and p.url contains '.html'" | sort: "title" -%}
+    {%- assign specs = site.html_pages | where_exp: "p", "p.url contains '/spec/' and p.url contains '.html'" | sort: "title" -%}
+
+    <div class="layout">
+      <aside class="sidebar" aria-label="Documentation navigation">
+        <a class="brand" href="{{ '/' | relative_url }}">{{ site.title | default: "Documentation" | escape }}</a>
+        <nav class="site-nav">
+          <a class="nav-item{% if page.url == '/' %} active{% endif %}" href="{{ '/' | relative_url }}">Home</a>
+
+          <p class="nav-section"><a href="{{ '/user-guide/' | relative_url }}">User guide</a></p>
+          <ul>
+            {%- for p in guides -%}
+            <li><a class="nav-item{% if p.url == page.url %} active{% endif %}" href="{{ p.url | relative_url }}">{{ p.title | escape }}</a></li>
+            {%- endfor -%}
+          </ul>
+
+          <p class="nav-section"><a href="{{ '/spec/' | relative_url }}">Design &amp; reference</a></p>
+          <ul>
+            {%- for p in specs -%}
+            <li><a class="nav-item{% if p.url == page.url %} active{% endif %}" href="{{ p.url | relative_url }}">{{ p.title | escape }}</a></li>
+            {%- endfor -%}
+          </ul>
+        </nav>
+      </aside>
+
+      <main class="content" aria-label="Content">
+        <div class="wrapper">
+          {{ content }}
+        </div>
+      </main>
+    </div>
+
+    {%- include footer.html -%}
+
+  </body>
+
+</html>

--- a/docs/_layouts/home.html
+++ b/docs/_layouts/home.html
@@ -1,0 +1,8 @@
+---
+layout: default
+---
+{%- comment -%}
+  The index page is the docs/README.md content — render it directly, without
+  minima's home.html blog-post listing.
+{%- endcomment -%}
+{{ content }}

--- a/docs/_layouts/page.html
+++ b/docs/_layouts/page.html
@@ -1,0 +1,8 @@
+---
+layout: default
+---
+{%- comment -%}
+  Content pages render their own H1 from the leading Markdown heading, so this
+  layout intentionally does not add minima's post-title header (which duplicated it).
+{%- endcomment -%}
+{{ content }}


### PR DESCRIPTION
Replaces minima's top-nav wall-of-links with a grouped left sidebar (User guide / Design & reference), and drops the duplicated page title. Keeps minima's typography; adds a custom layout + sidebar CSS. No content changes.