### PR TITLE
chore: remove the sbtn thin client from the devshell

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,11 +23,11 @@ sbt test
 sbt "testOnly *SpecificTestSuite*"
 ```
 
-**Note on `sbt` vs `sbtn`**: the build runs on **sbt 2** (`project/build.properties`). The bundled
-`sbtn` thin client is sbt 1.x and cannot drive an sbt 2 server (it reports
-`unknown event: sbt/exec`), so use `sbt`, not `sbtn`, until nixpkgs ships an sbt 2 launcher. If a
-warm server from a previous sbt 1.x session is still running, `sbt shutdown` (or `sbtn shutdown`)
-first, then re-launch `sbt` so it reboots into the version named in `build.properties`.
+**Note on `sbt`**: the build runs on **sbt 2** (`project/build.properties`). The `sbtn` thin client
+bundled with nixpkgs `sbt` is sbt 1.x and cannot drive an sbt 2 server (it reports
+`unknown event: sbt/exec`), so the devshell **removes `sbtn`** — use `sbt`. If a warm server from a
+previous session is still running on the wrong version, `sbt shutdown` first, then re-launch `sbt`
+so it reboots into the version named in `build.properties`. (Restore `sbtn` once nixpkgs ships sbt 2.)
 
 **Note**: IDEA (and Claude Code) are launched from within the Nix shell, so `sbt` and other tools
 are available directly — no `nix develop --command` prefix needed.

--- a/README.md
+++ b/README.md
@@ -79,8 +79,7 @@ Launch IDEA from within the Nix shell so `sbt` and the other tools are on `PATH`
 
 ### Building and testing
 
-Enter the sbt shell with `sbt` (or `sbtn` for a faster, resident server inside
-the Nix shell):
+Enter the sbt shell with `sbt`:
 
 ```shell
 sbt

--- a/design/init-tx-parsing.md
+++ b/design/init-tx-parsing.md
@@ -92,7 +92,7 @@ the config, not L1.
 ## Implementation plan
 
 Steps map to the five tasks: A→T1, C+«codec»→T4, D→T3, E+F→T2, G→T5. Ordered so each compiles and is
-testable (`just build-werror`; `sbtn "testOnly *InitializationTxSeq* *ConfigurationCodec* *Metadata*"`).
+testable (`just build-werror`; `sbt "testOnly *InitializationTxSeq* *ConfigurationCodec* *Metadata*"`).
 
 **A. Metadata: add `totalEquity`** (T1) — **done.** `Metadata.Initialization` gained `totalEquity: Coin`
 (`asMap` + `parseInner`); `InitializationTx.Build` writes `config.initialEquityContributed`.

--- a/docs/user-guide/DEPLOYMENT.md
+++ b/docs/user-guide/DEPLOYMENT.md
@@ -142,7 +142,7 @@ not using Nix (the runtime passes `--sun-misc-unsafe-memory-access=allow`).
 
 ```bash
 nix develop            # or direnv (.envrc = use flake .)
-sbt compile            # sbtn for the resident client
+sbt compile            # compile the project
 just test              # unit tests
 just integration-fast  # multi-peer integration subset
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,13 +6,13 @@ transcript (a "tutorial") of what happens when you run it.
 Every example runs **fully in-process against a mock L1** — no Yaci DevKit, no testnet, no keys, no
 network. It reuses the integration test harness (`MultiPeerHeadHarness`, `TestPeers`), so a reviewer
 can bring up a real multi-peer head with genuine fast + slow consensus and watch it drive L1
-operations, all from one `sbtn` command.
+operations, all from one `sbt` command.
 
 ## Examples
 
 | Example | What it shows | Run | Tutorial |
 | --- | --- | --- | --- |
-| Transient tokens | Minting and burning tokens inside the L2 ledger, scoped to the head's lifetime | `sbtn "examples/testOnly *TransientTokenDemo*"` | [tutorials/transient-tokens.md](tutorials/transient-tokens.md) |
+| Transient tokens | Minting and burning tokens inside the L2 ledger, scoped to the head's lifetime | `sbt "examples/testOnly *TransientTokenDemo*"` | [tutorials/transient-tokens.md](tutorials/transient-tokens.md) |
 
 ## How the examples are built
 

--- a/examples/tutorials/transient-tokens.md
+++ b/examples/tutorials/transient-tokens.md
@@ -1,6 +1,6 @@
 # Transient L2 tokens
 
-*Runs with:* `sbtn "examples/testOnly *TransientTokenDemo*"` — fully in-process against a mock L1.
+*Runs with:* `sbt "examples/testOnly *TransientTokenDemo*"` — fully in-process against a mock L1.
 
 ## What this demo shows
 

--- a/flake.nix
+++ b/flake.nix
@@ -23,9 +23,16 @@
         jdk = pkgs.openjdk25;
         # The nixpkgs sbt launcher (1.x) reads project/build.properties and bootstraps whatever
         # sbt version it names — including sbt 2.x — so no launcher pin is needed here.
-        # NB: the bundled `sbtn` thin client is sbt 1.x and cannot drive an sbt 2 server
-        # (it reports `unknown event: sbt/exec`); use `sbt`, not `sbtn`, until nixpkgs ships sbt 2.
         sbt0 = pkgs.sbt.override { jre = jdk; };
+        # The nixpkgs `sbt` package also bundles the `sbtn` thin client (sbt 1.x), which cannot
+        # drive an sbt 2 server (it reports `unknown event: sbt/exec`). Strip it so only `sbt` is on
+        # PATH — nobody should reach for the broken client by habit. Restore once nixpkgs ships an
+        # sbt 2 `sbtn`.
+        sbtNoSbtn = pkgs.symlinkJoin {
+          name = "sbt-no-sbtn";
+          paths = [ sbt0 ];
+          postBuild = "rm -f $out/bin/sbtn";
+        };
         visualvm = pkgs.visualvm.override { jdk = jdk; };
         # Define the hooks
         pre-commit-check = git-hooks.lib.${system}.run {
@@ -56,7 +63,7 @@
             libnotify # used in justfile
             ltex-ls # Language server for markdown: https://github.com/valentjn/ltex-ls
             nixfmt
-            sbt0
+            sbtNoSbtn
             scala-cli
             scalafix
             scalafmt

--- a/src/main/scala/hydrozoa/config/HydrozoaBlueprint.scala
+++ b/src/main/scala/hydrozoa/config/HydrozoaBlueprint.scala
@@ -48,7 +48,7 @@ object HydrozoaBlueprint {
                     if s == null then {
                         throw new IllegalStateException(
                           s"Blueprint resource not found: $blueprintResourcePath. " +
-                              "Make sure to run 'nix develop --command sbtn compile' first."
+                              "Make sure to run 'nix develop --command sbt compile' first."
                         )
                     }
                     s

--- a/src/main/scala/hydrozoa/rulebased/ledger/l1/script/plutus/Export.scala
+++ b/src/main/scala/hydrozoa/rulebased/ledger/l1/script/plutus/Export.scala
@@ -86,7 +86,7 @@ object Export {
 
     /** Main method for standalone execution.
       *
-      * Run with: nix develop --command sbtn "runMain
+      * Run with: nix develop --command sbt "runMain
       * hydrozoa.rulebased.ledger.l1.script.plutus.Export"
       */
     def main(args: Array[String]): Unit = {

--- a/src/test/scala/hydrozoa/rulebased/ledger/l1/script/plutus/ExportTest.scala
+++ b/src/test/scala/hydrozoa/rulebased/ledger/l1/script/plutus/ExportTest.scala
@@ -56,7 +56,7 @@ class ExportTest extends AnyFunSuite {
           "Dispute Resolution script hash mismatch. " +
               s"Expected: ${existingDispute.hash}, " +
               s"Got: ${freshDispute.hash}. " +
-              "Please run: nix develop --command sbtn 'runMain hydrozoa.rulebased.ledger.l1.script.plutus.Export'"
+              "Please run: nix develop --command sbt 'runMain hydrozoa.rulebased.ledger.l1.script.plutus.Export'"
         ) {
             freshDispute.hash
         }
@@ -64,7 +64,7 @@ class ExportTest extends AnyFunSuite {
         assertResult(
           existingDispute.compiledCode,
           "Dispute Resolution compiled code should match. " +
-              "Please run: nix develop --command sbtn 'runMain hydrozoa.rulebased.ledger.l1.script.plutus.Export'"
+              "Please run: nix develop --command sbt 'runMain hydrozoa.rulebased.ledger.l1.script.plutus.Export'"
         ) {
             freshDispute.compiledCode
         }
@@ -78,7 +78,7 @@ class ExportTest extends AnyFunSuite {
           "Rule-Based Treasury script hash mismatch. " +
               s"Expected: ${existingTreasury.hash}, " +
               s"Got: ${freshTreasury.hash}. " +
-              "Please run: nix develop --command sbtn 'runMain hydrozoa.rulebased.ledger.l1.script.plutus.Export'"
+              "Please run: nix develop --command sbt 'runMain hydrozoa.rulebased.ledger.l1.script.plutus.Export'"
         ) {
             freshTreasury.hash
         }
@@ -86,7 +86,7 @@ class ExportTest extends AnyFunSuite {
         assertResult(
           existingTreasury.compiledCode,
           "Rule-Based Treasury compiled code should match. " +
-              "Please run: nix develop --command sbtn 'runMain hydrozoa.rulebased.ledger.l1.script.plutus.Export'"
+              "Please run: nix develop --command sbt 'runMain hydrozoa.rulebased.ledger.l1.script.plutus.Export'"
         ) {
             freshTreasury.compiledCode
         }


### PR DESCRIPTION
nixpkgs `sbt` bundles `sbtn` (sbt 1.x), which can't drive an sbt 2 server (`unknown event: sbt/exec`). This strips it so only `sbt` is on PATH — nobody reaches for the broken client by habit.

- **flake.nix**: `sbtNoSbtn = symlinkJoin [ sbt0 ]` + postBuild `rm -f $out/bin/sbtn`, used in the devshell in place of `sbt0`.
- Swept every `sbtn` *usage* reference (README, CLAUDE.md, DEPLOYMENT, examples, design notes, Export/ExportTest/HydrozoaBlueprint messages) to `sbt`. Remaining `sbtn` mentions only explain the removal.

Verified in an isolated devshell (`nix develop --ignore-environment`): `sbt` resolves, `sbtn` is gone. Restore once nixpkgs ships an sbt 2 `sbtn`.

**Note:** after merging, reload direnv / re-enter `nix develop` to drop `sbtn` from your current session.