### PR TITLE
fix(build): stage the launcher at the path the justfile expects

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -78,6 +78,12 @@ lazy val core: Project = (project in file("."))
         // logback.xml. `$1` here is the subcommand (runs before the launcher's own arg processing).
         """if [ "${1:-}" != "serve" ]; then addJava "-Dlogback.configurationFile=logback-cli.xml"; fi"""
       ),
+      // sbt 2 stages under target/out/jvm/scala-<v>/core/; pin the local `stage` output to the
+      // stable repo-root path the justfile's deployment recipes expect
+      // (target/universal/stage/bin/hydrozoa). Docker packaging keeps its own staging dir. The key
+      // is qualified because JavaAppPackaging and DockerPlugin both re-export `stagingDirectory`.
+      Universal / com.typesafe.sbt.packager.Keys.stagingDirectory :=
+          baseDirectory.value / "target" / "universal" / "stage",
       // Docker settings
       Docker / packageName := "cardano-hydrozoa/hydrozoa",
       Docker / version := version.value,


### PR DESCRIPTION
`just stage && just scaffold` (and every other deployment recipe) fails with:

```
error: the 'hydrozoa' launcher isn't built — run 'just stage' first
```

even though `just stage` succeeded. The sbt-2 migration relocated app packaging into the `core` project **and** sbt 2 stages under `target/out/jvm/scala-<v>/core/universal/stage/`, but the justfile still expects `target/universal/stage/bin/hydrozoa` (checked by `_require-launcher`, used by `scaffold`, `keygen-fleet`, `build-head-config`, `serve`, …). Same class of sbt-2 leftover as #590.

**Fix:** pin `core / Universal / stagingDirectory` to the stable repo-root `target/universal/stage`, so the recipes resolve the launcher again. Version-independent (no hard-coded `scala-<v>/core` in any path), and Docker packaging is untouched (it keeps its own `Docker / stagingDirectory`).

Verified locally:
- `sbt stage` → `target/universal/stage/bin/hydrozoa` present and runs (`hydrozoa 0.1.1`).
- `just scaffold <dir>` now scaffolds successfully (guard passes) instead of erroring.