### PR TITLE
feat(consensus): cap blocks at maxRequestsPerBlock (fairness + overflow)

### DIFF
--- a/src/main/scala/hydrozoa/bootstrap/Bootstrap.scala
+++ b/src/main/scala/hydrozoa/bootstrap/Bootstrap.scala
@@ -9,6 +9,7 @@ import hydrozoa.config.ScriptReferenceUtxos
 import hydrozoa.config.head.HeadConfig
 import hydrozoa.config.head.coil.{CoilPeerData, CoilPeers}
 import hydrozoa.config.head.initialization.{InitialBlock, InitializationParameters}
+import hydrozoa.config.head.multisig.block.BlockConfig
 import hydrozoa.config.head.multisig.fallback.FallbackContingency
 import hydrozoa.config.head.multisig.fallback.FallbackContingency.mkFallbackContingencyWithDefaults
 import hydrozoa.config.head.multisig.settlement.SettlementConfig
@@ -157,6 +158,7 @@ object Bootstrap:
         fallbackContingency: FallbackContingency,
         disputeResolutionConfig: DisputeResolutionConfig,
         settlementConfig: SettlementConfig,
+        blockConfig: BlockConfig,
         coilQuorum: Int
     )
 
@@ -334,6 +336,7 @@ object Bootstrap:
           fallbackContingency = bhp.fallbackContingency,
           disputeResolutionConfig = bhp.disputeResolutionConfig,
           settlementConfig = bhp.settlementConfig,
+          blockConfig = bhp.blockConfig,
           coilQuorum = bhp.coilQuorum,
           // Placeholder: the L2 params hash is not consumed yet. Hash32 requires 32 bytes, so use
           // a zero hash rather than empty bytes (which fail the length check).
@@ -1231,6 +1234,7 @@ object InitBootstrapFiles:
               ),
               disputeResolutionConfig = DisputeResolutionConfig.default(network.slotConfig),
               settlementConfig = SettlementConfig(PositiveInt.unsafeApply(100)),
+              blockConfig = BlockConfig(PositiveInt.unsafeApply(1000)),
               coilQuorum = coilQuorum
             )
             // Demo equity: head peer 0 funds the whole head, the rest contribute zero and co-sign.

--- a/src/main/scala/hydrozoa/config/head/multisig/block/BlockConfig.scala
+++ b/src/main/scala/hydrozoa/config/head/multisig/block/BlockConfig.scala
@@ -1,0 +1,30 @@
+package hydrozoa.config.head.multisig.block
+
+import hydrozoa.lib.number.PositiveInt
+import io.circe.*
+import io.circe.generic.semiauto.*
+
+/** The per-block production limits the peers agree upon. Head-agreed (hashed into the treasury
+  * datum), so every peer packs and reproduces blocks under the same ceiling.
+  */
+final case class BlockConfig(
+    override val maxRequestsPerBlock: PositiveInt
+) extends BlockConfig.Section {
+    override transparent inline def blockConfig: BlockConfig = this
+}
+
+object BlockConfig {
+    trait Section {
+        def blockConfig: BlockConfig
+
+        /** The maximum number of user requests a single block may hold. The leader packs at most
+          * this many per block; the overflow rolls into the next block. Also anchors the mesh pull
+          * ceiling and the request-sequencer backpressure (see docs/spec/fast-consensus.md).
+          */
+        def maxRequestsPerBlock: PositiveInt = blockConfig.maxRequestsPerBlock
+    }
+
+    given blockConfigEncoder: Encoder[BlockConfig] = deriveEncoder[BlockConfig]
+
+    given blockConfigDecoder: Decoder[BlockConfig] = deriveDecoder[BlockConfig]
+}

--- a/src/main/scala/hydrozoa/config/head/parameters/HeadParameters.scala
+++ b/src/main/scala/hydrozoa/config/head/parameters/HeadParameters.scala
@@ -1,5 +1,6 @@
 package hydrozoa.config.head.parameters
 
+import hydrozoa.config.head.multisig.block.BlockConfig
 import hydrozoa.config.head.multisig.fallback.FallbackContingency
 import hydrozoa.config.head.multisig.settlement.SettlementConfig
 import hydrozoa.config.head.multisig.timing.TxTiming
@@ -18,6 +19,7 @@ final case class HeadParameters(
     override val fallbackContingency: FallbackContingency,
     override val disputeResolutionConfig: DisputeResolutionConfig,
     override val settlementConfig: SettlementConfig,
+    override val blockConfig: BlockConfig,
     // QUESTION: (from Peter to Ilia): I don't think we need to pin the coil quorum here, do we?
     //   It will be in the multisig native script; the hash will change if the peers don't agree.
     override val coilQuorum: Int,
@@ -39,7 +41,8 @@ object HeadParameters {
         extends TxTiming.Section,
           FallbackContingency.Section,
           DisputeResolutionConfig.Section,
-          SettlementConfig.Section {
+          SettlementConfig.Section,
+          BlockConfig.Section {
         def headParameters: HeadParameters
 
         /** A black-box, L2-specific blake2b-256 hash of the L2 parameters that the peers agree upon
@@ -72,5 +75,8 @@ object HeadParameters {
 
         def settlementConfig: SettlementConfig =
             headParameters.settlementConfig
+
+        def blockConfig: BlockConfig =
+            headParameters.blockConfig
     }
 }

--- a/src/main/scala/hydrozoa/multisig/consensus/BlockWeaver.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/BlockWeaver.scala
@@ -3,6 +3,7 @@ import cats.effect.IO
 import cats.implicits.*
 import com.suprnation.actor.Actor.{Actor, Receive}
 import com.suprnation.actor.ActorRef.ActorRef
+import hydrozoa.config.head.multisig.block.BlockConfig
 import hydrozoa.config.head.multisig.timing.TxTiming
 import hydrozoa.config.head.multisig.timing.TxTiming.BlockTimes.{BlockCreationEndTime, BlockCreationStartTime}
 import hydrozoa.config.head.network.CardanoNetwork
@@ -14,6 +15,7 @@ import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.HeadMultisigRegimeManager
 import hydrozoa.multisig.consensus.BlockWeaver.State.Leader.AwaitingConfirmation.StartedBlock.{NotStarted, Started}
 import hydrozoa.multisig.consensus.mempool.Mempool
+import hydrozoa.multisig.consensus.peer.{HeadPeerNumber, PeerId}
 import hydrozoa.multisig.consensus.pollresults.PollResults
 import hydrozoa.multisig.ledger.block.{Block, BlockBrief, BlockNumber}
 import hydrozoa.multisig.ledger.event.RequestId
@@ -72,7 +74,17 @@ final case class BlockWeaver(
 
 object BlockWeaver {
     type Config = CardanoNetwork.Section & OwnPeerPublic.Section &
-        NodeOperationMultisigConfig.Section
+        NodeOperationMultisigConfig.Section & BlockConfig.Section
+
+    /** This peer's head-peer number. Only ever called on the leader path, which a coil peer never
+      * reaches ([[OwnPeerPublic.Section.canLeadFast]] is always false there).
+      */
+    private def ownHeadPeerNum(config: OwnPeerPublic.Section): HeadPeerNumber =
+        config.ownPeerId match {
+            case PeerId.Head(n) => n
+            case PeerId.Coil(_) =>
+                throw IllegalStateException("BlockWeaver leader path reached on a coil peer")
+        }
 
     final case class Connections private[BlockWeaver] (
         blockWeaver: BlockWeaver.Handle,
@@ -639,7 +651,8 @@ object BlockWeaver {
                 override def act(config: Config): IO[Some[NextReactiveState]] = for {
                     _ <- logStateTransition
                     _ <- realTimeQuantizedInstant(config.slotConfig)
-                    requests <- extractRequestsInOrder
+                    extracted <- extractRequestsForBlock(config)
+                    (requests, survivingMempool) = extracted
                     isBlockStarted <-
                         if requests.isEmpty
                         then IO.pure(NotStarted)
@@ -652,16 +665,28 @@ object BlockWeaver {
                       Leader.AwaitingConfirmation(
                         this,
                         leadingBlockNum,
-                        isBlockStarted
+                        isBlockStarted,
+                        survivingMempool,
+                        requestsInBlock = requests.size
                       )
                     )
                 } yield newState
 
-                private def extractRequestsInOrder: IO[List[UserRequestWithId]] = {
-                    val requests = mempool.extractRequestsInOrder
+                /** Extract at most [[BlockConfig.Section.maxRequestsPerBlock]] requests for the
+                  * block this peer is leading, preferring this peer's own requests (fairness); the
+                  * overflow stays in the surviving mempool for later blocks.
+                  */
+                private def extractRequestsForBlock(
+                    config: Config
+                ): IO[(List[UserRequestWithId], Mempool)] = {
+                    val (requests, survivingMempool) =
+                        mempool.extractInOrderPreferring(
+                          ownHeadPeerNum(config),
+                          config.maxRequestsPerBlock
+                        )
                     tracer.traceWith(
                       BlockWeaverEvent.MempoolExtracted(requests.map(_.requestId))
-                    ) >> IO.pure(requests)
+                    ) >> IO.pure((requests, survivingMempool))
                 }
             }
 
@@ -691,8 +716,16 @@ object BlockWeaver {
                 override val pollResults: PollResults,
                 override val finalizationLocallyTriggered: LocalFinalizationTrigger,
                 leadingBlockNumber: BlockNumber,
-                isBlockStarted: Leader.AwaitingConfirmation.StartedBlock
-            ) extends Reactive {
+                isBlockStarted: Leader.AwaitingConfirmation.StartedBlock,
+                // Overflow held back once the open block reached its request cap; rolls into the next
+                // block. Empty while the block is below the cap.
+                override val mempool: Mempool,
+                // How many requests the open block already holds. Once it reaches
+                // `config.maxRequestsPerBlock`, further requests are held in `mempool` instead of
+                // being forwarded to the joint ledger.
+                requestsInBlock: Int
+            ) extends Reactive,
+                  WithMempool {
                 override transparent inline def stateName: String = "Leader.AwaitingConfirmation"
 
                 export Leader.AwaitingConfirmation.{NextReactiveState, Unexpected}
@@ -702,7 +735,8 @@ object BlockWeaver {
                         case ur: UserRequestWithId =>
                             // First block is implicitly confirmed, so we complete it immediately —
                             // as the final block when finalization was requested (mirroring
-                            // completeNextBlock below), regular otherwise.
+                            // completeNextBlock below), regular otherwise. Any capped-out overflow
+                            // rolls into the next block.
                             def completeFirstBlock =
                                 if finalizationLocallyTriggered.asBoolean
                                 then sendCompleteFinalBlockAsLeader(config) >> stop()
@@ -714,25 +748,49 @@ object BlockWeaver {
                                           tracer,
                                           pollResults,
                                           finalizationLocallyTriggered,
-                                          mempool = Mempool.empty,
+                                          mempool = mempool,
                                           nextBlockNumber = leadingBlockNumber.increment
                                         ).act(config)
                                     } yield newState
 
-                            for {
-                                _ <- IO.whenA(isBlockStarted == NotStarted)(
-                                  sendStartBlock(config)(leadingBlockNumber)
-                                )
+                            def forwardIntoBlock =
+                                for {
+                                    _ <- IO.whenA(isBlockStarted == NotStarted)(
+                                      sendStartBlock(config)(leadingBlockNumber)
+                                    )
+                                    _ <- tracer.traceWith(
+                                      BlockWeaverEvent.RequestSentToJointLedger(ur.requestId)
+                                    )
+                                    _ <- connections.jointLedger ! ur
+                                    res <-
+                                        if leadingBlockNumber == BlockNumber.zero.increment
+                                        then completeFirstBlock
+                                        else
+                                            pure(
+                                              this.copy(
+                                                isBlockStarted = Started,
+                                                requestsInBlock = requestsInBlock + 1
+                                              )
+                                            )
+                                } yield res
 
-                                _ <- tracer.traceWith(
-                                  BlockWeaverEvent.RequestSentToJointLedger(ur.requestId)
-                                )
-                                _ <- connections.jointLedger ! ur
-                                res <-
-                                    if leadingBlockNumber == BlockNumber.zero.increment
-                                    then completeFirstBlock
-                                    else pure(this.copy(isBlockStarted = Started))
-                            } yield res
+                            // Once the open block reaches the cap, hold further requests in the
+                            // mempool for the next block instead of forwarding them to the joint
+                            // ledger. The first block is exempt: it completes on its first request,
+                            // so it is below the cap by construction.
+                            def holdForNextBlock =
+                                for {
+                                    _ <- tracer.traceWith(
+                                      BlockWeaverEvent.RequestAddedToMempool(ur.requestId)
+                                    )
+                                    newMempool <- storeRequest(ur)
+                                    res <- pure(this.copy(mempool = newMempool))
+                                } yield res
+
+                            if leadingBlockNumber == BlockNumber.zero.increment ||
+                                requestsInBlock < config.maxRequestsPerBlock
+                            then forwardIntoBlock
+                            else holdForNextBlock
 
                         case bc: Block.SoftConfirmed.NonFinal =>
                             def completeBlockRegular =
@@ -742,7 +800,7 @@ object BlockWeaver {
                                       tracer,
                                       pollResults,
                                       finalizationLocallyTriggered = finalizationLocallyTriggered,
-                                      mempool = Mempool.empty,
+                                      mempool = mempool,
                                       nextBlockNumber = leadingBlockNumber.increment
                                     ).act(config)
 
@@ -761,6 +819,10 @@ object BlockWeaver {
                                 if isBlockStarted == Started
                                 then completeNextBlock
                                 else
+                                    // NotStarted here implies no request was ever forwarded, hence an
+                                    // empty mempool (a non-empty mempool would have been extracted at
+                                    // arming and started the block), so no overflow is dropped by
+                                    // handing off to AwaitingRequest.
                                     tracer.traceWith(
                                       BlockWeaverEvent.PreviousBlockConfirmation(bc.blockNum)
                                     ) >> scheduleWakeupFiber(config, bc) >>
@@ -900,7 +962,9 @@ object BlockWeaver {
                 private[State] def apply(
                     state: State,
                     blockNumber: BlockNumber,
-                    isBlockStarted: StartedBlock
+                    isBlockStarted: StartedBlock,
+                    mempool: Mempool,
+                    requestsInBlock: Int
                 ): Leader.AwaitingConfirmation =
                     import state.*
                     Leader.AwaitingConfirmation(
@@ -909,7 +973,9 @@ object BlockWeaver {
                       pollResults,
                       finalizationLocallyTriggered,
                       blockNumber,
-                      isBlockStarted
+                      isBlockStarted,
+                      mempool,
+                      requestsInBlock
                     )
 
                 enum StartedBlock:

--- a/src/main/scala/hydrozoa/multisig/consensus/mempool/Mempool.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/mempool/Mempool.scala
@@ -1,6 +1,7 @@
 package hydrozoa.multisig.consensus.mempool
 
 import hydrozoa.multisig.consensus.UserRequestWithId
+import hydrozoa.multisig.consensus.peer.HeadPeerNumber
 import hydrozoa.multisig.ledger.event.RequestId
 import scala.annotation.tailrec
 
@@ -122,6 +123,39 @@ final case class Mempool(
                 )
             })
             .toList
+
+    /** Extract up to `limit` requests for block production, preferring those authored by
+      * `preferredPeer` so a leader's own users are not starved when the mempool is full (fairness).
+      * Within each author the arrival (i.e. request-number) order is preserved — only the
+      * cross-author interleaving changes — so the per-author stream ordering is unaffected.
+      *
+      * @return
+      *   the chosen requests, in the order they should enter the block, and the surviving mempool
+      *   with those requests removed.
+      */
+    def extractInOrderPreferring(
+        preferredPeer: HeadPeerNumber,
+        limit: Int
+    ): (List[UserRequestWithId], Mempool) = {
+        val ordered: Vector[UserRequestWithId] = arrivalOrder.map(id =>
+            requests.getOrElse(
+              id,
+              throw RuntimeException(
+                s"Panic: the mempool's `arrivalOrder` vector has a request ID (${id.asI64}) that" +
+                    " is missing from the mempool's `requests` map."
+              )
+            )
+        )
+        // `partition` is stable, so each side keeps its arrival order; own requests lead.
+        val (own, others) = ordered.partition(_.requestId.peerNum == preferredPeer)
+        val chosen = (own ++ others).take(limit).toList
+        val chosenIds = chosen.iterator.map(_.requestId).toSet
+        val survivingMempool = copy(
+          requests = requests -- chosenIds,
+          arrivalOrder = arrivalOrder.filterNot(chosenIds.contains)
+        )
+        (chosen, survivingMempool)
+    }
 }
 
 object Mempool {

--- a/src/test/scala/hydrozoa/bootstrap/BootstrapMembershipTest.scala
+++ b/src/test/scala/hydrozoa/bootstrap/BootstrapMembershipTest.scala
@@ -1,6 +1,7 @@
 package hydrozoa.bootstrap
 
 import cats.effect.unsafe.implicits.global
+import hydrozoa.config.head.multisig.block.BlockConfig
 import hydrozoa.config.head.multisig.fallback.FallbackContingency.mkFallbackContingencyWithDefaults
 import hydrozoa.config.head.multisig.settlement.SettlementConfig
 import hydrozoa.config.head.multisig.timing.TxTiming
@@ -147,6 +148,7 @@ class BootstrapMembershipTest extends AnyFunSuite {
           fallbackContingency = network.mkFallbackContingencyWithDefaults(Coin.ada(3), Coin.ada(3)),
           disputeResolutionConfig = DisputeResolutionConfig.default(network.slotConfig),
           settlementConfig = SettlementConfig(PositiveInt.unsafeApply(100)),
+          blockConfig = BlockConfig(PositiveInt.unsafeApply(1000)),
           coilQuorum = coilQuorum
         )
         Bootstrap.BootstrapDefaults(

--- a/src/test/scala/hydrozoa/config/head/multisig/block/BlockConfigGen.scala
+++ b/src/test/scala/hydrozoa/config/head/multisig/block/BlockConfigGen.scala
@@ -1,0 +1,9 @@
+package hydrozoa.config.head.multisig.block
+
+import hydrozoa.lib.number.PositiveInt
+import org.scalacheck.Gen
+
+type BlockConfigGen = Gen[BlockConfig]
+
+val generateBlockConfig: BlockConfigGen =
+    Gen.choose(1, 2000).map(i => BlockConfig(PositiveInt(i).get))

--- a/src/test/scala/hydrozoa/config/head/parameters/HeadParametersGen.scala
+++ b/src/test/scala/hydrozoa/config/head/parameters/HeadParametersGen.scala
@@ -1,6 +1,7 @@
 package hydrozoa.config.head.parameters
 
 import cats.data.*
+import hydrozoa.config.head.multisig.block.{BlockConfig, generateBlockConfig}
 import hydrozoa.config.head.multisig.fallback.{FallbackContingency, generateFallbackContingency}
 import hydrozoa.config.head.multisig.settlement.{SettlementConfig, generateSettlementConfig}
 import hydrozoa.config.head.multisig.timing.{TxTiming, generateDefaultTxTiming}
@@ -17,6 +18,7 @@ def generateHeadParameters(
     generateDisputeResolutionConfig: GenWithTestPeers[DisputeResolutionConfig] =
         generateDisputeResolutionConfig,
     generateSettlementConfig: Gen[SettlementConfig] = generateSettlementConfig,
+    generateBlockConfig: Gen[BlockConfig] = generateBlockConfig,
     generateL2ParamsHash: Gen[Hash32] = Arbitrary.arbitrary[Hash32],
     generateL2Ledger: Gen[L2LedgerKind] = Gen.const(L2LedgerKind.CardanoEutxo),
     // Default identity-isomorphism ON (headId pin NOT enforced) so generated L2 txs, which carry no
@@ -28,6 +30,7 @@ def generateHeadParameters(
         fallbackContingency <- generateFallbackContingency
         disputeResolutionConfig <- generateDisputeResolutionConfig
         settlementConfig <- ReaderT.liftF(generateSettlementConfig)
+        blockConfig <- ReaderT.liftF(generateBlockConfig)
         l2ParamsHash <- ReaderT.liftF(generateL2ParamsHash)
         l2Ledger <- ReaderT.liftF(generateL2Ledger)
         identityIsomorphism <- ReaderT.liftF(generateIdentityIsomorphism)
@@ -36,6 +39,7 @@ def generateHeadParameters(
       fallbackContingency = fallbackContingency.fallbackContingency,
       disputeResolutionConfig = disputeResolutionConfig,
       settlementConfig = settlementConfig,
+      blockConfig = blockConfig,
       // TODO: Generate
       coilQuorum = 0,
       l2ParamsHash = l2ParamsHash,

--- a/src/test/scala/hydrozoa/multisig/consensus/BlockWeaverTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/BlockWeaverTest.scala
@@ -8,15 +8,20 @@ import com.suprnation.actor.ActorSystem
 import com.suprnation.actor.event.Error as ActorError
 import com.suprnation.actor.test.TestKit
 import com.suprnation.typelevel.actors.syntax.*
-import hydrozoa.config.head.HeadConfig
+import hydrozoa.config.head.multisig.block.BlockConfig
 import hydrozoa.config.head.multisig.timing.TxTiming.BlockTimes.{BlockCreationEndTime, BlockCreationStartTime}
+import hydrozoa.config.head.parameters.generateHeadParameters
+import hydrozoa.config.head.{HeadConfig, generateHeadConfig, generateHeadConfigBootstrap}
 import hydrozoa.config.node.MultiNodeConfig
 import hydrozoa.lib.cardano.scalus.QuantizedTime.QuantizedInstant.realTimeQuantizedInstant
 import hydrozoa.lib.logging.Slf4jTracer
+import hydrozoa.lib.number.PositiveInt
 import hydrozoa.multisig.consensus.UserRequest.TransactionRequest
 import hydrozoa.multisig.consensus.UserRequestBody.TransactionRequestBody
 import hydrozoa.multisig.consensus.peer.HeadPeerNumber
 import hydrozoa.multisig.ledger.block.{Block, BlockBody, BlockBrief, BlockHeader, BlockNumber, BlockVersion}
+import hydrozoa.multisig.ledger.event.RequestId
+import hydrozoa.multisig.ledger.event.RequestId.ValidityFlag
 import hydrozoa.multisig.ledger.joint.JointLedger
 import hydrozoa.multisig.ledger.joint.JointLedger.Requests.{CompleteBlockFinal, CompleteBlockRegular, StartBlock}
 import java.time.Instant
@@ -40,14 +45,11 @@ object BlockWeaverTestHelpers {
         jointLedgerMockActor: JointLedger.Handle
     )
 
-    val defaultResource: PropertyM[IO, Resource[IO, TestR]] =
+    private def mkResource(
+        genConfig: Gen[MultiNodeConfig]
+    ): PropertyM[IO, Resource[IO, TestR]] =
         PropertyM
-            .pick[IO, MultiNodeConfig](
-              MultiNodeConfig
-                  .generate(
-                    TestPeersSpec.default.withPeersNumberSpec(PeersNumberSpec.Exact(3))
-                  )()
-            )
+            .pick[IO, MultiNodeConfig](genConfig)
             .map { multiNodeConfig =>
                 for {
                     system <- ActorSystem[IO]("Weaver SUT")
@@ -57,6 +59,34 @@ object BlockWeaverTestHelpers {
                     )
                 } yield TestR(multiNodeConfig, system, jointLedgerMock, jointLedgerMockActor)
             }
+
+    val defaultResource: PropertyM[IO, Resource[IO, TestR]] =
+        mkResource(
+          MultiNodeConfig.generate(
+            TestPeersSpec.default.withPeersNumberSpec(PeersNumberSpec.Exact(3))
+          )()
+        )
+
+    /** The block-request cap pinned by [[smallCapResource]] — small enough that a modest request
+      * list overflows it, exercising the overflow-to-next-block path.
+      */
+    val smallCap: Int = 3
+
+    /** A three-peer config with `maxRequestsPerBlock` pinned to [[smallCap]]. */
+    val smallCapResource: PropertyM[IO, Resource[IO, TestR]] =
+        mkResource(
+          MultiNodeConfig.generate(
+            TestPeersSpec.default.withPeersNumberSpec(PeersNumberSpec.Exact(3))
+          )(
+            generateHeadConfig = generateHeadConfig(
+              genHeadConfigBootstrap = generateHeadConfigBootstrap(
+                generateHeadParams = generateHeadParameters(
+                  generateBlockConfig = Gen.const(BlockConfig(PositiveInt.unsafeApply(smallCap)))
+                )
+              )
+            )
+          )
+        )
 
     /** A dummy user request whose content is not interesting to the block weaver — only the request
       * id matters.
@@ -127,6 +157,36 @@ object BlockWeaverTestHelpers {
                 requests = List.empty,
                 depositsRejected = List.empty
               )
+            )
+        })
+
+    /** A minor block brief for `blockNum` carrying `requests`, used to drive a follower
+      * reproduction (the follower re-feeds exactly these ids from its mempool).
+      */
+    def mkMinorBriefWith(
+        blockNum: BlockNumber,
+        config: HeadConfig,
+        requests: List[(RequestId, ValidityFlag)]
+    ): BWTest[BlockBrief.Minor] =
+        lift(for {
+            now <- realTimeQuantizedInstant(config.slotConfig)
+        } yield {
+            val blockCreationStartTime = BlockCreationStartTime(now)
+            val blockCreationEndTime = BlockCreationEndTime(now + 1.second)
+            val fallbackTxStartTime = config.txTiming.newFallbackStartTime(blockCreationEndTime)
+            val forcedMajorBlockWakeupTime =
+                config.txTiming.forcedMajorBlockWakeupTime(fallbackTxStartTime)
+            BlockBrief.Minor(
+              BlockHeader.Minor(
+                blockNum = blockNum,
+                blockVersion = BlockVersion.Full(0, 0),
+                startTime = blockCreationStartTime,
+                endTime = blockCreationEndTime,
+                fallbackTxStartTime = fallbackTxStartTime,
+                forcedMajorBlockWakeupTime = forcedMajorBlockWakeupTime,
+                mDepositDecisionWakeupTime = None
+              ),
+              BlockBody.Minor(requests = requests, depositsRejected = List.empty)
             )
         })
 
@@ -398,6 +458,61 @@ object BlockWeaverTest extends Properties("Block weaver test"), TestKit {
             fedRequests == expected,
             "feed the first block's worth of residual mempool requests, own author first, in order: " +
                 s"expected ${expected.map(_.requestId)}, got ${fedRequests.map(_.requestId)}"
+          )
+      } yield true
+    )
+
+    // ===================================
+    // Carol (2) rolls capped-out overflow into the next block (held, not dropped)
+    // ===================================
+    val _ = property("Carol (2) rolls capped-out overflow into the next block") = run(
+      resource = smallCapResource,
+      testM = for {
+          env <- ask
+          config = env.multiNodeConfig.nodeConfigs(Carol.headPeerNumber)
+          cap = config.maxRequestsPerBlock
+          // More than one block's worth, but at most two, so block 2 fills to the cap and the
+          // remainder must roll into block 3.
+          requests <- pick(
+            Gen
+                .listOfN(2 * smallCap, genUserRequest)
+                .map(_.distinctBy(_.requestId))
+                .retryUntil(reqs => reqs.sizeIs > cap)
+          )
+          // The leader packs its own author's requests first: block 2 takes the cap, the rest spill.
+          partitioned = requests.partition(_.requestId.peerNum == Carol.headPeerNumber)
+          ordered = partitioned._1 ++ partitioned._2
+          block2Expected = ordered.take(cap)
+          overflowExpected = ordered.drop(cap)
+          weaver <- mkBlockWeaverActor(Carol.headPeerNumber)
+          _ <- lift(requests.traverse_(weaver ! _))
+          // Follow block 1 and arm as leader of block 2: block 2 gets exactly the cap.
+          brief1 <- mkDummyBlockBrief1(config.headConfig)
+          _ <- lift((weaver ! brief1) >> env.system.waitForIdle())
+          _ <- settle(env.jointLedgerMock.events.get == block2Expected)
+          // Soft-confirm block 1 so Carol completes block 2 and becomes the follower of block 3,
+          // still holding the overflow in her mempool.
+          _ <- lift(
+            (weaver ! Block.SoftConfirmed.Minor(
+              brief1,
+              headerMultiSigned = List.empty,
+              finalizationRequested = false
+            )) >> env.system.waitForIdle()
+          )
+          // Block 3's brief carries the overflow ids; the follower can only reproduce them if it
+          // retained (did not drop) the overflow when block 2 filled up.
+          brief3 <- mkMinorBriefWith(
+            BlockNumber(3),
+            config.headConfig,
+            overflowExpected.map(r => (r.requestId, ValidityFlag.Valid))
+          )
+          _ <- lift((weaver ! brief3) >> env.system.waitForIdle())
+          _ <- settle(env.jointLedgerMock.events.get == ordered)
+          fed <- lift(IO(env.jointLedgerMock.events.get))
+          _ <- assertWith(
+            fed == ordered,
+            "capped-out overflow must roll into block 3, not be dropped: " +
+                s"expected ${ordered.map(_.requestId)}, got ${fed.map(_.requestId)}"
           )
       } yield true
     )

--- a/src/test/scala/hydrozoa/multisig/consensus/BlockWeaverTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/BlockWeaverTest.scala
@@ -372,6 +372,11 @@ object BlockWeaverTest extends Properties("Block weaver test"), TestKit {
           )
           weaver <- mkBlockWeaverActor(Carol.headPeerNumber)
           config = env.multiNodeConfig.nodeConfigs(Carol.headPeerNumber)
+          // The leader packs at most maxRequestsPerBlock requests, its own author's first
+          // (fairness), each author's order preserved; the overflow stays in the mempool.
+          cap = config.maxRequestsPerBlock
+          partitioned = requests.partition(_.requestId.peerNum == Carol.headPeerNumber)
+          expected = (partitioned._1 ++ partitioned._2).take(cap)
           _ <- lift(requests.traverse_(weaver ! _))
           brief <- mkDummyBlockBrief1(config.headConfig)
           _ <- lift(weaver ! brief)
@@ -387,12 +392,12 @@ object BlockWeaverTest extends Properties("Block weaver test"), TestKit {
                   ) =>
                   ()
           })
-          _ <- settle(env.jointLedgerMock.events.get == requests)
+          _ <- settle(env.jointLedgerMock.events.get == expected)
           fedRequests <- lift(IO(env.jointLedgerMock.events.get))
           _ <- assertWith(
-            fedRequests == requests,
-            "feed all residual/recovered mempool requests in order: " +
-                s"expected ${requests.map(_.requestId)}, got ${fedRequests.map(_.requestId)}"
+            fedRequests == expected,
+            "feed the first block's worth of residual mempool requests, own author first, in order: " +
+                s"expected ${expected.map(_.requestId)}, got ${fedRequests.map(_.requestId)}"
           )
       } yield true
     )
@@ -404,13 +409,15 @@ object BlockWeaverTest extends Properties("Block weaver test"), TestKit {
       resource = defaultResource,
       testM = for {
           env <- ask
+          config = env.multiNodeConfig.nodeConfigs(Carol.headPeerNumber)
+          // Feed at most one block's worth so every event is forwarded rather than held back by the
+          // cap — this property is about immediate pass-through, not the overflow behaviour.
           events <- pick(
             Gen
                 .nonEmptyListOf(genUserRequest)
-                .map(_.distinctBy(_.requestId))
+                .map(_.distinctBy(_.requestId).take(config.maxRequestsPerBlock))
           )
           weaver <- mkBlockWeaverActor(Carol.headPeerNumber)
-          config = env.multiNodeConfig.nodeConfigs(Carol.headPeerNumber)
           brief <- mkDummyBlockBrief1(config.headConfig)
           _ <- lift(weaver ! brief)
           _ <- lift(events.traverse_ { e =>


### PR DESCRIPTION
First of two slices addressing the jumbo-block head-of-line-blocking incident on the preprod v0.1.2 head (block 15 reached **229,966** requests; deterministic follower replay re-paid the full per-request cost on every peer). Design notes in the branch's working doc.

This slice **caps the block**; the follow-up slice adds mesh/sequencer **backpressure** (stacked PR on top of this one).

## What changed

**Config (`27ff2cb4`)** — new head-agreed `maxRequestsPerBlock: PositiveInt` (default **1000**) in its own one-field `BlockConfig` (mirrors `SettlementConfig`), mixed into `HeadParameters.Section` so it is hashed into the treasury datum and shared by all peers. Threaded through `BootstrapHeadParams` → `mkSharedHeadConfig`, the demo defaults, `BootstrapMembershipTest`, `HeadParametersGen`, and a new `BlockConfigGen`. It is head-agreed — distinct from the node-local `peerLiaisonMaxRequestsPerBatch`.

**Weaver (`a4599509`)** — the leader packs at most `maxRequestsPerBlock` requests per block:
- `Mempool.extractInOrderPreferring(preferredPeer, limit)` — extracts up to `limit`, preferring this peer's own requests so its users aren't starved when the mempool is full. Each author's stream order is preserved (stable partition); only the cross-author interleaving changes.
- `Leader.AwaitingConfirmation` now carries a mempool + a `requestsInBlock` count: it forwards to the joint ledger until the open block is full, then holds the overflow in the mempool to roll into the next block.
- **Completion stays confirmation-driven** (pipeline depth 1) — the cap only limits what a block *holds*. The first block is exempt (it completes on its first request). Followers reproduce the leader's capped brief unchanged, so no follower-side change is needed.

## Testing

`BlockWeaverTest` passes 100 runs per property with `maxRequestsPerBlock` drawn randomly from 1–2000 (so the cap + overflow paths, including `cap=1`, are exercised and the consensus properties hold). Compile is `-Wunused`/`-Wvalue-discard` clean (so `-Werror` CI is green).