### PR TITLE
fix(server): log request rejections concisely, not as errors

### DIFF
--- a/src/main/scala/hydrozoa/multisig/consensus/RequestSequencer.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/RequestSequencer.scala
@@ -129,8 +129,8 @@ trait RequestSequencer(
                                   IO.pure(
                                     Left(
                                       UserRequest.Rejected(
-                                        "Request rejected: too many unconfirmed requests" +
-                                            " (backpressure); retry shortly."
+                                        "too many unconfirmed requests (backpressure);" +
+                                            " retry shortly."
                                       )
                                     )
                                   )

--- a/src/main/scala/hydrozoa/multisig/server/HydrozoaHttpEvent.scala
+++ b/src/main/scala/hydrozoa/multisig/server/HydrozoaHttpEvent.scala
@@ -34,6 +34,11 @@ object HydrozoaHttpEvent:
     /** The request body decoded to a domain object (debug). */
     final case class RequestDecoded(path: String, decoded: String) extends HydrozoaHttpEvent
 
+    /** A request was rejected by screening or backpressure — an expected 400, not a fault, so it
+      * carries only the client-facing reason (no exception or stack trace).
+      */
+    final case class RequestRejected(path: String, reason: String) extends HydrozoaHttpEvent
+
     /** An exception escaped the route handler. */
     final case class RequestFailed(path: String, cause: Throwable) extends HydrozoaHttpEvent
 

--- a/src/main/scala/hydrozoa/multisig/server/HydrozoaHttpEventFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/server/HydrozoaHttpEventFormat.scala
@@ -35,6 +35,8 @@ object HydrozoaHttpEventFormat:
                 error(s"$path - Decode error history: $history")
             case RequestDecoded(path, decoded) =>
                 debug(s"$path - Decoded: $decoded")
+            case RequestRejected(path, reason) =>
+                warn(s"$path - Rejected: $reason")
             case RequestFailed(path, cause) =>
                 LogEvent(
                   hydrozoa.lib.logging.Level.Error,

--- a/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
+++ b/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
@@ -622,7 +622,7 @@ class HydrozoaRoutes(
         path: String,
         body: SubmitRequestView
     ): IO[Either[(StatusCode, ErrorResponse), RequestAcceptedResponse]] =
-        val handled =
+        val handled: IO[Either[(StatusCode, ErrorResponse), RequestAcceptedResponse]] =
             for {
                 userRequest <- ApiDto.toUserRequest(body) match {
                     case Left(message) =>
@@ -631,20 +631,23 @@ class HydrozoaRoutes(
                     case Right(request) => IO.pure(request)
                 }
                 _ <- tracer.traceWith(RequestDecoded(path, userRequest.toString))
-                requestId <- (requestSequencer ?: userRequest).flatMap {
-                    case Right(id) => IO.pure(id)
-                    // A screen rejection surfaces as a 400 via handleErrorWith below.
-                    case Left(rejected) => IO.raiseError(new RuntimeException(rejected.reason))
+                result <- (requestSequencer ?: userRequest).flatMap {
+                    case Right(id) =>
+                        IO.pure(Right(ApiDto.mkRequestAcceptedResponse(id)))
+                    // Screening / backpressure rejection: an expected 400, not a fault — log the
+                    // client-facing reason concisely (no exception/stack) instead of raising.
+                    case Left(rejected) =>
+                        tracer
+                            .traceWith(RequestRejected(path, rejected.reason))
+                            .as(Left(fail(StatusCode.BadRequest, rejected.reason)))
                 }
-            } yield ApiDto.mkRequestAcceptedResponse(requestId)
+            } yield result
 
-        handled
-            .map(Right(_))
-            .handleErrorWith(err =>
-                tracer
-                    .traceWith(RequestFailed(path, err))
-                    .as(Left(fail(StatusCode.BadRequest, err.getMessage)))
-            )
+        handled.handleErrorWith(err =>
+            tracer
+                .traceWith(RequestFailed(path, err))
+                .as(Left(fail(StatusCode.BadRequest, err.getMessage)))
+        )
 
     /** The block-details body for `num`: block 0 is synthesized from the head config; any other
       * block resolves through its persisted brief, or a 404.


### PR DESCRIPTION
## Log request rejections concisely, not as errors

A screening or backpressure rejection is an expected `400`, not a fault — but it was raised as a
`RuntimeException` and logged through `RequestFailed` at **ERROR with the full exception + stack
trace**. Under backpressure that means a stack dump per rejected request:

```
ERROR HydrozoaHttp - POST /head/requests - Error: Request rejected: too many unconfirmed requests (backpressure); retry shortly.
java.lang.RuntimeException: Request rejected: too many unconfirmed requests (backpressure); retry shortly.
        at hydrozoa.multisig.server.HydrozoaRoutes...
        at map @ hydrozoa.lib.actor.SyncRequest$...
        (10+ frames)
```

### Change
- New `RequestRejected(path, reason)` event → logged at **WARN**, one line, **no stack trace**.
- `acceptUserRequest` short-circuits the rejection path (returns the 400 directly) instead of
  raising a `RuntimeException` that funnels into `RequestFailed`.
- Genuine handler failures still log at ERROR with the cause (`RequestFailed` unchanged).
- Dropped the redundant `"Request rejected:"` prefix from the backpressure reason so it reads
  uniformly with screening reasons in both the log line and the 400 body.

### After
```
WARN HydrozoaHttp - POST /head/requests - Rejected: too many unconfirmed requests (backpressure); retry shortly.
```

The client still receives `400` with the reason body. No logback change (reuses the `HydrozoaHttp`
routing key; WARN clears the docker config's `root=warn`). Covers both rejection sources — screening
and sequencer-window backpressure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
