### PR TITLE
fix(build): use sbt-2 command syntax in build-werror recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -51,7 +51,7 @@ test:
 build-werror:
   #!/usr/bin/env bash
   trap 'just notify "build-werror"' EXIT
-  CI=true sbt Test/compile integration/Test/compile
+  CI=true sbt "Test/compile; integration/Test/compile"
 
 # Build the packaged `hydrozoa` launcher (target/universal/stage/bin/hydrozoa). Run this once after
 # changing code; the deployment recipes below then invoke it directly, with no sbt startup cost.


### PR DESCRIPTION
`just build-werror` broke after the sbt-2 migration (#580).

The recipe passed two commands space-separated:

```
CI=true sbt Test/compile integration/Test/compile
```

sbt **1.x** treated each argv element as a separate command. sbt **2.x** concatenates all args into one command line and parses it as a single command, where commands must be separated by `;` — so it fails with a parse error (`Expected '/'` after `Test/compile`) before compiling anything.

Fix: join the two compiles with a semicolon in one argument.

```diff
-  CI=true sbt Test/compile integration/Test/compile
+  CI=true sbt "Test/compile; integration/Test/compile"
```

Verified green locally (`just build-werror` → `success`, exit 0). Swept the rest of the justfile, READMEs, CLAUDE.md, and docs — this was the only invocation using the stale space-separated multi-command form.