### PR TITLE
transport: configurable WS idle timeout + keep-alive pings

### DIFF
--- a/src/main/scala/hydrozoa/multisig/consensus/CardanoLiaison.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/CardanoLiaison.scala
@@ -681,9 +681,13 @@ trait CardanoLiaison(
                     // From the whole state we need to know only utxo ids
                     utxoIds <- IO.pure(l1State.keySet)
                     // This may not the ideal place to have it. Every time we get a new head state, we
-                    // forward it to the block weaver.
+                    // forward it to the block weaver — unless the rule-based handoff has been
+                    // dispatched: the liaison outlives the handoff (to process refunds and finish
+                    // rollouts) but the BlockWeaver is stopped with the other multisig children, so
+                    // forwarding would only produce dead letters.
                     conn <- getConnections
-                    _ <- conn.blockWeaver ! PollResults(utxoIds)
+                    handedOff <- lastHandoffDispatchedFor.get.map(_.nonEmpty)
+                    _ <- IO.unlessA(handedOff)(conn.blockWeaver ! PollResults(utxoIds))
 
                     // 2. Based on the local state, find all due actions
                     state <- stateRef.get

--- a/src/main/scala/hydrozoa/multisig/consensus/transport/HubWsTransport.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/transport/HubWsTransport.scala
@@ -14,6 +14,7 @@ import org.http4s.HttpRoutes
 import org.http4s.dsl.io.*
 import org.http4s.server.websocket.WebSocketBuilder2
 import org.http4s.websocket.WebSocketFrame
+import scala.concurrent.duration.FiniteDuration
 
 /** The hub side of a hub↔coil link, in the abstract. Concrete impls: [[HubWsTransport]] (real WS)
   * and [[InProcessHubCoilTransport.Hub]] (test harness).
@@ -41,6 +42,7 @@ trait HubTransport {
 final class HubWsTransport private (
     private val outboxes: Map[CoilPeerNumber, Queue[IO, String]],
     private val inboundRef: Ref[IO, Map[CoilPeerNumber, PeerLiaisonHubToCoil.Handle]],
+    private val keepAlivePing: FiniteDuration,
     private val tracer: ContraTracer[IO, HubWsTransportEvent],
 )(using CardanoNetwork.Section)
     extends HubTransport {
@@ -80,14 +82,15 @@ final class HubWsTransport private (
     private def serverHandler(wsb: WebSocketBuilder2[IO]): IO[org.http4s.Response[IO]] =
         for {
             coilD <- Deferred[IO, CoilPeerNumber]
-            sendStream: Stream[IO, WebSocketFrame] =
-                Stream
-                    .eval(coilD.get)
-                    .flatMap { coil =>
-                        Stream
-                            .fromQueueUnterminated(outboxes(coil))
-                            .map(line => WebSocketFrame.Text(line))
-                    }
+            sendStream: Stream[IO, WebSocketFrame] = NodeWsServer.withKeepAlive(keepAlivePing)(
+              Stream
+                  .eval(coilD.get)
+                  .flatMap { coil =>
+                      Stream
+                          .fromQueueUnterminated(outboxes(coil))
+                          .map(line => WebSocketFrame.Text(line))
+                  }
+            )
             receivePipe: fs2.Pipe[IO, WebSocketFrame, Unit] = _.evalMap {
                 case WebSocketFrame.Text(s, _) =>
                     CoilFrame.parse(s) match {
@@ -126,11 +129,12 @@ object HubWsTransport {
     def create(
         coils: List[CoilPeerNumber],
         tracer: ContraTracer[IO, HubWsTransportEvent],
+        keepAlivePing: FiniteDuration = NodeWsServer.defaultKeepAlivePing,
     )(using CardanoNetwork.Section): IO[HubWsTransport] =
         for {
             outboxes <- coils
                 .traverse(c => Queue.unbounded[IO, String].map(c -> _))
                 .map(_.toMap)
             inboundRef <- Ref[IO].of(Map.empty[CoilPeerNumber, PeerLiaisonHubToCoil.Handle])
-        } yield new HubWsTransport(outboxes, inboundRef, tracer)
+        } yield new HubWsTransport(outboxes, inboundRef, keepAlivePing, tracer)
 }

--- a/src/main/scala/hydrozoa/multisig/consensus/transport/NodeWsServer.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/transport/NodeWsServer.scala
@@ -3,6 +3,7 @@ package hydrozoa.multisig.consensus.transport
 import cats.effect.{IO, Resource}
 import cats.syntax.semigroupk.*
 import com.comcast.ip4s.{Host, Port}
+import fs2.Stream
 import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.consensus.transport.NodeWsServerEvent.Bound
 import org.http4s.HttpRoutes
@@ -10,7 +11,8 @@ import org.http4s.ember.server.EmberServerBuilder
 import org.http4s.implicits.*
 import org.http4s.server.Server
 import org.http4s.server.websocket.WebSocketBuilder2
-import scala.concurrent.duration.Duration
+import org.http4s.websocket.WebSocketFrame
+import scala.concurrent.duration.{Duration, DurationInt, FiniteDuration}
 
 /** The single WebSocket server a peer binds, shared by every WS link the peer runs. A pure head
   * peer mounts only the head-mesh route ([[WsPeerTransport.routes]]); a hub head peer mounts that
@@ -22,20 +24,28 @@ import scala.concurrent.duration.Duration
   */
 object NodeWsServer {
 
+    /** Keep-alive ping interval, comfortably below `resource`'s default `idleTimeout` so the
+      * ping/pong round-trip resets the read-idle timer before it fires. The transports always ping
+      * at this interval (prod and tests alike, so tests match production).
+      */
+    val defaultKeepAlivePing: FiniteDuration = 10.seconds
+
     def resource(
         bindHost: Host,
         bindPort: Port,
         routes: List[WebSocketBuilder2[IO] => HttpRoutes[IO]],
         tracer: ContraTracer[IO, NodeWsServerEvent],
+        idleTimeout: Duration = 20.seconds,
     ): Resource[IO, Server] =
         EmberServerBuilder
             .default[IO]
             .withHost(bindHost)
             .withPort(bindPort)
-            // Ember closes idle WS sockets after 60s by default. The liaison protocols' own
-            // retransmit timers self-heal a stalled link, so in production we'd set this to
-            // `Duration.Inf`; we leave the default in place so tests exercise reconnect handling.
-            // TODO: surface as a config parameter (default `Inf` for production; short in tests).
+            // Close a WS socket after `idleTimeout` of I/O inactivity (Ember's own default is 60s).
+            // A short 20s window is fine because the transports send sub-`idleTimeout` keep-alive
+            // pings, so an idle-but-live link stays open while a genuinely dead peer is dropped
+            // within the window.
+            .withIdleTimeout(idleTimeout)
             // Don't wait for open connections to drain on shutdown — by the time the Resource is
             // released the protocol is complete and there is nothing left to deliver.
             .withShutdownTimeout(Duration.Zero)
@@ -48,4 +58,14 @@ object NodeWsServer {
             )
             .build
             .evalTap(_ => tracer.traceWith(Bound(bindHost, bindPort)))
+
+    /** Merge periodic `Ping` frames into a WS server send stream so an idle-but-live link isn't
+      * dropped by `resource`'s `idleTimeout` (nor by NAT/proxy idle timeouts on the path) during
+      * the long L1-bound quiet periods the liaison protocols have. The peer auto-responds with
+      * `Pong`, which resets the server's read-idle timer. Pick `pingEvery < idleTimeout`.
+      */
+    def withKeepAlive(
+        pingEvery: FiniteDuration
+    )(send: Stream[IO, WebSocketFrame]): Stream[IO, WebSocketFrame] =
+        send.merge(Stream.awakeEvery[IO](pingEvery).as(WebSocketFrame.Ping()))
 }

--- a/src/main/scala/hydrozoa/multisig/consensus/transport/PeerTransport.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/transport/PeerTransport.scala
@@ -51,6 +51,7 @@ final class WsPeerTransport private (
     val ownPeerId: HeadPeerId,
     private val outboxes: Map[HeadPeerId, Queue[IO, String]],
     private val inboundRef: Ref[IO, Map[HeadPeerId, PeerLiaisonHeadToHead.Handle]],
+    private val keepAlivePing: FiniteDuration,
     private val tracer: ContraTracer[IO, PeerTransportEvent],
 )(using CardanoNetwork.Section)
     extends PeerTransport {
@@ -133,14 +134,15 @@ final class WsPeerTransport private (
     private def serverHandler(wsb: WebSocketBuilder2[IO]): IO[org.http4s.Response[IO]] =
         for {
             peerD <- cats.effect.Deferred[IO, HeadPeerId]
-            sendStream: Stream[IO, WebSocketFrame] =
-                Stream
-                    .eval(peerD.get)
-                    .flatMap { remote =>
-                        Stream
-                            .fromQueueUnterminated(outboxes(remote))
-                            .map(line => WebSocketFrame.Text(line))
-                    }
+            sendStream: Stream[IO, WebSocketFrame] = NodeWsServer.withKeepAlive(keepAlivePing)(
+              Stream
+                  .eval(peerD.get)
+                  .flatMap { remote =>
+                      Stream
+                          .fromQueueUnterminated(outboxes(remote))
+                          .map(line => WebSocketFrame.Text(line))
+                  }
+            )
             receivePipe: fs2.Pipe[IO, WebSocketFrame, Unit] = _.evalMap {
                 case WebSocketFrame.Text(s, _) =>
                     HeadFrame.parse(s) match {
@@ -211,11 +213,12 @@ object WsPeerTransport {
         ownPeerId: HeadPeerId,
         remoteIds: List[HeadPeerId],
         tracer: ContraTracer[IO, PeerTransportEvent],
+        keepAlivePing: FiniteDuration = NodeWsServer.defaultKeepAlivePing,
     )(using CardanoNetwork.Section): IO[WsPeerTransport] =
         for {
             outboxes <- remoteIds
                 .traverse(rid => Queue.unbounded[IO, String].map(rid -> _))
                 .map(_.toMap)
             inboundRef <- Ref[IO].of(Map.empty[HeadPeerId, PeerLiaisonHeadToHead.Handle])
-        } yield new WsPeerTransport(ownPeerId, outboxes, inboundRef, tracer)
+        } yield new WsPeerTransport(ownPeerId, outboxes, inboundRef, keepAlivePing, tracer)
 }


### PR DESCRIPTION
Follow-up to #612. Stops the Ember WebSocket disconnects seen during the RBR MBT's live-Preview runs.

## Problem
`org.http4s.ember.server` closes an idle WS socket after **60s** (its default). During the liaison protocols' long L1-bound quiet periods — deposit maturity, the 5-min voting deadline, ~20s Preview block cadence — no L2 consensus frames flow for over a minute, so Ember drops the (live) link and the dialer reconnects. Benign but noisy; the existing `NodeWsServer` TODO already called for surfacing this as config.

## Change
- **`NodeWsServer.resource`** gains an `idleTimeout: Duration` param (**default `20.seconds`**) → `EmberServerBuilder.withIdleTimeout`.
- **`NodeWsServer.withKeepAlive`** merges periodic `WebSocketFrame.Ping()` frames into a server send stream. The peer auto-responds with `Pong`, resetting the server's read-idle timer, so a live-but-quiet link stays open — while a genuinely dead peer is still dropped within the (short) window.
- **`WsPeerTransport.create` / `HubWsTransport.create`** gain `keepAlivePing: FiniteDuration = NodeWsServer.defaultKeepAlivePing` (**10s**), applied to their server send streams.
- **Always on** — production and tests ping identically (no on/off option), so test behavior matches production. Reconnect handling is now exercised only on genuine failures (dead peer / dropped connection), not on benign idle.

## Notes
- The 20s idle timeout is now a dead-peer detector (pings keep live links warm; a peer that stops ponging is dropped within 20s). Server-side pings only — client-side pings / NAT-proxy tuning are a possible further step.
- Compile / `-Werror` / scalafmt / scalafix clean.