### PR TITLE
fix(logging): async, never-block appenders so logging can't stall consensus

### DIFF
--- a/src/main/resources/logback-docker.xml
+++ b/src/main/resources/logback-docker.xml
@@ -11,8 +11,20 @@
             <pattern>%d{HH:mm:ss.SSS} %-5level %logger{48} - %msg%n</pattern>
         </encoder>
     </appender>
-    <root level="warn">
+    <!-- Logging must never block a cats-effect compute worker. A synchronous ConsoleAppender does a
+         blocking write+flush on the calling thread; if the stdout sink (journald / docker json-file)
+         drains slower than the producer, that thread parks in the write and — since consensus logs on
+         the compute pool — a stalled worker can freeze block production (the failure mode confirmed in
+         the remote ledger). Wrap it in an AsyncAppender with neverBlock=true: the caller offers the
+         event to a bounded queue and moves on; on overflow events are dropped, never blocked. The
+         default discardingThreshold sheds TRACE/DEBUG/INFO first, so WARN/ERROR survive under load. -->
+    <appender name="ASYNC_STDOUT" class="ch.qos.logback.classic.AsyncAppender">
         <appender-ref ref="STDOUT"/>
+        <neverBlock>true</neverBlock>
+        <queueSize>8192</queueSize>
+    </appender>
+    <root level="warn">
+        <appender-ref ref="ASYNC_STDOUT"/>
     </root>
     <logger name="hydrozoa" level="info"/>
     <logger name="com.bloxbean" level="warn"/>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,11 +1,21 @@
 <configuration>
+    <!-- The console and human log file are wrapped in an AsyncAppender with neverBlock=true (below).
+         This config runs at `trace`, so a slow console/disk would otherwise block the writing thread
+         — and since consensus logs on the cats-effect compute pool, a blocked appender write can
+         stall block production (the failure mode confirmed in the remote ledger). neverBlock makes
+         the caller offer-and-move-on; under overload log events are dropped, never the work.
+         TRACE_FILE is deliberately left synchronous — see its note below. -->
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) %cyan(%logger{64}) %n%msg%n
             </pattern>
         </encoder>
     </appender>
-    <!-- Protocol trace: writes JSONL to file, no formatting overhead -->
+    <!-- Protocol trace: writes JSONL to file, no formatting overhead. Kept SYNCHRONOUS (not
+         async/neverBlock like the others): this is a dev-only, lossless protocol trace for replay
+         and analysis, and dropping events under load would leave gaps that make it useless. It is a
+         local-debugging artifact only — absent from the shipped container config (logback-docker.xml
+         has no file appenders) — so it is never on the production hot path. -->
     <appender name="TRACE_FILE" class="ch.qos.logback.core.FileAppender">
         <file>hydrozoa-trace.jsonl</file>
         <encoder><pattern>%msg%n</pattern></encoder>
@@ -16,12 +26,22 @@
              (those belong on the console, not in a file you grep/less). -->
         <encoder><pattern>%d{HH:mm:ss.SSS} %-5level %logger{64} %n%msg%n</pattern></encoder>
     </appender>
+    <appender name="ASYNC_STDOUT" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="STDOUT"/>
+        <neverBlock>true</neverBlock>
+        <queueSize>8192</queueSize>
+    </appender>
+    <appender name="ASYNC_LOG_FILE" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="LOG_FILE"/>
+        <neverBlock>true</neverBlock>
+        <queueSize>8192</queueSize>
+    </appender>
     <logger name="hydrozoa.trace" level="info" additivity="false">
         <appender-ref ref="TRACE_FILE"/>
     </logger>
     <root level="trace">
-        <appender-ref ref="STDOUT"/>
-        <appender-ref ref="LOG_FILE"/>
+        <appender-ref ref="ASYNC_STDOUT"/>
+        <appender-ref ref="ASYNC_LOG_FILE"/>
     </root>
     <logger name="CardanoBackend" level="warn"/>
     <!-- Bloxbean's backend logs every Blockfrost request at DEBUG; mute the flood (noise in both


### PR DESCRIPTION
## What
Wrap every Logback appender in an `AsyncAppender` with `neverBlock=true` (8192 queue) in both shipped configs (`logback.xml`, `logback-docker.xml`). Under overload the compute worker offers the event and moves on; log *events* are dropped, never the work. Default `discardingThreshold` sheds TRACE/DEBUG/INFO first so WARN/ERROR survive.

## Why
The remote L2 ledger's hot-path freeze (fixed on its side) turned out to be **synchronous blocking log writes** stalling a runtime worker. Hydrozoa had the same shape:
- all appenders were synchronous `ConsoleAppender`/`FileAppender` — write+flush on the calling thread;
- consensus logs via log4cats on the **cats-effect compute pool** (`IO.delay`, not a blocking EC), so a blocked appender write parks a compute worker — the analogue of the ledger's blocked tokio worker;
- the default `logback.xml` runs `root=trace` with two per-event-flushed `FileAppender`s. Invisible at `warn`, dangerous at debug/trace.

This is defensive: the ~23s stalls we observed were the ledger, not Hydrozoa logging (a thread dump during a gap showed compute workers parked, not blocked in an appender). But the vulnerability is real and latent — this removes it, and also de-risks the `.scratch` debug config used for diagnosis (observer effect).

## Notes
- Test configs deliberately stay **synchronous** — deterministic, complete test output; not latency-critical.
- Residual (separate, minor): trace-level log *formatting* still runs on the compute worker; async removes only the blocking, not the formatting cost. Only relevant at trace.

## Testing
Both shipped configs load cleanly via the CLI (`Main --help`) with no logback `ERROR`/`WARN`; all appender-refs resolve. No Scala changed.
