### PR TITLE
docs(site): fix sidebar CSS injection + compact + version badge

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -11,6 +11,10 @@ description: >-
 
 theme: minima
 
+# Shown as a badge in the sidebar. Keep in sync with `version :=` in build.sbt
+# (the `inThisBuild` release version).
+hydrozoa_version: "0.1.1"
+
 # Project site served under the repository path. Update both if the repo is
 # renamed or a custom domain is configured.
 url: "https://cardano-hydrozoa.github.io"

--- a/docs/_includes/custom-head.html
+++ b/docs/_includes/custom-head.html
@@ -1,67 +1,87 @@
 <style>
-  /* Two-column docs layout: a sticky left navigation sidebar + the content column.
-     Layered on top of minima (which supplies base typography, code, and tables);
-     this file only adds the sidebar and adjusts the content wrapper. */
+  /* Compact two-column docs layout: a fixed left navigation sidebar + content column.
+     Layered on top of minima (base typography, code, tables); this file adds the
+     sidebar, pins its brand + version header, and adjusts the content wrapper. */
 
   :root {
-    --sidebar-w: 264px;
+    --sidebar-w: 220px;
     --accent: #0b7a85;
     --nav-line: #e6ebeb;
     --nav-bg: #fafcfc;
+    --nav-fg: #37424a;
   }
 
   body { margin: 0; }
 
-  .layout {
-    display: flex;
-    align-items: flex-start;
-  }
+  .layout { display: flex; align-items: stretch; }
 
+  /* Full-height flex column: the header (brand + version) stays put while the
+     nav list scrolls, so the version is always on screen. */
   .sidebar {
     flex: 0 0 var(--sidebar-w);
     position: sticky;
     top: 0;
-    max-height: 100vh;
-    overflow-y: auto;
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
     box-sizing: border-box;
-    padding: 22px 16px 40px;
     border-right: 1px solid var(--nav-line);
     background: var(--nav-bg);
+    font-size: 13px;
   }
 
-  .sidebar .brand {
-    display: block;
+  .sidebar-head {
+    flex: none;
+    display: flex;
+    align-items: baseline;
+    gap: 7px;
+    padding: 14px 14px 10px;
+    border-bottom: 1px solid var(--nav-line);
+  }
+  .sidebar-head .brand {
     font-weight: 600;
-    font-size: 1.02rem;
-    line-height: 1.3;
+    font-size: 0.92rem;
+    line-height: 1.2;
     color: #1a1a1a;
     text-decoration: none;
-    margin-bottom: 16px;
   }
-  .sidebar .brand:hover { color: var(--accent); }
+  .sidebar-head .brand:hover { color: var(--accent); }
+  .sidebar-head .version {
+    font-size: 0.68rem;
+    font-weight: 600;
+    color: var(--accent);
+    background: #e2f0f0;
+    padding: 1px 6px;
+    border-radius: 999px;
+    white-space: nowrap;
+  }
 
-  .site-nav ul { list-style: none; margin: 0 0 6px; padding: 0; }
+  .site-nav {
+    flex: 1 1 auto;
+    overflow-y: auto;
+    padding: 8px 10px 28px;
+  }
+  .site-nav ul { list-style: none; margin: 0 0 4px; padding: 0; }
 
-  .site-nav .nav-section { margin: 18px 0 4px; }
+  .site-nav .nav-section { margin: 14px 0 3px; padding: 0 6px; }
   .site-nav .nav-section a {
-    font-size: 0.7rem;
+    font-size: 0.64rem;
     letter-spacing: 0.07em;
     text-transform: uppercase;
     font-weight: 700;
-    color: #6b7577;
+    color: #78838a;
     text-decoration: none;
   }
   .site-nav .nav-section a:hover { color: var(--accent); }
 
   .site-nav .nav-item {
     display: block;
-    padding: 5px 9px;
-    margin: 1px 0;
-    font-size: 0.9rem;
-    line-height: 1.35;
-    color: #333;
+    padding: 3px 8px;
+    font-size: 0.8rem;
+    line-height: 1.3;
+    color: var(--nav-fg);
     text-decoration: none;
-    border-radius: 7px;
+    border-radius: 5px;
   }
   .site-nav .nav-item:hover { background: #eef3f3; color: #111; }
   .site-nav .nav-item.active {
@@ -70,7 +90,7 @@
     font-weight: 600;
   }
 
-  /* Content column: keep a readable measure; let wide code/tables scroll inside. */
+  /* Content column: readable measure; wide code/tables scroll inside. */
   .content { flex: 1 1 auto; min-width: 0; }
   .content .wrapper {
     max-width: 820px;
@@ -80,18 +100,16 @@
   .content pre,
   .content table { overflow-x: auto; }
 
-  /* The site footer (minima) sits full width beneath the two columns. */
-  .site-footer { border-top: 1px solid var(--nav-line); }
-
   @media (max-width: 900px) {
     .layout { display: block; }
     .sidebar {
       position: static;
-      max-height: none;
+      height: auto;
       width: auto;
       border-right: none;
       border-bottom: 1px solid var(--nav-line);
     }
+    .site-nav { overflow-y: visible; }
     .content .wrapper { padding: 8px 24px 48px; }
   }
 </style>

--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -1,0 +1,17 @@
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  {%- seo -%}
+  <link rel="stylesheet" href="{{ "/assets/main.css" | relative_url }}">
+  {%- feed_meta -%}
+  {%- if jekyll.environment == 'production' and site.google_analytics -%}
+    {%- include google-analytics.html -%}
+  {%- endif -%}
+  {%- comment -%}
+    minima 2.5.1's own head.html does NOT include custom-head.html (that hook was
+    added in minima 3.x). Overriding head.html here is what gets the sidebar CSS
+    into <head>; without it the sidebar renders unstyled and stacks on top.
+  {%- endcomment -%}
+  {%- include custom-head.html -%}
+</head>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -15,7 +15,13 @@
 
     <div class="layout">
       <aside class="sidebar" aria-label="Documentation navigation">
-        <a class="brand" href="{{ '/' | relative_url }}">{{ site.title | default: "Documentation" | escape }}</a>
+        {%- comment -%} Fixed header: brand + version stay visible while the nav scrolls. {%- endcomment -%}
+        <div class="sidebar-head">
+          <a class="brand" href="{{ '/' | relative_url }}">{{ site.title | default: "Documentation" | escape }}</a>
+          {%- if site.hydrozoa_version -%}
+          <span class="version" title="Hydrozoa release">v{{ site.hydrozoa_version }}</span>
+          {%- endif -%}
+        </div>
         <nav class="site-nav">
           <a class="nav-item{% if page.url == '/' %} active{% endif %}" href="{{ '/' | relative_url }}">Home</a>
 
@@ -41,8 +47,6 @@
         </div>
       </main>
     </div>
-
-    {%- include footer.html -%}
 
   </body>
 


### PR DESCRIPTION
Fixes the sidebar not appearing on the left: minima 2.5.1 (github-pages gem) has no `custom-head.html` include, so the layout CSS never loaded and the nav stacked on top. Overrides `head.html` to inject it. Also makes the sidebar compact (220px, smaller type), pins a brand+version header while the nav scrolls, and shows a `v0.1.1` badge (always on screen).