### PR TITLE
feat(server): peer statistics endpoints (/head/stats + /head/metrics)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,9 @@ Working design and reference docs (`docs/spec/`):
   queries: `GET /l2/cardano-eutxo/utxos/{address}` and `GET /l2/cardano-eutxo/transactions` (EUTXO-only).
 - [`observability-endpoints.md`](docs/spec/observability-endpoints.md) — the user-facing server's
   `/health` (liveness) and `/ready` (readiness) endpoints and the `NodeStatus` behind them.
+- [`peer-stats-endpoint.md`](docs/spec/peer-stats-endpoint.md) — the per-peer statistics surface:
+  the push-based `PeerMetrics` registry (atomic counters + a 1 Hz EWMA sampler) behind
+  `GET /head/stats` (JSON) and `GET /head/metrics` (Prometheus).
 
 **Testing**
 - [`integration-stages.md`](docs/spec/integration-stages.md) — the stage1/stage4 integration test

--- a/design/peer-stats-endpoint.md
+++ b/design/peer-stats-endpoint.md
@@ -20,8 +20,8 @@ cannot measurably affect throughput.
 - Report, per peer:
   - **local incoming requests** — total counter + TPS (now / 1m / 5m / 15m, `top`-style).
   - **peer-to-peer requests** — total counter *per head peer* + TPS the same way.
-  - **block statistics** — total minor/major, average and maximum block size (events), and block +
-    request counts over fixed trailing windows (10s / 30s / 60s / 5m / 10m) with their TPS.
+  - **block statistics** — total minor/major, average and maximum block size (events), and EWMA
+    throughput rates for blocks/sec and requests-in-blocks/sec (now / 1m / 5m / 15m).
   - **stack statistics** — total hard-confirmed, last stack number, seconds since last hard-confirm,
     mean inter-stack gap, and average/maximum stack size (blocks absorbed).
 - Ship **two representations of the same registry**: a human/dashboard JSON view (`GET /head/stats`)
@@ -41,8 +41,7 @@ cannot measurably affect throughput.
 1. **Push, don't pull.** Each counter is incremented at the moment its event happens — a single
    atomic add (nanoseconds, no allocation, no lock). The endpoint never scans anything.
 2. **Derive rolling views off the hot path.** One background fiber, waking at a fixed cadence (1 Hz),
-   rolls the trailing-window ring and updates the EWMA load averages. The hot path only ever
-   increments.
+   updates the EWMA load averages. The hot path only ever increments.
 3. **Snapshot read, no actor ask.** The endpoint materializes the current numbers from an in-memory
    registry, mirroring how `/ready` reads a `NodeStatus` value instead of issuing a `GetState` to an
    actor (`HydrozoaServer` already threads `nodeStatus: IO[NodeStatus]` into the routes — the stats
@@ -100,7 +99,7 @@ buys nothing):
 Only the **peer-request** counters can be written concurrently (ingestion fans in from multiple
 peer-liaison actors/threads), so those use `LongAdder`, which is built for high-contention adds.
 
-The `rolling` view (ring + EWMAs) is written only by the single sampler fiber, so a `@volatile`
+The `rolling` view (the EWMA rates) is written only by the single sampler fiber, so a `@volatile`
 reference / `AtomicReference` publishes it to readers.
 
 ## Metrics catalog
@@ -114,8 +113,8 @@ reference / `AtomicReference` publishes it to readers.
 | `blocksMinor` / `blocksMajor` | counter | soft-confirmed blocks by type |
 | avg block size | derived | `blockEventsSum / (blocksMinor + blocksMajor)` |
 | max block size | gauge | `blockEventsMax` |
-| blocks per window | derived | 10s / 30s / 60s / 5m / 10m, from the ring |
-| requests-in-blocks per window + TPS | derived | same windows, from the ring |
+| block rate | EWMA | blocks/sec: now / 1m / 5m / 15m |
+| requests-in-blocks rate | EWMA | req/sec: now / 1m / 5m / 15m |
 | local & peer TPS | EWMA | now / 1m / 5m / 15m |
 | `stacksTotal` | counter | hard-confirmed stacks |
 | last stack number | gauge | `lastStackNum` |
@@ -138,19 +137,12 @@ Three call sites, all on paths that already exist — no new plumbing:
 Because `completeCell` / `completeStack` are the *only* places a soft-confirmed block / hard-confirmed
 stack is produced, those stats need exactly one line each and can never drift from reality.
 
-## Rolling windows: a cumulative ring
+## All rates are EWMA
 
-Keep a ring of **per-second cumulative snapshots** — 900 slots = 15 min (covers every requested
-window with headroom). Each second the sampler writes the current cumulative counters into
-`ring[t % 900]`. A windowed count is then a subtraction:
-
-```
-countOverLast(W seconds) = cumulativeNow − ring[(t − W) % 900]
-```
-
-This is race-free (nothing is zeroed), exact, and diffing a few longs is free. Memory: 900 × a
-handful of longs ≈ a few KB. Blocks and requests-in-blocks share the same ring, so
-"requests in those blocks + corresponding TPS" falls straight out (`requestsInWindow / W`).
+There are **no fixed-window rings**. Every rate — local requests, per-peer requests, block
+production, and requests-in-blocks — is a top-style EWMA load average (now / 1m / 5m / 15m). The
+sampler holds one small set of EWMA accumulators (a few doubles each) and never stores per-second
+history, so nothing has to be recomputed or aged out.
 
 ## TPS load averages (EWMA)
 
@@ -223,24 +215,8 @@ Cost: three `exp` + three multiply-adds per second.
   bias correction `v / (1 − decayⁿ)` for the first few ticks — not worth it, the ramp is expected.
 - **Idle decay is free and correct.** No traffic → `instant = 0` → averages glide to 0, matching
   `top` when load drops.
-- **Single-writer visibility.** Only the sampler writes the EWMAs and the ring → `@volatile` is
-  sufficient for the endpoint to read a fresh value.
-
-### EWMA vs the ring — use both
-
-They answer different questions:
-
-| | EWMA (1m/5m/15m) | Cumulative ring (10s…10m) |
-|---|---|---|
-| memory | one double per horizon | ~900 slots × few longs |
-| semantics | smoothed, soft-edged (top-style) | **exact** count in the window |
-| boundary artifacts | none | a sample leaving the window is a step |
-| best for | load-average feel, trend | precise "how many in the last 30s" |
-
-Use **EWMA for the load-average triple** and the **ring for the exact fixed-window counts + TPS**. The
-sampler computes `delta`/`instant` once and feeds both — zero marginal cost. EWMA-5m and the exact
-5m-window value will not read identically (decayed vs hard average); that is expected, so label them
-distinctly (`load5m` vs `avg5m`).
+- **Single-writer visibility.** Only the sampler writes the EWMA accumulators → the published
+  `Rolling` snapshot (one `AtomicReference`) is what the endpoint reads.
 
 ## The endpoints
 
@@ -271,7 +247,6 @@ DTO sketch (final shapes live in `ApiDto`):
 
 ```scala
 final case class RateView(now: Double, load1m: Double, load5m: Double, load15m: Double)
-final case class WindowCounts(last10s: Long, last30s: Long, last60s: Long, last5m: Long, last10m: Long)
 final case class CounterWithRate(total: Long, rate: RateView)
 
 final case class BlockStatsView(
@@ -279,9 +254,8 @@ final case class BlockStatsView(
     major: Long,
     avgEvents: Double,
     maxEvents: Long,
-    blocksPerWindow: WindowCounts,
-    requestsPerWindow: WindowCounts,
-    requestsTpsPerWindow: WindowCounts  // requestsPerWindow / window, as rates
+    blockRate: RateView,   // blocks/sec, EWMA
+    requestRate: RateView  // requests-in-blocks/sec, EWMA
 )
 
 final case class StackStatsView(
@@ -307,7 +281,7 @@ final case class PeerStatsView(
 ### Prometheus mapping
 
 The Prometheus idiom is to expose **monotonic counters** (`_total`) and let the server compute rates
-with `rate(...[5m])`; the EWMA/window rates are a human convenience and are exposed as *gauges*. Both
+with `rate(...[5m])`; the EWMA rates are a human convenience and are exposed as *gauges*. Both
 endpoints read the same snapshot, so they never disagree. Naming (`hydrozoa_` prefix, `_total`
 suffix on counters, labels for dimensions):
 
@@ -349,11 +323,12 @@ It cannot meaningfully affect throughput — which is the requirement.
 
 ## Resolved decisions
 
-- **Both EWMA and exact windows.** EWMA for the 1m/5m/15m load-average triple; the cumulative ring for
-  the exact 10s–10m windows. Both are shipped.
+- **EWMA only — no fixed-window rings.** Every rate (local, per-peer, block, requests-in-blocks) is a
+  top-style EWMA load average (now / 1m / 5m / 15m). No per-second history is kept, so nothing has to
+  be recomputed or aged out.
 - **No persistence.** Counters are in-memory and process-lifetime; they reset on restart. Documented in
   the endpoint descriptions. (Persisting would add hot-path cost for little operational value.)
-- **Sampler cadence: 1 Hz.** The ring depth (900) and EWMA τ are independent of it.
+- **Sampler cadence: 1 Hz.** The EWMA τ values are independent of it.
 - **Stacks are first-class**, not an extension — instrumented at `SlowConsensusActor.completeStack`.
 - **Prometheus from day one** — `GET /head/metrics` alongside the JSON `GET /head/stats`, both over the
   same snapshot.

--- a/design/peer-stats-endpoint.md
+++ b/design/peer-stats-endpoint.md
@@ -1,0 +1,366 @@
+# Peer statistics endpoint
+
+Status: **design / in-flight**. A cheap, always-on `GET /head/stats` that reports live operational
+metrics for a single peer without touching storage or perturbing the hot path.
+
+## Motivation
+
+Today the only ways to see what a peer is doing are the logs (which, under the shipped
+`logback-docker.xml`, run at `root=warn` and hide all the fast-consensus INFO detail) and the
+`/head/blocks` listing (which returns *every* block — thousands of entries — and says nothing about
+rates). Answering simple operational questions — "how many requests per second is this peer taking?",
+"are blocks filling up or running near-empty?", "how much of the load is local vs pulled from
+peers?" — currently means scraping logs or post-processing the full block list.
+
+We want a single endpoint that answers those questions in O(1), is safe to poll continuously, and
+cannot measurably affect throughput.
+
+## Goals
+
+- Report, per peer:
+  - **local incoming requests** — total counter + TPS (now / 1m / 5m / 15m, `top`-style).
+  - **peer-to-peer requests** — total counter *per head peer* + TPS the same way.
+  - **block statistics** — total minor/major, average and maximum block size (events), and block +
+    request counts over fixed trailing windows (10s / 30s / 60s / 5m / 10m) with their TPS.
+  - **stack statistics** — total hard-confirmed, last stack number, seconds since last hard-confirm,
+    mean inter-stack gap, and average/maximum stack size (blocks absorbed).
+- Ship **two representations of the same registry**: a human/dashboard JSON view (`GET /head/stats`)
+  and a **Prometheus** text exposition (`GET /head/metrics`) — both from day one.
+- Be **cheap**: no RocksDB reads, no scan of the block history, no actor `ask` on the hot path.
+- Be **safe to poll**: a monitoring agent hitting it every second must not compete with consensus.
+
+## Non-goals
+
+- Durable metrics. Counters are process-lifetime and reset on restart (see
+  [Resolved decisions](#resolved-decisions)).
+- A full time-series database. This is a point-in-time snapshot; graphing is the caller's job — a
+  Prometheus scrape target (`GET /head/metrics`) is provided, but not storage/retention.
+
+## Design principles
+
+1. **Push, don't pull.** Each counter is incremented at the moment its event happens — a single
+   atomic add (nanoseconds, no allocation, no lock). The endpoint never scans anything.
+2. **Derive rolling views off the hot path.** One background fiber, waking at a fixed cadence (1 Hz),
+   rolls the trailing-window ring and updates the EWMA load averages. The hot path only ever
+   increments.
+3. **Snapshot read, no actor ask.** The endpoint materializes the current numbers from an in-memory
+   registry, mirroring how `/ready` reads a `NodeStatus` value instead of issuing a `GetState` to an
+   actor (`HydrozoaServer` already threads `nodeStatus: IO[NodeStatus]` into the routes — the stats
+   registry is threaded the same way).
+
+## Architecture: the `PeerMetrics` registry
+
+One object, created at boot, shared **by reference** to the actors that emit events and to
+`HydrozoaRoutes`.
+
+```scala
+/** Process-lifetime peer metrics. Hot-path methods are lock-free side effects; `snapshot`
+  * produces a consistent read for the /head/stats endpoint. */
+final class PeerMetrics private (
+    // ---- cumulative counters (hot path) ----
+    localAccepted:      AtomicLong,                 // RequestSequencer -> Right(id)
+    localRejScreening:  AtomicLong,                 // RequestSequencer -> Left(Rejected), screening
+    localRejBackpressure: AtomicLong,               // RequestSequencer -> Left(Rejected), window full
+    peerRequests:       Map[HeadPeerId, LongAdder], // requests ingested from each remote peer
+    blocksMinor:        AtomicLong,
+    blocksMajor:        AtomicLong,
+    blockEventsSum:     AtomicLong,                 // Σ events, for the running average
+    blockEventsMax:     AtomicLong,                 // max via CAS
+    stacksTotal:        AtomicLong,
+    lastStackNum:       AtomicLong,
+    lastStackMillis:    AtomicLong,                 // wall-clock of the last hard-confirm
+    stackGapSumMillis:  AtomicLong,                 // Σ inter-stack gaps, for the mean
+    stackBlocksSum:     AtomicLong,                 // Σ blocks absorbed, for the average
+    stackBlocksMax:     AtomicLong,                 // max via CAS
+    startedAtMillis:    Long,
+    // ---- derived, owned by the 1 Hz sampler fiber ----
+    rolling:            AtomicReference[PeerMetrics.Rolling]
+):
+    // hot path (called from the owning actor)
+    def onLocalAccepted(): Unit
+    def onLocalRejected(kind: RejectionKind): Unit
+    def onPeerRequests(from: HeadPeerId, n: Int): Unit
+    def onBlockConfirmed(isMajor: Boolean, events: Int): Unit
+    def onStackConfirmed(stackNum: StackNumber, blocksAbsorbed: Int): Unit
+
+    // read path (called from the HTTP thread)
+    def snapshot: PeerStats
+```
+
+### Threading model — `AtomicLong` vs `LongAdder`
+
+Each cats-actor drains its mailbox **serially**, so a counter written from inside one actor is
+**single-writer**. It still needs *safe publication* to the HTTP reader thread — a bare `var Long`
+is not enough — but a plain `AtomicLong` suffices (no write contention, so `LongAdder`'s striping
+buys nothing):
+
+- `localAccepted` / `localRej*` — written only by `RequestSequencer` → `AtomicLong`.
+- `blocks*` / `blockEvents*` — written only by `FastConsensusActor` → `AtomicLong`.
+
+Only the **peer-request** counters can be written concurrently (ingestion fans in from multiple
+peer-liaison actors/threads), so those use `LongAdder`, which is built for high-contention adds.
+
+The `rolling` view (ring + EWMAs) is written only by the single sampler fiber, so a `@volatile`
+reference / `AtomicReference` publishes it to readers.
+
+## Metrics catalog
+
+| Metric | Type | Notes |
+|---|---|---|
+| `localAccepted` | counter + rate | requests this peer sequenced successfully |
+| `localRejScreening` | counter | rejected by L1/L2 screening |
+| `localRejBackpressure` | counter | rejected by the sequencer window (backpressure) |
+| `peerRequests[p]` | counter + rate, per peer | requests pulled from remote head peer `p` |
+| `blocksMinor` / `blocksMajor` | counter | soft-confirmed blocks by type |
+| avg block size | derived | `blockEventsSum / (blocksMinor + blocksMajor)` |
+| max block size | gauge | `blockEventsMax` |
+| blocks per window | derived | 10s / 30s / 60s / 5m / 10m, from the ring |
+| requests-in-blocks per window + TPS | derived | same windows, from the ring |
+| local & peer TPS | EWMA | now / 1m / 5m / 15m |
+| `stacksTotal` | counter | hard-confirmed stacks |
+| last stack number | gauge | `lastStackNum` |
+| seconds since last hard-confirm | derived | `now - lastStackMillis` |
+| mean inter-stack gap | derived | `stackGapSumMillis / (stacksTotal - 1)` |
+| avg / max stack size | derived / gauge | blocks absorbed: `stackBlocksSum / stacksTotal`, `stackBlocksMax` |
+| uptime | derived | `now - startedAtMillis` |
+
+## Instrumentation points
+
+Three call sites, all on paths that already exist — no new plumbing:
+
+| Metric | Hook |
+|---|---|
+| local accepted / rejected(kind) | `RequestSequencer` — the `Right(id)` vs `Left(UserRequest.Rejected(...))` decision branches (screening vs backpressure are already distinct branches). Counting here — not in the route — also captures any non-HTTP submission path. |
+| peer-to-peer requests per peer | the request lane where a remote peer's requests enter the local mempool (the peer liaison / puller receive path); `onPeerRequests(from, batch.size)`. |
+| blocks minor/major + event count | `FastConsensusActor.completeCell` — the single funnel every soft-confirmed block passes through. It already computes `brief`, already switches `Minor`/`Major`, and `brief.requests.size` is the event count. One `metrics.onBlockConfirmed(isMajor, brief.requests.size)` next to the existing `BlockSoftConfirmed` emission. |
+| stacks + size | `SlowConsensusActor.completeStack` — the single funnel where a `Stack.HardConfirmed` is produced. `stackBrief.stackNum` and `lastBlockNum - firstBlockNum + 1` (blocks absorbed) give the size. One `metrics.onStackConfirmed(stackNum, blocksAbsorbed)`. |
+
+Because `completeCell` / `completeStack` are the *only* places a soft-confirmed block / hard-confirmed
+stack is produced, those stats need exactly one line each and can never drift from reality.
+
+## Rolling windows: a cumulative ring
+
+Keep a ring of **per-second cumulative snapshots** — 900 slots = 15 min (covers every requested
+window with headroom). Each second the sampler writes the current cumulative counters into
+`ring[t % 900]`. A windowed count is then a subtraction:
+
+```
+countOverLast(W seconds) = cumulativeNow − ring[(t − W) % 900]
+```
+
+This is race-free (nothing is zeroed), exact, and diffing a few longs is free. Memory: 900 × a
+handful of longs ≈ a few KB. Blocks and requests-in-blocks share the same ring, so
+"requests in those blocks + corresponding TPS" falls straight out (`requestsInWindow / W`).
+
+## TPS load averages (EWMA)
+
+An **exponentially weighted moving average** keeps *one number* instead of a window of samples; each
+new sample pushes the average toward itself and old samples fade geometrically. This is exactly what
+`top`/`uptime` load averages are, so we mirror them.
+
+### Recurrence
+
+```
+avgₙ = avgₙ₋₁ · decay + sampleₙ · (1 − decay)
+where decay = exp(−Δt / τ)
+```
+
+- **τ (tau)** — the time constant / memory length. After τ seconds a sample's weight has decayed to
+  1/e ≈ 37%. The `top`-style triple uses τ = 60s, 300s, 900s.
+- **Δt** — elapsed time since the last update.
+- **sample** — the instantaneous rate this tick = `(events since last tick) / Δt`. Feed the *rate*
+  (req/s), not the raw count, so the units stay stable when Δt jitters.
+
+`decay` is the fraction of the old value kept; `1 − decay` is how much the new sample counts. Long τ →
+decay near 1 → smooth/sluggish. Short τ → snappy/noisy. Note a "1-minute load average" is not "the
+average over exactly the last 60s" — it is a smoothing with ~1-minute memory. That soft edge is the
+point.
+
+### How `top` does it
+
+`top` samples every 5s and folds into three EWMAs. With Δt = 5s:
+
+| horizon | τ | decay = exp(−5/τ) |
+|---|---|---|
+| 1 min | 60 s | 0.9200 |
+| 5 min | 300 s | 0.9835 |
+| 15 min | 900 s | 0.9945 |
+
+(The kernel stores these fixed-point as `EXP_1=1884, EXP_5=2014, EXP_15=2037` out of 2048.)
+
+### Implementation
+
+```scala
+/** One EWMA horizon. Written only by the sampler fiber; `get` is read cross-thread. */
+final class Ewma(tauSeconds: Double):
+    @volatile private var v: Double = 0.0
+    def observe(ratePerSec: Double, dtSeconds: Double): Unit =
+        val decay = math.exp(-dtSeconds / tauSeconds)   // recompute per tick — see below
+        v = v * decay + ratePerSec * (1.0 - decay)
+    def get: Double = v
+```
+
+Driven by the same 1 Hz sampler that rolls the ring:
+
+```scala
+val dt      = (now - last).toDouble                 // actual elapsed, seconds
+val delta   = cumulativeNow - cumulativeAtLastTick  // events this interval
+val instant = delta / dt                            // req/s "now"
+ewma1m.observe(instant, dt); ewma5m.observe(instant, dt); ewma15m.observe(instant, dt)
+```
+
+Cost: three `exp` + three multiply-adds per second.
+
+### Practical choices
+
+- **Recompute `decay` from the measured Δt each tick.** `top` hard-codes constants for a fixed 5s
+  cadence; if the sampler fiber is ever late (GC, scheduling) a fixed constant silently overweights
+  that interval. `exp(−Δt/τ)` from the real Δt is self-correcting and free.
+- **Sampler interval.** 1s (finer than `top`'s 5s) gives a responsive "now" and smooth 1/5/15 lines.
+  Report **"now"** as the last tick's raw `instant` (or the ring's last-10s count / 10); 1m/5m/15m
+  are the EWMAs.
+- **Cold start.** Initialize to 0.0; averages ramp over ~τ (like `top` right after boot). Optional
+  bias correction `v / (1 − decayⁿ)` for the first few ticks — not worth it, the ramp is expected.
+- **Idle decay is free and correct.** No traffic → `instant = 0` → averages glide to 0, matching
+  `top` when load drops.
+- **Single-writer visibility.** Only the sampler writes the EWMAs and the ring → `@volatile` is
+  sufficient for the endpoint to read a fresh value.
+
+### EWMA vs the ring — use both
+
+They answer different questions:
+
+| | EWMA (1m/5m/15m) | Cumulative ring (10s…10m) |
+|---|---|---|
+| memory | one double per horizon | ~900 slots × few longs |
+| semantics | smoothed, soft-edged (top-style) | **exact** count in the window |
+| boundary artifacts | none | a sample leaving the window is a step |
+| best for | load-average feel, trend | precise "how many in the last 30s" |
+
+Use **EWMA for the load-average triple** and the **ring for the exact fixed-window counts + TPS**. The
+sampler computes `delta`/`instant` once and feeds both — zero marginal cost. EWMA-5m and the exact
+5m-window value will not read identically (decayed vs hard average); that is expected, so label them
+distinctly (`load5m` vs `avg5m`).
+
+## The endpoints
+
+Two read-only, unauthenticated endpoints over the **same** `metrics.snapshot`:
+
+```scala
+// GET /head/stats  — human/dashboard JSON
+private val statsEndpoint: ServerEndpoint[Any, IO] =
+    endpoint.get.in("head" / "stats")
+        .name("getHeadStats").tag("Observability")
+        .out(jsonBody[PeerStatsView])
+        .errorOut(errorOut)
+        .description("Live operational metrics for this peer. Cheap; process-lifetime counters.")
+        .serverLogic(_ => IO(metrics.snapshot).map(ApiDto.mkPeerStatsView).map(Right(_)))
+
+// GET /head/metrics  — Prometheus text exposition (version 0.0.4)
+private val metricsEndpoint: ServerEndpoint[Any, IO] =
+    endpoint.get.in("head" / "metrics")
+        .name("getHeadMetrics").tag("Observability")
+        .out(stringBody.and(header(Header.contentType(
+              MediaType.unsafeParse("text/plain; version=0.0.4; charset=utf-8")))))
+        .errorOut(errorOut)
+        .description("Same metrics in Prometheus exposition format.")
+        .serverLogic(_ => IO(metrics.snapshot).map(PrometheusFormat.render).map(Right(_)))
+```
+
+DTO sketch (final shapes live in `ApiDto`):
+
+```scala
+final case class RateView(now: Double, load1m: Double, load5m: Double, load15m: Double)
+final case class WindowCounts(last10s: Long, last30s: Long, last60s: Long, last5m: Long, last10m: Long)
+final case class CounterWithRate(total: Long, rate: RateView)
+
+final case class BlockStatsView(
+    minor: Long,
+    major: Long,
+    avgEvents: Double,
+    maxEvents: Long,
+    blocksPerWindow: WindowCounts,
+    requestsPerWindow: WindowCounts,
+    requestsTpsPerWindow: WindowCounts  // requestsPerWindow / window, as rates
+)
+
+final case class StackStatsView(
+    total: Long,
+    lastStackNumber: Long,
+    secondsSinceLastHardConfirm: Long,
+    meanInterStackGapSeconds: Double,
+    avgBlocksAbsorbed: Double,
+    maxBlocksAbsorbed: Long
+)
+
+final case class PeerStatsView(
+    uptimeSeconds: Long,
+    localRequests: CounterWithRate,
+    localRejectedScreening: Long,
+    localRejectedBackpressure: Long,
+    peerRequests: Map[Int, CounterWithRate],  // keyed by head-peer id
+    blocks: BlockStatsView,
+    stacks: StackStatsView
+)
+```
+
+### Prometheus mapping
+
+The Prometheus idiom is to expose **monotonic counters** (`_total`) and let the server compute rates
+with `rate(...[5m])`; the EWMA/window rates are a human convenience and are exposed as *gauges*. Both
+endpoints read the same snapshot, so they never disagree. Naming (`hydrozoa_` prefix, `_total`
+suffix on counters, labels for dimensions):
+
+```
+# HELP hydrozoa_local_requests_total Requests this peer sequenced successfully.
+# TYPE hydrozoa_local_requests_total counter
+hydrozoa_local_requests_total 1234
+# TYPE hydrozoa_local_requests_rejected_total counter
+hydrozoa_local_requests_rejected_total{reason="screening"} 5
+hydrozoa_local_requests_rejected_total{reason="backpressure"} 4210
+# TYPE hydrozoa_peer_requests_total counter
+hydrozoa_peer_requests_total{peer="1"} 987
+# TYPE hydrozoa_blocks_total counter
+hydrozoa_blocks_total{type="minor"} 3860
+hydrozoa_blocks_total{type="major"} 2
+# TYPE hydrozoa_block_events_max gauge
+hydrozoa_block_events_max 1000
+# TYPE hydrozoa_stacks_total counter
+hydrozoa_stacks_total 10
+# TYPE hydrozoa_stack_last_number gauge
+hydrozoa_stack_last_number 10
+# TYPE hydrozoa_seconds_since_last_hard_confirm gauge
+hydrozoa_seconds_since_last_hard_confirm 42
+# TYPE hydrozoa_local_requests_load gauge
+hydrozoa_local_requests_load{window="1m"} 3.7
+```
+
+`PrometheusFormat.render(snapshot): String` is a pure function over the snapshot — no framework
+dependency, trivially unit-testable line-by-line.
+
+## Cost analysis
+
+- **Hot path:** one atomic add per request / block — nanoseconds, no allocation, no lock. `LongAdder`
+  only where writes actually contend (peer ingestion).
+- **Background:** one fiber per second rolling ~a few KB and doing 3 `exp`s.
+- **Endpoint:** a bounded snapshot (O(1) counters + one pass over the ring), no I/O.
+
+It cannot meaningfully affect throughput — which is the requirement.
+
+## Resolved decisions
+
+- **Both EWMA and exact windows.** EWMA for the 1m/5m/15m load-average triple; the cumulative ring for
+  the exact 10s–10m windows. Both are shipped.
+- **No persistence.** Counters are in-memory and process-lifetime; they reset on restart. Documented in
+  the endpoint descriptions. (Persisting would add hot-path cost for little operational value.)
+- **Sampler cadence: 1 Hz.** The ring depth (900) and EWMA τ are independent of it.
+- **Stacks are first-class**, not an extension — instrumented at `SlowConsensusActor.completeStack`.
+- **Prometheus from day one** — `GET /head/metrics` alongside the JSON `GET /head/stats`, both over the
+  same snapshot.
+- **Auth.** Both endpoints are read-only and non-sensitive, so unauthenticated like `/head/info` and
+  `/head/blocks`.
+
+## Later / out of scope
+
+- **Block-size distribution** (p50/p95 via a small fixed-bucket histogram) — average+max ship now;
+  percentiles can follow if the cap behavior needs finer visibility.

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -356,6 +356,33 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ReadinessResponse'
+  /head/stats:
+    get:
+      tags:
+      - Observability
+      description: 'Live operational metrics for this peer (in-memory, process-lifetime;
+        reset on restart). Cheap: served from a snapshot, no storage reads.'
+      operationId: getHeadStats
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PeerStats'
+  /head/metrics:
+    get:
+      tags:
+      - Observability
+      description: The same peer metrics in Prometheus text exposition format.
+      operationId: getHeadMetrics
+      responses:
+        '200':
+          description: ''
+          content:
+            text/plain:
+              schema:
+                type: string
   /version:
     get:
       description: The build identity (version, git commit, build time) baked in at
@@ -835,6 +862,33 @@ components:
         type:
           type: string
           const: SOFT_CONFIRMED
+    BlockStats:
+      title: BlockStats
+      type: object
+      required:
+      - minor
+      - major
+      - avgEvents
+      - maxEvents
+      - blocksPerWindow
+      - requestsPerWindow
+      properties:
+        minor:
+          type: integer
+          format: int64
+        major:
+          type: integer
+          format: int64
+        avgEvents:
+          type: number
+          format: double
+        maxEvents:
+          type: integer
+          format: int64
+        blocksPerWindow:
+          $ref: '#/components/schemas/WindowStats'
+        requestsPerWindow:
+          $ref: '#/components/schemas/WindowStats'
     BlockSummary:
       title: BlockSummary
       type: object
@@ -1093,6 +1147,26 @@ components:
         type:
           type: string
           const: initialization
+    LocalRequestStats:
+      title: LocalRequestStats
+      type: object
+      required:
+      - total
+      - rate
+      - rejectedScreening
+      - rejectedBackpressure
+      properties:
+        total:
+          type: integer
+          format: int64
+        rate:
+          $ref: '#/components/schemas/RateStats'
+        rejectedScreening:
+          type: integer
+          format: int64
+        rejectedBackpressure:
+          type: integer
+          format: int64
     Major:
       title: Major
       type: object
@@ -1163,6 +1237,65 @@ components:
         type:
           type: string
           const: minor
+    PeerRequestStats:
+      title: PeerRequestStats
+      type: object
+      required:
+      - peer
+      - total
+      - rate
+      properties:
+        peer:
+          type: integer
+          format: int32
+        total:
+          type: integer
+          format: int64
+        rate:
+          $ref: '#/components/schemas/RateStats'
+    PeerStats:
+      title: PeerStats
+      type: object
+      required:
+      - uptimeSeconds
+      - localRequests
+      - blocks
+      - stacks
+      properties:
+        uptimeSeconds:
+          type: integer
+          format: int64
+        localRequests:
+          $ref: '#/components/schemas/LocalRequestStats'
+        peerRequests:
+          type: array
+          items:
+            $ref: '#/components/schemas/PeerRequestStats'
+        blocks:
+          $ref: '#/components/schemas/BlockStats'
+        stacks:
+          $ref: '#/components/schemas/StackStats'
+    RateStats:
+      title: RateStats
+      type: object
+      required:
+      - now
+      - load1m
+      - load5m
+      - load15m
+      properties:
+        now:
+          type: number
+          format: double
+        load1m:
+          type: number
+          format: double
+        load5m:
+          type: number
+          format: double
+        load15m:
+          type: number
+          format: double
     ReadinessResponse:
       title: ReadinessResponse
       type: object
@@ -1401,6 +1534,35 @@ components:
         type:
           type: string
           const: settlement
+    StackStats:
+      title: StackStats
+      type: object
+      required:
+      - total
+      - lastStackNumber
+      - secondsSinceLastHardConfirm
+      - meanInterStackGapSeconds
+      - avgBlocksAbsorbed
+      - maxBlocksAbsorbed
+      properties:
+        total:
+          type: integer
+          format: int64
+        lastStackNumber:
+          type: integer
+          format: int64
+        secondsSinceLastHardConfirm:
+          type: integer
+          format: int64
+        meanInterStackGapSeconds:
+          type: number
+          format: double
+        avgBlocksAbsorbed:
+          type: number
+          format: double
+        maxBlocksAbsorbed:
+          type: integer
+          format: int64
     SubmitDeposit:
       title: SubmitDeposit
       type: object
@@ -1502,6 +1664,31 @@ components:
           type: string
         buildTime:
           type: string
+    WindowStats:
+      title: WindowStats
+      type: object
+      required:
+      - last10s
+      - last30s
+      - last60s
+      - last5m
+      - last10m
+      properties:
+        last10s:
+          type: integer
+          format: int64
+        last30s:
+          type: integer
+          format: int64
+        last60s:
+          type: integer
+          format: int64
+        last5m:
+          type: integer
+          format: int64
+        last10m:
+          type: integer
+          format: int64
   securitySchemes:
     httpAuth:
       type: http

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -870,8 +870,8 @@ components:
       - major
       - avgEvents
       - maxEvents
-      - blocksPerWindow
-      - requestsPerWindow
+      - blockRate
+      - requestRate
       properties:
         minor:
           type: integer
@@ -885,10 +885,10 @@ components:
         maxEvents:
           type: integer
           format: int64
-        blocksPerWindow:
-          $ref: '#/components/schemas/WindowStats'
-        requestsPerWindow:
-          $ref: '#/components/schemas/WindowStats'
+        blockRate:
+          $ref: '#/components/schemas/RateStats'
+        requestRate:
+          $ref: '#/components/schemas/RateStats'
     BlockSummary:
       title: BlockSummary
       type: object
@@ -1664,31 +1664,6 @@ components:
           type: string
         buildTime:
           type: string
-    WindowStats:
-      title: WindowStats
-      type: object
-      required:
-      - last10s
-      - last30s
-      - last60s
-      - last5m
-      - last10m
-      properties:
-        last10s:
-          type: integer
-          format: int64
-        last30s:
-          type: integer
-          format: int64
-        last60s:
-          type: integer
-          format: int64
-        last5m:
-          type: integer
-          format: int64
-        last10m:
-          type: integer
-          format: int64
   securitySchemes:
     httpAuth:
       type: http

--- a/docs/spec/peer-stats-endpoint.md
+++ b/docs/spec/peer-stats-endpoint.md
@@ -1,7 +1,8 @@
 # Peer statistics endpoint
 
-Status: **design / in-flight**. A cheap, always-on `GET /head/stats` that reports live operational
-metrics for a single peer without touching storage or perturbing the hot path.
+Status: **as-built reference**. A cheap, always-on `GET /head/stats` (and Prometheus
+`GET /head/metrics`) that reports live operational metrics for a single peer without touching storage
+or perturbing the hot path.
 
 ## Motivation
 

--- a/integration/src/test/scala/hydrozoa/integration/harness/MultiPeerHeadHarness.scala
+++ b/integration/src/test/scala/hydrozoa/integration/harness/MultiPeerHeadHarness.scala
@@ -23,6 +23,7 @@ import hydrozoa.lib.logging.{ContraTracer, LogEvent, Slf4jMsg, Slf4jMsgFormat, S
 import hydrozoa.multisig.backend.cardano.{CardanoBackend as L1Backend, CardanoBackendMock, FirewalledCardanoBackendEvent, MockState, yaciTestSauceGenesis}
 import hydrozoa.multisig.consensus.peer.{CoilPeerNumber, HeadPeerId, HeadPeerNumber, PeerId}
 import hydrozoa.multisig.consensus.transport.*
+import hydrozoa.multisig.metrics.PeerMetrics
 import hydrozoa.multisig.consensus.{CardanoLiaison, RequestSequencer}
 import hydrozoa.multisig.ledger.block.BlockVersion.Major.given_Conversion_Major_Int
 import hydrozoa.multisig.ledger.eutxol2.EutxoL2Screener
@@ -1028,12 +1029,17 @@ object MultiPeerHeadHarness:
                             Persistence.fromBackend(backendStore, persistenceTracer)
                         }
                         l2Ledger <- Resource.eval(InMemoryL2Store.ledger(nodeConfig))
+                        metrics = PeerMetrics.create(
+                          0L,
+                          nodeConfig.headConfig.headPeerNums.toList.map(_.convert).toVector
+                        )
                         mrm <- HeadMultisigRegimeManager.resource(
                           nodeConfig,
                           cardanoBackend,
                           l2Ledger,
                           EutxoL2Screener(nodeConfig),
                           persistence,
+                          metrics,
                           mrmTracer,
                           peerFactory,
                           hubFactory,
@@ -1071,11 +1077,16 @@ object MultiPeerHeadHarness:
                         Persistence.fromBackend(backendStore, persistenceTracer)
                     }
                     l2Ledger <- Resource.eval(InMemoryL2Store.ledger(coilConfig))
+                    metrics = PeerMetrics.create(
+                      0L,
+                      coilConfig.headConfig.headPeerNums.toList.map(_.convert).toVector
+                    )
                     mrm <- CoilMultisigRegimeManager.resource(
                       coilConfig,
                       cardanoBackend,
                       l2Ledger,
                       persistence,
+                      metrics,
                       mrmTracer,
                       uplinkFactory,
                     )
@@ -1114,6 +1125,10 @@ object MultiPeerHeadHarness:
             )
             val httpTracer: ContraTracer[IO, HydrozoaHttpEvent] =
                 Slf4jTracer.sink.contramap(HydrozoaHttpEventFormat.humanFormat)
+            val metrics = PeerMetrics.create(
+              0L,
+              nodeConfig.headConfig.headPeerNums.toList.map(_.convert).toVector
+            )
             HydrozoaRoutes(
               requestSequencer,
               conns.blockWeaver,
@@ -1125,6 +1140,7 @@ object MultiPeerHeadHarness:
               None,
               nodeConfig.headConfig,
               serverConfig,
+              metrics,
               httpTracer,
             ).map { hydrozoaRoutes =>
                 val client: Http4sClient[IO] =

--- a/integration/src/test/scala/hydrozoa/integration/harness/MultiPeerHeadHarness.scala
+++ b/integration/src/test/scala/hydrozoa/integration/harness/MultiPeerHeadHarness.scala
@@ -23,12 +23,12 @@ import hydrozoa.lib.logging.{ContraTracer, LogEvent, Slf4jMsg, Slf4jMsgFormat, S
 import hydrozoa.multisig.backend.cardano.{CardanoBackend as L1Backend, CardanoBackendMock, FirewalledCardanoBackendEvent, MockState, yaciTestSauceGenesis}
 import hydrozoa.multisig.consensus.peer.{CoilPeerNumber, HeadPeerId, HeadPeerNumber, PeerId}
 import hydrozoa.multisig.consensus.transport.*
-import hydrozoa.multisig.metrics.PeerMetrics
 import hydrozoa.multisig.consensus.{CardanoLiaison, RequestSequencer}
 import hydrozoa.multisig.ledger.block.BlockVersion.Major.given_Conversion_Major_Int
 import hydrozoa.multisig.ledger.eutxol2.EutxoL2Screener
 import hydrozoa.multisig.ledger.eutxol2.store.InMemoryL2Store
 import hydrozoa.multisig.ledger.l1.tx.{EnrichedTx, SettlementTx}
+import hydrozoa.multisig.metrics.PeerMetrics
 import hydrozoa.multisig.persistence.rocksdb.RocksDbBackendStore
 import hydrozoa.multisig.persistence.{BackendStore, Cf, ConsensusStoreReader, InMemoryBackendStore, Persistence, PersistenceEvent, PersistenceEventFormat}
 import hydrozoa.multisig.server.{HydrozoaHttpEvent, HydrozoaHttpEventFormat, HydrozoaRoutes, HydrozoaServer, SubmissionClient}

--- a/integration/src/test/scala/hydrozoa/integration/stage1/Suite.scala
+++ b/integration/src/test/scala/hydrozoa/integration/stage1/Suite.scala
@@ -27,6 +27,7 @@ import hydrozoa.multisig.backend.cardano.CardanoBackendBlockfrost.URL
 import hydrozoa.multisig.backend.cardano.{CardanoBackend, CardanoBackendBlockfrost, CardanoBackendEventFormat, CardanoBackendMock, MockState, yaciTestSauceGenesis}
 import hydrozoa.multisig.consensus.peer.HeadPeerNumber
 import hydrozoa.multisig.consensus.{BlockWeaver, CardanoLiaison, CardanoLiaisonEvent, CardanoLiaisonEventFormat, FastConsensusActor, FastConsensusActorEvent, FastConsensusActorEventFormat, RequestSequencer, StackComposer}
+import hydrozoa.multisig.metrics.PeerMetrics
 import hydrozoa.multisig.ledger.block.{Block, BlockNumber, BlockVersion}
 import hydrozoa.multisig.ledger.eutxol2.store.InMemoryL2Store
 import hydrozoa.multisig.ledger.eutxol2.toUtxos
@@ -584,7 +585,13 @@ case class Suite(
                     stackComposer = stackComposerStub,
                   )
                   consensusActor <- system.actorOf(
-                    FastConsensusActor(nodeConfig, consensusConnections, fcaTracer, persistence)
+                    FastConsensusActor(
+                      nodeConfig,
+                      consensusConnections,
+                      fcaTracer,
+                      persistence,
+                      PeerMetrics.create(0L, Vector.empty)
+                    )
                   )
                   _ <- consensusActorD.complete(consensusActor)
               } yield Stage1Sut(

--- a/integration/src/test/scala/hydrozoa/integration/stage1/Suite.scala
+++ b/integration/src/test/scala/hydrozoa/integration/stage1/Suite.scala
@@ -27,13 +27,13 @@ import hydrozoa.multisig.backend.cardano.CardanoBackendBlockfrost.URL
 import hydrozoa.multisig.backend.cardano.{CardanoBackend, CardanoBackendBlockfrost, CardanoBackendEventFormat, CardanoBackendMock, MockState, yaciTestSauceGenesis}
 import hydrozoa.multisig.consensus.peer.HeadPeerNumber
 import hydrozoa.multisig.consensus.{BlockWeaver, CardanoLiaison, CardanoLiaisonEvent, CardanoLiaisonEventFormat, FastConsensusActor, FastConsensusActorEvent, FastConsensusActorEventFormat, RequestSequencer, StackComposer}
-import hydrozoa.multisig.metrics.PeerMetrics
 import hydrozoa.multisig.ledger.block.{Block, BlockNumber, BlockVersion}
 import hydrozoa.multisig.ledger.eutxol2.store.InMemoryL2Store
 import hydrozoa.multisig.ledger.eutxol2.toUtxos
 import hydrozoa.multisig.ledger.event.RequestNumber
 import hydrozoa.multisig.ledger.joint.{JointLedger, JointLedgerEventFormat}
 import hydrozoa.multisig.ledger.l1.tx.RawTx
+import hydrozoa.multisig.metrics.PeerMetrics
 import hydrozoa.multisig.persistence.{InMemoryBackendStore, Persistence, PersistenceEventFormat}
 import java.util.concurrent.TimeUnit
 import org.scalacheck.commands.{ModelBasedSuite, ScenarioGen}

--- a/src/main/scala/hydrozoa/app/Serve.scala
+++ b/src/main/scala/hydrozoa/app/Serve.scala
@@ -21,6 +21,7 @@ import hydrozoa.multisig.ledger.eutxol2.store.RocksDbL2Store
 import hydrozoa.multisig.ledger.eutxol2.{EutxoL2Ledger, EutxoL2Screener}
 import hydrozoa.multisig.ledger.l2.{EutxoL2LedgerReader, L2Ledger, L2Screener}
 import hydrozoa.multisig.ledger.remote.{RemoteL2Ledger, RemoteL2LedgerEventFormat, RemoteL2Screener}
+import hydrozoa.multisig.metrics.PeerMetrics
 import hydrozoa.multisig.persistence.rocksdb.RocksDbBackendStore
 import hydrozoa.multisig.persistence.{Cf, ConsensusStoreReader, Persistence, PersistenceEventFormat}
 import hydrozoa.multisig.server.{HydrozoaHttpEvent, HydrozoaHttpEventFormat, HydrozoaServer}
@@ -107,6 +108,19 @@ object Serve {
             result <- Resource.eval(setupIO)
             (backend, nodeConfig) = result
 
+            // Peer stats registry (design/peer-stats-endpoint.md): created once, threaded into the
+            // instrumented actors and the HTTP server, with its 1 Hz sampler running for the node's
+            // lifetime. In-memory only — counters reset on restart.
+            metrics <- Resource.eval(
+              IO.realTime.map(t =>
+                  PeerMetrics.create(
+                    t.toMillis,
+                    nodeConfig.headConfig.headPeerNums.toList.map(_.convert).toVector
+                  )
+              )
+            )
+            _ <- metrics.sampler().background
+
             // Select the L2 ledger the peers agreed on (HeadParameters.l2Ledger): the built-in
             // in-process EUTXO ledger, or a remote black box reached over this node's
             // `remoteLedgerUri`. Only the EUTXO ledger is also an EutxoL2LedgerReader, so only it
@@ -149,6 +163,7 @@ object Serve {
                       l2Screener,
                       l2QueryReader,
                       persistence,
+                      metrics,
                       headTracer,
                       wsClient,
                       ownHeadNum,
@@ -166,6 +181,7 @@ object Serve {
                       backend,
                       l2Ledger,
                       persistence,
+                      metrics,
                       coilTracer,
                       wsClient,
                       ownCoilNum,
@@ -175,9 +191,9 @@ object Serve {
             consensusReader = ConsensusStoreReader.fromPersistence(persistence)(using
               nodeConfig.headConfig
             )
-        } yield (nodeConfig, system, nodeRun, consensusReader)
+        } yield (nodeConfig, system, nodeRun, consensusReader, metrics)
 
-        resource.use { case (nodeConfig, system, nodeRun, consensusReader) =>
+        resource.use { case (nodeConfig, system, nodeRun, consensusReader, metrics) =>
             nodeRun match {
                 case NodeRun.HeadNode(mrm, l2QueryReader) =>
                     runHeadNode(
@@ -186,6 +202,7 @@ object Serve {
                       mrm,
                       consensusReader,
                       l2QueryReader,
+                      metrics,
                       httpExtraTracer
                     )
                 case NodeRun.CoilNode(mrm) =>
@@ -240,6 +257,7 @@ object Serve {
         l2Screener: L2Screener[IO],
         l2QueryReader: Option[EutxoL2LedgerReader[IO]],
         persistence: Persistence[IO],
+        metrics: PeerMetrics,
         mrmTracer: ContraTracer[IO, HeadRegimeManagerEvent],
         wsClient: org.http4s.client.websocket.WSClient[IO],
         ownHeadNum: HeadPeerNumber,
@@ -331,6 +349,7 @@ object Serve {
               l2Ledger,
               l2Screener,
               persistence,
+              metrics,
               mrmTracer,
               peerFactory,
               hubFactory,
@@ -346,6 +365,7 @@ object Serve {
         backend: CardanoBackend[IO],
         l2Ledger: L2Ledger[IO],
         persistence: Persistence[IO],
+        metrics: PeerMetrics,
         mrmTracer: ContraTracer[IO, CoilRegimeManagerEvent],
         wsClient: org.http4s.client.websocket.WSClient[IO],
         ownCoilNum: CoilPeerNumber,
@@ -381,6 +401,7 @@ object Serve {
               backend,
               l2Ledger,
               persistence,
+              metrics,
               mrmTracer,
               coilFactory,
             )
@@ -393,6 +414,7 @@ object Serve {
         mrm: HeadMultisigRegimeManager,
         consensusReader: ConsensusStoreReader[IO],
         l2QueryReader: Option[EutxoL2LedgerReader[IO]],
+        metrics: PeerMetrics,
         httpExtraTracer: ContraTracer[IO, HydrozoaHttpEvent],
     ): IO[ExitCode] =
         for {
@@ -437,6 +459,7 @@ object Serve {
                           l2QueryReader,
                           nodeConfig.headConfig,
                           serverConfig,
+                          metrics,
                           httpTracer,
                         )
                         .use(_ => IO.never)

--- a/src/main/scala/hydrozoa/app/Serve.scala
+++ b/src/main/scala/hydrozoa/app/Serve.scala
@@ -108,7 +108,7 @@ object Serve {
             result <- Resource.eval(setupIO)
             (backend, nodeConfig) = result
 
-            // Peer stats registry (design/peer-stats-endpoint.md): created once, threaded into the
+            // Peer stats registry (docs/spec/peer-stats-endpoint.md): created once, threaded into the
             // instrumented actors and the HTTP server, with its 1 Hz sampler running for the node's
             // lifetime. In-memory only — counters reset on restart.
             metrics <- Resource.eval(

--- a/src/main/scala/hydrozoa/multisig/CoilMultisigRegimeManager.scala
+++ b/src/main/scala/hydrozoa/multisig/CoilMultisigRegimeManager.scala
@@ -14,6 +14,7 @@ import hydrozoa.multisig.consensus.peer.PeerId
 import hydrozoa.multisig.consensus.peer.PeerId.{Coil, Head}
 import hydrozoa.multisig.consensus.transport.{CoilTransport, RemoteHubProxy}
 import hydrozoa.multisig.ledger.l2.L2Ledger
+import hydrozoa.multisig.metrics.PeerMetrics
 import hydrozoa.multisig.persistence.Persistence
 import hydrozoa.rulebased.RuleBasedRegimeManager
 
@@ -33,6 +34,7 @@ trait CoilMultisigRegimeManager(
     cardanoBackend: CardanoBackend[IO],
     l2Ledger: L2Ledger[IO],
     persistence: Persistence[IO],
+    override protected val metrics: PeerMetrics,
     override protected val tracer: ContraTracer[IO, CoilRegimeManagerEvent],
     /** Coil-uplink transport toward this coil peer's single hub. */
     coilTransport: ActorContext[IO, Request, Any] => CoilTransport,
@@ -181,6 +183,7 @@ object CoilMultisigRegimeManager {
         cardanoBackend: CardanoBackend[IO],
         virtualLedger: L2Ledger[IO],
         persistence: Persistence[IO],
+        metrics: PeerMetrics,
         tracer: ContraTracer[IO, CoilRegimeManagerEvent],
         coilTransport: Resource[IO, ActorContext[IO, Request, Any] => CoilTransport],
     ): Resource[IO, CoilMultisigRegimeManager] =
@@ -192,6 +195,7 @@ object CoilMultisigRegimeManager {
                   cardanoBackend,
                   virtualLedger,
                   persistence,
+                  metrics,
                   tracer,
                   factory,
                 ) {}

--- a/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManager.scala
+++ b/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManager.scala
@@ -16,6 +16,7 @@ import hydrozoa.multisig.consensus.peer.{CoilPeerNumber, HeadPeerNumber, PeerId}
 import hydrozoa.multisig.consensus.transport.{HubTransport, PeerTransport, RemoteCoilProxy, RemotePeerProxy}
 import hydrozoa.multisig.ledger.joint.JointLedger
 import hydrozoa.multisig.ledger.l2.{L2Ledger, L2Screener}
+import hydrozoa.multisig.metrics.PeerMetrics
 import hydrozoa.multisig.persistence.Persistence
 import hydrozoa.rulebased.RuleBasedRegimeManager
 
@@ -25,6 +26,7 @@ trait HeadMultisigRegimeManager(
     l2Ledger: L2Ledger[IO],
     l2Screener: L2Screener[IO],
     persistence: Persistence[IO],
+    override protected val metrics: PeerMetrics,
     override protected val tracer: ContraTracer[IO, HeadRegimeManagerEvent],
     peerTransport: ActorContext[IO, Request, Any] => PeerTransport,
     /** Hub-side coil transport, populated iff this peer hubs any coil peers; required when
@@ -70,7 +72,8 @@ trait HeadMultisigRegimeManager(
                 pendingConnections,
                 l2Screener,
                 tracers.eventSequencer,
-                persistence
+                persistence,
+                metrics
               )
             )
 
@@ -96,7 +99,8 @@ trait HeadMultisigRegimeManager(
                             pid,
                             pendingConnections,
                             tracers.peerLiaison(PeerId.Head(pid.peerNum)),
-                            persistence
+                            persistence,
+                            metrics
                           )
                         )
                     )
@@ -344,6 +348,7 @@ object HeadMultisigRegimeManager {
         virtualLedger: L2Ledger[IO],
         l2Screener: L2Screener[IO],
         persistence: Persistence[IO],
+        metrics: PeerMetrics,
         tracer: ContraTracer[IO, HeadRegimeManagerEvent],
         peerTransport: Resource[IO, ActorContext[IO, Request, Any] => PeerTransport],
         hubCoilTransport: Option[Resource[IO, ActorContext[IO, Request, Any] => HubTransport]] =
@@ -360,6 +365,7 @@ object HeadMultisigRegimeManager {
                   virtualLedger,
                   l2Screener,
                   persistence,
+                  metrics,
                   tracer,
                   peerFactory,
                   hubFactory,

--- a/src/main/scala/hydrozoa/multisig/MultisigRegimeManagerBase.scala
+++ b/src/main/scala/hydrozoa/multisig/MultisigRegimeManagerBase.scala
@@ -15,6 +15,7 @@ import hydrozoa.multisig.backend.cardano.CardanoBackend
 import hydrozoa.multisig.consensus.*
 import hydrozoa.multisig.ledger.joint.JointLedger
 import hydrozoa.multisig.ledger.l2.L2Ledger
+import hydrozoa.multisig.metrics.PeerMetrics
 import hydrozoa.multisig.persistence.Persistence
 import scala.concurrent.duration.DurationInt
 
@@ -44,6 +45,11 @@ trait MultisigRegimeManagerBase[E >: LifecycleEvent <: RegimeManagerEvent]
       * coil); both implement [[HasCoreTracers]] so [[spawnCoreActors]] sees a uniform surface.
       */
     protected def tracers: HasCoreTracers
+
+    /** The peer metrics registry, supplied by the subclass and threaded into the instrumented
+      * actors (see `design/peer-stats-endpoint.md`).
+      */
+    protected def metrics: PeerMetrics
 
     /** Completed by the subclass's [[preStartLocal]] once every actor is spawned and the
       * `Connections` slots are populated.
@@ -131,7 +137,8 @@ trait MultisigRegimeManagerBase[E >: LifecycleEvent <: RegimeManagerEvent]
                 config,
                 pendingConnections,
                 tracers.fastConsensusActor,
-                persistence
+                persistence,
+                metrics
               )
             )
             jointLedger <- context.actorOf(
@@ -145,7 +152,8 @@ trait MultisigRegimeManagerBase[E >: LifecycleEvent <: RegimeManagerEvent]
                 config,
                 pendingConnections,
                 tracers.slowConsensusActor,
-                persistence
+                persistence,
+                metrics
               )
             )
         } yield CoreActors(

--- a/src/main/scala/hydrozoa/multisig/MultisigRegimeManagerBase.scala
+++ b/src/main/scala/hydrozoa/multisig/MultisigRegimeManagerBase.scala
@@ -47,7 +47,7 @@ trait MultisigRegimeManagerBase[E >: LifecycleEvent <: RegimeManagerEvent]
     protected def tracers: HasCoreTracers
 
     /** The peer metrics registry, supplied by the subclass and threaded into the instrumented
-      * actors (see `design/peer-stats-endpoint.md`).
+      * actors (see `docs/spec/peer-stats-endpoint.md`).
       */
     protected def metrics: PeerMetrics
 

--- a/src/main/scala/hydrozoa/multisig/consensus/FastConsensusActor.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/FastConsensusActor.scala
@@ -301,9 +301,12 @@ class FastConsensusActor(
             confirmed.blockBrief.blockVersion.minor: Int
           )
         )
-        // Peer stats (docs/spec/peer-stats-endpoint.md): count the block and its events. A final block
-        // is bucketed with major for the minor/major split.
-        _ <- IO(metrics.onBlockConfirmed(confirmedBlockType != "minor", brief.requests.size))
+        // Peer stats (docs/spec/peer-stats-endpoint.md): count the block and its events. A final
+        // block is bucketed with major for the minor/major split.
+        isMajorBlock = brief match
+            case _: BlockBrief.Minor => false
+            case _                   => true
+        _ <- IO(metrics.onBlockConfirmed(isMajorBlock, brief.requests.size))
 
         // Persist the SoftConfirmation record (header + aggregated multisig) before fanning out
         // (CR4 write-before-send). `softConfirmed` derives as max(SoftConfirmation.key); we keep

--- a/src/main/scala/hydrozoa/multisig/consensus/FastConsensusActor.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/FastConsensusActor.scala
@@ -13,6 +13,7 @@ import hydrozoa.multisig.HeadMultisigRegimeManager
 import hydrozoa.multisig.consensus.ack.{SoftAck, SoftAckId}
 import hydrozoa.multisig.consensus.peer.{HeadPeerNumber, PeerId}
 import hydrozoa.multisig.ledger.block.{Block, BlockBrief, BlockHeader, BlockNumber}
+import hydrozoa.multisig.metrics.PeerMetrics
 import hydrozoa.multisig.persistence.recovery.ReplayCursors
 import hydrozoa.multisig.persistence.{Persistence, StoreKey, Timestamped, WriteBatch}
 import scala.util.control.NonFatal
@@ -113,7 +114,8 @@ object FastConsensusActor:
         pendingConnections: HeadMultisigRegimeManager.PendingConnections |
             FastConsensusActor.Connections,
         tracer: ContraTracer[IO, FastConsensusActorEvent],
-        persistence: Persistence[IO]
+        persistence: Persistence[IO],
+        metrics: PeerMetrics
     ): IO[FastConsensusActor] =
         for {
             stateRef <- Ref[IO].of(State.initial)
@@ -122,7 +124,8 @@ object FastConsensusActor:
           pendingConnections = pendingConnections,
           stateRef = stateRef,
           tracer = tracer,
-          persistence = persistence
+          persistence = persistence,
+          metrics = metrics
         )
 
     enum Error extends Throwable:
@@ -154,7 +157,8 @@ class FastConsensusActor(
         FastConsensusActor.Connections,
     stateRef: Ref[IO, FastConsensusActor.State],
     tracer: ContraTracer[IO, FastConsensusActorEvent],
-    persistence: Persistence[IO]
+    persistence: Persistence[IO],
+    metrics: PeerMetrics
 ) extends Actor[IO, FastConsensusActor.Request]:
     import FastConsensusActor.*
 
@@ -297,6 +301,9 @@ class FastConsensusActor(
             confirmed.blockBrief.blockVersion.minor: Int
           )
         )
+        // Peer stats (design/peer-stats-endpoint.md): count the block and its events. A final block
+        // is bucketed with major for the minor/major split.
+        _ <- IO(metrics.onBlockConfirmed(confirmedBlockType != "minor", brief.requests.size))
 
         // Persist the SoftConfirmation record (header + aggregated multisig) before fanning out
         // (CR4 write-before-send). `softConfirmed` derives as max(SoftConfirmation.key); we keep

--- a/src/main/scala/hydrozoa/multisig/consensus/FastConsensusActor.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/FastConsensusActor.scala
@@ -301,7 +301,7 @@ class FastConsensusActor(
             confirmed.blockBrief.blockVersion.minor: Int
           )
         )
-        // Peer stats (design/peer-stats-endpoint.md): count the block and its events. A final block
+        // Peer stats (docs/spec/peer-stats-endpoint.md): count the block and its events. A final block
         // is bucketed with major for the minor/major split.
         _ <- IO(metrics.onBlockConfirmed(confirmedBlockType != "minor", brief.requests.size))
 

--- a/src/main/scala/hydrozoa/multisig/consensus/RequestSequencer.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/RequestSequencer.scala
@@ -21,6 +21,7 @@ import hydrozoa.multisig.consensus.peer.{HeadPeerNumber, PeerId}
 import hydrozoa.multisig.ledger.event.{RequestId, RequestNumber}
 import hydrozoa.multisig.ledger.l1.tx.DepositL1Screening
 import hydrozoa.multisig.ledger.l2.L2Screener
+import hydrozoa.multisig.metrics.{PeerMetrics, RejectionKind}
 import hydrozoa.multisig.persistence.{JournalKey, JournalValue, Markers, Persistence, WriteBatch}
 
 /** The first actor responsible for processing events from end-users, as received by the
@@ -35,7 +36,8 @@ trait RequestSequencer(
     pendingConnections: HeadMultisigRegimeManager.PendingConnections | RequestSequencer.Connections,
     l2Screener: L2Screener[IO],
     tracer: ContraTracer[IO, EventSequencerEvent],
-    persistence: Persistence[IO]
+    persistence: Persistence[IO],
+    metrics: PeerMetrics
 ) extends Actor[IO, Request] {
     private val connections = Ref.unsafe[IO, Option[RequestSequencer.Connections]](None)
     private val state = State()
@@ -119,21 +121,24 @@ trait RequestSequencer(
                           }
                   }
                   screened.flatMap {
-                      case Left(reason) => IO.pure(Left(UserRequest.Rejected(reason)))
-                      case Right(())    =>
+                      case Left(reason) =>
+                          IO(metrics.onLocalRejected(RejectionKind.Screening)) *>
+                              IO.pure(Left(UserRequest.Rejected(reason)))
+                      case Right(()) =>
                           // Backpressure: refuse to author more than one block's worth of requests
                           // beyond this peer's own confirmed high-water, so the mesh mempool cannot
                           // exceed maxRequestsPerBlock * nHeadPeers (docs/spec/fast-consensus.md).
                           state.tryNextRequestNum(config.maxRequestsPerBlock).flatMap {
                               case None =>
-                                  IO.pure(
-                                    Left(
-                                      UserRequest.Rejected(
-                                        "Request rejected: too many unconfirmed requests" +
-                                            " (backpressure); retry shortly."
+                                  IO(metrics.onLocalRejected(RejectionKind.Backpressure)) *>
+                                      IO.pure(
+                                        Left(
+                                          UserRequest.Rejected(
+                                            "Request rejected: too many unconfirmed requests" +
+                                                " (backpressure); retry shortly."
+                                          )
+                                        )
                                       )
-                                    )
-                                  )
                               case Some(newNum) =>
                                   val newId = RequestId(ownHeadPeerNum, newNum)
                                   val newRequestWithId = UserRequestWithId(
@@ -146,6 +151,7 @@ trait RequestSequencer(
                                         EventSequencerEvent
                                             .RequestIdAssigned(newId.peerNum, newId.requestNum)
                                       )
+                                      _ <- IO(metrics.onLocalAccepted())
                                       // CR1: persist the assigned request to the Request lane BEFORE
                                       // telling the user the id (durable before observable; CR1/CR4).
                                       stamp <- persistence.arrivalStamp
@@ -221,9 +227,19 @@ object RequestSequencer {
         pendingConnections: HeadMultisigRegimeManager.PendingConnections,
         l2Screener: L2Screener[IO],
         tracer: ContraTracer[IO, EventSequencerEvent],
-        persistence: Persistence[IO]
+        persistence: Persistence[IO],
+        metrics: PeerMetrics
     ): IO[RequestSequencer] =
-        IO(new RequestSequencer(config, pendingConnections, l2Screener, tracer, persistence) {})
+        IO(
+          new RequestSequencer(
+            config,
+            pendingConnections,
+            l2Screener,
+            tracer,
+            persistence,
+            metrics
+          ) {}
+        )
 
     // `& CardanoNetwork.Section`: the Request-lane codec (UserRequestWithId) is Section-dependent;
     // the full configs passed in satisfy it.

--- a/src/main/scala/hydrozoa/multisig/consensus/SlowConsensusActor.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/SlowConsensusActor.scala
@@ -370,7 +370,7 @@ final case class SlowConsensusActor(
         _ <- conn.stackComposer ! hardConfirmed
         _ <- stateRef.update(_.dropCell(stackNum))
         _ <- tracer.traceWith(SlowConsensusActorEvent.StackHardConfirmed(hardConfirmed))
-        // Peer stats (design/peer-stats-endpoint.md): count the stack and the blocks it absorbed.
+        // Peer stats (docs/spec/peer-stats-endpoint.md): count the stack and the blocks it absorbed.
         blocksAbsorbed = (hardConfirmed.brief.lastBlockNum: Int) -
             (hardConfirmed.brief.firstBlockNum: Int) + 1
         _ <- IO.realTime.flatMap(t =>

--- a/src/main/scala/hydrozoa/multisig/consensus/SlowConsensusActor.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/SlowConsensusActor.scala
@@ -14,6 +14,7 @@ import hydrozoa.multisig.consensus.ack.HardAck
 import hydrozoa.multisig.consensus.peer.PeerId
 import hydrozoa.multisig.ledger.block.BlockNumber
 import hydrozoa.multisig.ledger.stack.{EffectIds, PartitionEffects, Stack, StackBrief, StackEffects, StackNumber}
+import hydrozoa.multisig.metrics.PeerMetrics
 import hydrozoa.multisig.persistence.{Persistence, StoreKey, Timestamped, WriteBatch}
 
 /** Slow-consensus actor.
@@ -58,7 +59,8 @@ final case class SlowConsensusActor(
     pendingConnections: HeadMultisigRegimeManager.PendingConnections |
         SlowConsensusActor.Connections,
     tracer: ContraTracer[IO, SlowConsensusActorEvent],
-    persistence: Persistence[IO]
+    persistence: Persistence[IO],
+    metrics: PeerMetrics
 ) extends Actor[IO, SlowConsensusActor.Request] {
     import SlowConsensusActor.*
 
@@ -368,6 +370,12 @@ final case class SlowConsensusActor(
         _ <- conn.stackComposer ! hardConfirmed
         _ <- stateRef.update(_.dropCell(stackNum))
         _ <- tracer.traceWith(SlowConsensusActorEvent.StackHardConfirmed(hardConfirmed))
+        // Peer stats (design/peer-stats-endpoint.md): count the stack and the blocks it absorbed.
+        blocksAbsorbed = (hardConfirmed.brief.lastBlockNum: Int) -
+            (hardConfirmed.brief.firstBlockNum: Int) + 1
+        _ <- IO.realTime.flatMap(t =>
+            IO(metrics.onStackConfirmed(stackNum, blocksAbsorbed, t.toMillis))
+        )
     } yield ()
 
     /** Persist the full multisigned `HardConfirmation` record for the just-confirmed stack — the §6

--- a/src/main/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonHeadToHead.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonHeadToHead.scala
@@ -19,6 +19,7 @@ import hydrozoa.multisig.consensus.{BlockWeaver, CoilRelay, FastConsensusActor, 
 import hydrozoa.multisig.ledger.block.{BlockBrief, BlockNumber}
 import hydrozoa.multisig.ledger.event.RequestNumber
 import hydrozoa.multisig.ledger.stack.{StackBrief, StackNumber}
+import hydrozoa.multisig.metrics.PeerMetrics
 import hydrozoa.multisig.persistence.recovery.{LaneIncomingCursors, LaneOutgoingBacking}
 import hydrozoa.multisig.persistence.{JournalKey, JournalValue, Persistence, WriteBatch}
 
@@ -37,7 +38,8 @@ abstract class PeerLiaisonHeadToHead(
     pendingConnections: HeadMultisigRegimeManager.PendingConnections |
         PeerLiaisonHeadToHead.Connections,
     tracer: ContraTracer[IO, PeerLiaisonEvent],
-    persistence: Persistence[IO]
+    persistence: Persistence[IO],
+    metrics: PeerMetrics
 ) extends Actor[IO, LiaisonProtocol.HeadToHeadRequest] {
 
     // `config` is a `CardanoNetwork.Section`; expose it as a given so the inbound-lane `WriteBatch`
@@ -254,6 +256,11 @@ abstract class PeerLiaisonHeadToHead(
                 _ <- m.block.traverse_(conn.blockWeaver ! _)
                 _ <- m.stack.traverse_(conn.stackComposer ! _)
                 _ <- m.requests.traverse_(conn.blockWeaver ! _)
+                // Peer stats (design/peer-stats-endpoint.md): count requests ingested from this
+                // remote head peer.
+                _ <- IO.whenA(m.requests.nonEmpty)(
+                  IO(metrics.onPeerRequests(remoteHead.peerNum.convert, m.requests.size))
+                )
                 _ <- m.softAck.traverse_(conn.consensusActor ! _)
                 _ <- m.headHardAck.traverse_(conn.slowConsensusActor ! _)
                 _ <- m.hubHardAck.traverse_(hc => conn.slowConsensusActor ! hc.ack)
@@ -448,10 +455,18 @@ object PeerLiaisonHeadToHead {
         remoteHead: HeadPeerId,
         pendingConnections: HeadMultisigRegimeManager.PendingConnections | Connections,
         tracer: ContraTracer[IO, PeerLiaisonEvent],
-        persistence: Persistence[IO]
+        persistence: Persistence[IO],
+        metrics: PeerMetrics
     ): IO[PeerLiaisonHeadToHead] =
         IO(
-          new PeerLiaisonHeadToHead(config, remoteHead, pendingConnections, tracer, persistence) {}
+          new PeerLiaisonHeadToHead(
+            config,
+            remoteHead,
+            pendingConnections,
+            tracer,
+            persistence,
+            metrics
+          ) {}
         )
 
     type Config =

--- a/src/main/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonHeadToHead.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonHeadToHead.scala
@@ -256,7 +256,7 @@ abstract class PeerLiaisonHeadToHead(
                 _ <- m.block.traverse_(conn.blockWeaver ! _)
                 _ <- m.stack.traverse_(conn.stackComposer ! _)
                 _ <- m.requests.traverse_(conn.blockWeaver ! _)
-                // Peer stats (design/peer-stats-endpoint.md): count requests ingested from this
+                // Peer stats (docs/spec/peer-stats-endpoint.md): count requests ingested from this
                 // remote head peer.
                 _ <- IO.whenA(m.requests.nonEmpty)(
                   IO(metrics.onPeerRequests(remoteHead.peerNum.convert, m.requests.size))

--- a/src/main/scala/hydrozoa/multisig/metrics/PeerMetrics.scala
+++ b/src/main/scala/hydrozoa/multisig/metrics/PeerMetrics.scala
@@ -1,0 +1,270 @@
+package hydrozoa.multisig.metrics
+
+import cats.effect.IO
+import java.util.concurrent.atomic.{AtomicLong, AtomicReference, LongAdder}
+import scala.concurrent.duration.*
+
+/** Why a request was refused, split so the stats endpoints can answer "is backpressure firing?"
+  * without log-diving.
+  */
+enum RejectionKind:
+    case Screening, Backpressure
+
+/** Process-lifetime, in-memory peer metrics behind `GET /head/stats` and `GET /head/metrics` (see
+  * `design/peer-stats-endpoint.md`).
+  *
+  * The hot-path `on*` methods are lock-free side effects (a single atomic add). Each counter except
+  * the peer-request map is written by exactly one actor — cats actors drain their mailbox serially
+  * — so a plain [[java.util.concurrent.atomic.AtomicLong AtomicLong]] publishes safely to the HTTP
+  * reader without [[java.util.concurrent.atomic.LongAdder LongAdder]]'s striping. Peer-request
+  * ingestion fans in from multiple liaison actors, so those counters use `LongAdder`. The derived
+  * rolling view (EWMA load averages + exact windows) is owned by the single [[sampler]] fiber and
+  * published through one [[java.util.concurrent.atomic.AtomicReference AtomicReference]].
+  *
+  * Counters are not persisted: they reset on restart.
+  */
+final class PeerMetrics private (startedAtMillis: Long, headPeerNums: Vector[Int]):
+    import PeerMetrics.*
+
+    // ---- local requests (written by RequestSequencer) ----
+    private val localAccepted = new AtomicLong(0)
+    private val localRejScreening = new AtomicLong(0)
+    private val localRejBackpressure = new AtomicLong(0)
+
+    // ---- peer requests, per remote head peer (written by the peer liaisons, multi-writer) ----
+    private val peerRequests: Map[Int, LongAdder] =
+        headPeerNums.map(_ -> new LongAdder).toMap
+
+    // ---- blocks (written by FastConsensusActor) ----
+    private val blocksMinor = new AtomicLong(0)
+    private val blocksMajor = new AtomicLong(0)
+    private val blockEventsSum = new AtomicLong(0)
+    private val blockEventsMax = new AtomicLong(0)
+
+    // ---- stacks (written by SlowConsensusActor) ----
+    private val stacksTotal = new AtomicLong(0)
+    private val lastStackNum = new AtomicLong(-1)
+    private val lastStackMillis = new AtomicLong(0)
+    private val stackGapSumMillis = new AtomicLong(0)
+    private val stackBlocksSum = new AtomicLong(0)
+    private val stackBlocksMax = new AtomicLong(0)
+
+    // ---- derived rolling view (written only by the sampler fiber) ----
+    private val rolling = new AtomicReference[Rolling](Rolling.empty(headPeerNums))
+
+    /** Record a locally-sequenced request. */
+    def onLocalAccepted(): Unit = { val _ = localAccepted.incrementAndGet() }
+
+    /** Record a locally-rejected request, tagged by reason. */
+    def onLocalRejected(kind: RejectionKind): Unit =
+        val _ = kind match
+            case RejectionKind.Screening    => localRejScreening.incrementAndGet()
+            case RejectionKind.Backpressure => localRejBackpressure.incrementAndGet()
+
+    /** Record `n` requests ingested from remote head peer `fromPeerNum`. */
+    def onPeerRequests(fromPeerNum: Int, n: Int): Unit =
+        peerRequests.get(fromPeerNum).foreach(_.add(n.toLong))
+
+    /** Record a soft-confirmed block of the given type carrying `events` requests. */
+    def onBlockConfirmed(isMajor: Boolean, events: Int): Unit =
+        val _ = if isMajor then blocksMajor.incrementAndGet() else blocksMinor.incrementAndGet()
+        blockEventsSum.addAndGet(events.toLong)
+        updateMax(blockEventsMax, events.toLong)
+
+    /** Record a hard-confirmed stack absorbing `blocksAbsorbed` blocks, at wall-clock `nowMillis`.
+      */
+    def onStackConfirmed(stackNum: Int, blocksAbsorbed: Int, nowMillis: Long): Unit =
+        val prev = lastStackMillis.getAndSet(nowMillis)
+        if prev > 0 then { val _ = stackGapSumMillis.addAndGet(nowMillis - prev) }
+        stacksTotal.incrementAndGet()
+        lastStackNum.set(stackNum.toLong)
+        stackBlocksSum.addAndGet(blocksAbsorbed.toLong)
+        updateMax(stackBlocksMax, blocksAbsorbed.toLong)
+
+    /** A consistent, cheap read for the endpoints. `nowMillis` is the caller's wall-clock. */
+    def snapshot(nowMillis: Long): PeerStats =
+        val roll = rolling.get()
+        val minor = blocksMinor.get()
+        val major = blocksMajor.get()
+        val blocksTotal = minor + major
+        val eventsSum = blockEventsSum.get()
+        val stacks = stacksTotal.get()
+        PeerStats(
+          uptimeSeconds = math.max(0L, (nowMillis - startedAtMillis) / 1000),
+          localAccepted = localAccepted.get(),
+          localRate = roll.localRate,
+          localRejScreening = localRejScreening.get(),
+          localRejBackpressure = localRejBackpressure.get(),
+          peerRequests = headPeerNums.map { p =>
+              p -> CounterWithRate(
+                peerRequests(p).sum(),
+                roll.peerRates.getOrElse(p, RateView.zero)
+              )
+          }.toMap,
+          blocks = BlockStats(
+            minor = minor,
+            major = major,
+            avgEvents = if blocksTotal > 0 then eventsSum.toDouble / blocksTotal else 0.0,
+            maxEvents = blockEventsMax.get(),
+            blocksPerWindow = roll.blocksPerWindow,
+            requestsPerWindow = roll.requestsPerWindow
+          ),
+          stacks = StackStats(
+            total = stacks,
+            lastStackNumber = lastStackNum.get(),
+            secondsSinceLastHardConfirm =
+                if lastStackMillis.get() > 0 then (nowMillis - lastStackMillis.get()) / 1000
+                else 0L,
+            meanInterStackGapSeconds =
+                if stacks > 1 then stackGapSumMillis.get().toDouble / (stacks - 1) / 1000.0
+                else 0.0,
+            avgBlocksAbsorbed = if stacks > 0 then stackBlocksSum.get().toDouble / stacks else 0.0,
+            maxBlocksAbsorbed = stackBlocksMax.get()
+          )
+        )
+
+    /** The 1 Hz sampler: rolls the exact-window ring and updates the EWMA load averages, then
+      * publishes one immutable [[Rolling]]. Run as a background fiber for the node's lifetime. The
+      * ring and EWMA state are fiber-local (single writer), so they need no synchronization.
+      */
+    def sampler(period: FiniteDuration = 1.second): IO[Unit] =
+        val blocksRing = Array.fill(RingSize)(0L)
+        val eventsRing = Array.fill(RingSize)(0L)
+        val ewmaLocal = mkEwmas()
+        val ewmaPeer = headPeerNums.map(_ -> mkEwmas()).toMap
+
+        def loop(
+            tick: Long,
+            lastMillis: Long,
+            lastLocal: Long,
+            lastPeer: Map[Int, Long]
+        ): IO[Unit] =
+            IO.sleep(period) >> IO.realTime.flatMap { now =>
+                val nowMillis = now.toMillis
+                val dt = math.max(1e-3, (nowMillis - lastMillis) / 1000.0)
+
+                val curLocal = localAccepted.get()
+                observe(ewmaLocal, (curLocal - lastLocal) / dt, dt)
+
+                val curPeer = headPeerNums.map(p => p -> peerRequests(p).sum()).toMap
+                headPeerNums.foreach { p =>
+                    observe(ewmaPeer(p), (curPeer(p) - lastPeer.getOrElse(p, 0L)) / dt, dt)
+                }
+
+                val idx = (tick % RingSize).toInt
+                blocksRing(idx) = blocksMinor.get() + blocksMajor.get()
+                eventsRing(idx) = blockEventsSum.get()
+
+                rolling.set(
+                  Rolling(
+                    localRate = rateOf(ewmaLocal, (curLocal - lastLocal) / dt),
+                    peerRates = headPeerNums.map { p =>
+                        p -> rateOf(ewmaPeer(p), (curPeer(p) - lastPeer.getOrElse(p, 0L)) / dt)
+                    }.toMap,
+                    blocksPerWindow = windows(blocksRing, blocksRing(idx), tick),
+                    requestsPerWindow = windows(eventsRing, eventsRing(idx), tick)
+                  )
+                )
+                loop(tick + 1, nowMillis, curLocal, curPeer)
+            }
+
+        IO.realTime.flatMap(t0 =>
+            loop(0L, t0.toMillis, localAccepted.get(), headPeerNums.map(_ -> 0L).toMap)
+        )
+
+object PeerMetrics:
+    /** Ring depth in seconds — 15 min, covering every window with headroom. */
+    private val RingSize = 900
+    private val Taus: Vector[Double] = Vector(60.0, 300.0, 900.0) // 1m / 5m / 15m
+
+    def create(nowMillis: Long, headPeerNums: Vector[Int]): PeerMetrics =
+        new PeerMetrics(nowMillis, headPeerNums)
+
+    /** One EWMA horizon; fiber-local, so a plain `var` is fine. */
+    private final class Ewma(tauSeconds: Double):
+        private var v: Double = 0.0
+        def observe(ratePerSec: Double, dtSeconds: Double): Unit =
+            val decay = math.exp(-dtSeconds / tauSeconds)
+            v = v * decay + ratePerSec * (1.0 - decay)
+        def get: Double = v
+
+    private def mkEwmas(): Vector[Ewma] = Taus.map(new Ewma(_))
+    private def observe(es: Vector[Ewma], rate: Double, dt: Double): Unit =
+        es.foreach(_.observe(rate, dt))
+    private def rateOf(es: Vector[Ewma], now: Double): RateView =
+        RateView(now = now, load1m = es(0).get, load5m = es(1).get, load15m = es(2).get)
+
+    private def updateMax(m: AtomicLong, v: Long): Unit =
+        var cur = m.get()
+        while v > cur && !m.compareAndSet(cur, v) do cur = m.get()
+
+    /** Windowed count from a cumulative ring: `cur - cumulative(tick - w)`; before enough history
+      * has accrued, everything since boot.
+      */
+    private def windows(ring: Array[Long], cur: Long, tick: Long): WindowCounts =
+        def ago(w: Int): Long =
+            if tick < w then cur else cur - ring(((tick - w) % RingSize).toInt)
+        WindowCounts(ago(10), ago(30), ago(60), ago(300), ago(600))
+
+    /** The sampler's published output. */
+    private final case class Rolling(
+        localRate: RateView,
+        peerRates: Map[Int, RateView],
+        blocksPerWindow: WindowCounts,
+        requestsPerWindow: WindowCounts
+    )
+    private object Rolling:
+        def empty(headPeerNums: Vector[Int]): Rolling =
+            Rolling(
+              RateView.zero,
+              headPeerNums.map(_ -> RateView.zero).toMap,
+              WindowCounts.zero,
+              WindowCounts.zero
+            )
+
+// ---- snapshot data (plain, framework-free; ApiDto builds the JSON view, PrometheusFormat the text) ----
+
+final case class RateView(now: Double, load1m: Double, load5m: Double, load15m: Double)
+object RateView:
+    val zero: RateView = RateView(0.0, 0.0, 0.0, 0.0)
+
+final case class WindowCounts(
+    last10s: Long,
+    last30s: Long,
+    last60s: Long,
+    last5m: Long,
+    last10m: Long
+)
+object WindowCounts:
+    val zero: WindowCounts = WindowCounts(0, 0, 0, 0, 0)
+
+final case class CounterWithRate(total: Long, rate: RateView)
+
+final case class BlockStats(
+    minor: Long,
+    major: Long,
+    avgEvents: Double,
+    maxEvents: Long,
+    blocksPerWindow: WindowCounts,
+    requestsPerWindow: WindowCounts
+)
+
+final case class StackStats(
+    total: Long,
+    lastStackNumber: Long,
+    secondsSinceLastHardConfirm: Long,
+    meanInterStackGapSeconds: Double,
+    avgBlocksAbsorbed: Double,
+    maxBlocksAbsorbed: Long
+)
+
+final case class PeerStats(
+    uptimeSeconds: Long,
+    localAccepted: Long,
+    localRate: RateView,
+    localRejScreening: Long,
+    localRejBackpressure: Long,
+    peerRequests: Map[Int, CounterWithRate],
+    blocks: BlockStats,
+    stacks: StackStats
+)

--- a/src/main/scala/hydrozoa/multisig/metrics/PeerMetrics.scala
+++ b/src/main/scala/hydrozoa/multisig/metrics/PeerMetrics.scala
@@ -17,9 +17,12 @@ enum RejectionKind:
   * the peer-request map is written by exactly one actor — cats actors drain their mailbox serially
   * — so a plain [[java.util.concurrent.atomic.AtomicLong AtomicLong]] publishes safely to the HTTP
   * reader without [[java.util.concurrent.atomic.LongAdder LongAdder]]'s striping. Peer-request
-  * ingestion fans in from multiple liaison actors, so those counters use `LongAdder`. The derived
-  * rolling view (EWMA load averages + exact windows) is owned by the single [[sampler]] fiber and
-  * published through one [[java.util.concurrent.atomic.AtomicReference AtomicReference]].
+  * ingestion fans in from multiple liaison actors, so those counters use `LongAdder`.
+  *
+  * All rates are top-style EWMA load averages (now / 1m / 5m / 15m), maintained by the single
+  * [[sampler]] fiber and published through one
+  * [[java.util.concurrent.atomic.AtomicReference AtomicReference]]. There are no fixed-window
+  * rings.
   *
   * Counters are not persisted: they reset on restart.
   */
@@ -49,7 +52,7 @@ final class PeerMetrics private (startedAtMillis: Long, headPeerNums: Vector[Int
     private val stackBlocksSum = new AtomicLong(0)
     private val stackBlocksMax = new AtomicLong(0)
 
-    // ---- derived rolling view (written only by the sampler fiber) ----
+    // ---- derived rates (written only by the sampler fiber) ----
     private val rolling = new AtomicReference[Rolling](Rolling.empty(headPeerNums))
 
     /** Record a locally-sequenced request. */
@@ -106,8 +109,8 @@ final class PeerMetrics private (startedAtMillis: Long, headPeerNums: Vector[Int
             major = major,
             avgEvents = if blocksTotal > 0 then eventsSum.toDouble / blocksTotal else 0.0,
             maxEvents = blockEventsMax.get(),
-            blocksPerWindow = roll.blocksPerWindow,
-            requestsPerWindow = roll.requestsPerWindow
+            blockRate = roll.blockRate,
+            requestRate = roll.blockRequestRate
           ),
           stacks = StackStats(
             total = stacks,
@@ -123,58 +126,61 @@ final class PeerMetrics private (startedAtMillis: Long, headPeerNums: Vector[Int
           )
         )
 
-    /** The 1 Hz sampler: rolls the exact-window ring and updates the EWMA load averages, then
-      * publishes one immutable [[Rolling]]. Run as a background fiber for the node's lifetime. The
-      * ring and EWMA state are fiber-local (single writer), so they need no synchronization.
+    /** The 1 Hz sampler: feeds every rate's EWMAs from the cumulative counters, then publishes one
+      * immutable [[Rolling]]. Run as a background fiber for the node's lifetime. The EWMA state is
+      * fiber-local (single writer), so it needs no synchronization.
       */
     def sampler(period: FiniteDuration = 1.second): IO[Unit] =
-        val blocksRing = Array.fill(RingSize)(0L)
-        val eventsRing = Array.fill(RingSize)(0L)
         val ewmaLocal = mkEwmas()
         val ewmaPeer = headPeerNums.map(_ -> mkEwmas()).toMap
+        val ewmaBlocks = mkEwmas()
+        val ewmaBlockReqs = mkEwmas()
 
         def loop(
-            tick: Long,
             lastMillis: Long,
             lastLocal: Long,
-            lastPeer: Map[Int, Long]
+            lastPeer: Map[Int, Long],
+            lastBlocks: Long,
+            lastBlockReqs: Long
         ): IO[Unit] =
             IO.sleep(period) >> IO.realTime.flatMap { now =>
                 val nowMillis = now.toMillis
                 val dt = math.max(1e-3, (nowMillis - lastMillis) / 1000.0)
 
                 val curLocal = localAccepted.get()
-                observe(ewmaLocal, (curLocal - lastLocal) / dt, dt)
+                val localInst = (curLocal - lastLocal) / dt
+                observe(ewmaLocal, localInst, dt)
 
                 val curPeer = headPeerNums.map(p => p -> peerRequests(p).sum()).toMap
-                headPeerNums.foreach { p =>
-                    observe(ewmaPeer(p), (curPeer(p) - lastPeer.getOrElse(p, 0L)) / dt, dt)
-                }
+                val peerInst = headPeerNums.map { p =>
+                    p -> (curPeer(p) - lastPeer.getOrElse(p, 0L)) / dt
+                }.toMap
+                headPeerNums.foreach(p => observe(ewmaPeer(p), peerInst(p), dt))
 
-                val idx = (tick % RingSize).toInt
-                blocksRing(idx) = blocksMinor.get() + blocksMajor.get()
-                eventsRing(idx) = blockEventsSum.get()
+                val curBlocks = blocksMinor.get() + blocksMajor.get()
+                val blockInst = (curBlocks - lastBlocks) / dt
+                observe(ewmaBlocks, blockInst, dt)
+
+                val curBlockReqs = blockEventsSum.get()
+                val blockReqInst = (curBlockReqs - lastBlockReqs) / dt
+                observe(ewmaBlockReqs, blockReqInst, dt)
 
                 rolling.set(
                   Rolling(
-                    localRate = rateOf(ewmaLocal, (curLocal - lastLocal) / dt),
-                    peerRates = headPeerNums.map { p =>
-                        p -> rateOf(ewmaPeer(p), (curPeer(p) - lastPeer.getOrElse(p, 0L)) / dt)
-                    }.toMap,
-                    blocksPerWindow = windows(blocksRing, blocksRing(idx), tick),
-                    requestsPerWindow = windows(eventsRing, eventsRing(idx), tick)
+                    localRate = rateOf(ewmaLocal, localInst),
+                    peerRates = headPeerNums.map(p => p -> rateOf(ewmaPeer(p), peerInst(p))).toMap,
+                    blockRate = rateOf(ewmaBlocks, blockInst),
+                    blockRequestRate = rateOf(ewmaBlockReqs, blockReqInst)
                   )
                 )
-                loop(tick + 1, nowMillis, curLocal, curPeer)
+                loop(nowMillis, curLocal, curPeer, curBlocks, curBlockReqs)
             }
 
         IO.realTime.flatMap(t0 =>
-            loop(0L, t0.toMillis, localAccepted.get(), headPeerNums.map(_ -> 0L).toMap)
+            loop(t0.toMillis, localAccepted.get(), headPeerNums.map(_ -> 0L).toMap, 0L, 0L)
         )
 
 object PeerMetrics:
-    /** Ring depth in seconds — 15 min, covering every window with headroom. */
-    private val RingSize = 900
     private val Taus: Vector[Double] = Vector(60.0, 300.0, 900.0) // 1m / 5m / 15m
 
     def create(nowMillis: Long, headPeerNums: Vector[Int]): PeerMetrics =
@@ -198,28 +204,20 @@ object PeerMetrics:
         var cur = m.get()
         while v > cur && !m.compareAndSet(cur, v) do cur = m.get()
 
-    /** Windowed count from a cumulative ring: `cur - cumulative(tick - w)`; before enough history
-      * has accrued, everything since boot.
-      */
-    private def windows(ring: Array[Long], cur: Long, tick: Long): WindowCounts =
-        def ago(w: Int): Long =
-            if tick < w then cur else cur - ring(((tick - w) % RingSize).toInt)
-        WindowCounts(ago(10), ago(30), ago(60), ago(300), ago(600))
-
-    /** The sampler's published output. */
+    /** The sampler's published output — all rates as EWMA load averages. */
     private final case class Rolling(
         localRate: RateView,
         peerRates: Map[Int, RateView],
-        blocksPerWindow: WindowCounts,
-        requestsPerWindow: WindowCounts
+        blockRate: RateView,
+        blockRequestRate: RateView
     )
     private object Rolling:
         def empty(headPeerNums: Vector[Int]): Rolling =
             Rolling(
               RateView.zero,
               headPeerNums.map(_ -> RateView.zero).toMap,
-              WindowCounts.zero,
-              WindowCounts.zero
+              RateView.zero,
+              RateView.zero
             )
 
 // ---- snapshot data (plain, framework-free; ApiDto builds the JSON view, PrometheusFormat the text) ----
@@ -228,16 +226,6 @@ final case class RateView(now: Double, load1m: Double, load5m: Double, load15m: 
 object RateView:
     val zero: RateView = RateView(0.0, 0.0, 0.0, 0.0)
 
-final case class WindowCounts(
-    last10s: Long,
-    last30s: Long,
-    last60s: Long,
-    last5m: Long,
-    last10m: Long
-)
-object WindowCounts:
-    val zero: WindowCounts = WindowCounts(0, 0, 0, 0, 0)
-
 final case class CounterWithRate(total: Long, rate: RateView)
 
 final case class BlockStats(
@@ -245,8 +233,8 @@ final case class BlockStats(
     major: Long,
     avgEvents: Double,
     maxEvents: Long,
-    blocksPerWindow: WindowCounts,
-    requestsPerWindow: WindowCounts
+    blockRate: RateView,
+    requestRate: RateView
 )
 
 final case class StackStats(

--- a/src/main/scala/hydrozoa/multisig/metrics/PeerMetrics.scala
+++ b/src/main/scala/hydrozoa/multisig/metrics/PeerMetrics.scala
@@ -11,7 +11,7 @@ enum RejectionKind:
     case Screening, Backpressure
 
 /** Process-lifetime, in-memory peer metrics behind `GET /head/stats` and `GET /head/metrics` (see
-  * `design/peer-stats-endpoint.md`).
+  * `docs/spec/peer-stats-endpoint.md`).
   *
   * The hot-path `on*` methods are lock-free side effects (a single atomic add). Each counter except
   * the peer-request map is written by exactly one actor — cats actors drain their mailbox serially

--- a/src/main/scala/hydrozoa/multisig/metrics/PrometheusFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/metrics/PrometheusFormat.scala
@@ -1,0 +1,122 @@
+package hydrozoa.multisig.metrics
+
+/** Renders a [[PeerStats]] snapshot as Prometheus text exposition (version 0.0.4).
+  *
+  * Canonical values are the monotonic `_total` counters — Prometheus computes rates from those with
+  * `rate(...[5m])`. The EWMA load averages and exact windows are exposed as gauges for convenience
+  * and to mirror the JSON view; both endpoints read the same snapshot, so they never disagree.
+  */
+object PrometheusFormat:
+
+    /** The content type for the endpoint's response header. */
+    val contentType: String = "text/plain; version=0.0.4; charset=utf-8"
+
+    def render(s: PeerStats): String =
+        val b = new StringBuilder
+
+        def counter(name: String, help: String, value: Long, labels: String = ""): Unit =
+            b.append(s"# HELP $name $help\n# TYPE $name counter\n$name$labels $value\n")
+        def gauge(name: String, help: String, value: Long): Unit =
+            b.append(s"# HELP $name $help\n# TYPE $name gauge\n$name $value\n")
+        def gaugeD(name: String, help: String, value: Double): Unit =
+            b.append(s"# HELP $name $help\n# TYPE $name gauge\n$name ${fmt(value)}\n")
+
+        gauge(
+          "hydrozoa_uptime_seconds",
+          "Seconds since this peer's metrics started.",
+          s.uptimeSeconds
+        )
+
+        counter(
+          "hydrozoa_local_requests_total",
+          "Requests this peer sequenced successfully.",
+          s.localAccepted
+        )
+        b.append("# HELP hydrozoa_local_requests_rejected_total Locally-rejected requests.\n")
+        b.append("# TYPE hydrozoa_local_requests_rejected_total counter\n")
+        b.append(
+          s"""hydrozoa_local_requests_rejected_total{reason="screening"} ${s.localRejScreening}\n"""
+        )
+        b.append(
+          s"""hydrozoa_local_requests_rejected_total{reason="backpressure"} ${s.localRejBackpressure}\n"""
+        )
+        rate("hydrozoa_local_requests", "Local request rate (req/s).", s.localRate, b)
+
+        b.append("# HELP hydrozoa_peer_requests_total Requests ingested from a remote head peer.\n")
+        b.append("# TYPE hydrozoa_peer_requests_total counter\n")
+        s.peerRequests.toVector.sortBy(_._1).foreach { case (peer, c) =>
+            b.append(s"""hydrozoa_peer_requests_total{peer="$peer"} ${c.total}\n""")
+        }
+
+        b.append("# HELP hydrozoa_blocks_total Soft-confirmed blocks by type.\n")
+        b.append("# TYPE hydrozoa_blocks_total counter\n")
+        b.append(s"""hydrozoa_blocks_total{type="minor"} ${s.blocks.minor}\n""")
+        b.append(s"""hydrozoa_blocks_total{type="major"} ${s.blocks.major}\n""")
+        gaugeD("hydrozoa_block_events_avg", "Average events per block.", s.blocks.avgEvents)
+        gauge("hydrozoa_block_events_max", "Maximum events in any block.", s.blocks.maxEvents)
+        window(
+          "hydrozoa_blocks_window",
+          "Blocks in the trailing window.",
+          s.blocks.blocksPerWindow,
+          b
+        )
+        window(
+          "hydrozoa_block_requests_window",
+          "Requests in blocks in the trailing window.",
+          s.blocks.requestsPerWindow,
+          b
+        )
+
+        counter("hydrozoa_stacks_total", "Hard-confirmed stacks.", s.stacks.total)
+        gauge(
+          "hydrozoa_stack_last_number",
+          "Most recent hard-confirmed stack number.",
+          s.stacks.lastStackNumber
+        )
+        gauge(
+          "hydrozoa_seconds_since_last_hard_confirm",
+          "Seconds since the last stack hard-confirmed.",
+          s.stacks.secondsSinceLastHardConfirm
+        )
+        gaugeD(
+          "hydrozoa_stack_gap_seconds_mean",
+          "Mean seconds between hard-confirmed stacks.",
+          s.stacks.meanInterStackGapSeconds
+        )
+        gaugeD(
+          "hydrozoa_stack_blocks_avg",
+          "Average blocks absorbed per stack.",
+          s.stacks.avgBlocksAbsorbed
+        )
+        gauge(
+          "hydrozoa_stack_blocks_max",
+          "Maximum blocks absorbed by any stack.",
+          s.stacks.maxBlocksAbsorbed
+        )
+
+        b.toString
+
+    private def rate(name: String, help: String, r: RateView, b: StringBuilder): Unit =
+        b.append(s"# HELP ${name}_per_second $help\n# TYPE ${name}_per_second gauge\n")
+        b.append(s"${name}_per_second ${fmt(r.now)}\n")
+        b.append(s"# HELP ${name}_load $help (EWMA load average).\n# TYPE ${name}_load gauge\n")
+        b.append(s"""${name}_load{window="1m"} ${fmt(r.load1m)}\n""")
+        b.append(s"""${name}_load{window="5m"} ${fmt(r.load5m)}\n""")
+        b.append(s"""${name}_load{window="15m"} ${fmt(r.load15m)}\n""")
+
+    private def window(name: String, help: String, w: WindowCounts, b: StringBuilder): Unit =
+        b.append(s"# HELP $name $help\n# TYPE $name gauge\n")
+        b.append(s"""$name{window="10s"} ${w.last10s}\n""")
+        b.append(s"""$name{window="30s"} ${w.last30s}\n""")
+        b.append(s"""$name{window="60s"} ${w.last60s}\n""")
+        b.append(s"""$name{window="5m"} ${w.last5m}\n""")
+        b.append(s"""$name{window="10m"} ${w.last10m}\n""")
+
+    /** Prometheus wants a plain decimal, not `1.0E-4` / `NaN`. Round to 4 dp and drop trailing
+      * zeros; non-finite and zero collapse to `0`.
+      */
+    private def fmt(d: Double): String =
+        if d.isNaN || d.isInfinite || d == 0.0 then "0"
+        else
+            val bd = BigDecimal(d).setScale(4, BigDecimal.RoundingMode.HALF_UP).bigDecimal
+            if bd.signum() == 0 then "0" else bd.stripTrailingZeros().toPlainString()

--- a/src/main/scala/hydrozoa/multisig/metrics/PrometheusFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/metrics/PrometheusFormat.scala
@@ -54,18 +54,8 @@ object PrometheusFormat:
         b.append(s"""hydrozoa_blocks_total{type="major"} ${s.blocks.major}\n""")
         gaugeD("hydrozoa_block_events_avg", "Average events per block.", s.blocks.avgEvents)
         gauge("hydrozoa_block_events_max", "Maximum events in any block.", s.blocks.maxEvents)
-        window(
-          "hydrozoa_blocks_window",
-          "Blocks in the trailing window.",
-          s.blocks.blocksPerWindow,
-          b
-        )
-        window(
-          "hydrozoa_block_requests_window",
-          "Requests in blocks in the trailing window.",
-          s.blocks.requestsPerWindow,
-          b
-        )
+        rate("hydrozoa_blocks", "Block production rate (blocks/s).", s.blocks.blockRate, b)
+        rate("hydrozoa_block_requests", "Requests-in-blocks rate (req/s).", s.blocks.requestRate, b)
 
         counter("hydrozoa_stacks_total", "Hard-confirmed stacks.", s.stacks.total)
         gauge(
@@ -103,14 +93,6 @@ object PrometheusFormat:
         b.append(s"""${name}_load{window="1m"} ${fmt(r.load1m)}\n""")
         b.append(s"""${name}_load{window="5m"} ${fmt(r.load5m)}\n""")
         b.append(s"""${name}_load{window="15m"} ${fmt(r.load15m)}\n""")
-
-    private def window(name: String, help: String, w: WindowCounts, b: StringBuilder): Unit =
-        b.append(s"# HELP $name $help\n# TYPE $name gauge\n")
-        b.append(s"""$name{window="10s"} ${w.last10s}\n""")
-        b.append(s"""$name{window="30s"} ${w.last30s}\n""")
-        b.append(s"""$name{window="60s"} ${w.last60s}\n""")
-        b.append(s"""$name{window="5m"} ${w.last5m}\n""")
-        b.append(s"""$name{window="10m"} ${w.last10m}\n""")
 
     /** Prometheus wants a plain decimal, not `1.0E-4` / `NaN`. Round to 4 dp and drop trailing
       * zeros; non-finite and zero collapse to `0`.

--- a/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
+++ b/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
@@ -8,6 +8,7 @@ import hydrozoa.multisig.ledger.block.{BlockBrief, BlockHeader}
 import hydrozoa.multisig.ledger.event.RequestId
 import hydrozoa.multisig.ledger.event.RequestId.ValidityFlag
 import hydrozoa.multisig.ledger.l2.{L2TxKind, L2TxSummary}
+import hydrozoa.multisig.metrics.{PeerStats, RateView, WindowCounts}
 import hydrozoa.multisig.persistence.DepositDecision
 import io.bullet.borer.Cbor
 import io.circe.derivation.{Configuration as CirceConfig, ConfiguredCodec}
@@ -170,6 +171,101 @@ object ApiDto {
         case NodeStatus.Active               => NodeStatusView.Active
         case NodeStatus.Finalized            => NodeStatusView.Finalized
         case NodeStatus.HandedOffToRuleBased => NodeStatusView.HandedOffToRuleBased
+
+    // ---- Peer statistics (GET /head/stats); see design/peer-stats-endpoint.md ----
+
+    /** A rate as an instantaneous value plus top-style 1m/5m/15m EWMA load averages (req/s). */
+    final case class RateStatsView(now: Double, load1m: Double, load5m: Double, load15m: Double)
+    given Codec[RateStatsView] = deriveCodec
+
+    /** A count over fixed trailing windows. */
+    final case class WindowStatsView(
+        last10s: Long,
+        last30s: Long,
+        last60s: Long,
+        last5m: Long,
+        last10m: Long
+    )
+    given Codec[WindowStatsView] = deriveCodec
+
+    /** Requests ingested from one remote head peer. */
+    final case class PeerRequestStatsView(peer: Int, total: Long, rate: RateStatsView)
+    given Codec[PeerRequestStatsView] = deriveCodec
+
+    /** Locally-submitted requests: accepted total + rate, and rejections split by cause. */
+    final case class LocalRequestStatsView(
+        total: Long,
+        rate: RateStatsView,
+        rejectedScreening: Long,
+        rejectedBackpressure: Long
+    )
+    given Codec[LocalRequestStatsView] = deriveCodec
+
+    /** Block production: minor/major totals, event-size average+max, and per-window counts. */
+    final case class BlockStatsView(
+        minor: Long,
+        major: Long,
+        avgEvents: Double,
+        maxEvents: Long,
+        blocksPerWindow: WindowStatsView,
+        requestsPerWindow: WindowStatsView
+    )
+    given Codec[BlockStatsView] = deriveCodec
+
+    /** Slow-cycle stacks: total hard-confirmed, cadence, and blocks-absorbed size. */
+    final case class StackStatsView(
+        total: Long,
+        lastStackNumber: Long,
+        secondsSinceLastHardConfirm: Long,
+        meanInterStackGapSeconds: Double,
+        avgBlocksAbsorbed: Double,
+        maxBlocksAbsorbed: Long
+    )
+    given Codec[StackStatsView] = deriveCodec
+
+    /** The full peer-stats body. */
+    final case class PeerStatsView(
+        uptimeSeconds: Long,
+        localRequests: LocalRequestStatsView,
+        peerRequests: List[PeerRequestStatsView],
+        blocks: BlockStatsView,
+        stacks: StackStatsView
+    )
+    given Codec[PeerStatsView] = deriveCodec
+
+    /** Map a [[hydrozoa.multisig.metrics.PeerStats]] snapshot to its JSON body. */
+    def mkPeerStatsView(s: PeerStats): PeerStatsView =
+        def rate(r: RateView): RateStatsView = RateStatsView(r.now, r.load1m, r.load5m, r.load15m)
+        def window(w: WindowCounts): WindowStatsView =
+            WindowStatsView(w.last10s, w.last30s, w.last60s, w.last5m, w.last10m)
+        PeerStatsView(
+          uptimeSeconds = s.uptimeSeconds,
+          localRequests = LocalRequestStatsView(
+            total = s.localAccepted,
+            rate = rate(s.localRate),
+            rejectedScreening = s.localRejScreening,
+            rejectedBackpressure = s.localRejBackpressure
+          ),
+          peerRequests = s.peerRequests.toList
+              .sortBy(_._1)
+              .map((peer, c) => PeerRequestStatsView(peer, c.total, rate(c.rate))),
+          blocks = BlockStatsView(
+            minor = s.blocks.minor,
+            major = s.blocks.major,
+            avgEvents = s.blocks.avgEvents,
+            maxEvents = s.blocks.maxEvents,
+            blocksPerWindow = window(s.blocks.blocksPerWindow),
+            requestsPerWindow = window(s.blocks.requestsPerWindow)
+          ),
+          stacks = StackStatsView(
+            total = s.stacks.total,
+            lastStackNumber = s.stacks.lastStackNumber,
+            secondsSinceLastHardConfirm = s.stacks.secondsSinceLastHardConfirm,
+            meanInterStackGapSeconds = s.stacks.meanInterStackGapSeconds,
+            avgBlocksAbsorbed = s.stacks.avgBlocksAbsorbed,
+            maxBlocksAbsorbed = s.stacks.maxBlocksAbsorbed
+          )
+        )
 
     /** `{ "status": "success", "message": ... }` — the finalize-trigger body. */
     final case class FinalizeResponse(status: String, message: String)

--- a/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
+++ b/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
@@ -8,7 +8,7 @@ import hydrozoa.multisig.ledger.block.{BlockBrief, BlockHeader}
 import hydrozoa.multisig.ledger.event.RequestId
 import hydrozoa.multisig.ledger.event.RequestId.ValidityFlag
 import hydrozoa.multisig.ledger.l2.{L2TxKind, L2TxSummary}
-import hydrozoa.multisig.metrics.{PeerStats, RateView, WindowCounts}
+import hydrozoa.multisig.metrics.{PeerStats, RateView}
 import hydrozoa.multisig.persistence.DepositDecision
 import io.bullet.borer.Cbor
 import io.circe.derivation.{Configuration as CirceConfig, ConfiguredCodec}
@@ -178,16 +178,6 @@ object ApiDto {
     final case class RateStatsView(now: Double, load1m: Double, load5m: Double, load15m: Double)
     given Codec[RateStatsView] = deriveCodec
 
-    /** A count over fixed trailing windows. */
-    final case class WindowStatsView(
-        last10s: Long,
-        last30s: Long,
-        last60s: Long,
-        last5m: Long,
-        last10m: Long
-    )
-    given Codec[WindowStatsView] = deriveCodec
-
     /** Requests ingested from one remote head peer. */
     final case class PeerRequestStatsView(peer: Int, total: Long, rate: RateStatsView)
     given Codec[PeerRequestStatsView] = deriveCodec
@@ -201,14 +191,14 @@ object ApiDto {
     )
     given Codec[LocalRequestStatsView] = deriveCodec
 
-    /** Block production: minor/major totals, event-size average+max, and per-window counts. */
+    /** Block production: minor/major totals, event-size average+max, and EWMA throughput rates. */
     final case class BlockStatsView(
         minor: Long,
         major: Long,
         avgEvents: Double,
         maxEvents: Long,
-        blocksPerWindow: WindowStatsView,
-        requestsPerWindow: WindowStatsView
+        blockRate: RateStatsView,
+        requestRate: RateStatsView
     )
     given Codec[BlockStatsView] = deriveCodec
 
@@ -236,8 +226,6 @@ object ApiDto {
     /** Map a [[hydrozoa.multisig.metrics.PeerStats]] snapshot to its JSON body. */
     def mkPeerStatsView(s: PeerStats): PeerStatsView =
         def rate(r: RateView): RateStatsView = RateStatsView(r.now, r.load1m, r.load5m, r.load15m)
-        def window(w: WindowCounts): WindowStatsView =
-            WindowStatsView(w.last10s, w.last30s, w.last60s, w.last5m, w.last10m)
         PeerStatsView(
           uptimeSeconds = s.uptimeSeconds,
           localRequests = LocalRequestStatsView(
@@ -254,8 +242,8 @@ object ApiDto {
             major = s.blocks.major,
             avgEvents = s.blocks.avgEvents,
             maxEvents = s.blocks.maxEvents,
-            blocksPerWindow = window(s.blocks.blocksPerWindow),
-            requestsPerWindow = window(s.blocks.requestsPerWindow)
+            blockRate = rate(s.blocks.blockRate),
+            requestRate = rate(s.blocks.requestRate)
           ),
           stacks = StackStatsView(
             total = s.stacks.total,

--- a/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
+++ b/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
@@ -172,7 +172,7 @@ object ApiDto {
         case NodeStatus.Finalized            => NodeStatusView.Finalized
         case NodeStatus.HandedOffToRuleBased => NodeStatusView.HandedOffToRuleBased
 
-    // ---- Peer statistics (GET /head/stats); see design/peer-stats-endpoint.md ----
+    // ---- Peer statistics (GET /head/stats); see docs/spec/peer-stats-endpoint.md ----
 
     /** A rate as an instantaneous value plus top-style 1m/5m/15m EWMA load averages (req/s). */
     final case class RateStatsView(now: Double, load1m: Double, load5m: Double, load15m: Double)

--- a/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
+++ b/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
@@ -11,6 +11,7 @@ import hydrozoa.multisig.consensus.{BlockWeaver, RequestSequencer, UserRequestWi
 import hydrozoa.multisig.ledger.block.{BlockBrief, BlockNumber}
 import hydrozoa.multisig.ledger.event.RequestId
 import hydrozoa.multisig.ledger.l2.EutxoL2LedgerReader
+import hydrozoa.multisig.metrics.{PeerMetrics, PrometheusFormat}
 import hydrozoa.multisig.persistence.{ConsensusStoreReader, RequestBlockEntry}
 import hydrozoa.multisig.server.ApiDto.*
 import hydrozoa.multisig.server.HydrozoaHttpEvent.*
@@ -47,6 +48,7 @@ class HydrozoaRoutes(
     l2QueryReader: Option[EutxoL2LedgerReader[IO]],
     headConfig: HeadConfig,
     serverConfig: HydrozoaServer.Config,
+    metrics: PeerMetrics,
     tracer: ContraTracer[IO, HydrozoaHttpEvent]
 ) {
     import HydrozoaRoutes.{apiTitle, apiVersion, l2ApiTitle}
@@ -502,6 +504,35 @@ class HydrozoaRoutes(
                 }
             )
 
+    private val statsEndpoint: ServerEndpoint[Any, IO] =
+        endpoint.get
+            .in("head" / "stats")
+            .name("getHeadStats")
+            .tag("Observability")
+            .out(jsonBody[PeerStatsView])
+            .description(
+              "Live operational metrics for this peer (in-memory, process-lifetime; reset on " +
+                  "restart). Cheap: served from a snapshot, no storage reads."
+            )
+            .serverLogicSuccess(_ =>
+                IO.realTime
+                    .flatMap(t => IO(metrics.snapshot(t.toMillis)))
+                    .map(ApiDto.mkPeerStatsView)
+            )
+
+    private val metricsEndpoint: ServerEndpoint[Any, IO] =
+        endpoint.get
+            .in("head" / "metrics")
+            .name("getHeadMetrics")
+            .tag("Observability")
+            .out(stringBody)
+            .description("The same peer metrics in Prometheus text exposition format.")
+            .serverLogicSuccess(_ =>
+                IO.realTime
+                    .flatMap(t => IO(metrics.snapshot(t.toMillis)))
+                    .map(PrometheusFormat.render)
+            )
+
     private val finalizeEndpoint: ServerEndpoint[Any, IO] =
         endpoint.post
             // Optional credentials so the security logic runs (and logs) even when the header is
@@ -569,6 +600,8 @@ class HydrozoaRoutes(
           blockRolloutEndpoint,
           healthEndpoint,
           readyEndpoint,
+          statsEndpoint,
+          metricsEndpoint,
           versionEndpoint,
           finalizeEndpoint
         ) ++ blockEffectKindEndpoints
@@ -923,6 +956,7 @@ object HydrozoaRoutes {
         l2QueryReader: Option[EutxoL2LedgerReader[IO]],
         headConfig: HeadConfig,
         serverConfig: HydrozoaServer.Config,
+        metrics: PeerMetrics,
         tracer: ContraTracer[IO, HydrozoaHttpEvent]
     ): IO[HydrozoaRoutes] =
         IO.pure(
@@ -934,6 +968,7 @@ object HydrozoaRoutes {
             l2QueryReader,
             headConfig,
             serverConfig,
+            metrics,
             tracer
           )
         )

--- a/src/main/scala/hydrozoa/multisig/server/HydrozoaServer.scala
+++ b/src/main/scala/hydrozoa/multisig/server/HydrozoaServer.scala
@@ -7,6 +7,7 @@ import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.NodeStatus
 import hydrozoa.multisig.consensus.{BlockWeaver, RequestSequencer}
 import hydrozoa.multisig.ledger.l2.EutxoL2LedgerReader
+import hydrozoa.multisig.metrics.PeerMetrics
 import hydrozoa.multisig.persistence.ConsensusStoreReader
 import hydrozoa.multisig.server.HydrozoaHttpEvent.ServerStarted
 import org.http4s.ember.server.EmberServerBuilder
@@ -59,6 +60,7 @@ object HydrozoaServer {
         l2QueryReader: Option[EutxoL2LedgerReader[IO]],
         headConfig: HeadConfig,
         config: Config,
+        metrics: PeerMetrics,
         tracer: ContraTracer[IO, HydrozoaHttpEvent]
     ): Resource[IO, Server] =
         for {
@@ -71,6 +73,7 @@ object HydrozoaServer {
                 l2QueryReader,
                 headConfig,
                 config,
+                metrics,
                 tracer
               )
             )
@@ -95,6 +98,7 @@ object HydrozoaServer {
         l2QueryReader: Option[EutxoL2LedgerReader[IO]],
         headConfig: HeadConfig,
         config: Config,
+        metrics: PeerMetrics,
         tracer: ContraTracer[IO, HydrozoaHttpEvent]
     ): IO[Nothing] = {
         create(
@@ -105,6 +109,7 @@ object HydrozoaServer {
           l2QueryReader,
           headConfig,
           config,
+          metrics,
           tracer
         )
             .use(_ => IO.never)

--- a/src/test/scala/hydrozoa/multisig/metrics/PeerMetricsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/metrics/PeerMetricsTest.scala
@@ -62,7 +62,7 @@ class PeerMetricsTest extends AnyFunSuite:
           s"stacks: $s"
         )
 
-    test("sampler fills the exact windows and moves the EWMA load average after activity"):
+    test("sampler moves the EWMA load averages for local, block, and request rates after activity"):
         val program = TestControl.executeEmbed {
             for {
                 m <- IO.realTime.map(t => PeerMetrics.create(t.toMillis, Vector(0, 1)))
@@ -81,9 +81,9 @@ class PeerMetricsTest extends AnyFunSuite:
         }
         val s = program.unsafeRunSync()
         assert(
-          s.blocks.minor == 5 && s.blocks.blocksPerWindow.last10s == 5 &&
-              s.blocks.blocksPerWindow.last60s == 5 &&
-              s.blocks.requestsPerWindow.last10s == 10 && // 5 blocks * 2 events
-              s.localRate.load1m > 0.0, // steady local traffic registers on the EWMA
+          s.blocks.minor == 5 &&
+              s.localRate.load1m > 0.0 && // steady local traffic registers on the EWMA
+              s.blocks.blockRate.load1m > 0.0 && // ~1 block/s
+              s.blocks.requestRate.load1m > s.blocks.blockRate.load1m, // 2 events per block
           s"snapshot: $s"
         )

--- a/src/test/scala/hydrozoa/multisig/metrics/PeerMetricsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/metrics/PeerMetricsTest.scala
@@ -1,0 +1,89 @@
+package hydrozoa.multisig.metrics
+
+import cats.effect.IO
+import cats.effect.testkit.TestControl
+import cats.effect.unsafe.implicits.global
+import cats.implicits.*
+import org.scalatest.funsuite.AnyFunSuite
+import scala.concurrent.duration.*
+
+class PeerMetricsTest extends AnyFunSuite:
+
+    private def fresh(peers: Vector[Int] = Vector(0, 1)): PeerMetrics =
+        PeerMetrics.create(0L, peers)
+
+    test("local accepted/rejected counters accumulate and split by cause"):
+        val m = fresh()
+        (1 to 5).foreach(_ => m.onLocalAccepted())
+        (1 to 3).foreach(_ => m.onLocalRejected(RejectionKind.Screening))
+        (1 to 7).foreach(_ => m.onLocalRejected(RejectionKind.Backpressure))
+        val s = m.snapshot(1000L)
+        assert(
+          s.localAccepted == 5 && s.localRejScreening == 3 &&
+              s.localRejBackpressure == 7 && s.uptimeSeconds == 1,
+          s"snapshot: $s"
+        )
+
+    test("peer requests are counted per peer; unknown peers are dropped, not crashed"):
+        val m = fresh(Vector(0, 1, 2))
+        m.onPeerRequests(1, 4)
+        m.onPeerRequests(1, 6)
+        m.onPeerRequests(2, 3)
+        m.onPeerRequests(99, 100) // unknown -> ignored
+        val s = m.snapshot(0L)
+        assert(
+          s.peerRequests(1).total == 10 && s.peerRequests(2).total == 3 &&
+              s.peerRequests(0).total == 0 && !s.peerRequests.contains(99),
+          s"peerRequests: ${s.peerRequests}"
+        )
+
+    test("block stats: minor/major counts, average and max events; empty is zero"):
+        val m = fresh()
+        m.onBlockConfirmed(isMajor = false, events = 10)
+        m.onBlockConfirmed(isMajor = false, events = 20)
+        m.onBlockConfirmed(isMajor = true, events = 30)
+        val b = m.snapshot(0L).blocks
+        assert(
+          b.minor == 2 && b.major == 1 && b.maxEvents == 30 && b.avgEvents == 20.0 &&
+              fresh().snapshot(0L).blocks.avgEvents == 0.0,
+          s"blocks: $b"
+        )
+
+    test("stack stats: totals, size, mean inter-stack gap, and seconds-since"):
+        val m = fresh()
+        m.onStackConfirmed(stackNum = 1, blocksAbsorbed = 100, nowMillis = 1000L)
+        m.onStackConfirmed(stackNum = 2, blocksAbsorbed = 200, nowMillis = 4000L) // gap 3s
+        m.onStackConfirmed(stackNum = 3, blocksAbsorbed = 300, nowMillis = 7000L) // gap 3s
+        val s = m.snapshot(10000L).stacks
+        assert(
+          s.total == 3 && s.lastStackNumber == 3 && s.maxBlocksAbsorbed == 300 &&
+              s.avgBlocksAbsorbed == 200.0 && s.meanInterStackGapSeconds == 3.0 &&
+              s.secondsSinceLastHardConfirm == 3,
+          s"stacks: $s"
+        )
+
+    test("sampler fills the exact windows and moves the EWMA load average after activity"):
+        val program = TestControl.executeEmbed {
+            for {
+                m <- IO.realTime.map(t => PeerMetrics.create(t.toMillis, Vector(0, 1)))
+                fiber <- m.sampler(1.second).start
+                // one local request + one 2-event block per second for 5 seconds
+                _ <- (1 to 5).toList.traverse_ { _ =>
+                    IO {
+                        m.onLocalAccepted()
+                        m.onBlockConfirmed(isMajor = false, events = 2)
+                    } >> IO.sleep(1.second)
+                }
+                _ <- IO.sleep(1.second) // let the sampler observe the last tick
+                s <- IO.realTime.flatMap(t => IO(m.snapshot(t.toMillis)))
+                _ <- fiber.cancel
+            } yield s
+        }
+        val s = program.unsafeRunSync()
+        assert(
+          s.blocks.minor == 5 && s.blocks.blocksPerWindow.last10s == 5 &&
+              s.blocks.blocksPerWindow.last60s == 5 &&
+              s.blocks.requestsPerWindow.last10s == 10 && // 5 blocks * 2 events
+              s.localRate.load1m > 0.0, // steady local traffic registers on the EWMA
+          s"snapshot: $s"
+        )

--- a/src/test/scala/hydrozoa/multisig/metrics/PrometheusFormatTest.scala
+++ b/src/test/scala/hydrozoa/multisig/metrics/PrometheusFormatTest.scala
@@ -1,0 +1,77 @@
+package hydrozoa.multisig.metrics
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class PrometheusFormatTest extends AnyFunSuite:
+
+    private val sample = PeerStats(
+      uptimeSeconds = 42,
+      localAccepted = 1234,
+      localRate = RateView(now = 3.7, load1m = 3.5, load5m = 2.0, load15m = 1.0),
+      localRejScreening = 5,
+      localRejBackpressure = 4210,
+      peerRequests = Map(1 -> CounterWithRate(987, RateView(1.0, 1.0, 1.0, 1.0))),
+      blocks = BlockStats(
+        minor = 3860,
+        major = 2,
+        avgEvents = 1.5,
+        maxEvents = 1000,
+        blocksPerWindow = WindowCounts(1, 3, 6, 30, 60),
+        requestsPerWindow = WindowCounts(2, 6, 12, 60, 120)
+      ),
+      stacks = StackStats(
+        total = 10,
+        lastStackNumber = 10,
+        secondsSinceLastHardConfirm = 42,
+        meanInterStackGapSeconds = 180.0,
+        avgBlocksAbsorbed = 386.0,
+        maxBlocksAbsorbed = 900
+      )
+    )
+
+    test("counters carry the _total suffix and a TYPE line"):
+        val out = PrometheusFormat.render(sample)
+        assert(
+          out.contains("# TYPE hydrozoa_local_requests_total counter") &&
+              out.contains("hydrozoa_local_requests_total 1234") &&
+              out.contains("# TYPE hydrozoa_stacks_total counter") &&
+              out.contains("hydrozoa_stacks_total 10"),
+          out
+        )
+
+    test("dimensions are labels, not separate metric names"):
+        val out = PrometheusFormat.render(sample)
+        assert(
+          out.contains("""hydrozoa_local_requests_rejected_total{reason="screening"} 5""") &&
+              out.contains(
+                """hydrozoa_local_requests_rejected_total{reason="backpressure"} 4210"""
+              ) &&
+              out.contains("""hydrozoa_peer_requests_total{peer="1"} 987""") &&
+              out.contains("""hydrozoa_blocks_total{type="minor"} 3860""") &&
+              out.contains("""hydrozoa_blocks_total{type="major"} 2"""),
+          out
+        )
+
+    test("windows and load averages are gauges"):
+        val out = PrometheusFormat.render(sample)
+        assert(
+          out.contains("""hydrozoa_blocks_window{window="10s"} 1""") &&
+              out.contains("""hydrozoa_block_requests_window{window="10m"} 120""") &&
+              out.contains("""hydrozoa_local_requests_load{window="1m"} 3.5""") &&
+              out.contains("hydrozoa_local_requests_per_second 3.7"),
+          out
+        )
+
+    test("fmt renders clean plain decimals and tames NaN / Infinity"):
+        val bad = sample.copy(
+          localRate = RateView(Double.NaN, Double.PositiveInfinity, 0.0001, 12345.678)
+        )
+        val out = PrometheusFormat.render(bad)
+        assert(
+          out.contains("hydrozoa_local_requests_per_second 0") && // NaN -> 0
+              out.contains("""hydrozoa_local_requests_load{window="1m"} 0""") && // Inf -> 0
+              out.contains("""hydrozoa_local_requests_load{window="5m"} 0.0001""") &&
+              out.contains("""hydrozoa_local_requests_load{window="15m"} 12345.678""") &&
+              !out.contains("E-"), // no scientific notation
+          out
+        )

--- a/src/test/scala/hydrozoa/multisig/metrics/PrometheusFormatTest.scala
+++ b/src/test/scala/hydrozoa/multisig/metrics/PrometheusFormatTest.scala
@@ -16,8 +16,8 @@ class PrometheusFormatTest extends AnyFunSuite:
         major = 2,
         avgEvents = 1.5,
         maxEvents = 1000,
-        blocksPerWindow = WindowCounts(1, 3, 6, 30, 60),
-        requestsPerWindow = WindowCounts(2, 6, 12, 60, 120)
+        blockRate = RateView(now = 2.0, load1m = 1.9, load5m = 1.5, load15m = 1.0),
+        requestRate = RateView(now = 3.0, load1m = 2.8, load5m = 2.0, load15m = 1.2)
       ),
       stacks = StackStats(
         total = 10,
@@ -52,13 +52,15 @@ class PrometheusFormatTest extends AnyFunSuite:
           out
         )
 
-    test("windows and load averages are gauges"):
+    test("load averages (including block/request throughput) are gauges"):
         val out = PrometheusFormat.render(sample)
         assert(
-          out.contains("""hydrozoa_blocks_window{window="10s"} 1""") &&
-              out.contains("""hydrozoa_block_requests_window{window="10m"} 120""") &&
-              out.contains("""hydrozoa_local_requests_load{window="1m"} 3.5""") &&
-              out.contains("hydrozoa_local_requests_per_second 3.7"),
+          out.contains("""hydrozoa_local_requests_load{window="1m"} 3.5""") &&
+              out.contains("hydrozoa_local_requests_per_second 3.7") &&
+              out.contains("hydrozoa_blocks_per_second 2") &&
+              out.contains("""hydrozoa_blocks_load{window="5m"} 1.5""") &&
+              out.contains("hydrozoa_block_requests_per_second 3") &&
+              out.contains("""hydrozoa_block_requests_load{window="1m"} 2.8"""),
           out
         )
 

--- a/src/test/scala/hydrozoa/multisig/server/HeadBlocksEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/HeadBlocksEndpointsTest.scala
@@ -1,5 +1,4 @@
 package hydrozoa.multisig.server
-
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import com.suprnation.actor.Actor.{Actor, Receive}
@@ -15,6 +14,7 @@ import hydrozoa.multisig.ledger.block.{Block, BlockBody, BlockBrief, BlockHeader
 import hydrozoa.multisig.ledger.event.RequestId
 import hydrozoa.multisig.ledger.joint.EvacuationMap
 import hydrozoa.multisig.ledger.stack.{PartitionEffects, StackBrief, StackEffects, StackNumber, StandaloneEvacuationCommitment}
+import hydrozoa.multisig.metrics.PeerMetrics
 import hydrozoa.multisig.persistence.{ArrivalStamp, ConsensusStoreReader, DepositDecision, RequestBlockEntry, Timestamped}
 import hydrozoa.rulebased.ledger.l1.state.StandaloneEvacuationCommitmentOnchain
 import io.circe.Json
@@ -177,6 +177,7 @@ class HeadBlocksEndpointsTest extends AnyFunSuite:
                       None,
                       headConfig,
                       HydrozoaServer.Config(adminUsername = "admin", adminPassword = "admin"),
+                      PeerMetrics.create(0L, Vector.empty),
                       ContraTracer[IO, HydrozoaHttpEvent](_ => IO.unit)
                     )
                     _ <- check(routes.routes.orNotFound)

--- a/src/test/scala/hydrozoa/multisig/server/HeadEffectsEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/HeadEffectsEndpointsTest.scala
@@ -1,5 +1,4 @@
 package hydrozoa.multisig.server
-
 import cats.data.NonEmptyList
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
@@ -21,6 +20,7 @@ import hydrozoa.multisig.ledger.event.RequestId.ValidityFlag
 import hydrozoa.multisig.ledger.event.{RequestId, RequestNumber}
 import hydrozoa.multisig.ledger.joint.EvacuationMap
 import hydrozoa.multisig.ledger.stack.{EffectIds, PartitionEffects, StackBrief, StackEffects, StackNumber, StandaloneEvacuationCommitment}
+import hydrozoa.multisig.metrics.PeerMetrics
 import hydrozoa.multisig.persistence.{ArrivalStamp, ConsensusStoreReader, DepositDecision, RequestBlockEntry, Timestamped}
 import hydrozoa.rulebased.ledger.l1.state.StandaloneEvacuationCommitmentOnchain
 import io.circe.Json
@@ -176,6 +176,7 @@ class HeadEffectsEndpointsTest extends AnyFunSuite:
                           None,
                           headConfig,
                           HydrozoaServer.Config(adminUsername = "admin", adminPassword = "admin"),
+                          PeerMetrics.create(0L, Vector.empty),
                           ContraTracer[IO, HydrozoaHttpEvent](_ => IO.unit)
                         )
                         _ <- check(routes.routes.orNotFound)

--- a/src/test/scala/hydrozoa/multisig/server/HeadRequestsEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/HeadRequestsEndpointsTest.scala
@@ -1,5 +1,4 @@
 package hydrozoa.multisig.server
-
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import com.suprnation.actor.Actor.{Actor, Receive}
@@ -15,6 +14,7 @@ import hydrozoa.multisig.ledger.block.{Block, BlockBrief, BlockNumber}
 import hydrozoa.multisig.ledger.event.RequestId.ValidityFlag
 import hydrozoa.multisig.ledger.event.{RequestId, RequestNumber}
 import hydrozoa.multisig.ledger.stack.{StackBrief, StackEffects, StackNumber}
+import hydrozoa.multisig.metrics.PeerMetrics
 import hydrozoa.multisig.persistence.{ArrivalStamp, ConsensusStoreReader, DepositDecision, RequestBlockEntry, Timestamped}
 import io.circe.Json
 import java.time.Instant
@@ -141,6 +141,7 @@ class HeadRequestsEndpointsTest extends AnyFunSuite:
                       None,
                       headConfig,
                       HydrozoaServer.Config(adminUsername = "admin", adminPassword = "admin"),
+                      PeerMetrics.create(0L, Vector.empty),
                       ContraTracer[IO, HydrozoaHttpEvent](_ => IO.unit)
                     )
                     _ <- check(routes.routes.orNotFound)

--- a/src/test/scala/hydrozoa/multisig/server/L2QueryEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/L2QueryEndpointsTest.scala
@@ -1,5 +1,4 @@
 package hydrozoa.multisig.server
-
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import cats.syntax.all.*
@@ -15,6 +14,7 @@ import hydrozoa.multisig.ledger.eutxol2.EutxoL2Ledger
 import hydrozoa.multisig.ledger.eutxol2.store.InMemoryL2Store
 import hydrozoa.multisig.ledger.event.RequestId
 import hydrozoa.multisig.ledger.l2.{L2CommandNumber, L2LedgerCommand}
+import hydrozoa.multisig.metrics.PeerMetrics
 import hydrozoa.multisig.persistence.ConsensusStoreReader
 import io.circe.{Json, Printer}
 import org.http4s.circe.*
@@ -96,6 +96,7 @@ class L2QueryEndpointsTest extends AnyFunSuite:
                       Some(ledger),
                       multiNodeConfig.headConfig,
                       HydrozoaServer.Config(adminUsername = "admin", adminPassword = "admin"),
+                      PeerMetrics.create(0L, Vector.empty),
                       ContraTracer[IO, HydrozoaHttpEvent](_ => IO.unit)
                     )
                     _ <- check(routes.routes.orNotFound, ledger)
@@ -129,6 +130,7 @@ class L2QueryEndpointsTest extends AnyFunSuite:
                       None,
                       multiNodeConfig.headConfig,
                       HydrozoaServer.Config(adminUsername = "admin", adminPassword = "admin"),
+                      PeerMetrics.create(0L, Vector.empty),
                       ContraTracer[IO, HydrozoaHttpEvent](_ => IO.unit)
                     )
                     _ <- check(routes.routes.orNotFound)

--- a/src/test/scala/hydrozoa/multisig/server/OpenApiSchemaTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/OpenApiSchemaTest.scala
@@ -1,5 +1,4 @@
 package hydrozoa.multisig.server
-
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import com.suprnation.actor.Actor.{Actor, Receive}
@@ -9,6 +8,7 @@ import hydrozoa.config.node.MultiNodeConfig
 import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.NodeStatus
 import hydrozoa.multisig.consensus.{BlockWeaver, RequestSequencer}
+import hydrozoa.multisig.metrics.PeerMetrics
 import hydrozoa.multisig.persistence.ConsensusStoreReader
 import java.nio.file.{Files, Path}
 import org.scalacheck.Gen
@@ -61,6 +61,7 @@ class OpenApiSchemaTest extends AnyFunSuite:
                       None,
                       multiNodeConfig.headConfig,
                       HydrozoaServer.Config(adminUsername = "admin", adminPassword = "admin"),
+                      PeerMetrics.create(0L, Vector.empty),
                       ContraTracer[IO, HydrozoaHttpEvent](_ => IO.unit)
                     )
                 } yield use(routes)

--- a/src/test/scala/hydrozoa/multisig/server/ReadyEndpointTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/ReadyEndpointTest.scala
@@ -1,5 +1,4 @@
 package hydrozoa.multisig.server
-
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import com.suprnation.actor.Actor.{Actor, Receive}
@@ -9,6 +8,7 @@ import hydrozoa.config.node.MultiNodeConfig
 import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.NodeStatus
 import hydrozoa.multisig.consensus.{BlockWeaver, RequestSequencer}
+import hydrozoa.multisig.metrics.PeerMetrics
 import hydrozoa.multisig.persistence.ConsensusStoreReader
 import io.circe.Json
 import org.http4s.circe.*
@@ -55,6 +55,7 @@ class ReadyEndpointTest extends AnyFunSuite:
                       None,
                       multiNodeConfig.headConfig,
                       HydrozoaServer.Config(adminUsername = "admin", adminPassword = "admin"),
+                      PeerMetrics.create(0L, Vector.empty),
                       ContraTracer[IO, HydrozoaHttpEvent](_ => IO.unit)
                     )
                     resp <- routes.routes.orNotFound.run(Request[IO](Method.GET, uri"/ready"))


### PR DESCRIPTION
## Peer statistics endpoints — `/head/stats` (JSON) + `/head/metrics` (Prometheus)

A cheap, always-on per-peer stats surface. Spec: `docs/spec/peer-stats-endpoint.md`.

### What it reports
- **Local requests** — accepted total + EWMA TPS (now / 1m / 5m / 15m), and rejections split
  **screening vs backpressure**.
- **Peer-to-peer requests** — per remote head peer, total + the same EWMA TPS triple.
- **Blocks** — minor/major totals, avg + max event size, and EWMA throughput rates for **blocks/sec**
  and **requests-in-blocks/sec** (now / 1m / 5m / 15m).
- **Stacks** — total hard-confirmed, last stack number, seconds-since-last, mean inter-stack gap,
  avg + max blocks absorbed. (Surfaces the `hardStackMinPeriod` cadence directly.)

### How it stays cheap
- **Push, don't pull:** each event bumps a lock-free counter (`AtomicLong` for the single-writer
  actor counters — cats actors drain serially; `LongAdder` only for the multi-writer peer-request
  counters). No RocksDB reads, no block-history scan, no actor `ask`.
- **All rates are EWMA — no fixed-window rings.** One 1 Hz sampler fiber holds a small set of EWMA
  accumulators (a few doubles each) and publishes one immutable snapshot; nothing per-second is
  stored, rolled, or recomputed. The endpoints read that snapshot.
- In-memory only — counters reset on restart (documented; no persistence cost on the hot path).

### Instrumentation points (one line each, at the single funnels)
| Metric | Hook |
|---|---|
| local accepted / rejected(kind) | `RequestSequencer` decision branches |
| per-peer requests | `PeerLiaisonHeadToHead.dispatch` |
| blocks minor/major + events | `FastConsensusActor.completeCell` |
| stacks + blocks absorbed | `SlowConsensusActor.completeStack` |

### Endpoints
- `GET /head/stats` — JSON (`PeerStatsView`).
- `GET /head/metrics` — Prometheus text exposition (0.0.4): monotonic `_total` counters (Prometheus
  derives rates) + gauges for the EWMA load averages. `PrometheusFormat.render` is a pure function.
- Both unauthenticated (read-only), like `/head/info` and `/head/blocks`.

### Wiring & tests
- `PeerMetrics` created in `Serve`, threaded through the MRM assembly into the four instrumented
  actors and into `HydrozoaServer`/`HydrozoaRoutes`; the 1 Hz sampler runs for the node's lifetime.
- Regenerated `docs/api/openapi.yaml` (adds both endpoints + schemas).
- Unit tests: `PeerMetrics` counters/snapshot + the sampler's EWMA rates under `TestControl`;
  `PrometheusFormat` exposition format (labels, `_total`, NaN/Inf handling).
- Green locally under `-Werror` (core + tests + integration); server + metrics suites pass (47 + 9).

### Notes for review
- Prometheus content-type uses tapir's default `stringBody` (`text/plain; charset=utf-8`) rather
  than the exact `version=0.0.4` header param — scrapers accept it; say the word to pin the version.
- `final` blocks are bucketed with `major` in the minor/major split (rare, terminal).

### Commits
1. `docs(design)`: the spec
2. `feat(server)`: endpoints + registry + instrumentation + tests
3. `refactor(server)`: EWMA-only — drop the fixed-window rings
4. `docs(spec)`: graduate the spec from `design/` → `docs/spec/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
