### PR TITLE
docs(deployment): align release+deploy docs with compose path/image changes

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,12 +15,13 @@ the image with `sbt Docker/stage` and pushes it to ghcr. No manual `docker push`
    and `GET /version` — keep it equal to the git tag below. The same image tag is **hard-coded** in
    a few deployment files that do *not* read `build.sbt`, so bump them in lockstep:
 
-   - `hydrozoa.sh` — `HYDROZOA_VERSION` default
-   - `docker-compose.yml` — the default `${HYDROZOA_IMAGE:-ghcr.io/cardano-hydrozoa/hydrozoa:X.Y.Z}`
+   - `src/main/resources/scaffold/hydrozoa.sh` — `HYDROZOA_VERSION` default
+   - `src/main/resources/scaffold/docker-compose.yml` — the default
+     `${HYDROZOA_IMAGE:-ghcr.io/cardano-hydrozoa/hydrozoa:X.Y.Z}`
    - `docs/user-guide/DEPLOYMENT.md` — the `…/hydrozoa:X.Y.Z` pull/run examples
 
    Catch stragglers with `grep -rn "hydrozoa:<previous-version>"` (and the bare previous version in
-   `hydrozoa.sh`). Not bumped: `HydrozoaRoutes.apiVersion` + `docs/openapi*.yaml` (the API-contract
+   `scaffold/hydrozoa.sh`). Not bumped: `HydrozoaRoutes.apiVersion` + `docs/openapi*.yaml` (the API-contract
    version, separate from the release version). Commit the bump on `main` (via PR; `main` is
    protected).
 

--- a/docs/user-guide/DEPLOYMENT.md
+++ b/docs/user-guide/DEPLOYMENT.md
@@ -153,11 +153,11 @@ Two ways to use your build:
 
 **A local Docker image** — the same image as the published one, from your sources. It is tagged
 both `cardano-hydrozoa/hydrozoa:0.1.2` and `ghcr.io/cardano-hydrozoa/hydrozoa:0.1.2`, so it matches
-`docker compose`'s default image name — no `HYDROZOA_IMAGE` override needed:
+`docker compose`'s default image name — the scaffolded head (§5) picks it up with no `HYDROZOA_IMAGE`
+override:
 
 ```bash
 just docker-image      # -> cardano-hydrozoa/hydrozoa:0.1.2 + ghcr.io/… (base eclipse-temurin:25-jre)
-docker compose up -d   # picks up the local ghcr.io/cardano-hydrozoa/hydrozoa:0.1.2 build
 ```
 
 **Locally-compiled code (development)** — `just stage` builds the `hydrozoa` launcher from the
@@ -358,8 +358,9 @@ At this point every node has its two files, and the composition (§5) mounts
 `docker-compose.yml` — one `hydrozoa` container per node on a single user-defined bridge network,
 `mesh`.
 
-- Config mounts come from `${HYDROZOA_HOME:-./head/demo}`: the shared `head-config.json` plus
-  `head-N/private.json` or `coil-N/private.json` per node. The image defaults to the published
+- Config mounts resolve against `.` — the head directory the compose file was scaffolded into — so
+  running compose from there mounts that dir's shared `head-config.json` plus each node's
+  `head-N/private.json` or `coil-N/private.json`. The image defaults to the published
   `ghcr.io/cardano-hydrozoa/hydrozoa:0.1.2` (pulled on first run); set `${HYDROZOA_IMAGE}` to use
   another, e.g. a locally built `cardano-hydrozoa/hydrozoa:0.1.2`.
 
@@ -378,27 +379,14 @@ Caveats:
 
 ### Bringing up the head
 
-Default — pull the published image and run the scaffolded head (`hydrozoa.sh` exports
-`HYDROZOA_HOME`, so `docker compose` mounts the same workspace the CLI generated into):
+The `docker-compose.yml` is scaffolded into the head directory, so `cd` there first — its config
+paths resolve against `.` (that directory).
+
+Default — pull the published image and run the scaffolded head:
 
 ```bash
-docker compose up -d           # pulls ghcr.io/cardano-hydrozoa/hydrozoa:0.1.2 on first run
-```
-
-**Another image** — `HYDROZOA_IMAGE` (default `ghcr.io/cardano-hydrozoa/hydrozoa:0.1.2`), e.g. a
-locally built one (§3):
-
-```bash
-HYDROZOA_IMAGE=cardano-hydrozoa/hydrozoa:0.1.2 docker compose up -d
-```
-
-**Another configuration** — `HYDROZOA_HOME` selects the directory each container mounts
-`head-config.json` + its `private.json` from (`hydrozoa.sh` sets it to your scaffolded workspace; the
-compose file itself falls back to `./head/demo`, the local `just` default). It's the same variable
-the CLI generates into, so one value drives both the build and the run:
-
-```bash
-HYDROZOA_HOME=/abs/path/to/other-head docker compose up -d
+cd "$HYDROZOA_HOME"            # the scaffolded head dir (default head/demo)
+docker compose up -d          # pulls ghcr.io/cardano-hydrozoa/hydrozoa:0.1.2 on first run
 ```
 
 Stack 0 initializes once both head peers + any `coilQuorum` coil peers are signing.
@@ -422,6 +410,16 @@ this section:
 The `(0,0)` entry under `happyPathEffects` is the initialization tx — open its hash in the
 network's explorer to check it out. Every following happy-path effect (settlements, the
 finalization) appears in the same section as the head progresses.
+
+**Another image** — `HYDROZOA_IMAGE` (default `ghcr.io/cardano-hydrozoa/hydrozoa:0.1.2`), e.g. a
+locally built one (§3):
+
+```bash
+HYDROZOA_IMAGE=cardano-hydrozoa/hydrozoa:0.1.2 docker compose up -d
+```
+
+**Another head** — each head directory carries its own `docker-compose.yml`, so switch heads by
+`cd`-ing into a different one (e.g. a per-network `head/release/preview`) before `docker compose up`.
 
 ### Restarting the head
 


### PR DESCRIPTION
Follow-up to the compose changes on `release/0.1.2` (`9b6236a6` hardcode `.` for config mounts / drop `HYDROZOA_HOME`; `ee40fa80` default image tag from `HYDROZOA_VERSION`) — the docs were not updated in lockstep.

- **RELEASE.md** — point the version-bump checklist (and the `grep` straggler hint) at `src/main/resources/scaffold/hydrozoa.sh` and `.../docker-compose.yml`, their new home.
- **docs/user-guide/DEPLOYMENT.md** — drop `HYDROZOA_HOME` throughout; config mounts now resolve against `.`, so the flow is `cd` into the scaffolded head dir then `docker compose up`. Move the `HYDROZOA_IMAGE` override note down and add an "Another head" note (switch heads by `cd`-ing into a different dir).

Docs-only, no code.