### PR TITLE
docs(onchain): fix unresolved scaladoc links

### DIFF
--- a/cardano-onchain/src/main/scala/hydrozoa/multisig/ledger/joint/EvacuationKey.scala
+++ b/cardano-onchain/src/main/scala/hydrozoa/multisig/ledger/joint/EvacuationKey.scala
@@ -2,7 +2,7 @@ package hydrozoa.multisig.ledger.joint
 
 import scalus.uplc.builtin.ByteString
 
-/** Key identifying a UTxO slot in the evacuation map. Wraps a raw [[ByteString]]. */
+/** Key identifying a UTxO slot in the evacuation map. Wraps a raw `ByteString`. */
 final case class EvacuationKey private (byteString: ByteString)
 
 object EvacuationKey:

--- a/cardano-onchain/src/main/scala/hydrozoa/rulebased/ledger/l1/state/VoteState.scala
+++ b/cardano-onchain/src/main/scala/hydrozoa/rulebased/ledger/l1/state/VoteState.scala
@@ -67,18 +67,19 @@ object VoteState:
     given ToData[VoteDatum] = ToData.derived
 
     /** Status of a single vote utxo at the dispute resolution address. Maps to the foundation
-      * spec's phases: [[AwaitingVote]] is Reserved; [[Voted]] and [[Abstain]] are Open.
+      * spec's phases: [[VoteStatus.AwaitingVote]] is Reserved; [[VoteStatus.Voted]] and
+      * [[VoteStatus.Abstain]] are Open.
       *
-      *   - [[AwaitingVote]] — Reserved phase: the named peer can transition this box to [[Voted]]
-      *     or [[Abstain]] via the permissioned one-shot path.
-      *   - [[Voted]] — Open phase: a KZG commitment + minor block version. Any multisigned SEC with
-      *     a strictly higher `versionMinor` (under the same `versionMajor`) can ratchet this status
-      *     forward, regardless of who signs the transaction.
-      *   - [[Abstain]] — Open phase: the reserved peer opted out (e.g. when no SEC is available
-      *     because the latest hard-confirmed stack is Initial or a Major with no trailing minors —
-      *     closes the gap left by the KZG-out-of-BlockHeader refactor). A subsequent multisigned
-      *     SEC can still ratchet this to [[Voted]] (with any `versionMinor > 0`), enlarging the
-      *     open-phase pool.
+      *   - [[VoteStatus.AwaitingVote]] — Reserved phase: the named peer can transition this box to
+      *     [[VoteStatus.Voted]] or [[VoteStatus.Abstain]] via the permissioned one-shot path.
+      *   - [[VoteStatus.Voted]] — Open phase: a KZG commitment + minor block version. Any
+      *     multisigned SEC with a strictly higher `versionMinor` (under the same `versionMajor`)
+      *     can ratchet this status forward, regardless of who signs the transaction.
+      *   - [[VoteStatus.Abstain]] — Open phase: the reserved peer opted out (e.g. when no SEC is
+      *     available because the latest hard-confirmed stack is Initial or a Major with no trailing
+      *     minors — closes the gap left by the KZG-out-of-BlockHeader refactor). A subsequent
+      *     multisigned SEC can still ratchet this to [[VoteStatus.Voted]] (with any
+      *     `versionMinor > 0`), enlarging the open-phase pool.
       */
     enum VoteStatus:
         case AwaitingVote(peer: PubKeyHash)


### PR DESCRIPTION
`sbt doc` emitted two "Couldn't resolve a member for the given link query" warnings; both are fixed.

- **`EvacuationKey.scala`** — `[[ByteString]]` links a third-party (scalus) type scaladoc can't index. Switched to a monospace `` `ByteString` `` span (you don't hyperlink external types).
- **`VoteState.scala`** — the `VoteStatus` enum-case links (`[[AwaitingVote]]`, `[[Voted]]`, `[[Abstain]]`) resolved from the wrong scope. Qualified them as `[[VoteStatus.AwaitingVote]]` etc.

Verified: `sbt cardanoOnchain/doc` now completes with no resolve warnings. (The unrelated `-Xplugin is currently not supported` line remains — that's the scalus compiler plugin not applying to the `doc` task, not a doc-link issue.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)