### PR TITLE
test(rbr): run the RBR dispute→evacuation MBT against public Preview testnet

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -225,10 +225,10 @@ lazy val core: Project = (project in file("."))
         BuildInfoKey.action("gitCommit") {
             scala.util
                 .Try(
-                    scala.sys.process
-                        .Process("git describe --tags --always --dirty --abbrev=8")
-                        .!!
-                        .trim
+                  scala.sys.process
+                      .Process("git describe --tags --always --dirty --abbrev=8")
+                      .!!
+                      .trim
                 )
                 .getOrElse("unknown")
         }
@@ -268,7 +268,8 @@ lazy val integration: Project = (project in file("integration"))
     .settings(
       // Compile / mainClass := Some("hydrozoa.demo.Workload"),
       publish / skip := true,
-      // Yaci suites require Docker / a running Yaci DevKit instance; exclude from default test run.
+      // Yaci suites require Docker / a running Yaci DevKit instance, and the Preview suite requires
+      // a live public testnet + a funded master wallet; exclude both from the default test run.
       // Run explicitly, e.g.: integration/testOnly hydrozoa.integration.stage1.Stage1PropertiesYaci
       // NB: using * with testOnly still respects the excluded tests
       Test / testOptions += Tests.Exclude(
@@ -277,7 +278,8 @@ lazy val integration: Project = (project in file("integration"))
           "hydrozoa.integration.yaci.YaciDevnetSmokeTest",
           "hydrozoa.integration.yaci.YaciSetupProbe",
           "hydrozoa.integration.yaci.YaciMultiPeerProbe",
-          "hydrozoa.integration.rbr.mbt.RbrMbtPropertiesYaci"
+          "hydrozoa.integration.rbr.mbt.RbrMbtPropertiesYaci",
+          "hydrozoa.integration.rbr.mbt.RbrMbtPropertiesPublic"
         )
       ),
       // test dependencies

--- a/integration/src/test/resources/logback-test.xml
+++ b/integration/src/test/resources/logback-test.xml
@@ -54,8 +54,9 @@
     <!-- default: warn -->
     <!-- The RBR MBT arms the settlement firewall on purpose, so it drops a settlement every tick
          post-fallback (thousands of expected warnings). Observers capture what we need; silence the
-         per-drop warning. -->
-    <logger name="FirewalledCardanoBackend" level="error"/>
+         per-drop warning. NB: temporarily at `info` to surface each tx's submit result (incl. the
+         init-tx Preview rejection) while diagnosing the public-testnet run; restore to `error`. -->
+    <logger name="FirewalledCardanoBackend" level="info"/>
     <logger name="org.scalacheck.commands.ModelBasedSuite" level="warn"/>
     <logger name="test.CardanoBackendMock" level="warn"/>
     <logger name="CardanoBackend" level="warn"/>
@@ -87,11 +88,11 @@
     <logger name="FastConsensusActor" level="debug"/>
     <logger name="SlowConsensusActor" level="debug"/>
     <logger name="EventSequencer" level="info"/>
-    <logger name="CardanoLiaison" level="warn"/>
+    <logger name="CardanoLiaison" level="debug"/>
     <logger name="JointLedger" level="info"/>
     <logger name="HeadMultisigRegimeManager" level="info"/>
     <logger name="CoilMultisigRegimeManager" level="info"/>
-    <logger name="RuleBasedActor" level="info"/>
+    <logger name="RuleBasedActor" level="debug"/>
     <logger name="Limiter" level="debug"/>
     <logger name="PeerLiaison" level="debug"/>
     <logger name="PeerLiaison.HeadToHead" level="debug"/>

--- a/integration/src/test/scala/hydrozoa/integration/harness/MultiPeerHeadHarness.scala
+++ b/integration/src/test/scala/hydrozoa/integration/harness/MultiPeerHeadHarness.scala
@@ -22,6 +22,7 @@ import hydrozoa.config.{HydrozoaBlueprint, ScriptReferenceUtxos, generateScriptR
 import hydrozoa.integration.yaci.DevKit
 import hydrozoa.lib.cardano.scalus.QuantizedTime.{QuantizedFiniteDuration, quantize}
 import hydrozoa.lib.logging.{ContraTracer, LogEvent, Slf4jMsg, Slf4jMsgFormat, Slf4jTracer, info}
+import io.circe.{Json, parser}
 import hydrozoa.multisig.backend.cardano.{CardanoBackend as L1Backend, CardanoBackendBlockfrost, CardanoBackendEvent, CardanoBackendEventFormat, CardanoBackendMock, FirewalledCardanoBackendEvent, MockState, yaciTestSauceGenesis}
 import hydrozoa.multisig.consensus.peer.{CoilPeerNumber, HeadPeerId, HeadPeerNumber, PeerId}
 import hydrozoa.multisig.consensus.transport.*
@@ -48,7 +49,7 @@ import org.scalacheck.{Gen, PropertyM}
 import scala.concurrent.duration.{DurationLong, FiniteDuration}
 import scalus.cardano.address.{Network, ShelleyAddress}
 import scalus.cardano.ledger.rules.{Context, UtxoEnv}
-import scalus.cardano.ledger.{CardanoInfo, CertState, ProtocolParams, SlotConfig, Utxos}
+import scalus.cardano.ledger.{CardanoInfo, CertState, Coin, ProtocolParams, SlotConfig, Utxos}
 import test.{GenWithTestPeers, TestPeerName, TestPeers, given}
 
 /** Scaffold for a multi-peer head (+ optional coil followers) [[Resource]] backed by a shared L1 —
@@ -147,6 +148,35 @@ object MultiPeerHeadHarness:
             )
     }
 
+    /** Public-testnet timing (Preview): every sub-block window is lifted above Preview's ~20s block
+      * cadence so the protocol doesn't race the chain. Deposit maturity is 2min so the
+      * CardanoLiaison poll — capped at `depositMaturityDuration / 5` — can sit around 20s (see
+      * `previewLiveBackendPollingPeriod`); the settlement/inactivity windows are minutes so the
+      * init window and the Minor→Major deadman don't fire before a block confirms.
+      */
+    val previewTxTiming: GenWithTestPeers[TxTiming] = ReaderT { (network: TestPeers) =>
+        Gen.const(
+          TxTiming(
+            minSettlementDuration = MinSettlementDuration(3.minutes.quantize(network.slotConfig)),
+            inactivityMarginDuration =
+                InactivityMarginDuration(3.minutes.quantize(network.slotConfig)),
+            silenceDuration = SilenceDuration(40.seconds.quantize(network.slotConfig)),
+            depositSubmissionDuration =
+                DepositSubmissionDuration(40.seconds.quantize(network.slotConfig)),
+            depositMaturityDuration =
+                DepositMaturityDuration(2.minutes.quantize(network.slotConfig)),
+            depositAbsorptionDuration =
+                DepositAbsorptionDuration(5.minutes.quantize(network.slotConfig)),
+          )
+        )
+    }
+
+    /** CardanoLiaison / evacuation-bot poll period for the public Preview backend — kept near one
+      * block (~20s) so per-tick Blockfrost probes don't storm the API, while staying under
+      * `previewTxTiming`'s `depositMaturityDuration / 5` (24s) invariant.
+      */
+    val previewLiveBackendPollingPeriod: FiniteDuration = 20.seconds
+
     /** Static fast voting deadline (5s `votingDuration`) so the deadline-gated tally path unblocks
       * within a wall-clock scenario budget — the default generator picks 1h..5d. Shared by the
       * dispute-flow tests via [[mkResource]]'s default.
@@ -158,6 +188,24 @@ object MultiPeerHeadHarness:
                 votingDuration = QuantizedFiniteDuration(
                   slotConfig = network.slotConfig,
                   finiteDuration = 5.seconds,
+                )
+              )
+            )
+        }
+
+    /** Public-testnet voting deadline. The 5s [[fastDisputeResolutionConfig]] is always already
+      * elapsed by the time the rule-based actor detects fallback and runs the dispute on a slow
+      * live chain, so every peer skips its vote and the dispute resolves to the default (base) map
+      * with no votes. Give the window minutes so peers can actually build + submit + confirm their
+      * vote/ratchet txs on ~20s blocks before the deadline gates the tally.
+      */
+    val previewDisputeResolutionConfig: GenWithTestPeers[DisputeResolutionConfig] =
+        ReaderT { (network: TestPeers) =>
+            Gen.const(
+              DisputeResolutionConfig(
+                votingDuration = QuantizedFiniteDuration(
+                  slotConfig = network.slotConfig,
+                  finiteDuration = 5.minutes,
                 )
               )
             )
@@ -214,18 +262,77 @@ object MultiPeerHeadHarness:
         val peerLabel = peerId match
             case PeerId.Head(n) => s"head-$n"
             case PeerId.Coil(n) => s"coil-$n"
-        Slf4jTracer.sink.contramap {
+        val from = LogEvent.From(Map("peer" -> peerLabel), "FirewalledCardanoBackend")
+        def emit(e: LogEvent): IO[Unit] = Slf4jTracer.sink.traceWith(e)
+        ContraTracer[IO, FirewalledCardanoBackendEvent] {
             case FirewalledCardanoBackendEvent.DroppedOutboundTx(etx) =>
-                LogEvent
-                    .From(Map("peer" -> peerLabel), "FirewalledCardanoBackend")
-                    .warn(s"firewall DROPPED tx ${etx.tx.id} family=${etx.transactionFamily}")
-            case FirewalledCardanoBackendEvent.SubmittedTx(etx, result) =>
-                LogEvent
-                    .From(Map("peer" -> peerLabel), "FirewalledCardanoBackend")
-                    .info(
-                      s"firewall passed tx ${etx.tx.id} family=${etx.transactionFamily} result=$result"
-                    )
+                emit(from.warn(s"firewall DROPPED tx ${etx.tx.id} family=${etx.transactionFamily}"))
+            case FirewalledCardanoBackendEvent.SubmittedTx(etx, Right(())) =>
+                emit(
+                  from.info(
+                    s"firewall passed tx ${etx.tx.id} family=${etx.transactionFamily} → accepted"
+                  )
+                )
+            case FirewalledCardanoBackendEvent.SubmittedTx(etx, Left(err)) =>
+                val head =
+                    s"firewall passed tx ${etx.tx.id} family=${etx.transactionFamily} → REJECTED"
+                val (summary, full) = SubmitErrorFormat.summarize(err.getMessage)
+                // INFO: a one-line summary (status code + the actual ledger error); DEBUG: the full
+                // pretty-printed report.
+                emit(from.info(s"$head: $summary")) >>
+                    emit(from.debug(s"$head — full submit error:\n$full"))
         }
+
+    /** Renders a Blockfrost submit-error blob (`{error, message, status_code}`, whose `message` is
+      * usually a stringified ledger-error JSON) into a one-line summary (for INFO) and a
+      * pretty-printed full report (for DEBUG). Falls back to the raw string when it isn't JSON.
+      */
+    private object SubmitErrorFormat:
+        def summarize(raw: String): (String, String) =
+            parser.parse(raw) match
+                case Left(_) => (truncate(raw), raw)
+                case Right(json) =>
+                    val c = json.hcursor
+                    val status = c.get[Int]("status_code").toOption
+                    val topError = c.get[String]("error").toOption
+                    val messageStr = c.get[String]("message").toOption
+                    val messageJson = messageStr.flatMap(s => parser.parse(s).toOption)
+                    val ledgerErrors = messageJson.map(collectLedgerErrors).getOrElse(Nil)
+                    val body =
+                        if ledgerErrors.nonEmpty then ledgerErrors.mkString("; ")
+                        else
+                            messageStr
+                                .map(m => truncate(m))
+                                .orElse(topError)
+                                .getOrElse("(no message)")
+                    val summary =
+                        status.fold(body)(s => topError.fold(s"[$s] $body")(e => s"[$s $e] $body"))
+                    // Re-embed the parsed message so the DEBUG report is a readable tree, not a
+                    // string-of-JSON.
+                    val fullJson =
+                        messageJson.fold(json)(mj => json.mapObject(_.add("message", mj)))
+                    (summary, fullJson.spaces2)
+
+        /** Every `"error": [<strings>]` array anywhere in the ledger-error tree (the
+          * `Conway*Failure` messages).
+          */
+        private def collectLedgerErrors(json: Json): List[String] =
+            json.fold(
+              jsonNull = Nil,
+              jsonBoolean = _ => Nil,
+              jsonNumber = _ => Nil,
+              jsonString = _ => Nil,
+              jsonArray = _.toList.flatMap(collectLedgerErrors),
+              jsonObject = obj =>
+                  val here = obj("error")
+                      .flatMap(_.asArray)
+                      .map(_.toList.flatMap(_.asString))
+                      .getOrElse(Nil)
+                  here ++ obj.values.toList.flatMap(collectLedgerErrors)
+            )
+
+        private def truncate(s: String, n: Int = 300): String =
+            if s.length <= n then s else s.take(n) + "…"
 
     /** The standard head-peer handle for the dispute-flow tests: each head peer exposes its
       * `RequestSequencer.Handle`; coil peers expose `None`.
@@ -353,6 +460,16 @@ object MultiPeerHeadHarness:
         // Real on-chain script references (deployed on a Yaci devnet); `None` fabricates them,
         // which only works against the mock backend.
         scriptReferenceUtxos: Option[ScriptReferenceUtxos] = None,
+        // Poll period for a real (script-refs-present) backend's CardanoLiaison + evacuation bot.
+        // The mock path ignores it (it polls sub-second). Defaults to 1s for the Yaci devnet; raise
+        // it (see `previewLiveBackendPollingPeriod`) for a slower public testnet so per-tick
+        // Blockfrost probes stay near the block cadence.
+        liveBackendPollingPeriod: FiniteDuration = 1.second,
+        // Total L2 equity (split across head peers) the init generator draws from. Each peer's
+        // genesis UTxO must exceed `contingency + its equity share + ~20 ADA`, so a tight funding
+        // budget (a public testnet funded from one wallet) can cap this low to keep the per-peer
+        // floor small. Default matches `GenWithDeps`'s own range.
+        equityRange: (Coin, Coin) = Coin(5_000_000) -> Coin(500_000_000),
     ): PropertyM[IO, (Option[Instant], MultiNodeConfig)] =
         for {
             takeoffTime <- PropertyM.run(
@@ -373,7 +490,8 @@ object MultiPeerHeadHarness:
                                 Gen.const(
                                   testPeerToUtxos.map { case (k, v) => k.headPeerNumber -> v }
                                 )
-                            )
+                            ),
+                            equityRange = equityRange,
                           )
                         ),
                         generateScriptReferenceUtxos = scriptReferenceUtxos
@@ -397,29 +515,32 @@ object MultiPeerHeadHarness:
                     generateNodeOperationEvacuationConfig = w =>
                         Gen.const(
                           NodeOperationEvacuationConfig(
-                            // Mock (no real script refs) polls fast; a real Yaci backend polls
-                            // every 1s so per-tick blockfrost probes don't overwhelm the yaci-store.
+                            // Mock (no real script refs) polls fast; a real Blockfrost-backed
+                            // backend polls at `liveBackendPollingPeriod` so per-tick probes don't
+                            // overwhelm the store (yaci) / API (public testnet).
                             evacuationBotPollingPeriod =
-                                if scriptReferenceUtxos.isDefined then 1.second else 100.millis,
+                                if scriptReferenceUtxos.isDefined then liveBackendPollingPeriod
+                                else 100.millis,
                             ruleBasedWallet = w,
                           )
                         ),
                     generateNodeOperationMultisigConfig = hc =>
                         val nomc = generateNodeOperationMultisigConfig(
                           maxPollingPeriod =
-                              if scriptReferenceUtxos.isDefined then 1.second
+                              if scriptReferenceUtxos.isDefined then liveBackendPollingPeriod
                               else hc.maxCardanoLiaisonPollingPeriod / 2,
                           rateLimits = RateLimits(
                             softBlockMinPeriod = 500.millis,
                             hardStackMinPeriod = 250.millis,
                           ),
                         )
-                        // Yaci: pin the CL poll to exactly 1s (not a uniform sample up to 1s) so it
-                        // doesn't storm the yaci-store with sub-second resubmits of an in-flight
-                        // effect. `yaciTxTiming`'s 6s deposit maturity keeps this within the
-                        // `CL <= depositMaturityDuration / 5` invariant.
+                        // Real backend: pin the CL poll to exactly `liveBackendPollingPeriod` (not a
+                        // uniform sample up to it) so it doesn't storm the store/API with
+                        // sub-period resubmits of an in-flight effect. The chosen timing's deposit
+                        // maturity keeps this within the `CL <= depositMaturityDuration / 5`
+                        // invariant (6s for yaci, 2min for preview).
                         if scriptReferenceUtxos.isDefined then
-                            nomc.map(_.copy(cardanoLiaisonPollingPeriod = 1.second))
+                            nomc.map(_.copy(cardanoLiaisonPollingPeriod = liveBackendPollingPeriod))
                         else nomc
                   )
                   .label("MultiNodeConfig")
@@ -702,15 +823,22 @@ object MultiPeerHeadHarness:
     // ===================================
 
     object CardanoBackend:
-        /** Which L1 every peer shares: an in-memory mock, or a real Yaci devnet reached over its
-          * Blockfrost-compatible API. `Yaci` carries the devnet's `Custom` network (built from
-          * `DevKit.devnetInfo`) so protocol evaluation and slot arithmetic line up with the chain.
+        /** Which L1 every peer shares: an in-memory mock, a real Yaci devnet, or a public testnet —
+          * the latter two both reached over a Blockfrost(-compatible) API. `Yaci` / `Public` carry
+          * a `Custom` network (Yaci's from `DevKit.devnetInfo`, Preview's from [[previewNetwork]])
+          * so protocol evaluation and slot arithmetic line up with the chain. `Public` also carries
+          * the Blockfrost project id (`apiKey`); the Yaci store needs none.
           */
         enum Mode:
             case Mock
             case Yaci(
                 network: CardanoNetwork.Custom,
                 url: String = DevKit.defaultBlockfrostApiBaseUri
+            )
+            case Public(
+                network: CardanoNetwork.Custom,
+                url: String,
+                apiKey: String,
             )
 
         /** The Yaci devnet's `Custom` network from a live `devKit.devnetInfo` query: its slot
@@ -740,6 +868,29 @@ object MultiPeerHeadHarness:
                 CardanoNetwork.Custom(cardanoInfo, info.protocolMagic.toLong)
             }
 
+        /** Preview's `Custom` network with LIVE protocol params fetched from Blockfrost. Mirrors
+          * [[yaciNetwork]] but takes Preview's fixed slot config + protocol magic straight from
+          * `CardanoInfo.preview` (no per-devnet block-time query). Fetching the live params —
+          * rather than the bundled `CardanoInfo.preview` cost models, which drift from the chain —
+          * is what keeps the Plutus deploy/dispute/evacuation txs from failing
+          * `PPViewHashesDontMatch`.
+          */
+        def previewNetwork(apiKey: String): IO[CardanoNetwork.Custom] =
+            val backend = CardanoBackendBlockfrost.apply_(
+              Left(CardanoNetwork.Preview),
+              apiKey,
+              tracer = Slf4jTracer.sink.contramap(CardanoBackendEventFormat.humanFormat),
+            )
+            backend.fetchLatestParams.flatMap(IO.fromEither).map { params =>
+                val base = CardanoInfo.preview
+                val cardanoInfo = CardanoInfo(
+                  protocolParams = params,
+                  network = base.network,
+                  slotConfig = base.slotConfig,
+                )
+                CardanoNetwork.Custom(cardanoInfo, CardanoNetwork.Preview.protocolMagic)
+            }
+
         /** Build the shared L1 backend and its `l1Snapshot` for the chosen [[Mode]]. */
         def mk(
             mode: Mode,
@@ -750,53 +901,66 @@ object MultiPeerHeadHarness:
             tracer: ContraTracer[IO, CardanoBackendEvent],
             extraSnapshotAddresses: Set[ShelleyAddress],
         ): IO[(L1Backend[IO], IO[Utxos])] =
+            def snapshotAddresses =
+                blockfrostSnapshotAddresses(
+                  preinitPeerUtxosL1,
+                  cardanoInfo,
+                  headMultisigAddress,
+                  extraSnapshotAddresses,
+                )
             mode match
                 case Mode.Mock => mkMock(preinitPeerUtxosL1, scriptReferenceUtxos, cardanoInfo)
                 case Mode.Yaci(network, url) =>
-                    // Blockfrost has no "all UTxOs" query, so scope the snapshot to the addresses
-                    // that hold head-relevant UTxOs: the pre-init peer wallets (from
-                    // `preinitPeerUtxosL1`), the treasury + dispute script addresses (where head
-                    // funds and open disputes sit), the deploy-time burn address (where the
-                    // treasury + dispute reference scripts and the G2 setup ladder rungs live), and
-                    // the head multisig address (where the regime witness utxo lives, both before
-                    // and after fallback — the treasury moves to the rule-based address on fallback
-                    // but the regime witness stays), plus any `extraSnapshotAddresses` the test
-                    // supplies (e.g. the RBR evacuation payout address). That matches the mock
-                    // backend's whole-ledger view for the head's slice.
-                    val peerAddresses = preinitPeerUtxosL1.values
-                        .flatMap(_.values.map(_.address))
-                        .collect { case a: ShelleyAddress => a }
-                        .toSet
-                    val scriptAddresses = Set(
-                      HydrozoaBlueprint.mkTreasuryAddress(cardanoInfo.network),
-                      HydrozoaBlueprint.mkDisputeAddress(cardanoInfo.network),
-                      DeploymentTx.mkBurnAddress(cardanoInfo.network),
-                      headMultisigAddress,
-                    )
-                    mkYaci(
-                      network,
-                      url,
-                      peerAddresses ++ scriptAddresses ++ extraSnapshotAddresses,
-                      tracer
-                    )
+                    mkBlockfrost(network, url, snapshotAddresses, tracer)
+                case Mode.Public(network, url, apiKey) =>
+                    mkBlockfrost(network, url, snapshotAddresses, tracer, apiKey)
 
-        /** Real Yaci devnet backend over its Blockfrost-compatible API, shared by every peer (the
-          * devnet is the shared ledger). The `l1Snapshot` unions the UTxOs at each address the
-          * caller supplies (peer wallets + treasury/dispute script addresses + deploy burn address
-          * — see the `Mode.Yaci` branch of [[mk]] for the composition).
+        /** Addresses to scope a Blockfrost `l1Snapshot` to (Blockfrost has no "all UTxOs" query):
+          * the pre-init peer wallets (from `preinitPeerUtxosL1`), the treasury + dispute script
+          * addresses (where head funds and open disputes sit), the deploy-time burn address (where
+          * the treasury + dispute reference scripts and the G2 setup ladder rungs live), the head
+          * multisig address (where the regime witness utxo lives, before and after fallback — the
+          * treasury moves to the rule-based address on fallback but the regime witness stays), and
+          * any `extraSnapshotAddresses` the test supplies (e.g. the RBR evacuation payout address).
+          * That matches the mock backend's whole-ledger view for the head's slice.
           */
-        def mkYaci(
+        private def blockfrostSnapshotAddresses(
+            preinitPeerUtxosL1: Map[HeadPeerNumber, Utxos],
+            cardanoInfo: CardanoInfo,
+            headMultisigAddress: ShelleyAddress,
+            extraSnapshotAddresses: Set[ShelleyAddress],
+        ): Set[ShelleyAddress] =
+            val peerAddresses = preinitPeerUtxosL1.values
+                .flatMap(_.values.map(_.address))
+                .collect { case a: ShelleyAddress => a }
+                .toSet
+            val scriptAddresses = Set(
+              HydrozoaBlueprint.mkTreasuryAddress(cardanoInfo.network),
+              HydrozoaBlueprint.mkDisputeAddress(cardanoInfo.network),
+              DeploymentTx.mkBurnAddress(cardanoInfo.network),
+              headMultisigAddress,
+            )
+            peerAddresses ++ scriptAddresses ++ extraSnapshotAddresses
+
+        /** Real Blockfrost-backed L1 shared by every peer (the chain is the shared ledger). Serves
+          * both the Yaci devnet (empty `apiKey`) and a public testnet (Blockfrost project id). The
+          * `l1Snapshot` unions the UTxOs at each address the caller supplies (see
+          * [[blockfrostSnapshotAddresses]]).
+          */
+        def mkBlockfrost(
             network: CardanoNetwork.Custom,
             url: String,
             snapshotAddresses: Set[ShelleyAddress],
             tracer: ContraTracer[IO, CardanoBackendEvent],
+            apiKey: String = "",
         ): IO[(L1Backend[IO], IO[Utxos])] =
-            CardanoBackendBlockfrost(Right((network, url)), tracer = tracer).map { backend =>
-                val snapshot: IO[Utxos] =
-                    snapshotAddresses.toList
-                        .traverse(a => backend.utxosAt(a).flatMap(IO.fromEither))
-                        .map(_.foldLeft(Map.empty: Utxos)(_ ++ _))
-                (backend, snapshot)
+            CardanoBackendBlockfrost(Right((network, url)), apiKey = apiKey, tracer = tracer).map {
+                backend =>
+                    val snapshot: IO[Utxos] =
+                        snapshotAddresses.toList
+                            .traverse(a => backend.utxosAt(a).flatMap(IO.fromEither))
+                            .map(_.foldLeft(Map.empty: Utxos)(_ ++ _))
+                    (backend, snapshot)
             }
 
         /** Single mock L1 shared by every peer, seeded with the merged pre-init UTxOs plus the

--- a/integration/src/test/scala/hydrozoa/integration/preview/PublicSetup.scala
+++ b/integration/src/test/scala/hydrozoa/integration/preview/PublicSetup.scala
@@ -1,0 +1,339 @@
+package hydrozoa.integration.preview
+
+import cats.effect.{IO, IOApp}
+import cats.syntax.all.*
+import hydrozoa.app.DeployScriptsAndG2Setup
+import hydrozoa.config.head.network.CardanoNetwork
+import hydrozoa.integration.harness.MultiPeerHeadHarness
+import hydrozoa.integration.yaci.YaciSetup
+import hydrozoa.lib.cardano.scalus.VerificationKeyExtra.shelleyAddress
+import hydrozoa.lib.logging.{Slf4jMsgFormat, Slf4jTracer, info}
+import hydrozoa.multisig.backend.cardano.{CardanoBackend, CardanoBackendBlockfrost, CardanoBackendEventFormat}
+import hydrozoa.multisig.consensus.peer.PeerWallet
+import hydrozoa.multisig.ledger.l1.tx.RawTx
+import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters
+import scalus.cardano.address.ShelleyAddress
+import scalus.cardano.ledger.{Coin, EvaluatorMode, PlutusScriptEvaluator, Transaction, TransactionHash, TransactionOutput, Utxo, Utxos, Value}
+import scalus.cardano.node.BlockfrostProvider
+import scalus.cardano.txbuilder.TransactionBuilderStep.{Send, Spend}
+import scalus.cardano.txbuilder.{Change, TransactionBuilder}
+import scalus.crypto.ed25519.{SigningKey, VerificationKey}
+import scalus.uplc.builtin.ByteString
+import scala.concurrent.duration.*
+import test.{SeedPhrase, TestPeerName, TestPeers}
+
+/** Orchestrates a public testnet (Preview) into the inputs the multipeer harness config generator
+  * needs — the public-Blockfrost analog of [[hydrozoa.integration.yaci.YaciSetup]]. Where the Yaci
+  * setup funds peers from the devnet faucet (`devKit.topup`) and can `reset()` between iterations,
+  * a public chain has neither: peers are funded from ONE pre-funded master wallet via a single
+  * distribution tx, and each run inits a fresh head off the fresh UTxOs that tx produces.
+  *
+  * Feed the returned [[YaciSetup.Ready]] into [[MultiPeerHeadHarness.genDisputeMnc]]
+  * (`scriptReferenceUtxos = Some(...)`, genesis via `testPeerToUtxos`) and run the harness with
+  * [[MultiPeerHeadHarness.CardanoBackend.Mode.Public]].
+  */
+object PublicSetup {
+
+    /** 250 tADA per peer — comfortably above a head peer's genesis floor (`contingency ≈ 12 +
+      * equity share + ~20 ADA`, with equity capped low via the suite's `equityRange`) plus its
+      * self-scaling deposits and collateral. Kept small so the whole fleet (`nPeers * this +
+      * deployer extra + fees`) fits a modestly-funded master wallet (~2_500 tADA), not a fresh
+      * ~10_000 tADA faucet drop.
+      */
+    val defaultPeerFunding: Coin = Coin(250_000_000L)
+
+    /** Extra funding for head peer 0, which additionally deploys the treasury/dispute/G2 reference
+      * scripts (three chained deployment txs whose reference outputs each lock min-ADA-for-script;
+      * its post-deploy change becomes its genesis funding). Generous margin — the reference
+      * outputs' min-ADA plus fees run ~1_270+ tADA under live Preview params (bigger than the ~700
+      * the bundled params implied) and it varies with wallet-utxo fragmentation, so 1_000 left the
+      * dispute deploy tx ~19 tADA short.
+      */
+    val defaultDeployerExtraFunding: Coin = Coin(2_500_000_000L)
+
+    private val log = Slf4jTracer.sink.contramap(Slf4jMsgFormat.humanFormat("PublicSetup"))
+
+    /** Build the Preview `Custom` network (live params), fund every head + coil peer from the
+      * master wallet, deploy + resolve the reference scripts from head peer 0's wallet, and query
+      * each funded peer's genesis UTxOs. Coil peers are funded too because coil-side RBAs need
+      * ADA-only wallet UTxOs for collateral (see `yaciTestSauceGenesis`). The master wallet
+      * (`masterSigningKeyHex`, from the `keygen` CLI) must already hold enough tPreview-ADA (≈
+      * `nPeers * peerFunding + deployerExtraFunding + fees`).
+      */
+    def prepare(
+        apiKey: String,
+        masterSigningKeyHex: String,
+        nHeadPeers: Int,
+        nCoilPeers: Int,
+        url: String = BlockfrostProvider.previewUrl,
+        peerFunding: Coin = defaultPeerFunding,
+        deployerExtraFunding: Coin = defaultDeployerExtraFunding,
+    ): IO[YaciSetup.Ready] =
+        MultiPeerHeadHarness.CardanoBackend.previewNetwork(apiKey).flatMap { network =>
+            given CardanoNetwork.Section = network
+            val testPeers = TestPeers(SeedPhrase.Public, network, nHeadPeers, nCoilPeers)
+            val masterWallet = mkMasterWallet(masterSigningKeyHex)
+            val masterAddress = masterWallet.exportVerificationKey.shelleyAddress()
+            val backend: CardanoBackend[IO] = CardanoBackendBlockfrost.apply_(
+              Right((network, url)),
+              apiKey,
+              tracer = Slf4jTracer.sink.contramap(CardanoBackendEventFormat.humanFormat),
+            )
+            val headNames = List.tabulate(nHeadPeers)(TestPeerName.fromOrdinal)
+            val coilNames = List.tabulate(nCoilPeers)(i => TestPeerName.fromOrdinal(nHeadPeers + i))
+            val allNames = headNames ++ coilNames
+            def addrOf(n: TestPeerName): ShelleyAddress = testPeers.shelleyAddressFor(n)
+            val fundingPlan: List[(ShelleyAddress, Coin)] = allNames.zipWithIndex.map {
+                case (n, 0) => addrOf(n) -> Coin(peerFunding.value + deployerExtraFunding.value)
+                case (n, _) => addrOf(n) -> peerFunding
+            }
+            for {
+                _ <- log.info(
+                  s"Funding ${allNames.size} peer address(es) from master " +
+                      s"${masterAddress.toBech32.get}"
+                )
+                fundingTx <- mkFundingTx(network, backend, masterAddress, fundingPlan)
+                signed = masterWallet.signTx(fundingTx)
+                _ <- backend.submitTx(RawTx(signed)).flatMap(IO.fromEither)
+                _ <- log.info(s"Funding tx ${signed.id} submitted; awaiting on-chain confirmation")
+                _ <- allNames.traverse_(n => YaciSetup.awaitFunded(backend, addrOf(n)))
+                _ <- log.info("All peer funding confirmed; deploying reference scripts")
+                unresolved <- DeployScriptsAndG2Setup.deploy(
+                  backend,
+                  testPeers.walletFor(headNames.head),
+                )
+                resolved <- unresolved.resolve(backend).flatMap(IO.fromEither)
+                genesis <- awaitLiveGenesis(
+                  backend,
+                  allNames.map(n => n -> addrOf(n)),
+                  deployerName = headNames.head,
+                  fundingTxId = signed.id,
+                )
+            } yield YaciSetup.Ready(network, testPeers, backend, resolved, genesis)
+        }
+
+    /** Query each peer's genesis UTxOs, retrying until the snapshot is safe to build the init tx
+      * on. Two eventual-consistency hazards on the deployer (head peer 0), which spends its funding
+      * UTxO in the script-deploy ladder:
+      *   - Its captured genesis must not still be the pre-deploy funding output. Blockfrost's
+      *     address-utxo index (and even a direct `resolve`) can lag the deploy's spend, so a stale
+      *     funding UTxO looks live; the init tx built on it then fails `BadInputsUTxO` and the head
+      *     never initializes. We therefore require the deployer's genesis to no longer contain any
+      *     output of `fundingTxId` — i.e. the deploy has landed and its spend is indexed, so the
+      *     genesis is the deploy's change output.
+      *   - Every captured UTxO must still `resolve` live (a direct utxo lookup, catching a spend
+      *     the address index hasn't yet reflected).
+      * Non-deployer peers never spend their funding, so their funding output is their genesis.
+      */
+    private def awaitLiveGenesis(
+        backend: CardanoBackend[IO],
+        peers: List[(TestPeerName, ShelleyAddress)],
+        deployerName: TestPeerName,
+        fundingTxId: TransactionHash,
+        attemptsLeft: Int = 100, // 100 * (query + 3s) ≈ 5+ min
+    ): IO[Map[TestPeerName, Utxos]] =
+        for {
+            genesis <- peers
+                .traverse((n, a) => backend.utxosAt(a).flatMap(IO.fromEither).map(n -> _))
+                .map(_.toMap)
+            // The deploy consumes the deployer's funding output; until its spend is indexed the
+            // deployer's genesis is still that (about-to-be-spent) funding UTxO.
+            deployerDeployed = genesis
+                .get(deployerName)
+                .forall(_.keys.forall(_.transactionId != fundingTxId))
+            allLive <- genesis.values
+                .flatMap(_.keys)
+                .toList
+                .traverse(i =>
+                    backend.resolve(i).map { case Right(Some(_)) => true; case _ => false }
+                )
+                .map(_.forall(identity))
+            result <-
+                if deployerDeployed && allLive then
+                    log.info("All genesis UTxOs are live").as(genesis)
+                else if attemptsLeft > 0 then
+                    log.info(
+                      "Genesis UTxOs not yet consistent (deploy spends still propagating); " +
+                          s"retrying ($attemptsLeft attempts left)"
+                    ) *> IO.sleep(3.seconds) *> awaitLiveGenesis(
+                      backend,
+                      peers,
+                      deployerName,
+                      fundingTxId,
+                      attemptsLeft - 1,
+                    )
+                else
+                    log.info("Genesis UTxO liveness not confirmed after wait; proceeding")
+                        .as(genesis)
+        } yield result
+
+    /** Rebuild the master signing wallet from a raw Ed25519 signing-key hex (the "Signing key" the
+      * `keygen` CLI prints), deriving its verification key with the same bouncycastle primitive
+      * `Bootstrap.generateKeyPair` uses. The scalus-wallet reconstruction mirrors
+      * `DemoConfig.readWallet`; its address (`exportVerificationKey.shelleyAddress()`) is exactly
+      * what `keygen` reports as the "Testnet address".
+      */
+    private def mkMasterWallet(signingKeyHex: String): PeerWallet =
+        val skey = ByteString.fromHex(signingKeyHex)
+        val vkeyBytes = Ed25519PrivateKeyParameters(skey.bytes, 0).generatePublicKey().getEncoded
+        PeerWallet.scalusWallet(
+          VerificationKey.unsafeFromByteString(ByteString.fromArray(vkeyBytes)),
+          SigningKey.unsafeFromByteString(skey),
+        )
+
+    /** One payment tx spending all master UTxOs into a fixed output per peer, with change back to
+      * the master at output 0. Mirrors stage1's `mkMixSplitTx` builder chain, minus its random
+      * `CappedValueGen` split (the peer amounts here are fixed).
+      */
+    private def mkFundingTx(
+        network: CardanoNetwork,
+        backend: CardanoBackend[IO],
+        masterAddress: ShelleyAddress,
+        fundingPlan: List[(ShelleyAddress, Coin)],
+    ): IO[Transaction] =
+        for {
+            masterUtxos <- backend.utxosAt(masterAddress).flatMap(IO.fromEither)
+            _ <- IO.raiseWhen(masterUtxos.isEmpty)(
+              RuntimeException(
+                s"master wallet ${masterAddress.toBech32.get} has no UTxOs; fund it on Preview first"
+              )
+            )
+            tx <- IO.fromEither(
+              (for {
+                  unbalanced <- TransactionBuilder.build(
+                    network.cardanoInfo.network,
+                    masterUtxos.map { case (id, o) => Spend(Utxo(id, o)) }.toList
+                    // Output 0 is the master change placeholder (`changeOutputIdx = 0` below);
+                    // outputs 1.. are the fixed per-peer payments.
+                        ++ (Send(TransactionOutput.Babbage(masterAddress, Value.zero))
+                            :: fundingPlan.map { case (addr, coin) =>
+                                Send(TransactionOutput.Babbage(addr, Value(coin)))
+                            }),
+                  )
+                  balanced <- unbalanced.balanceContext(
+                    diffHandler = Change.changeOutputDiffHandler(
+                      _,
+                      _,
+                      protocolParams = network.cardanoProtocolParams,
+                      changeOutputIdx = 0,
+                    ),
+                    protocolParams = network.cardanoProtocolParams,
+                    evaluator = PlutusScriptEvaluator(
+                      network.cardanoInfo,
+                      EvaluatorMode.EvaluateAndComputeCost,
+                    ),
+                  )
+              } yield balanced.transaction).left.map(err => RuntimeException(err.toString))
+            )
+        } yield tx
+
+    /** Sweep every peer's remaining wallet UTxOs back to the master wallet — the inverse of the
+      * funding step, for reclaiming a run's leftover tADA (e.g. a run whose init tx never confirmed
+      * leaves the peer genesis UTxOs unspent) without going back to the faucet. One single-output
+      * sweep tx per peer, signed by that peer's own wallet. Use the same `nHeadPeers`/`nCoilPeers`
+      * the run funded, so the derived peer addresses match.
+      */
+    def reclaim(
+        apiKey: String,
+        masterSigningKeyHex: String,
+        nHeadPeers: Int,
+        nCoilPeers: Int,
+        url: String = BlockfrostProvider.previewUrl,
+    ): IO[Unit] =
+        MultiPeerHeadHarness.CardanoBackend.previewNetwork(apiKey).flatMap { network =>
+            given CardanoNetwork.Section = network
+            val testPeers = TestPeers(SeedPhrase.Public, network, nHeadPeers, nCoilPeers)
+            val masterAddress =
+                mkMasterWallet(masterSigningKeyHex).exportVerificationKey.shelleyAddress()
+            val backend: CardanoBackend[IO] = CardanoBackendBlockfrost.apply_(
+              Right((network, url)),
+              apiKey,
+              tracer = Slf4jTracer.sink.contramap(CardanoBackendEventFormat.humanFormat),
+            )
+            val headNames = List.tabulate(nHeadPeers)(TestPeerName.fromOrdinal)
+            val coilNames = List.tabulate(nCoilPeers)(i => TestPeerName.fromOrdinal(nHeadPeers + i))
+            val pairs: List[(TestPeerName, PeerWallet)] =
+                headNames
+                    .map(n => n -> testPeers.walletFor(n)) ++ coilNames.zip(testPeers.coilWallets)
+
+            def sweepOne(name: TestPeerName, wallet: PeerWallet): IO[Unit] =
+                val addr = testPeers.shelleyAddressFor(name)
+                backend.utxosAt(addr).flatMap(IO.fromEither).flatMap { utxos =>
+                    if utxos.isEmpty then log.info(s"$name has no UTxOs to reclaim")
+                    else
+                        for {
+                            tx <- IO.fromEither(mkSweepTx(network, utxos, masterAddress))
+                            signed = wallet.signTx(tx)
+                            _ <- backend.submitTx(RawTx(signed)).flatMap(IO.fromEither)
+                            _ <- log.info(s"reclaim from $name: tx ${signed.id}")
+                        } yield ()
+                }
+
+            for {
+                _ <- log.info(
+                  s"Reclaiming ${pairs.size} peer wallet(s) to master ${masterAddress.toBech32.get}"
+                )
+                _ <- pairs.traverse_((n, w) => sweepOne(n, w))
+                _ <- log.info("All reclaim txs submitted; awaiting on-chain confirmation")
+                _ <- pairs.traverse_((n, _) => awaitEmpty(backend, testPeers.shelleyAddressFor(n)))
+                master <- backend.utxosAt(masterAddress).flatMap(IO.fromEither)
+                _ <- log.info(s"Reclaim complete; master now holds ${master.size} UTxO(s)")
+            } yield ()
+        }
+
+    /** One sweep tx: spend every input UTxO into a single output at `dest`, all value minus fee
+      * flowing there via the change handler at output 0.
+      */
+    private def mkSweepTx(
+        network: CardanoNetwork,
+        inputUtxos: Utxos,
+        dest: ShelleyAddress,
+    ): Either[RuntimeException, Transaction] =
+        (for {
+            unbalanced <- TransactionBuilder.build(
+              network.cardanoInfo.network,
+              inputUtxos.map { case (id, o) => Spend(Utxo(id, o)) }.toList
+                  :+ Send(TransactionOutput.Babbage(dest, Value.zero)),
+            )
+            balanced <- unbalanced.balanceContext(
+              diffHandler = Change.changeOutputDiffHandler(
+                _,
+                _,
+                protocolParams = network.cardanoProtocolParams,
+                changeOutputIdx = 0,
+              ),
+              protocolParams = network.cardanoProtocolParams,
+              evaluator =
+                  PlutusScriptEvaluator(network.cardanoInfo, EvaluatorMode.EvaluateAndComputeCost),
+            )
+        } yield balanced.transaction).left.map(err => RuntimeException(err.toString))
+
+    /** Poll until `address` holds no UTxOs (its sweep tx confirmed). Best-effort: logs and returns
+      * on expiry rather than failing the reclaim.
+      */
+    private def awaitEmpty(
+        backend: CardanoBackend[IO],
+        address: ShelleyAddress,
+        attemptsLeft: Int = 100, // 100 * 3s = 5min
+    ): IO[Unit] =
+        backend.utxosAt(address).flatMap {
+            case Right(u) if u.isEmpty => log.info(s"reclaim confirmed for $address")
+            case _ if attemptsLeft > 0 =>
+                IO.sleep(3.seconds) *> awaitEmpty(backend, address, attemptsLeft - 1)
+            case _ => log.info(s"reclaim for $address not confirmed after wait (continuing)")
+        }
+}
+
+/** One-off entry point to reclaim the RBR MBT Preview peers' leftover tADA back to the master
+  * wallet (see [[PublicSetup.reclaim]]). Reads `BLOCKFROST_API_KEY` +
+  * `RBR_MBT_PREVIEW_MASTER_SIGNING_KEY` from the environment. Run with
+  * `integration/Test/runMain hydrozoa.integration.preview.ReclaimPeerFunds`.
+  */
+object ReclaimPeerFunds extends IOApp.Simple:
+    def run: IO[Unit] =
+        PublicSetup.reclaim(
+          apiKey = sys.env.getOrElse("BLOCKFROST_API_KEY", ""),
+          masterSigningKeyHex = sys.env.getOrElse("RBR_MBT_PREVIEW_MASTER_SIGNING_KEY", ""),
+          nHeadPeers = 3,
+          nCoilPeers = 3,
+        )

--- a/integration/src/test/scala/hydrozoa/integration/rbr/mbt/Runner.scala
+++ b/integration/src/test/scala/hydrozoa/integration/rbr/mbt/Runner.scala
@@ -1,6 +1,7 @@
 package hydrozoa.integration.rbr.mbt
 
 import org.scalacheck.{Test, YetAnotherProperties}
+import scala.concurrent.duration.*
 
 /** Registers the RBR fallback→evacuation MBT. One slow real-clock WS run per property, so cap at a
   * single successful evaluation (like the other multi-peer dispute suites).
@@ -30,4 +31,47 @@ object RbrMbtPropertiesYaci extends YetAnotherProperties("RBR MBT (Yaci)"):
           nCoilPeers = 3,
           maxVersionMinor = 2,
           backendSpec = RbrMbtSuite.BackendSpec.Yaci(),
+        ).property()
+
+/** Public-testnet variant of [[RbrMbtProperties]]. Same shape, same single-iteration cap, but runs
+  * the SUT against the real **Preview** testnet over Blockfrost: the 6 peers are funded from a
+  * pre-funded master wallet and the reference scripts are deployed on-chain per run (see
+  * [[hydrozoa.integration.preview.PublicSetup]]). Requires a valid Blockfrost key + a funded master
+  * wallet; excluded from the default test run (see build.sbt). Run explicitly with
+  * `integration/testOnly hydrozoa.integration.rbr.mbt.RbrMbtPropertiesPublic` (or
+  * `just integration-rbr-preview`), after exporting `RBR_MBT_PREVIEW_MASTER_SIGNING_KEY`.
+  */
+object RbrMbtPropertiesPublic extends YetAnotherProperties("RBR MBT (Preview)"):
+
+    override def overrideParameters(p: Test.Parameters): Test.Parameters =
+        p.withWorkers(1).withMinSuccessfulTests(1)
+
+    /** Preview Blockfrost project id. Sourced from `$BLOCKFROST_API_KEY` (the project convention —
+      * see `DeployScriptsAndG2Setup` / `Bootstrap`), falling back to the id
+      * [[hydrozoa.integration.stage1]]'s public run hardcodes. NB: that fallback is currently a
+      * dead token (403), so a live run needs `BLOCKFROST_API_KEY` exported (e.g. in
+      * `.envrc.local`).
+      */
+    private val previewBlockfrostKey =
+        sys.env.getOrElse("BLOCKFROST_API_KEY", "previewQQFamFAznFQgz0uRG9OntxgqJczreq9z")
+
+    /** Ed25519 signing key (hex) of the pre-funded Preview master wallet the 6 peers are funded
+      * from — a real wallet secret, so it's read from the environment rather than committed.
+      * Generate one with the `keygen` CLI (`hydrozoa keygen` prints the signing key + its Testnet
+      * address), fund that address from the Preview faucet with enough tPreview-ADA (≈ 6 × peer
+      * funding + the script-deploy ladder + fees), and export the signing key as
+      * `RBR_MBT_PREVIEW_MASTER_SIGNING_KEY`.
+      */
+    private val masterSigningKeyHex = sys.env.getOrElse("RBR_MBT_PREVIEW_MASTER_SIGNING_KEY", "")
+
+    val _ = property("ws: autonomous evacuation matches the RBRHlNet terminal (Preview)") =
+        RbrMbtSuite(
+          nHeadPeers = 3,
+          nCoilPeers = 3,
+          maxVersionMinor = 2,
+          backendSpec = RbrMbtSuite.BackendSpec.Public(previewBlockfrostKey, masterSigningKeyHex),
+          // Real ~20s block cadence: give fallback + dispute + evacuation a much wider budget than
+          // the fast Mock/Yaci backends, and wait several blocks for deposits to commit.
+          scenarioTimeout = 30.minutes,
+          depositCommitWindow = 5.minutes,
         ).property()

--- a/integration/src/test/scala/hydrozoa/integration/rbr/mbt/Suite.scala
+++ b/integration/src/test/scala/hydrozoa/integration/rbr/mbt/Suite.scala
@@ -247,7 +247,7 @@ case class RbrMbtSuite(
             settlementFirewallArmed <- Resource.eval(Ref[IO].of(false))
             peersEvacuationDone <- Resource.eval(Ref[IO].of(Set.empty[PeerId]))
             submittedSettlementInputs <- Resource.eval(Ref[IO].of(Set.empty[TransactionInput]))
-            committedMaps <- Resource.eval(Ref[IO].of(List.empty[(BlockVersion.Full, Int)]))
+            committedMaps <- Resource.eval(Ref[IO].of(Set.empty[(BlockVersion.Full, Int)]))
             settledMajors <- Resource.eval(Ref[IO].of(Set.empty[Int]))
             withdrawnOutputRefs <- Resource.eval(Ref[IO].of(Set.empty[TransactionInput]))
             submittedTxIds <- Resource.eval(Ref[IO].of(Set.empty[TransactionHash]))
@@ -433,7 +433,8 @@ case class RbrMbtSuite(
                   s"(M=${settledMajors.maxOption} initialMapSize=$initialMapSize " +
                   s"${depositUtxos.size} deposit(s), " +
                   s"payoutResidueDropped=${utxos.size - scopedUtxos.size} " +
-                  s"committedMaps=${committedMaps.sortBy((v, _) => (v.major: Int, v.minor: Int))})\n" +
+                  s"committedMaps=${committedMaps.toList
+                          .sortBy((v, _) => (v.major: Int, v.minor: Int))})\n" +
                   s"  alpha (model): $alpha\n  beta  (L1):    $betaEither"
             )
         yield
@@ -477,7 +478,7 @@ case class RbrMbtSuite(
       * map for `M` was ever traced.
       */
     private def observedCommittedSize(
-        committedMaps: List[(BlockVersion.Full, Int)],
+        committedMaps: Set[(BlockVersion.Full, Int)],
         settledMajors: Set[Int],
     ): Option[Int] =
         val m = settledMajors.maxOption.getOrElse(0)
@@ -515,7 +516,7 @@ case class RbrMbtSuite(
         evacuationDone: Deferred[IO, Unit],
         peersEvacuationDone: Ref[IO, Set[PeerId]],
         firstPayoutsLeft: Ref[IO, Option[Int]],
-        committedMaps: Ref[IO, List[(BlockVersion.Full, Int)]],
+        committedMaps: Ref[IO, Set[(BlockVersion.Full, Int)]],
     ): ContraTracer[IO, MultiPeerHeadHarness.Event] =
         val onEvent: PeerId => Any => IO[Unit] = peer => {
             case CommonChildEvent.CardanoLiaison(
@@ -526,7 +527,7 @@ case class RbrMbtSuite(
             case CommonChildEvent.StackComposer(
                   StackComposerEvent.CommittedMap(version, size)
                 ) =>
-                committedMaps.update((version -> size) :: _)
+                committedMaps.update(_ + (version -> size))
 
             case RuleBasedOnlyChildEvent.RuleBasedActor(
                   RuleBasedActorEvent.Evacuation.PayoutsLeft(n)

--- a/integration/src/test/scala/hydrozoa/integration/rbr/mbt/Suite.scala
+++ b/integration/src/test/scala/hydrozoa/integration/rbr/mbt/Suite.scala
@@ -10,6 +10,7 @@ import hydrozoa.integration.harness.MultiPeerHeadHarness.Transport.Mode as Trans
 import hydrozoa.integration.harness.{DiagnosticTracers, MultiPeerHeadHarness}
 import hydrozoa.integration.rbr.model.petri.hlpn.RBRHlNet
 import hydrozoa.integration.rbr.property.{ObservableMarking, RbrSeed}
+import hydrozoa.integration.preview.PublicSetup
 import hydrozoa.integration.stage4.Model
 import hydrozoa.integration.yaci.{DevKit, YaciDevnet, YaciSetup}
 import hydrozoa.lib.logging.{ContraTracer, Slf4jMsg, Slf4jMsgFormat, Slf4jTracer, info}
@@ -28,7 +29,8 @@ import org.scalacheck.{Gen, Prop, PropertyM}
 import scala.concurrent.duration.*
 import scalus.cardano.address.ShelleyAddress
 import scalus.cardano.ledger.DatumOption.Inline
-import scalus.cardano.ledger.{TransactionInput, TransactionOutput, Utxos}
+import scalus.cardano.ledger.{Coin, TransactionHash, TransactionInput, TransactionOutput, Utxos}
+import scalus.cardano.node.BlockfrostProvider
 import scalus.testing.yaci.YaciConfig
 import test.{SeedPhrase, TestPeerName, TestPeers}
 
@@ -52,21 +54,25 @@ case class RbrMbtSuite(
       * + redeploys per iteration, and runs the harness against real Blockfrost.
       */
     backendSpec: RbrMbtSuite.BackendSpec = RbrMbtSuite.BackendSpec.Mock,
+    /** Overall per-scenario wall-clock budget: fallback + dispute + evacuation must complete within
+      * it. 7min suits the fast Mock/Yaci backends; the public Preview backend needs far longer
+      * (~20-30min) for real ~20s block cadence — raise it at the call site.
+      */
+    scenarioTimeout: FiniteDuration = 7.minutes,
+    /** How long `beforeFinalize` waits, best-effort, for the generated deposits to commit before
+      * arming the firewall. Long enough to clear deposit maturity + one settlement so the common
+      * path exercises deposit evacuation; on expiry we arm anyway and the stragglers take the
+      * refund path (the committed-set computation keeps the model in agreement either way). Enlarge
+      * for a slow public testnet, where a deposit needs multiple blocks to commit.
+      */
+    depositCommitWindow: FiniteDuration = 90.seconds,
 ) extends ModelBasedSuite:
 
     override type Env = RbrMbtSuite.RbrMbtEnv
     override type State = Model.ModelState
     override type Sut = hydrozoa.integration.rbr.mbt.Sut
 
-    private val scenarioTimeout: FiniteDuration = 7.minutes
     private val quiescenceDelay: FiniteDuration = 2.seconds
-
-    /** How long `beforeFinalize` waits, best-effort, for the generated deposits to commit before
-      * arming the firewall. Long enough to clear deposit maturity + one settlement so the common
-      * path exercises deposit evacuation; on expiry we arm anyway and the stragglers take the
-      * refund path (the committed-set computation keeps the model in agreement either way).
-      */
-    private val depositCommitWindow: FiniteDuration = 90.seconds
 
     private val log: ContraTracer[IO, Slf4jMsg] =
         Slf4jTracer.sink.contramap(Slf4jMsgFormat.humanFormat("RbrMbt.Suite"))
@@ -84,6 +90,10 @@ case class RbrMbtSuite(
         case RbrMbtSuite.BackendSpec.Yaci(cfg) =>
             // Singleton container: first call warms it, every subsequent iteration reuses.
             PropertyM.run(YaciDevnet.acquireShared(cfg).map(RbrMbtSuite.RbrMbtEnv.Yaci.apply))
+        case RbrMbtSuite.BackendSpec.Public(key, signingKey) =>
+            // Nothing to acquire ahead of time — `PublicSetup.prepare` does the funding + deploy in
+            // `genInitialState`. Just carry the credentials through.
+            PropertyM.run(IO.pure(RbrMbtSuite.RbrMbtEnv.Public(key, signingKey)))
     }
 
     override def canStartupNewSut(): Boolean = true
@@ -137,6 +147,48 @@ case class RbrMbtSuite(
                   testPeerToUtxos = ready.genesisByPeer,
                   cardanoBackendMode = HarnessCardanoBackend.Mode
                       .Yaci(ready.network, devKit.blockfrostApiBaseUri),
+                )
+
+            case RbrMbtSuite.RbrMbtEnv.Public(key, signingKey) =>
+                for {
+                    _ <- PropertyM.run(
+                      log.info("Preparing the Preview testnet (master funding + script deploy)")
+                    )
+                    ready <- PropertyM.run(
+                      PublicSetup.prepare(key, signingKey, nHeadPeers, nCoilPeers)
+                    )
+                    takeoffAndMnc <- MultiPeerHeadHarness.genDisputeMnc(
+                      transportMode = TransportMode.WebSocket,
+                      testPeers = ready.testPeers,
+                      testPeerToUtxos = ready.genesisByPeer,
+                      // Longer takeoff so every peer's actor stack is up and synced before the head
+                      // takes off on the real ~20s-block chain.
+                      takeoffOffset = 60.seconds,
+                      // Public-testnet timing + a ~20s CardanoLiaison poll (near one block) so
+                      // per-tick probes don't storm Blockfrost.
+                      fastTxTiming = MultiPeerHeadHarness.previewTxTiming,
+                      // Minutes-long voting deadline so peers actually cast + confirm votes before
+                      // the tally gates (the 5s default is always already elapsed on the live chain,
+                      // resolving to the base map with no votes).
+                      disputeResolutionConfig = MultiPeerHeadHarness.previewDisputeResolutionConfig,
+                      scriptReferenceUtxos = Some(ready.scriptReferenceUtxos),
+                      liveBackendPollingPeriod =
+                          MultiPeerHeadHarness.previewLiveBackendPollingPeriod,
+                      coilPeers = ready.testPeers.coilPeersConfig(hub = HeadPeerNumber(0)),
+                      coilQuorum = nCoilPeers,
+                      // Cap total L2 equity low so each head peer's genesis floor
+                      // (contingency + equity share + ~20 ADA) stays small — the peers are funded
+                      // modestly from one master wallet, not a faucet-per-peer.
+                      equityRange = Coin(5_000_000) -> Coin(15_000_000),
+                    )
+                    (takeoffTime, mnc) = takeoffAndMnc
+                } yield mkModelState(
+                  config = mnc,
+                  takeoffTime = takeoffTime,
+                  testPeers = ready.testPeers,
+                  testPeerToUtxos = ready.genesisByPeer,
+                  cardanoBackendMode = HarnessCardanoBackend.Mode
+                      .Public(ready.network, BlockfrostProvider.previewUrl, key),
                 )
         }
 
@@ -198,6 +250,7 @@ case class RbrMbtSuite(
             committedMaps <- Resource.eval(Ref[IO].of(List.empty[(BlockVersion.Full, Int)]))
             settledMajors <- Resource.eval(Ref[IO].of(Set.empty[Int]))
             withdrawnOutputRefs <- Resource.eval(Ref[IO].of(Set.empty[TransactionInput]))
+            submittedTxIds <- Resource.eval(Ref[IO].of(Set.empty[TransactionHash]))
             harness <- MultiPeerHeadHarness.disputeHarnessResource(
               label = s"$label-ws",
               transportMode = TransportMode.WebSocket,
@@ -231,6 +284,7 @@ case class RbrMbtSuite(
                           submittedSettlementInputs,
                           settledMajors,
                           withdrawnOutputRefs,
+                          submittedTxIds,
                         ),
                   ),
               cardanoBackendMode = state.params.cardanoBackendMode,
@@ -250,6 +304,7 @@ case class RbrMbtSuite(
           committedMaps,
           settledMajors,
           withdrawnOutputRefs,
+          submittedTxIds,
         )
 
     /** Firewall observer over every outbound tx that clears the firewall (a `SubmittedTx`):
@@ -263,11 +318,18 @@ case class RbrMbtSuite(
       *     room, so this is not settlement-specific; keying on the accepted (`Right`) result and
       *     deduping by input means a dropped fallback settlement's withdrawals (which never land,
       *     staying in the committed map to evacuate) and any resubmission are both excluded.
+      *   - For every submitted tx (accepted or rejected): record its id (`submittedTxIds`).
+      *     `beforeFinalize` uses this set to scope `beta`'s payout buckets to outputs this run
+      *     produced, filtering the cross-run residue that accrues at the shared `payoutAddress` on
+      *     a non-resettable testnet. Ungated by result: a settlement byte-identical to an earlier
+      *     run's may report `already included` (a `Left`) yet its outputs are still legitimately
+      *     this run's, so scoping keys on submission, not acceptance.
       */
     private def firewallLedgerObserver(
         submittedSettlementInputs: Ref[IO, Set[TransactionInput]],
         settledMajors: Ref[IO, Set[Int]],
         withdrawnOutputRefs: Ref[IO, Set[TransactionInput]],
+        submittedTxIds: Ref[IO, Set[TransactionHash]],
     ): ContraTracer[IO, FirewalledCardanoBackendEvent] =
         val withdrawalMarker = RbrDatumSentinels.marker("withdrawal")
         def hasWithdrawalDatum(out: TransactionOutput): Boolean =
@@ -287,9 +349,18 @@ case class RbrMbtSuite(
                         }.toSet
                         IO.whenA(withdrawals.nonEmpty)(withdrawnOutputRefs.update(_ ++ withdrawals))
                     case Left(_) => IO.unit
-                settlementUpdate *> withdrawalUpdate
+                submittedTxIds.update(_ + etx.tx.id) *> settlementUpdate *> withdrawalUpdate
             case _ => IO.unit
         }
+
+    /** True if `out` carries the `"withdrawal"` or `"evacuation"` datum sentinel — the two payout
+      * buckets `beta` keys on a marker at the shared `RbrSeed.payoutAddress`, hence the two exposed
+      * to cross-run residue on a non-resettable testnet (see [[Sut.submittedTxIds]]).
+      */
+    private def isPayoutMarked(out: TransactionOutput): Boolean =
+        val markers =
+            Set(RbrDatumSentinels.marker("withdrawal"), RbrDatumSentinels.marker("evacuation"))
+        out.datumOption.exists { case Inline(d) => markers(d); case _ => false }
 
     // TODO (BLOCKED on fund14): assert the refund path, mirroring the WithdrawalOutput accounting.
     // A rejected/expired deposit (not absorbed into a committed major — absorb-XOR-refund is settled
@@ -339,18 +410,29 @@ case class RbrMbtSuite(
             committedMaps <- sut.committedMaps.get
             settledMajors <- sut.settledMajors.get
             withdrawnOutputRefs <- sut.withdrawnOutputRefs.get
+            submittedTxIds <- sut.submittedTxIds.get
             obligationCount =
                 observedCommittedSize(committedMaps, settledMajors).getOrElse(initialMapSize)
             // `W`: the withdrawals that landed on L1 pre-fallback, read from the firewall traces —
             // matched against the L1 snapshot's `"withdrawal"`-bucketed outputs by `beta`.
             withdrawalCount = withdrawnOutputRefs.size
             alpha = alphaTerminal(obligationCount, withdrawalCount)
-            betaEither = ObservableMarking.beta(utxos)(using sut.harness.multiNodeConfig)
+            // Scope `beta`'s two payout buckets to this run. `WithdrawalOutput`/`EvacuationOutput`
+            // are the only observable places keyed on a datum marker at the fixed, shared
+            // `RbrSeed.payoutAddress`; on a non-resettable public testnet that address accrues
+            // script-locked residue from earlier runs, which would inflate `beta`. Drop any
+            // payout-marked UTxO whose producing tx this run didn't submit (every other place is
+            // already run-scoped, so the rest of the snapshot passes through untouched).
+            scopedUtxos = utxos.filterNot { (in, out) =>
+                isPayoutMarked(out) && !submittedTxIds.contains(in.transactionId)
+            }
+            betaEither = ObservableMarking.beta(scopedUtxos)(using sut.harness.multiNodeConfig)
             _ <- log.info(
               s"beforeFinalize: firstPayoutsLeft=$payouts obligationCount=$obligationCount " +
                   s"withdrawalCount=$withdrawalCount " +
                   s"(M=${settledMajors.maxOption} initialMapSize=$initialMapSize " +
                   s"${depositUtxos.size} deposit(s), " +
+                  s"payoutResidueDropped=${utxos.size - scopedUtxos.size} " +
                   s"committedMaps=${committedMaps.sortBy((v, _) => (v.major: Int, v.minor: Int))})\n" +
                   s"  alpha (model): $alpha\n  beta  (L1):    $betaEither"
             )
@@ -480,6 +562,13 @@ object RbrMbtSuite:
         case Mock
         case Yaci(config: YaciConfig = YaciConfig())
 
+        /** Run against the public Preview testnet over real Blockfrost. `blockfrostKey` is the
+          * Blockfrost project id; `masterSigningKeyHex` is the Ed25519 signing key (from the
+          * `keygen` CLI) of a pre-funded Preview wallet the peers are funded from (see
+          * [[PublicSetup]]). No reset/faucet, so run a single iteration.
+          */
+        case Public(blockfrostKey: String, masterSigningKeyHex: String)
+
     /** Per-iteration environment threaded from [[RbrMbtSuite.initEnv]] to
       * [[RbrMbtSuite.genInitialState]]. `Mock` carries no state (the suite reconstructs `TestPeers`
       * from the fixed Preprod network). `Yaci` carries the shared devnet handle so the iteration
@@ -488,3 +577,4 @@ object RbrMbtSuite:
     enum RbrMbtEnv:
         case Mock
         case Yaci(devKit: DevKit)
+        case Public(blockfrostKey: String, masterSigningKeyHex: String)

--- a/integration/src/test/scala/hydrozoa/integration/rbr/mbt/Sut.scala
+++ b/integration/src/test/scala/hydrozoa/integration/rbr/mbt/Sut.scala
@@ -8,7 +8,7 @@ import hydrozoa.multisig.ledger.block.BlockVersion
 import hydrozoa.multisig.ledger.event.RequestId.ValidityFlag
 import hydrozoa.multisig.ledger.l1.tx.RawTx
 import org.scalacheck.commands.SutCommand
-import scalus.cardano.ledger.TransactionInput
+import scalus.cardano.ledger.{TransactionHash, TransactionInput}
 
 /** The running system-under-test: the multi-peer head harness, the milestone `Deferred`s the
   * observer completes, and `settlementFirewallArmed` — the dynamic gate the firewall consults. It
@@ -35,6 +35,14 @@ import scalus.cardano.ledger.TransactionInput
   * `beforeFinalize` seeds into the model's inert `WithdrawalOutput` place; the L1 snapshot's
   * `"withdrawal"`-bucketed outputs must match it. Deduped by input so a resubmitted tx can't
   * inflate the count.
+  *
+  * `submittedTxIds` accumulates the id of every tx the SUT put on the wire (observed at the
+  * firewall, regardless of accept/reject). `beforeFinalize` uses it to scope `beta`'s payout
+  * buckets (`WithdrawalOutput`/`EvacuationOutput`) to outputs this run actually produced: those are
+  * the only two places keyed on a datum marker at the fixed, shared `RbrSeed.payoutAddress`, which
+  * on a non-resettable public testnet accrues script-locked residue from earlier runs. Every other
+  * observable place is already run-scoped (script refs by input, token boxes by this head's
+  * `policyId`), so only these two need scoping.
   */
 final case class Sut(
     harness: MultiPeerHeadHarness.Harness[Option[RequestSequencer.Handle]],
@@ -46,6 +54,7 @@ final case class Sut(
     committedMaps: Ref[IO, List[(BlockVersion.Full, Int)]],
     settledMajors: Ref[IO, Set[Int]],
     withdrawnOutputRefs: Ref[IO, Set[TransactionInput]],
+    submittedTxIds: Ref[IO, Set[TransactionHash]],
 )
 
 /** SUT-side command execution. */

--- a/integration/src/test/scala/hydrozoa/integration/rbr/mbt/Sut.scala
+++ b/integration/src/test/scala/hydrozoa/integration/rbr/mbt/Sut.scala
@@ -22,12 +22,12 @@ import scalus.cardano.ledger.{TransactionHash, TransactionInput}
   * cardano-liaison refund path — so the model can agree with the SUT on each deposit's fate without
   * racing "peer submitted the tx" against "the tx appears on chain".
   *
-  * `committedMaps` accumulates every `StackComposer.CommittedMap` peer trace — the
-  * `(version, size)` of each committed evacuation map. `settledMajors` accumulates the majors of
-  * every settlement that cleared the firewall (i.e. settled on-chain). Together they let
-  * `beforeFinalize` read the committed map size the head resolves to under the last on-chain major
-  * `M` directly from the peer traces, instead of reconstructing it from the model's deposit
-  * accounting.
+  * `committedMaps` accumulates the distinct `StackComposer.CommittedMap` peer traces — the
+  * `(version, size)` of each committed evacuation map, deduped across peers (a `Set`, since every
+  * peer emits the same trace). `settledMajors` accumulates the majors of every settlement that
+  * cleared the firewall (i.e. settled on-chain). Together they let `beforeFinalize` read the
+  * committed map size the head resolves to under the last on-chain major `M` directly from the peer
+  * traces, instead of reconstructing it from the model's deposit accounting.
   *
   * `withdrawnOutputRefs` accumulates the L1 position (`TransactionInput`) of every withdrawal
   * output — an L2 output that exited to L1 pre-fallback, carrying the `"withdrawal"` datum sentinel
@@ -51,7 +51,7 @@ final case class Sut(
     firstPayoutsLeft: Ref[IO, Option[Int]],
     settlementFirewallArmed: Ref[IO, Boolean],
     submittedSettlementInputs: Ref[IO, Set[TransactionInput]],
-    committedMaps: Ref[IO, List[(BlockVersion.Full, Int)]],
+    committedMaps: Ref[IO, Set[(BlockVersion.Full, Int)]],
     settledMajors: Ref[IO, Set[Int]],
     withdrawnOutputRefs: Ref[IO, Set[TransactionInput]],
     submittedTxIds: Ref[IO, Set[TransactionHash]],

--- a/justfile
+++ b/justfile
@@ -123,6 +123,15 @@ graphviz:
   } > target/rbr-net/index.html
   echo "wrote target/rbr-net/index.html"
   "${BROWSER:-xdg-open}" target/rbr-net/index.html
+# RBR MBT against the public Preview testnet (real Blockfrost). Requires a valid Blockfrost key
+# (hardcoded in the Runner) and a funded master wallet: generate one with `hydrozoa keygen`, fund its
+# printed address from the Preview faucet, then export RBR_MBT_PREVIEW_MASTER_SIGNING_KEY first.
+# Bypasses the build.sbt Tests.Exclude that keeps it out of `just integration`.
+integration-rbr-preview:
+  #!/usr/bin/env bash
+  set -eo pipefail
+  trap 'just notify "integration-rbr-preview"' EXIT
+  sbt "; set integration/Test/testOptions := Seq() ; integration/testOnly hydrozoa.integration.rbr.mbt.RbrMbtPropertiesPublic"
 
 precommit: lint-check fmt-check nixfmt-check
   just notify "precommit"

--- a/src/main/scala/hydrozoa/multisig/backend/cardano/CardanoBackendBlockfrost.scala
+++ b/src/main/scala/hydrozoa/multisig/backend/cardano/CardanoBackendBlockfrost.scala
@@ -15,6 +15,9 @@ import hydrozoa.multisig.backend.cardano.CardanoBackend.Error.*
 import hydrozoa.multisig.backend.cardano.CardanoBackend.{ContinuingTx, Error}
 import hydrozoa.multisig.ledger.l1.tx.EnrichedTx
 import io.bullet.borer.Cbor
+import io.circe.parser.parse
+import java.net.URI
+import java.net.http.{HttpClient, HttpRequest, HttpResponse}
 import scala.collection.mutable
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -43,8 +46,15 @@ class CardanoBackendBlockfrost private (
     private val backendService: BackendService,
     private val pageSize: Int,
     private val blockfrostProviderFuture: Future[BlockfrostProvider],
-    protected val tracer: ContraTracer[IO, CardanoBackendEvent]
+    protected val tracer: ContraTracer[IO, CardanoBackendEvent],
+    // Base URL + project id for the raw tx-utxos read in [[continuingTx]] — BloxBean's
+    // `TxContentUtxoInputs` model drops the per-input tx_hash/output_index/collateral/reference we
+    // need there, so that one call goes straight to the JSON.
+    private val baseUrl: String,
+    private val apiKey: String
 ) extends CardanoBackend[IO] {
+
+    private val httpClient: HttpClient = HttpClient.newHttpClient()
 
     override def resolve(input: Input): IO[Either[Error, Option[ledger.Utxo]]] =
         (for {
@@ -409,11 +419,21 @@ class CardanoBackendBlockfrost private (
     ): IO[Either[CardanoBackend.Error, Option[ContinuingTx]]] = {
         (for {
             utxos <- EitherT(txUtxos(txHash))
+            // A redeemer's `tx_index` points into the tx's CANONICALLY-SORTED regular spend inputs
+            // (excluding reference + collateral), not Blockfrost's returned input order — so index
+            // the continuing (asset-bearing) input the same way, or `txRedeemer` looks it up at the
+            // wrong slot and returns `SpendingRedeemerNotFound`, silently dropping the tx. BloxBean's
+            // input model exposes neither the outref nor the reference/collateral flags, so we read
+            // them from the raw tx-utxos JSON. (Alternative: decode the tx CBOR — its inputs are
+            // already canonical and its redeemers carry input pointers — and pick the spend redeemer
+            // whose data parses as a treasury redeemer, dropping index-matching entirely.)
+            rawInputs <- EitherT(rawTxUtxoInputs(txHash))
             inputIx <- EitherT.fromOption[IO](
-              opt = utxos.getInputs.asScala.zipWithIndex
-                  .find { (input, _) =>
-                      input.getAmount.asScala.exists(_.getUnit == unit)
-                  }
+              opt = rawInputs
+                  .filterNot(i => i.collateral || i.reference)
+                  .sortBy(i => (i.txHash, i.outputIndex))
+                  .zipWithIndex
+                  .find { (input, _) => input.units.contains(unit) }
                   .map(_._2),
               ifNone = NoTxInputWithAsset(txHash, unit)
             )
@@ -505,6 +525,61 @@ class CardanoBackendBlockfrost private (
                   )
                 )
             )
+
+    /** One input of a Blockfrost `/txs/{hash}/utxos` response, carrying the fields BloxBean's
+      * `TxContentUtxoInputs` model omits: the outref (`txHash`#`outputIndex`, for canonical
+      * sorting) and the reference/collateral flags (to keep only regular spend inputs). See
+      * [[continuingTx]].
+      */
+    private final case class RawTxInput(
+        txHash: String,
+        outputIndex: Int,
+        collateral: Boolean,
+        reference: Boolean,
+        units: Set[String]
+    )
+
+    /** Read a tx's inputs straight from the Blockfrost `/txs/{hash}/utxos` JSON — see
+      * [[RawTxInput]] for why [[continuingTx]] bypasses BloxBean for this one call.
+      */
+    private def rawTxUtxoInputs(
+        txHash: TransactionHash
+    ): IO[Either[CardanoBackend.Error, List[RawTxInput]]] =
+        IO.blocking {
+            val request = HttpRequest
+                .newBuilder(URI.create(s"$baseUrl/txs/${txHash.toHex}/utxos"))
+                .header("project_id", apiKey)
+                .GET()
+                .build()
+            val response = httpClient.send(request, HttpResponse.BodyHandlers.ofString())
+            if response.statusCode() == 200 then
+                parse(response.body()) match {
+                    case Left(e) =>
+                        Left(Unexpected(s"Malformed tx-utxos JSON: ${e.getMessage}"))
+                    case Right(json) =>
+                        val inputs = json.hcursor.downField("inputs").values.getOrElse(Nil)
+                        Right(inputs.toList.map { i =>
+                            val c = i.hcursor
+                            RawTxInput(
+                              txHash = c.get[String]("tx_hash").getOrElse(""),
+                              outputIndex = c.get[Int]("output_index").getOrElse(0),
+                              collateral = c.get[Boolean]("collateral").getOrElse(false),
+                              reference = c.get[Boolean]("reference").getOrElse(false),
+                              units = c
+                                  .downField("amount")
+                                  .values
+                                  .getOrElse(Nil)
+                                  .flatMap(_.hcursor.get[String]("unit").toOption)
+                                  .toSet
+                            )
+                        })
+                }
+            else Left(Unexpected(s"tx-utxos HTTP ${response.statusCode()}: ${response.body()}"))
+        }.handleError(e =>
+            Left(Unexpected(s"${e.getMessage}, caused by: ${
+                    if e.getCause != null then e.getCause.getMessage else "N/A"
+                }"))
+        )
 
     private def txRedeemer(
         txHash: TransactionHash,
@@ -635,7 +710,9 @@ object CardanoBackendBlockfrost:
           backendService,
           pageSize,
           blockfrostProviderFuture,
-          tracer
+          tracer,
+          baseUrl,
+          apiKey
         )
     }
 

--- a/src/main/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonCoilToHub.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonCoilToHub.scala
@@ -1,6 +1,6 @@
 package hydrozoa.multisig.consensus.liaison
 
-import cats.effect.{IO, Ref}
+import cats.effect.{Fiber, IO, Ref}
 import cats.implicits.*
 import com.suprnation.actor.Actor.{Actor, Receive}
 import com.suprnation.actor.ActorRef.ActorRef
@@ -141,6 +141,10 @@ abstract class PeerLiaisonCoilToHub(
     // ---- Connections ----------------------------------------------------------------------------
     private val connections =
         Ref.unsafe[IO, Option[PeerLiaisonCoilToHub.Connections]](None)
+
+    // Handle to the resend-timer fiber ([[startResendTimer]]); cancelled in [[postStop]] so it
+    // doesn't outlive the actor.
+    private val resendFiber = Ref.unsafe[IO, Option[Fiber[IO, Throwable, Nothing]]](None)
 
     private def getConnections: IO[PeerLiaisonCoilToHub.Connections] =
         connections.get.flatMap(
@@ -351,7 +355,15 @@ abstract class PeerLiaisonCoilToHub(
     private def startResendTimer: IO[Unit] =
         (IO.sleep(
           config.peerLiaisonResendInterval
-        ) >> (context.self ! ResendCurrent)).foreverM.start.void
+        ) >> (context.self ! ResendCurrent)).foreverM.start
+            .flatMap(fib => resendFiber.set(Some(fib)))
+
+    /** Cancel the resend-timer fiber so it stops pinging `self` once the actor has stopped — e.g.
+      * when fallback tears down the multisig regime and this liaison — instead of leaking a fiber
+      * that keeps delivering `ResendCurrent` to a dead actor (dead letters).
+      */
+    override def postStop: IO[Unit] =
+        resendFiber.getAndSet(None).flatMap(_.fold(IO.unit)(_.cancel))
 }
 
 object PeerLiaisonCoilToHub {

--- a/src/main/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonHeadToHead.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonHeadToHead.scala
@@ -1,6 +1,6 @@
 package hydrozoa.multisig.consensus.liaison
 
-import cats.effect.{IO, Ref}
+import cats.effect.{Fiber, IO, Ref}
 import cats.implicits.*
 import com.suprnation.actor.Actor.{Actor, Receive}
 import com.suprnation.actor.ActorRef.ActorRef
@@ -148,6 +148,10 @@ abstract class PeerLiaisonHeadToHead(
 
     // ---- Connections ----------------------------------------------------------------------------
     private val connections = Ref.unsafe[IO, Option[PeerLiaisonHeadToHead.Connections]](None)
+
+    // Handle to the resend-timer fiber ([[startResendTimer]]); cancelled in [[postStop]] so it
+    // doesn't outlive the actor.
+    private val resendFiber = Ref.unsafe[IO, Option[Fiber[IO, Throwable, Nothing]]](None)
 
     private def getConnections: IO[PeerLiaisonHeadToHead.Connections] =
         connections.get.flatMap(
@@ -439,7 +443,15 @@ abstract class PeerLiaisonHeadToHead(
     private def startResendTimer: IO[Unit] =
         (IO.sleep(
           config.peerLiaisonResendInterval
-        ) >> (context.self ! ResendCurrent)).foreverM.start.void
+        ) >> (context.self ! ResendCurrent)).foreverM.start
+            .flatMap(fib => resendFiber.set(Some(fib)))
+
+    /** Cancel the resend-timer fiber so it stops pinging `self` once the actor has stopped — e.g.
+      * when fallback tears down the multisig regime and this liaison — instead of leaking a fiber
+      * that keeps delivering `ResendCurrent` to a dead actor (dead letters).
+      */
+    override def postStop: IO[Unit] =
+        resendFiber.getAndSet(None).flatMap(_.fold(IO.unit)(_.cancel))
 }
 
 object PeerLiaisonHeadToHead {

--- a/src/main/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonHubToCoil.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonHubToCoil.scala
@@ -1,6 +1,6 @@
 package hydrozoa.multisig.consensus.liaison
 
-import cats.effect.{IO, Ref}
+import cats.effect.{Fiber, IO, Ref}
 import cats.implicits.*
 import com.suprnation.actor.Actor.{Actor, Receive}
 import com.suprnation.actor.ActorRef.ActorRef
@@ -153,6 +153,10 @@ abstract class PeerLiaisonHubToCoil(
 
     // ---- Connections ----------------------------------------------------------------------------
     private val connections = Ref.unsafe[IO, Option[PeerLiaisonHubToCoil.Connections]](None)
+
+    // Handle to the resend-timer fiber ([[startResendTimer]]); cancelled in [[postStop]] so it
+    // doesn't outlive the actor.
+    private val resendFiber = Ref.unsafe[IO, Option[Fiber[IO, Throwable, Nothing]]](None)
 
     private def getConnections: IO[PeerLiaisonHubToCoil.Connections] =
         connections.get.flatMap(
@@ -378,7 +382,15 @@ abstract class PeerLiaisonHubToCoil(
     private def startResendTimer: IO[Unit] =
         (IO.sleep(
           config.peerLiaisonResendInterval
-        ) >> (context.self ! ResendCurrent)).foreverM.start.void
+        ) >> (context.self ! ResendCurrent)).foreverM.start
+            .flatMap(fib => resendFiber.set(Some(fib)))
+
+    /** Cancel the resend-timer fiber so it stops pinging `self` once the actor has stopped — e.g.
+      * when fallback tears down the multisig regime and this liaison — instead of leaking a fiber
+      * that keeps delivering `ResendCurrent` to a dead actor (dead letters).
+      */
+    override def postStop: IO[Unit] =
+        resendFiber.getAndSet(None).flatMap(_.fold(IO.unit)(_.cancel))
 }
 
 object PeerLiaisonHubToCoil {

--- a/src/main/scala/hydrozoa/rulebased/RuleBasedActor.scala
+++ b/src/main/scala/hydrozoa/rulebased/RuleBasedActor.scala
@@ -771,10 +771,10 @@ final case class RuleBasedActor(
             } yield ()
 
         /** Merge two ballot boxes via TallyTx. The continuing input must have a key strictly less
-          * than the removed input, so we sort. If any residual is still `AwaitingVote`, we defer
-          * until the voting deadline elapses — on-chain the tally would still succeed (maxVote
-          * treats AwaitingVote < Voted), but pre-deadline we don't want to submit txs whose
-          * validity range starts in the future and just park in the mempool.
+          * than the removed input, so we sort. We always defer until the voting deadline elapses: a
+          * public `Voted` box can be ratcheted by anyone until then, so no ballot is final
+          * pre-deadline, and the TallyTx's validity range starts at the deadline — submitting
+          * earlier just parks doomed txs in the mempool and spams the backend.
           */
         def tally(
             otherUtxos: NonEmptyList[BallotBox[VoteStatus]],
@@ -782,16 +782,10 @@ final case class RuleBasedActor(
             regimeUtxo: RuleBasedRegimeUtxo,
             collateralUtxo: CollateralUtxo
         ): EitherT[IO, Error.RecoverableErrors, Unit] = {
-            val hasAwaitingVote = otherUtxos.exists(_.ballotBoxOutput.status match {
-                case _: AwaitingVote => true
-                case _               => false
-            })
             val keySorted = otherUtxos.sortBy(_.ballotBoxOutput.key)
             val continuing = keySorted.head
             for {
-                _ <-
-                    if hasAwaitingVote then gateOnVotingDeadline(treasuryUtxo)
-                    else pure(())
+                _ <- gateOnVotingDeadline(treasuryUtxo)
                 _ <- traceRight(RuleBasedActorEvent.Tx.Tallying)
                 removed <- keySorted.tail.find(ballotBox =>
                     ballotBox.ballotBoxOutput.key == continuing.ballotBoxOutput.link
@@ -843,9 +837,9 @@ final case class RuleBasedActor(
             hasDeadlineElapsed(treasuryUtxo).flatMap {
                 case true => pure(())
                 case false =>
-                    traceRight(RuleBasedActorEvent.Dispute.WaitingForVotesBeforeDeadline) >>
+                    traceRight(RuleBasedActorEvent.Dispute.WaitingForVotingDeadline) >>
                         EitherT.leftT[IO, Unit](
-                          Error.TallyBlockedByAwaitingVote: Error.RecoverableErrors
+                          Error.TallyBlockedBeforeDeadline: Error.RecoverableErrors
                         )
             }
 
@@ -941,6 +935,14 @@ final case class RuleBasedActor(
                 // `parsePastRedeemers` gates non-empty, parses each withdrawal's redeemer, and
                 // extracts the resolution-time kzg from the oldest datum in one pass.
                 treasuryTxs <- Backend.continuingTreasuryTxsAfter(inputs.fallbackTxHash)
+                // Trace the surfaced chain length: `currentTreasury`/`parsePastRedeemers` turn an
+                // empty list into a silent `NoTreasuryFound` recoverable, so without this an
+                // evacuation stalled waiting for the resolution tx to surface is invisible.
+                _ <- EitherT.right[Error.RecoverableErrors](
+                  tracer.traceWith(
+                    RuleBasedActorEvent.Evacuation.ContinuingTreasuryTxs(treasuryTxs.size)
+                  )
+                )
                 treasuryUtxo <- currentTreasury(treasuryTxs)
                 parsed <- parsePastRedeemers(treasuryTxs)
                 (pastEvacuateRedeemers, resolutionKzg) = parsed
@@ -1103,7 +1105,13 @@ final case class RuleBasedActor(
                     getRegime.flatMap(Evacuation.handle(_, resolved.version._1))
             }
         } yield ()
-        et.value
+        // The tick swallows recoverable errors and retries next tick; trace the Left (at debug) so
+        // that retry is never fully silent. Backend errors already self-trace via `Backend.run`;
+        // this catches the logical recoverables (e.g. `NoTreasuryFound`) that don't.
+        et.value.flatTap {
+            case Left(e)  => tracer.traceWith(RuleBasedActorEvent.Tick.RecoverableRetry(e.toString))
+            case Right(_) => IO.unit
+        }
     }
 
     // preStart runs in the actor's lifecycle callback, outside the receive loop; posting a
@@ -1315,11 +1323,10 @@ object RuleBasedActor {
             wrapped: CardanoBackend.Error
         ) extends Recoverable
 
-        // Tally deferred: residuals contain an AwaitingVote and the voting deadline hasn't
-        // elapsed. On-chain the tally would still succeed (maxVote treats AwaitingVote < Voted),
-        // but pre-deadline we prefer to wait so the tx-builder isn't submitting future-validity
-        // txs that just park in the mempool.
-        case object TallyBlockedByAwaitingVote extends Recoverable
+        // Tally deferred: the voting deadline hasn't elapsed. A public Voted box can still be
+        // ratcheted by anyone until the deadline, and the TallyTx's validity range starts there,
+        // so we wait rather than submit future-validity txs that just park in the mempool.
+        case object TallyBlockedBeforeDeadline extends Recoverable
 
         type UnrecoverableErrors = Unrecoverable | Membership.MembershipCheckError
         sealed trait Unrecoverable extends Exception

--- a/src/main/scala/hydrozoa/rulebased/RuleBasedActorEvent.scala
+++ b/src/main/scala/hydrozoa/rulebased/RuleBasedActorEvent.scala
@@ -46,10 +46,11 @@ object RuleBasedActorEvent:
         case object ParsingResolve extends RuleBasedActorEvent
         case object ParsingEmptyVotes extends RuleBasedActorEvent
 
-        /** Residual set still contains an AwaitingVote ballot and the voting deadline has not
-          * elapsed; tally is deferred until on-chain time crosses the deadline.
+        /** The voting deadline has not elapsed; tally is deferred until on-chain time crosses it. A
+          * public Voted box can be ratcheted by anyone until the deadline, so no ballot is final
+          * and the TallyTx's validity range starts at the deadline.
           */
-        case object WaitingForVotesBeforeDeadline extends RuleBasedActorEvent
+        case object WaitingForVotingDeadline extends RuleBasedActorEvent
 
         /** Voting deadline has elapsed while the peer's own path (cast a vote for a head peer;
           * ratchet an open box for a coil peer) is still applicable. On-chain the corresponding tx
@@ -66,6 +67,14 @@ object RuleBasedActorEvent:
             case object AlreadyAtTarget extends RuleBasedActorEvent
             case object NoRatchetTarget extends RuleBasedActorEvent
 
+    object Tick:
+        /** The tick's `EitherT` ended in a recoverable error that the actor swallows and retries on
+          * the next tick. Emitted so that "recoverably fails and retries" is never fully silent —
+          * kept at `debug` since a healthy backend hits these only transiently; the specific
+          * evacuation stall has its own `info` event ([[Evacuation.ContinuingTreasuryTxs]]).
+          */
+        final case class RecoverableRetry(reason: String) extends RuleBasedActorEvent
+
     object Tx:
         final case class Building(family: String) extends RuleBasedActorEvent
         final case class Submitting(tx: EnrichedTx[?]) extends RuleBasedActorEvent
@@ -75,6 +84,15 @@ object RuleBasedActorEvent:
     object Evacuation:
         case object NoMore extends RuleBasedActorEvent
         final case class PayoutsLeft(n: Int) extends RuleBasedActorEvent
+
+        /** How many continuing treasury txs the backend surfaced after the fallback anchor
+          * (fallback → resolution → withdrawals). Zero means the resolution tx hasn't surfaced on
+          * the backend yet (eventual-consistency lag or a rollback), so `loadEvacuationState`
+          * recoverably retries from `NoTreasuryFound` — traced (unlike that empty-list path itself)
+          * so an evacuation stalled waiting for the chain is visible, and so a growing count shows
+          * the chain converging.
+          */
+        final case class ContinuingTreasuryTxs(count: Int) extends RuleBasedActorEvent
 
         /** DIAGNOSTIC: the candidate evacuation-map commitments loaded at evacuation time, and the
           * latest hard-confirmed stack they were derived from — logged to compare against the

--- a/src/main/scala/hydrozoa/rulebased/RuleBasedActorEventFormat.scala
+++ b/src/main/scala/hydrozoa/rulebased/RuleBasedActorEventFormat.scala
@@ -54,8 +54,8 @@ object RuleBasedActorEventFormat:
             case Dispute.ParsingTally      => info("Dispute state: ready to tally")
             case Dispute.ParsingResolve    => info("Dispute state: ready to resolve")
             case Dispute.ParsingEmptyVotes => warn("Dispute state: no vote utxos (unexpected)")
-            case Dispute.WaitingForVotesBeforeDeadline =>
-                info("Dispute state: awaiting peer votes; deadline not yet elapsed")
+            case Dispute.WaitingForVotingDeadline =>
+                info("Dispute state: deferring tally until voting deadline elapses")
             case Dispute.VotingDeadlineElapsed =>
                 info(
                   "Dispute state: voting deadline elapsed; skipping our own vote/ratchet " +
@@ -69,6 +69,9 @@ object RuleBasedActorEventFormat:
             case Dispute.Coil.NoRatchetTarget =>
                 info("Coil dispute state: no ratchet target; falling through to tally/resolve")
 
+            case Tick.RecoverableRetry(reason) =>
+                debug(s"Tick did not complete (recoverable); will retry. Reason: $reason")
+
             case Tx.Building(family) => info(s"Building $family")
             case Tx.Submitting(tx) =>
                 info(s"Submitting ${tx.transactionFamily} with Id ${tx.tx.id}")
@@ -80,6 +83,13 @@ object RuleBasedActorEventFormat:
                 info("No more evacuations to be done. Staying alive in case of rollbacks")
             case Evacuation.PayoutsLeft(n) =>
                 info(s"$n payout obligations left")
+            case Evacuation.ContinuingTreasuryTxs(0) =>
+                info(
+                  "Evacuation: no continuing treasury txs surfaced after the fallback anchor yet; " +
+                      "retrying (NoTreasuryFound)"
+                )
+            case Evacuation.ContinuingTreasuryTxs(n) =>
+                info(s"Evacuation: $n continuing treasury tx(s) surfaced after the fallback anchor")
 
             // Diagnostic-only events carry no production rendering — a test-side diagnostic tracer
             // (composed with `|+|`) formats them. Kept at trace so production stays silent.


### PR DESCRIPTION
Adds a third L1 backend to the RBR (rule-based-regime) fallback→evacuation MBT — **Public: Preview over real Blockfrost** — alongside Mock/Yaci, and lands the production/robustness fixes needed to make it pass on a live, non-resettable chain.

Validated green on live Preview:
```
+ RBR MBT (Preview).ws: autonomous evacuation matches the RBRHlNet terminal (Preview): OK, passed 1 tests.
```
with α (model) == β (L1) on every place — `WithdrawalOutput 2==2`, `EvacuationOutput 11==11`.

### Commits
- **rulebased: gate tally on voting deadline** — defer the tally until the on-chain voting deadline unconditionally (a public `Voted` box is ratchetable until then, and `TallyTx` validity starts at the deadline), not only when a ballot is still `AwaitingVote`. Kills the `OutsideValidityInterval` submission storm on a live chain. Adds `Tick.RecoverableRetry` / `Evacuation.ContinuingTreasuryTxs` trace events.
- **liaison: cancel resend fiber on postStop** — the periodic resend timer leaked a fiber per liaison; track and cancel it.
- **backend: live Blockfrost URL/apiKey; canonical continuingTx input sort** — real Preview Blockfrost support; `continuingTx` filters reference/collateral inputs and sorts spend inputs canonically so the redeemer `tx_index` matches (fixes the evacuation continuing-tx lookup).
- **integration: RBR MBT Public/Preview backend + cross-run scoping** — harness `Mode.Public` with live-params `previewNetwork`/timing; `PublicSetup` (master-wallet funding, script deploy, deploy-landed genesis guard against the Blockfrost address-index lag); Runner/Suite/Sut wiring; build.sbt/justfile/logback. `beforeFinalize` scopes the payout buckets (Withdrawal/Evacuation) to this run's submitted tx ids so script-locked residue from earlier runs at the shared payout address can't inflate β on a non-resettable testnet.
- **integration: dedupe committedMaps into a Set** — every peer emits the same `CommittedMap` trace, so the accumulated `List` carried one duplicate per peer (noisy in the `beforeFinalize` log). `observedCommittedSize` (a max over a filter) is unaffected.

### Notes
- Excluded from the default test set (needs a funded master wallet + live testnet); run via `just integration-rbr-preview`.
- Known live-chain follow-ups (not blocking, self-healing): Ember WS 60s idle timeout during long L1-bound quiet periods (add a heartbeat).