### PR TITLE
feat(consensus): request backpressure (mesh ceiling + sequencer window)

### DIFF
--- a/src/main/scala/hydrozoa/multisig/consensus/FastConsensusActor.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/FastConsensusActor.scala
@@ -13,6 +13,7 @@ import hydrozoa.multisig.HeadMultisigRegimeManager
 import hydrozoa.multisig.consensus.ack.{SoftAck, SoftAckId}
 import hydrozoa.multisig.consensus.peer.{HeadPeerNumber, PeerId}
 import hydrozoa.multisig.ledger.block.{Block, BlockBrief, BlockHeader, BlockNumber}
+import hydrozoa.multisig.persistence.recovery.ReplayCursors
 import hydrozoa.multisig.persistence.{Persistence, StoreKey, Timestamped, WriteBatch}
 import scala.util.control.NonFatal
 import scalus.crypto.ed25519.VerificationKey
@@ -313,6 +314,15 @@ class FastConsensusActor(
         // new lane protocol prunes per-reply, not on local confirmation.)
         _ <- conn.blockWeaver ! confirmed
         _ <- conn.stackComposer ! confirmed
+
+        // Backpressure: tell the sequencer and the mesh liaisons this block's per-author high-water
+        // request number so they can advance their confirmed-high-water windows. A block carries
+        // only the authors that appear in it, so an empty map is a no-op (docs/spec/fast-consensus).
+        requestHighWater = ReplayCursors.maxRequestNumberPerPeer(confirmed.requests.map(_._1))
+        _ <- IO.whenA(requestHighWater.nonEmpty) {
+            val msg = SoftConfirmedHighWater(requestHighWater)
+            conn.requestSequencer.traverse_(_ ! msg) >> conn.headPeerLiaisons.traverse_(_ ! msg)
+        }
 
         // Announce any postponed own-ack for the next block now that this cell is done.
         _ <- cell.postponedNextBlockOwnAck.traverse_(announceAck)

--- a/src/main/scala/hydrozoa/multisig/consensus/RequestSequencer.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/RequestSequencer.scala
@@ -6,6 +6,7 @@ import com.suprnation.actor.Actor.{Actor, Receive}
 import com.suprnation.actor.ActorRef.ActorRef
 import com.suprnation.typelevel.actors.syntax.BroadcastSyntax.*
 import hydrozoa.config.head.initialization.{InitialBlock, InitializationParameters}
+import hydrozoa.config.head.multisig.block.BlockConfig
 import hydrozoa.config.head.multisig.fallback.FallbackContingency
 import hydrozoa.config.head.multisig.timing.TxTiming
 import hydrozoa.config.head.network.CardanoNetwork
@@ -16,7 +17,7 @@ import hydrozoa.lib.cardano.scalus.QuantizedTime.QuantizedInstant.realTimeQuanti
 import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.HeadMultisigRegimeManager
 import hydrozoa.multisig.consensus.RequestSequencer.*
-import hydrozoa.multisig.consensus.peer.PeerId
+import hydrozoa.multisig.consensus.peer.{HeadPeerNumber, PeerId}
 import hydrozoa.multisig.ledger.event.{RequestId, RequestNumber}
 import hydrozoa.multisig.ledger.l1.tx.DepositL1Screening
 import hydrozoa.multisig.ledger.l2.L2Screener
@@ -38,6 +39,13 @@ trait RequestSequencer(
 ) extends Actor[IO, Request] {
     private val connections = Ref.unsafe[IO, Option[RequestSequencer.Connections]](None)
     private val state = State()
+
+    // The user-request surface is head-only, so the author is always a head peer.
+    private val ownHeadPeerNum: HeadPeerNumber = config.ownPeerId match {
+        case PeerId.Head(n) => n
+        case PeerId.Coil(_) =>
+            throw new IllegalStateException("RequestSequencer runs only on a head peer")
+    }
 
     /** `config` is a `CardanoNetwork.Section`; expose it as a given so the typed `Request`-lane
       * `WriteBatch.put` (the CR1 persist) picks it up.
@@ -78,7 +86,11 @@ trait RequestSequencer(
         PartialFunction.fromFunction(receiveTotal)
 
     private def receiveTotal(req: Request): IO[Unit] = req match {
-        case RequestSequencer.PreStart => preStartLocal
+        case RequestSequencer.PreStart  => preStartLocal
+        case hw: SoftConfirmedHighWater =>
+            // Advance this peer's own confirmed request high-water (merge by max); backpressure
+            // reads it. A block that carries none of this peer's requests leaves it unchanged.
+            hw.highWater.get(ownHeadPeerNum).traverse_(state.advanceConfirmedHighWater)
         case req: UserRequest.Sync =>
             req.request.handleSync(
               req,
@@ -108,44 +120,48 @@ trait RequestSequencer(
                   }
                   screened.flatMap {
                       case Left(reason) => IO.pure(Left(UserRequest.Rejected(reason)))
-                      case Right(()) =>
-                          for {
-                              conn <- getConnections
-                              newNum <- state.nextRequestNum()
-                              // The user-request surface is head-only, so the author is always a head peer.
-                              ownHeadPeerNum <- config.ownPeerId match {
-                                  case PeerId.Head(n) => IO.pure(n)
-                                  case PeerId.Coil(_) =>
-                                      IO.raiseError(
-                                        new IllegalStateException(
-                                          "RequestSequencer runs only on a head peer"
-                                        )
+                      case Right(())    =>
+                          // Backpressure: refuse to author more than one block's worth of requests
+                          // beyond this peer's own confirmed high-water, so the mesh mempool cannot
+                          // exceed maxRequestsPerBlock * nHeadPeers (docs/spec/fast-consensus.md).
+                          state.tryNextRequestNum(config.maxRequestsPerBlock).flatMap {
+                              case None =>
+                                  IO.pure(
+                                    Left(
+                                      UserRequest.Rejected(
+                                        "Request rejected: too many unconfirmed requests" +
+                                            " (backpressure); retry shortly."
                                       )
-                              }
-                              newId = RequestId(ownHeadPeerNum, newNum)
-                              newRequestWithId = UserRequestWithId(
-                                userRequest = userRequest,
-                                requestId = newId
-                              )
-                              _ <- tracer.traceWith(
-                                EventSequencerEvent
-                                    .RequestIdAssigned(newId.peerNum, newId.requestNum)
-                              )
-                              // CR1: persist the assigned request to the Request lane BEFORE telling
-                              // the user the id (durable before observable; §4 CR1/CR4).
-                              stamp <- persistence.arrivalStamp
-                              _ <- persistence.write(
-                                WriteBatch.start
-                                    .put(JournalKey.Request(ownHeadPeerNum, newNum))(
-                                      JournalValue(stamp, newRequestWithId)
                                     )
-                              )
-                              _ <- conn.blockWeaver ! newRequestWithId
-                              // To the head-peer mesh, and (on a hub) to CoilRelay so its coil peers
-                              // get the request content they need to reproduce block bodies.
-                              _ <- (conn.headPeerLiaisons ! newRequestWithId).parallel
-                              _ <- conn.coilRelay.traverse_(_ ! newRequestWithId)
-                          } yield Right(newId)
+                                  )
+                              case Some(newNum) =>
+                                  val newId = RequestId(ownHeadPeerNum, newNum)
+                                  val newRequestWithId = UserRequestWithId(
+                                    userRequest = userRequest,
+                                    requestId = newId
+                                  )
+                                  for {
+                                      conn <- getConnections
+                                      _ <- tracer.traceWith(
+                                        EventSequencerEvent
+                                            .RequestIdAssigned(newId.peerNum, newId.requestNum)
+                                      )
+                                      // CR1: persist the assigned request to the Request lane BEFORE
+                                      // telling the user the id (durable before observable; CR1/CR4).
+                                      stamp <- persistence.arrivalStamp
+                                      _ <- persistence.write(
+                                        WriteBatch.start
+                                            .put(JournalKey.Request(ownHeadPeerNum, newNum))(
+                                              JournalValue(stamp, newRequestWithId)
+                                            )
+                                      )
+                                      _ <- conn.blockWeaver ! newRequestWithId
+                                      // To the head-peer mesh, and (on a hub) to CoilRelay so its coil
+                                      // peers get the content they need to reproduce block bodies.
+                                      _ <- (conn.headPeerLiaisons ! newRequestWithId).parallel
+                                      _ <- conn.coilRelay.traverse_(_ ! newRequestWithId)
+                                  } yield Right(newId)
+                          }
                   }
               }
             )
@@ -154,31 +170,45 @@ trait RequestSequencer(
     private def preStartLocal: IO[Unit] =
         for {
             _ <- initializeConnections
-            // The user-request surface is head-only, so the author is always a head peer.
-            ownHeadPeerNum <- config.ownPeerId match {
-                case PeerId.Head(n) => IO.pure(n)
-                case PeerId.Coil(_) =>
-                    IO.raiseError(
-                      new IllegalStateException(
-                        "RequestSequencer runs only on a head peer"
-                      )
-                    )
-            }
             // R3: continue the request counter from `max(own Request) + 1` (CR3, no re-issue);
             // empty store -> RequestNumber(0), the same cold value.
             next <- Markers.recoverNextRequestNumber(persistence.backend, ownHeadPeerNum)
             _ <- state.seedNextRequestNum(next)
+            // Seed the confirmed high-water from the highest already-assigned own request (next - 1).
+            // Treating assigned-as-confirmed opens the backpressure window optimistically after a
+            // restart; the next real soft-confirmation re-tightens it.
+            _ <- state.seedConfirmedHighWater(next.previousOrZero)
         } yield ()
 
     private final class State {
         private val nextRequestNumRef = Ref.unsafe[IO, RequestNumber](RequestNumber(0))
+        private val ownConfirmedHighWaterRef = Ref.unsafe[IO, RequestNumber](RequestNumber.zero)
 
-        def nextRequestNum(): IO[RequestNumber] =
-            nextRequestNumRef.getAndUpdate(_.increment)
+        /** Assign the next request number, but only while it stays within `maxAhead` of this peer's
+          * own confirmed high-water (backpressure). Returns None when that window is full, leaving
+          * the counter untouched.
+          */
+        def tryNextRequestNum(maxAhead: Int): IO[Option[RequestNumber]] =
+            ownConfirmedHighWaterRef.get.flatMap { confirmed =>
+                val confirmedLong: Long = confirmed
+                val ceiling = RequestNumber(confirmedLong + maxAhead)
+                nextRequestNumRef.modify { cur =>
+                    if Ordering[RequestNumber].lteq(cur, ceiling) then (cur.increment, Some(cur))
+                    else (cur, None)
+                }
+            }
+
+        /** Merge a confirmed high-water for this peer (by max). */
+        def advanceConfirmedHighWater(confirmed: RequestNumber): IO[Unit] =
+            ownConfirmedHighWaterRef.update(cur => Ordering[RequestNumber].max(cur, confirmed))
 
         /** Seed the next-to-assign request number on recovery (R3). */
         def seedNextRequestNum(next: RequestNumber): IO[Unit] =
             nextRequestNumRef.set(next)
+
+        /** Seed the confirmed high-water on recovery. */
+        def seedConfirmedHighWater(confirmed: RequestNumber): IO[Unit] =
+            ownConfirmedHighWaterRef.set(confirmed)
     }
 }
 
@@ -201,7 +231,7 @@ object RequestSequencer {
     // parse and time-gate a deposit tx (DepositL1Screening.Config).
     type Config = OwnPeerPublic.Section & CardanoNetwork.Section & HeadPeers.Section &
         InitialBlock.Section & TxTiming.Section & InitializationParameters.Section &
-        FallbackContingency.Section
+        FallbackContingency.Section & BlockConfig.Section
 
     final case class Connections(
         blockWeaver: BlockWeaver.Handle,
@@ -214,7 +244,7 @@ object RequestSequencer {
 
     type Handle = ActorRef[IO, Request]
 
-    type Request = PreStart.type | UserRequest.Sync
+    type Request = PreStart.type | UserRequest.Sync | SoftConfirmedHighWater
 
     case object PreStart
 }

--- a/src/main/scala/hydrozoa/multisig/consensus/SoftConfirmedHighWater.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/SoftConfirmedHighWater.scala
@@ -1,0 +1,16 @@
+package hydrozoa.multisig.consensus
+
+import hydrozoa.multisig.consensus.peer.HeadPeerNumber
+import hydrozoa.multisig.ledger.event.RequestNumber
+
+/** A node-local notification the [[FastConsensusActor]] fans out to its [[RequestSequencer]] and
+  * its mesh [[liaison.PeerLiaisonHeadToHead]]s when a block soft-confirms: the per-author
+  * high-water request number carried by that block.
+  *
+  * Recipients merge it into their own confirmed-high-water view by max (a block carries only the
+  * authors that appear in it). It anchors request backpressure — the sequencer refuses to author
+  * more than `maxRequestsPerBlock` beyond its own confirmed high-water, and each mesh puller caps
+  * its request pull at `confirmedHighWater(remote) + maxRequestsPerBlock` — so the mempool cannot
+  * exceed `maxRequestsPerBlock * nHeadPeers`. See docs/spec/fast-consensus.md.
+  */
+final case class SoftConfirmedHighWater(highWater: Map[HeadPeerNumber, RequestNumber])

--- a/src/main/scala/hydrozoa/multisig/consensus/liaison/BatchMessages.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/liaison/BatchMessages.scala
@@ -34,6 +34,11 @@ object BatchMessages {
             block: BlockNumber,
             stack: StackNumber,
             request: RequestNumber,
+            // Backpressure: the highest request number the puller is willing to accept from this
+            // remote author right now — its confirmed high-water for this author plus one block's
+            // cap. The server truncates its request slice at this ceiling so the puller never buffers
+            // more than one cap of the author's unconfirmed requests (docs/spec/fast-consensus.md).
+            requestCeiling: RequestNumber,
             softAck: SoftAckNumber,
             headHardAck: HardAckNumber,
             hubHardAck: HubHardAckNumber

--- a/src/main/scala/hydrozoa/multisig/consensus/liaison/LaneBidirectional.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/liaison/LaneBidirectional.scala
@@ -24,7 +24,8 @@ final class LaneBidirectional[T, N] private (
 ) {
     // ---- Outbound ----
     def append(item: T): IO[Unit] = out.append(item)
-    def reply(remoteCursor: N): IO[LaneOutbound.Reply[T]] = out.reply(remoteCursor)
+    def reply(remoteCursor: N, ceiling: Option[N] = None): IO[LaneOutbound.Reply[T]] =
+        out.reply(remoteCursor, ceiling)
     def outboxIsEmpty: IO[Boolean] = out.outboxIsEmpty
     def seedHighWaterOutbox(highWater: Option[N]): IO[Unit] = out.seedHighWater(highWater)
 

--- a/src/main/scala/hydrozoa/multisig/consensus/liaison/LaneOutbound.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/liaison/LaneOutbound.scala
@@ -85,7 +85,13 @@ final class LaneOutbound[T, N] private (
       * [[OutOfBounds]] if the remote's cursor is ahead of what we could have produced (protocol
       * desync — the caller raises), else the (possibly empty) slice.
       */
-    def reply(remoteCursor: N): IO[Reply[T]] =
+    def reply(remoteCursor: N, ceiling: Option[N] = None): IO[Reply[T]] =
+        // `ceiling`, when set, is an absolute upper bound on the item numbers we may serve this reply
+        // (on top of `maxPerReply` and the released high-water) — the request lane passes the
+        // puller's backpressure ceiling. Items are monotonic ascending, so a `takeWhile`/`filter`
+        // keeps the contiguous prefix at or below it.
+        def withinCeiling(items: List[T]): List[T] =
+            ceiling.fold(items)(c => items.takeWhile(item => numberOf(item) <= c))
         lastAppended.get.flatMap { last =>
             // The remote may never legitimately ask past our next-producible number.
             val bound = next(last)
@@ -106,7 +112,7 @@ final class LaneOutbound[T, N] private (
                     .flatMap { pruned =>
                         pruned.headOption match
                             case Some(head) if numberOf(head) == remoteCursor =>
-                                IO.pure(Items(pruned.take(maxPerReply).toList))
+                                IO.pure(Items(withinCeiling(pruned.take(maxPerReply).toList)))
                             case _ =>
                                 // The store can hold entries already persisted but **not yet
                                 // released** onto this lane (e.g. a postponed own soft-ack that the
@@ -117,8 +123,10 @@ final class LaneOutbound[T, N] private (
                                 // out-of-bounds.
                                 backfill(remoteCursor, maxPerReply).map(fromStore =>
                                     Items(
-                                      last.fold(List.empty[T])(hw =>
-                                          fromStore.filter(item => numberOf(item) <= hw)
+                                      withinCeiling(
+                                        last.fold(List.empty[T])(hw =>
+                                            fromStore.filter(item => numberOf(item) <= hw)
+                                        )
                                       )
                                     )
                                 )

--- a/src/main/scala/hydrozoa/multisig/consensus/liaison/LiaisonProtocol.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/liaison/LiaisonProtocol.scala
@@ -2,8 +2,8 @@ package hydrozoa.multisig.consensus.liaison
 
 import cats.effect.IO
 import com.suprnation.actor.ActorRef.ActorRef
-import hydrozoa.multisig.consensus.UserRequestWithId
 import hydrozoa.multisig.consensus.ack.{HardAck, HardAckWithId, SoftAck}
+import hydrozoa.multisig.consensus.{SoftConfirmedHighWater, UserRequestWithId}
 import hydrozoa.multisig.ledger.block.BlockBrief
 import hydrozoa.multisig.ledger.stack.StackBrief
 
@@ -48,7 +48,7 @@ object LiaisonProtocol {
       * shape), and accepts that head peer's artifacts to append to its outbox.
       */
     type HeadToHeadRequest =
-        Control | BatchMessages.Mesh.Get | BatchMessages.Mesh.New |
+        Control | BatchMessages.Mesh.Get | BatchMessages.Mesh.New | SoftConfirmedHighWater |
             (BlockBrief.Next | StackBrief | UserRequestWithId | SoftAck | HardAck | HardAckWithId)
 
     /** Hub → coil: serves the full population pull ([[BatchMessages.Population.Get]] →

--- a/src/main/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonHeadToHead.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonHeadToHead.scala
@@ -5,6 +5,7 @@ import cats.implicits.*
 import com.suprnation.actor.Actor.{Actor, Receive}
 import com.suprnation.actor.ActorRef.ActorRef
 import hydrozoa.config.head.HeadConfig
+import hydrozoa.config.head.multisig.block.BlockConfig
 import hydrozoa.config.head.network.CardanoNetwork
 import hydrozoa.config.node.operation.multisig.NodeOperationMultisigConfig
 import hydrozoa.config.node.owninfo.OwnPeerPublic
@@ -14,7 +15,7 @@ import hydrozoa.multisig.consensus.ack.{HardAck, HardAckNumber, HardAckWithId, H
 import hydrozoa.multisig.consensus.liaison.BatchMessages.Mesh
 import hydrozoa.multisig.consensus.liaison.LiaisonProtocol.*
 import hydrozoa.multisig.consensus.peer.{HeadPeerId, HeadPeerNumber, PeerId}
-import hydrozoa.multisig.consensus.{BlockWeaver, CoilRelay, FastConsensusActor, SlowConsensusActor, StackComposer, UserRequestWithId}
+import hydrozoa.multisig.consensus.{BlockWeaver, CoilRelay, FastConsensusActor, SlowConsensusActor, SoftConfirmedHighWater, StackComposer, UserRequestWithId}
 import hydrozoa.multisig.ledger.block.{BlockBrief, BlockNumber}
 import hydrozoa.multisig.ledger.event.RequestNumber
 import hydrozoa.multisig.ledger.stack.{StackBrief, StackNumber}
@@ -138,6 +139,13 @@ abstract class PeerLiaisonHeadToHead(
               hubHardAckBacking.fold(IO.pure(List.empty[HardAckWithId]))(_.backfill(from, limit))
         )
 
+    // The remote head peer's confirmed request high-water, learned from the local FastConsensusActor
+    // on each soft-confirmation and merged by max. Anchors the request pull ceiling
+    // (confirmed + maxRequestsPerBlock) so this peer never buffers more than one cap of the remote's
+    // unconfirmed requests. Seeded on boot from the restored inbound request cursor.
+    private val confirmedRemoteRequestHighWater =
+        Ref.unsafe[IO, RequestNumber](RequestNumber.zero)
+
     // ---- Connections ----------------------------------------------------------------------------
     private val connections = Ref.unsafe[IO, Option[PeerLiaisonHeadToHead.Connections]](None)
 
@@ -154,6 +162,7 @@ abstract class PeerLiaisonHeadToHead(
       block = blockInitialCursor,
       stack = stackInitialCursor,
       request = RequestNumber.zero,
+      requestCeiling = requestCeiling(RequestNumber.zero),
       softAck = SoftAckNumber.zero.increment,
       headHardAck = HardAckNumber.zero,
       hubHardAck = HubHardAckNumber.zero
@@ -164,15 +173,21 @@ abstract class PeerLiaisonHeadToHead(
     private def stackInitialCursor: StackNumber =
         remoteHead.nextSlowLeaderStack(StackNumber.zero)
 
+    /** The request pull ceiling for a given confirmed high-water: one block's cap beyond it. */
+    private def requestCeiling(confirmed: RequestNumber): RequestNumber =
+        val confirmedLong: Long = confirmed
+        RequestNumber(confirmedLong + config.maxRequestsPerBlock)
+
     private def buildGet(batchNum: BatchNumber): IO[Mesh.Get] =
         for {
             b <- blockLane.cursor
             s <- stackLane.cursor
             r <- requestLane.cursor
+            confirmed <- confirmedRemoteRequestHighWater.get
             sa <- softAckLane.cursor
             hh <- hardAckLane.cursor
             hub <- hubHardAckLane.cursor
-        } yield Mesh.Get(batchNum, b, s, r, sa, hh, hub)
+        } yield Mesh.Get(batchNum, b, s, r, requestCeiling(confirmed), sa, hh, hub)
 
     private def accept(m: Mesh.New): IO[Either[String, Unit]] = {
         def check[T, N](
@@ -274,7 +289,8 @@ abstract class PeerLiaisonHeadToHead(
         for {
             blockR <- blockLane.reply(get.block)
             stackR <- stackLane.reply(get.stack)
-            reqR <- requestLane.reply(get.request)
+            // Cap the served request slice at the puller's backpressure ceiling.
+            reqR <- requestLane.reply(get.request, ceiling = Some(get.requestCeiling))
             saR <- softAckLane.reply(get.softAck)
             hhR <- hardAckLane.reply(get.headHardAck)
             hubR <- hubHardAckLane.reply(get.hubHardAck)
@@ -382,10 +398,19 @@ abstract class PeerLiaisonHeadToHead(
         PartialFunction.fromFunction(receiveTotal)
 
     private def receiveTotal(req: HeadToHeadRequest): IO[Unit] = req match {
-        case PreStart      => preStartLocal
-        case ResendCurrent => puller.resend
-        case get: Mesh.Get => server.handleGet(get)
-        case m: Mesh.New   => puller.handleReply(m)
+        case PreStart                   => preStartLocal
+        case ResendCurrent              => puller.resend
+        case get: Mesh.Get              => server.handleGet(get)
+        case m: Mesh.New                => puller.handleReply(m)
+        case hw: SoftConfirmedHighWater =>
+            // Advance the remote head peer's confirmed request high-water (merge by max); the pull
+            // ceiling reads it. A block that carries no request from this remote leaves it unchanged.
+            hw.highWater
+                .get(remoteHead.peerNum)
+                .traverse_(rn =>
+                    confirmedRemoteRequestHighWater
+                        .update(cur => Ordering[RequestNumber].max(cur, rn))
+                )
         case artifact @ (_: BlockBrief.Next | _: StackBrief | _: UserRequestWithId | _: SoftAck |
             _: HardAck | _: HardAckWithId) =>
             appendArtifact(artifact) >> server.afterAppend
@@ -402,6 +427,11 @@ abstract class PeerLiaisonHeadToHead(
             _ <- restoreOutboundHighWaters
             // Restore the inbound receive cursors so we re-pull only NEW remote entries.
             _ <- restoreInboundCursors
+            // Seed the remote's confirmed request high-water from the restored inbound request cursor
+            // (next-expected - 1 = highest received). Treating received-as-confirmed opens the pull
+            // ceiling optimistically after a restart; the next real soft-confirmation re-tightens it.
+            reqCursor <- requestLane.cursor
+            _ <- confirmedRemoteRequestHighWater.set(reqCursor.previousOrZero)
             _ <- puller.start
             _ <- startResendTimer
         } yield ()
@@ -425,7 +455,8 @@ object PeerLiaisonHeadToHead {
         )
 
     type Config =
-        OwnPeerPublic.Section & NodeOperationMultisigConfig.Section & HeadConfig.Bootstrap.Section
+        OwnPeerPublic.Section & NodeOperationMultisigConfig.Section & HeadConfig.Bootstrap.Section &
+            BlockConfig.Section
 
     type Handle = ActorRef[IO, LiaisonProtocol.HeadToHeadRequest]
 

--- a/src/main/scala/hydrozoa/multisig/ledger/event/RequestNumber.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/event/RequestNumber.scala
@@ -28,5 +28,9 @@ object RequestNumber {
             x.convert.compare(y.convert)
     }
 
-    extension (self: RequestNumber) def increment: RequestNumber = RequestNumber(self + 1)
+    extension (self: RequestNumber)
+        def increment: RequestNumber = RequestNumber(self + 1)
+
+        /** The preceding request number, clamped at zero. */
+        def previousOrZero: RequestNumber = if self <= 0L then zero else RequestNumber(self - 1)
 }

--- a/src/test/scala/hydrozoa/multisig/consensus/transport/CodecsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/transport/CodecsTest.scala
@@ -30,6 +30,7 @@ class CodecsTest extends AnyFunSuite {
       block = BlockNumber(1),
       stack = StackNumber(1),
       request = RequestNumber.zero,
+      requestCeiling = RequestNumber.zero,
       softAck = SoftAckNumber.zero.increment,
       headHardAck = HardAckNumber.zero,
       hubHardAck = HubHardAckNumber.zero
@@ -69,6 +70,7 @@ class CodecsTest extends AnyFunSuite {
           block = BlockNumber(99),
           stack = StackNumber(4),
           request = RequestNumber(7),
+          requestCeiling = RequestNumber(1007),
           softAck = SoftAckNumber(13),
           headHardAck = HardAckNumber(8),
           hubHardAck = HubHardAckNumber(5)
@@ -80,6 +82,7 @@ class CodecsTest extends AnyFunSuite {
                 val _ = assert(decoded.block == get.block)
                 val _ = assert(decoded.stack == get.stack)
                 val _ = assert(decoded.request == get.request)
+                val _ = assert(decoded.requestCeiling == get.requestCeiling)
                 val _ = assert(decoded.softAck == get.softAck)
                 val _ = assert(decoded.headHardAck == get.headHardAck)
                 assert(decoded.hubHardAck == get.hubHardAck)


### PR DESCRIPTION
Second slice of the jumbo-block fix, **stacked on #601** (the block cap). Review/merge #601 first; this PR targets `feature/block-cap-backpressure` and its diff is backpressure-only.

The cap (#601) bounds a single block. This slice bounds the **mempool** so the deterministic follower replay can't be handed an ever-growing backlog: `mempool ≤ maxRequestsPerBlock × nHeadPeers`.

## Mechanism (no `BlockBody` change — derive, don't embed)

The per-author high-water is a pure fold over the already-signed request list, so nothing new is persisted in the block.

- **`FastConsensusActor.completeCell`** folds the soft-confirmed block's requests into a `Map[HeadPeerNumber, RequestNumber]` (per-author max) and sends a node-local `SoftConfirmedHighWater` to the request sequencer and the mesh liaisons. Recipients keep a confirmed-high-water view and **merge by max** (a block carries only the authors it contains; the map starts at zero — block 0 has no soft-confirmation — and on recovery seeds from the restored request cursor).
- **Sequencer backpressure (2.4):** `RequestSequencer` refuses to author a request beyond `ownConfirmedHighWater + maxRequestsPerBlock`, rejecting the submit (`UserRequest.Rejected`). This alone delivers the mempool bound.
- **Mesh ceiling (2.3):** each puller sends `requestCeiling = confirmedHighWater(remote) + maxRequestsPerBlock` in its `Mesh.Get`; the server truncates its request slice at the ceiling (`LaneOutbound.reply` gains an optional absolute ceiling). Defense-in-depth on the same broadcast.

The node-local per-round batch cap (`peerLiaisonMaxRequestsPerBatch`) is unchanged and independent.

## Testing

`LaneOutboundTest`, `ServerTest`, `PullerTest`, `CodecsTest` (Mesh.Get round-trip with the new field), `CoilLiaisonTest`, and `BlockWeaverTest` all green.

## Notes

`SoftConfirmedHighWater` is node-local (FCA → same-node sequencer/liaisons), so no wire codec; only `Mesh.Get` crosses the wire and its derived codec picks up the new field automatically. All peers in a head run the same version, so the wire-format bump is safe.