### PR TITLE
chore(release): 0.1.4 — metrics + quieter rejection logs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -352,7 +352,7 @@ inThisBuild(
   List(
     // Release version — drives the Docker image tag, `hydrozoa.BuildInfo.version`, and `GET
     // /version`. Bump here for a release (see RELEASE.md), then tag `v<version>`.
-    version := "0.1.3",
+    version := "0.1.4",
     scalaVersion := "3.3.7",
     semanticdbEnabled := true,
     semanticdbVersion := scalafixSemanticdb.revision

--- a/docs/user-guide/DEPLOYMENT.md
+++ b/docs/user-guide/DEPLOYMENT.md
@@ -110,9 +110,9 @@ workspace from it:
 
 ```bash
 mkdir myhead && cd myhead
-docker pull ghcr.io/cardano-hydrozoa/hydrozoa:0.1.3
+docker pull ghcr.io/cardano-hydrozoa/hydrozoa:0.1.4
 docker run --rm -v "$PWD:/work" -w /work --user root \
-  ghcr.io/cardano-hydrozoa/hydrozoa:0.1.3 scaffold .
+  ghcr.io/cardano-hydrozoa/hydrozoa:0.1.4 scaffold .
 # writes docker-compose.yml, hydrozoa.sh, template/peer-private.template.json.local
 ```
 
@@ -123,13 +123,13 @@ under it. Then load the CLI alias and check you are on the version you expect:
 source ./hydrozoa.sh   # sets the `hydrozoa` alias + HYDROZOA_HOME (this folder, an absolute path)
 
 hydrozoa version       # verify the image you are running
-#   hydrozoa 0.1.3
-#   git:   v0.1.3
+#   hydrozoa 0.1.4
+#   git:   v0.1.4
 #   built: 2026-07-28 14:00:37.834-0600
 ```
 
-(The `git:` line is `git describe` provenance; a published image built from the `v0.1.3` tag reads a
-clean `v0.1.3`. A locally built image between releases shows the distance from the newest tag, e.g.
+(The `git:` line is `git describe` provenance; a published image built from the `v0.1.4` tag reads a
+clean `v0.1.4`. A locally built image between releases shows the distance from the newest tag, e.g.
 `v0.1.0-10-gaa9d7c69`.)
 
 Need a version that isn't in the registry? Build it from this repo — see §3.
@@ -152,12 +152,12 @@ just integration-fast  # multi-peer integration subset
 Two ways to use your build:
 
 **A local Docker image** — the same image as the published one, from your sources. It is tagged
-both `cardano-hydrozoa/hydrozoa:0.1.3` and `ghcr.io/cardano-hydrozoa/hydrozoa:0.1.3`, so it matches
+both `cardano-hydrozoa/hydrozoa:0.1.4` and `ghcr.io/cardano-hydrozoa/hydrozoa:0.1.4`, so it matches
 `docker compose`'s default image name — the scaffolded head (§5) picks it up with no `HYDROZOA_IMAGE`
 override:
 
 ```bash
-just docker-image      # -> cardano-hydrozoa/hydrozoa:0.1.3 + ghcr.io/… (base eclipse-temurin:25-jre)
+just docker-image      # -> cardano-hydrozoa/hydrozoa:0.1.4 + ghcr.io/… (base eclipse-temurin:25-jre)
 ```
 
 **Locally-compiled code (development)** — `just stage` builds the `hydrozoa` launcher from the
@@ -361,8 +361,8 @@ At this point every node has its two files, and the composition (§5) mounts
 - Config mounts resolve against `.` — the head directory the compose file was scaffolded into — so
   running compose from there mounts that dir's shared `head-config.json` plus each node's
   `head-N/private.json` or `coil-N/private.json`. The image defaults to the published
-  `ghcr.io/cardano-hydrozoa/hydrozoa:0.1.3` (pulled on first run); set `${HYDROZOA_IMAGE}` to use
-  another, e.g. a locally built `cardano-hydrozoa/hydrozoa:0.1.3`.
+  `ghcr.io/cardano-hydrozoa/hydrozoa:0.1.4` (pulled on first run); set `${HYDROZOA_IMAGE}` to use
+  another, e.g. a locally built `cardano-hydrozoa/hydrozoa:0.1.4`.
 
 Caveats:
 - **State is ephemeral.** No data volumes are mounted (only read-only config bind mounts), so both
@@ -386,7 +386,7 @@ Default — pull the published image and run the scaffolded head:
 
 ```bash
 cd "$HYDROZOA_HOME"            # the scaffolded head dir (default head/demo)
-docker compose up -d          # pulls ghcr.io/cardano-hydrozoa/hydrozoa:0.1.3 on first run
+docker compose up -d          # pulls ghcr.io/cardano-hydrozoa/hydrozoa:0.1.4 on first run
 ```
 
 Stack 0 initializes once both head peers + any `coilQuorum` coil peers are signing.
@@ -411,11 +411,11 @@ The `(0,0)` entry under `happyPathEffects` is the initialization tx — open its
 network's explorer to check it out. Every following happy-path effect (settlements, the
 finalization) appears in the same section as the head progresses.
 
-**Another image** — `HYDROZOA_IMAGE` (default `ghcr.io/cardano-hydrozoa/hydrozoa:0.1.3`), e.g. a
+**Another image** — `HYDROZOA_IMAGE` (default `ghcr.io/cardano-hydrozoa/hydrozoa:0.1.4`), e.g. a
 locally built one (§3):
 
 ```bash
-HYDROZOA_IMAGE=cardano-hydrozoa/hydrozoa:0.1.3 docker compose up -d
+HYDROZOA_IMAGE=cardano-hydrozoa/hydrozoa:0.1.4 docker compose up -d
 ```
 
 **Another head** — each head directory carries its own `docker-compose.yml`, so switch heads by

--- a/src/main/resources/scaffold/docker-compose.yml
+++ b/src/main/resources/scaffold/docker-compose.yml
@@ -20,7 +20,7 @@ networks:
       com.docker.network.driver.mtu: 1400
 
 x-hydrozoa: &hydrozoa
-  image: ${HYDROZOA_IMAGE:-ghcr.io/cardano-hydrozoa/hydrozoa:${HYDROZOA_VERSION:-0.1.3}}
+  image: ${HYDROZOA_IMAGE:-ghcr.io/cardano-hydrozoa/hydrozoa:${HYDROZOA_VERSION:-0.1.4}}
   # root: the image's non-root user cannot write the RocksDB stores / logs under the /opt/docker
   # workdir. State is ephemeral here (no volumes) — restarting re-initializes a fresh head (§5b).
   user: root

--- a/src/main/resources/scaffold/hydrozoa.sh
+++ b/src/main/resources/scaffold/hydrozoa.sh
@@ -13,7 +13,7 @@
 # scaffolded workspace — resolved to an absolute path, so the alias mounts correctly no matter which
 # directory you run it from. Override HYDROZOA_HOME (to an absolute path) or HYDROZOA_VERSION before
 # sourcing, or edit the defaults below.
-: "${HYDROZOA_VERSION:=0.1.3}"   # published image tag (ghcr.io/cardano-hydrozoa/hydrozoa)
+: "${HYDROZOA_VERSION:=0.1.4}"   # published image tag (ghcr.io/cardano-hydrozoa/hydrozoa)
 : "${HYDROZOA_HOME:=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)}"   # head directory (absolute)
 export HYDROZOA_VERSION HYDROZOA_HOME
 

--- a/src/main/scala/hydrozoa/multisig/ledger/joint/JointLedgerEventFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/joint/JointLedgerEventFormat.scala
@@ -50,7 +50,10 @@ object JointLedgerEventFormat:
                   "blockNum" -> s"${bn: Int}"
                 )
             case RequestInvalidated(rid, bn, reason) =>
-                warn(
+                // A request that fails ledger application (e.g. "order not found" for a tx that
+                // references a spent/absent order) is an expected per-request outcome, not an
+                // operational fault — DEBUG so it stays out of the INFO/WARN logs under load.
+                debug(
                   s"Request rejected ($rid): $reason",
                   "requestId" -> rid.toString,
                   "blockNum" -> s"${bn: Int}"


### PR DESCRIPTION
## Release 0.1.4

Bumps the release version and demotes a noisy log, on top of everything merged to `main` since
0.1.3 (peer-stats metrics `/head/stats` + `/head/metrics` #606, block-cap + request backpressure
#601/#603, concise request-rejection logging #605, deploy-docs #600).

### Changes in this PR
- **`fix(logging)`** — demote the `JointLedger` "Request rejected … order not found" log from
  **WARN → DEBUG**. It's an expected per-request outcome (a tx referencing a spent/absent order),
  not a fault, and was flooding the shipped logs (root=warn) under load.
- **`chore(release)`** — bump `0.1.3 → 0.1.4` in `build.sbt` + the hard-coded image tags in the
  scaffold `docker-compose.yml`/`hydrozoa.sh` and `docs/user-guide/DEPLOYMENT.md` (RELEASE.md step 1).

### RELEASE.md checklist
- **Step 1 (bump):** done; `grep hydrozoa:0.1.3` → no stragglers.
- **Step 2 (ref-UTxOs):** no `cardanoOnchain` source, `plutus.json`, or Scalus-version change since
  v0.1.3 → baked preprod/preview refs stay valid, **no redeploy**.
- **Step 3 (logger levels):** `logback-docker.xml` unchanged (root warn / hydrozoa info); the demoted
  log inherits root warn, so DEBUG keeps it out of the shipped logs.
- **Steps 5–7 (tag/push/verify):** after this merges — `git tag v0.1.4 && git push origin v0.1.4`
  triggers the release workflow (`:{0.1.4,0.1,latest}`), then verify the pulled image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
