### PR TITLE
docs(examples): update transient-token demo + tutorial to the L2 head-label metadata

### DIFF
--- a/examples/src/test/scala/hydrozoa/examples/transient/TransientTokenDemo.scala
+++ b/examples/src/test/scala/hydrozoa/examples/transient/TransientTokenDemo.scala
@@ -6,6 +6,7 @@ import cats.effect.unsafe.implicits.global
 import cats.syntax.all.*
 import hydrozoa.config.head.InitParamsType.Constant
 import hydrozoa.config.head.initialization.InitializationParameters
+import hydrozoa.config.head.initialization.InitializationParameters.HeadId
 import hydrozoa.config.head.multisig.timing.TxTiming.RequestTimes.{RequestValidityEndTime, RequestValidityStartTime}
 import hydrozoa.config.head.network.CardanoNetwork
 import hydrozoa.config.head.parameters.generateHeadParameters
@@ -24,10 +25,9 @@ import hydrozoa.multisig.consensus.UserRequestBody.TransactionRequestBody
 import hydrozoa.multisig.consensus.peer.HeadPeerNumber
 import hydrozoa.multisig.consensus.{RequestSequencer, SlowConsensusActorEvent, UserRequest, UserRequestBody, UserRequestHeader}
 import hydrozoa.multisig.ledger.eutxol2.toEvacuationKey
-import hydrozoa.multisig.ledger.eutxol2.tx.{L2Genesis, TransientOutputs}
+import hydrozoa.multisig.ledger.eutxol2.tx.{L2Genesis, L2Metadata}
 import hydrozoa.multisig.ledger.joint.obligation.Payout
 import hydrozoa.multisig.ledger.joint.{EvacuationMap, evacuationKeyOrdering}
-import hydrozoa.multisig.ledger.l1.token.CIP67
 import hydrozoa.multisig.ledger.stack.StackEffects
 import hydrozoa.rulebased.ledger.l1.script.plutus.RuleBasedTreasuryValidator.evacuationKeyToData
 import java.time.Instant
@@ -37,9 +37,8 @@ import org.scalacheck.{Gen, Prop, Properties}
 import scala.collection.immutable.{SortedMap, TreeMap}
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scalus.cardano.address.ShelleyAddress
-import scalus.cardano.ledger.AuxiliaryData.Metadata
 import scalus.cardano.ledger.TransactionOutput.Babbage
-import scalus.cardano.ledger.{AssetName, AuxiliaryData, Coin, KeepRaw, Metadatum, MultiAsset, PolicyId, Script, SlotConfig, Timelock, Transaction, TransactionHash, TransactionInput, TransactionOutput, Utxo, Utxos, Value, Word64}
+import scalus.cardano.ledger.{AssetName, AuxiliaryData, Coin, KeepRaw, MultiAsset, PolicyId, Script, SlotConfig, Timelock, Transaction, TransactionHash, TransactionInput, TransactionOutput, Utxo, Utxos, Value}
 import scalus.cardano.txbuilder.TransactionBuilderStep.{Fee, Mint, ModifyAuxiliaryData, Send, Spend}
 import scalus.cardano.txbuilder.{NativeScriptWitness, PubKeyWitness, TransactionBuilder, TransactionBuilderStep}
 import scalus.crypto.ed25519.VerificationKey
@@ -130,26 +129,20 @@ object TransientTokenDemo extends Properties("Transient token demo") {
           rateLimits = RateLimits(softBlockMinPeriod = 5.seconds, hardStackMinPeriod = 2.seconds)
         )
 
-    /** The head-label metadata for an L2 transaction: per-output L1(1)/L2(2) markers plus the
-      * transient declarations (Map shape when declarations exist, bare list otherwise).
+    /** The [[L2Metadata]] head-label metadata for an L2 transaction: the headId pin, the L1-bound
+      * output indices (marker 1), and the transient-token declarations.
       */
     private def mkHeadMetadata(
+        headId: HeadId,
         markers: List[Int],
         transientOutputs: Map[Int, MultiAsset]
     ): AuxiliaryData = {
-        val markerList =
-            Metadatum.List(markers.map(marker => Metadatum.Int(marker.toLong)).toIndexedSeq)
-        val headMetadatum =
-            if transientOutputs.isEmpty then markerList
-            else
-                Metadatum.Map(
-                  Map(
-                    Metadatum.Text("outputs") -> markerList,
-                    Metadatum.Text("transientOutputs") ->
-                        TransientOutputs.encodeMetadatum(transientOutputs)
-                  )
-                )
-        Metadata(Map(Word64(CIP67.Tags.head) -> headMetadatum))
+        // Marker 1 = L1-bound (withdrawal); every other output stays on L2.
+        val l1BoundOutputs = markers.zipWithIndex.collect { case (1, index) => index }
+        L2Metadata.asAuxData(
+          headId,
+          L2Metadata(l1BoundOutputs = l1BoundOutputs, l2TransientTokens = transientOutputs)
+        )
     }
 
     /** Build the deterministic chain of signed demo txs off the initial pot utxo. Tx ids are stable
@@ -187,7 +180,15 @@ object TransientTokenDemo extends Properties("Transient token demo") {
               Spend(Utxo(spentInput, Babbage(spentAddress, spentValue)), PubKeyWitness),
               Send(output),
               Fee(Coin.zero),
-              ModifyAuxiliaryData(_ => Some(mkHeadMetadata(List(marker), transientOutputs)))
+              ModifyAuxiliaryData(_ =>
+                  Some(
+                    mkHeadMetadata(
+                      mnc.nodeConfigs(HeadPeerNumber(0)).headId,
+                      List(marker),
+                      transientOutputs
+                    )
+                  )
+              )
             ) ++ mint.map(amount =>
                 Mint(policyId, demoAssetName, amount, NativeScriptWitness.attached(mintScript))
             )

--- a/examples/tutorials/transient-tokens.md
+++ b/examples/tutorials/transient-tokens.md
@@ -28,11 +28,18 @@ transaction itself declares which output tokens are transient, via a new optiona
 under the head's label:
 
 ```
-{HYDR}: {
-  "outputs":          [1|2, ...]                      # per-output L1/L2 marker, as before
-  "transientOutputs": { outputIndex: { policyId: { assetName: quantity } } }
+4937: {
+  "L2": {
+    <headId hex>: {
+      "l1BoundOutputs":    [outputIndex, ...]                            # withdrawal output indices (empty if none)
+      "l2TransientTokens": { outputIndex: { policyId: { assetName: quantity } } }
+    }
+  }
 }
 ```
+
+The metadata reuses Hydrozoa's L1 transaction layout (label 4937 → role `"L2"` → head-id → fields);
+outputs whose index is absent from `l1BoundOutputs` stay on L2.
 
 Validation then runs twice over two views of the same transaction:
 
@@ -54,8 +61,8 @@ lines:
 
 1. **Boot.** The head initializes; stack 0 hard-confirms; the init tx lands on the mock L1. The
    pot utxo exists only in L2.
-2. **Rejected withdrawal (submitted first).** A withdrawal marked `1` (L1-bound) whose output
-   declares the transient bundle. The head rejects it at validation — transient tokens cannot
+2. **Rejected withdrawal (submitted first).** A withdrawal (its output index listed in
+   `l1BoundOutputs`) whose output declares the transient bundle. The head rejects it at validation — transient tokens cannot
    leave the head. Its input stays unspent, which is what lets the rest of the chain proceed: the
    later burn spends the same utxo, so the burn's success doubles as proof of this rejection.
 3. **Mint.** The issuer submits an L2 transaction minting 1,000 DEMO under a native single-key
@@ -74,7 +81,7 @@ any kind appears on L1**, and the head produced no actor errors.
 ## What to take away
 
 - Minting/burning on L2 uses the standard Cardano mechanisms — mint fields, native or Plutus V3
-  policies, redeemers — with one addition: the `transientOutputs` declaration.
+  policies, redeemers — with one addition: the `l2TransientTokens` declaration.
 - The evacuation invariant is preserved *by construction*: the main compartment is validated by
   the same battle-tested conservation rule that validated it before this feature existed.
 - Applications issuing transient tokens should provide a redemption path (like the burn here), so


### PR DESCRIPTION
Follow-up to #591 (L2 tx metadata → L1 head-label format). Brings the `examples/` transient-token demo and its tutorial in line with the new metadata, so they no longer show the removed bare-list `"outputs"`/`"transientOutputs"` format.

- **`TransientTokenDemo.scala`** — `mkHeadMetadata` now builds via `L2Metadata.asAuxData` (headId pin + `l1BoundOutputs` + `l2TransientTokens`); marker `1` (withdrawal) → `l1BoundOutputs`; the caller threads `mnc.nodeConfigs(HeadPeerNumber(0)).headId`.
- **`tutorials/transient-tokens.md`** — metadata block + field references updated to `4937 → "L2" → headId → { l1BoundOutputs, l2TransientTokens }`.

**Note:** the `examples` module is **pre-broken on `main`** for unrelated API drift (`InitializationParameters.seedUtxo`, `consensus.UserRequestHeader`, etc.) and is **not in CI**, so it does not compile regardless. Verified locally that this change adds **no new** compile errors — the only errors are the pre-existing drift. Fixing that drift (and adding `examples` to CI) remains a separate deferred follow-up.