### PR TITLE
docs: interactive API reference (Redoc) in the user guide

### DIFF
--- a/docs/_layouts/redoc.html
+++ b/docs/_layouts/redoc.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>{{ page.title | default: "API reference" }} · Hydrozoa</title>
+  <style>
+    body { margin: 0; font-family: system-ui, -apple-system, "Segoe UI", sans-serif; }
+    .apibar {
+      position: sticky; top: 0; z-index: 10;
+      display: flex; align-items: center; gap: 12px; flex-wrap: wrap;
+      padding: 8px 16px; border-bottom: 1px solid #e2e8e8; background: #fafcfc; font-size: 14px;
+    }
+    .apibar a { color: #0b7a85; text-decoration: none; font-weight: 600; }
+    .apibar a:hover { text-decoration: underline; }
+    .apibar .sep { color: #cdd8d8; }
+    .apibar label { color: #566065; }
+    .apibar select {
+      font: inherit; padding: 3px 8px; border: 1px solid #cdd8d8; border-radius: 6px; background: #fff;
+    }
+  </style>
+</head>
+<body>
+  <div class="apibar">
+    <a href="{{ '/' | relative_url }}">← Hydrozoa docs</a>
+    <span class="sep">|</span>
+    <label for="specpick">API:</label>
+    <select id="specpick">
+      <option value="{{ '/spec/openapi.yaml' | relative_url }}">Head node API</option>
+      <option value="{{ '/spec/openapi-eutxo-l2.yaml' | relative_url }}">L2 EUTXO (query) API</option>
+    </select>
+  </div>
+  <div id="redoc"></div>
+  <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
+  <script>
+    (function () {
+      var pick = document.getElementById("specpick");
+      function render(url) {
+        Redoc.init(url, { hideDownloadButton: false, expandResponses: "200,201" },
+                   document.getElementById("redoc"));
+      }
+      pick.addEventListener("change", function () { render(pick.value); });
+      render(pick.value);
+    })();
+  </script>
+</body>
+</html>

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -10,6 +10,7 @@ repeating them.
 | [DEPOSIT.md](DEPOSIT.md) | Build a deposit: the L2 payload (EUTXO ledger) and the L1 deposit tx whose metadata pins the payload's hash. |
 | [L2TXS.md](L2TXS.md) | Build a basic L2 transaction (no mint/burn), including withdrawals and the mandatory tx metadata. |
 | [L2MINTING.md](L2MINTING.md) | Mint and burn tokens on L2: the transient-token declarations and the metadata a minting tx must carry. |
+| [API reference](api.html) | Interactive OpenAPI reference (Redoc): the head node API and the read-only L2 EUTXO query API. |
 
 Each of DEPOSIT / L2TXS / L2MINTING has a matching CLI subcommand of the packaged `hydrozoa`
 launcher (`submit-deposit`, `submit-l2-tx`) that serves as a runnable worked example; the guides

--- a/docs/user-guide/api.html
+++ b/docs/user-guide/api.html
@@ -1,0 +1,4 @@
+---
+layout: redoc
+title: API reference
+---


### PR DESCRIPTION
Renders the two OpenAPI specs as an interactive [Redoc](https://github.com/Redocly/redoc) page inside the docs site, discoverable from the **User guide** sidebar group.

## What

- `docs/_layouts/redoc.html` — full-screen Redoc layout (its own layout, not the sidebar `default`, so Redoc gets the whole viewport). A slim top bar carries a `← Hydrozoa docs` back link and a `<select>` to switch specs.
- `docs/user-guide/api.html` — the page (`layout: redoc`), so it lands in the user-guide sidebar group.
- `docs/user-guide/README.md` — adds an **API reference** row.

Both specs already deploy as static files under `/spec/` (verified `200 text/yaml` live), so Redoc fetches them client-side:
- `spec/openapi.yaml` — Hydrozoa node API
- `spec/openapi-eutxo-l2.yaml` — read-only L2 EUTXO query API

## Notes

- Docs-only change → CI skips the heavy build/test steps.
- Redoc loads from its CDN; allowed on Pages.