### PR TITLE
feat(metrics): leader mempool drain gauge, folded cell handlers, self-peer exclusion

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1294,6 +1294,7 @@ components:
       - stacks
       - blockTimings
       - mempoolSize
+      - leaderMempoolDrain
       - sequencerHeadroom
       properties:
         uptimeSeconds:
@@ -1312,6 +1313,9 @@ components:
         blockTimings:
           $ref: '#/components/schemas/BlockTimingSet'
         mempoolSize:
+          type: integer
+          format: int64
+        leaderMempoolDrain:
           type: integer
           format: int64
         sequencerHeadroom:

--- a/docs/spec/peer-stats-endpoint.md
+++ b/docs/spec/peer-stats-endpoint.md
@@ -110,7 +110,7 @@ reference / `AtomicReference` publishes it to readers.
 | `localAccepted` | counter + rate | requests this peer sequenced successfully |
 | `localRejScreening` | counter | rejected by L1/L2 screening |
 | `localRejBackpressure` | counter | rejected by the sequencer window (backpressure) |
-| `peerRequests[p]` | counter + rate, per peer | requests pulled from remote head peer `p` |
+| `peerRequests[p]` | counter + rate, per peer | requests pulled from remote head peer `p` (the own peer is excluded — self is never a request source) |
 | `blocksMinor` / `blocksMajor` | counter | soft-confirmed blocks by type |
 | avg block size | derived | `blockEventsSum / (blocksMinor + blocksMajor)` |
 | max block size | gauge | `blockEventsMax` |
@@ -123,8 +123,9 @@ reference / `AtomicReference` publishes it to readers.
 | mean inter-stack gap | derived | `stackGapSumMillis / (stacksTotal - 1)` |
 | avg / max stack size | derived / gauge | blocks absorbed: `stackBlocksSum / stacksTotal`, `stackBlocksMax` |
 | uptime | derived | `now - startedAtMillis` |
-| block-lifecycle timings (lead / replay / soft-consensus) | count + avg + top-N | per category: `count`, `avgMillis`, `avgMillisPerRequest` (lead/replay only), and the 10 **slowest blocks with their numbers**. **Lead** = became-leader → brief produced; **replay** = brief received → reproduced; **soft-consensus** = FCA cell spawned → soft-confirmed. Wall-clock (`System.currentTimeMillis`), so cheap and non-deterministic — a debug aid, not a control input. |
+| block-lifecycle timings (lead / replay / soft-consensus) | count + avg + top-N | per category: `count`, `avgMillis`, `avgMillisPerRequest` (lead/replay only), and the 10 **slowest blocks with their numbers**. **Lead** = became-leader → brief produced; **replay** = brief received → reproduced; **soft-consensus** = brief produced → soft-confirmed (the ack-collection tail of lead/replay). Wall-clock (`System.currentTimeMillis`), so cheap and non-deterministic — a debug aid, not a control input. |
 | mempool size | gauge | requests held in the `BlockWeaver` mempool, not yet packed into a block |
+| leader mempool drain | gauge | requests the last lead pulled from the mempool into its block |
 | sequencer headroom | gauge | how many more requests the sequencer will admit before shedding load — the free space in its `backpressureCoefficient * maxRequestsPerBlock` window (the window itself is derivable from config, so only the live headroom is reported) |
 
 ## Instrumentation points
@@ -137,8 +138,8 @@ Three call sites, all on paths that already exist — no new plumbing:
 | peer-to-peer requests per peer | the request lane where a remote peer's requests enter the local mempool (the peer liaison / puller receive path); `onPeerRequests(from, batch.size)`. |
 | blocks minor/major + event count | `FastConsensusActor.completeCell` — the single funnel every soft-confirmed block passes through. It already computes `brief`, already switches `Minor`/`Major`, and `brief.requests.size` is the event count. One `metrics.onBlockConfirmed(isMajor, brief.requests.size)` next to the existing `BlockSoftConfirmed` emission. |
 | stacks + size | `SlowConsensusActor.completeStack` — the single funnel where a `Stack.HardConfirmed` is produced. `stackBrief.stackNum` and `lastBlockNum - firstBlockNum + 1` (blocks absorbed) give the size. One `metrics.onStackConfirmed(stackNum, blocksAbsorbed)`. |
-| block-lifecycle timings | **starts** in `BlockWeaver` (via `Connections.metrics`): `onLeadStart` on entering `Leader.ProcessingReadyRequests`, `onReplayStart` on entering `Follower.ProcessingReadyRequests`. **Close**: lead/replay in `JointLedger.handleBlock` — `onBlockProduced(blockNum, requests)` where the brief is produced (own when leading, a reproduction when following); soft-consensus in `FastConsensusActor` (`onCellSpawned` in `withCell`, `onCellConfirmed` at soft-confirmation). `PeerMetrics` matches a produced block to whichever start (lead vs replay) the local peer opened, so the close site needs no lead/replay flag. |
-| mempool size | `BlockWeaver` — `onMempoolSize` where the mempool grows (`storeRequest`) and shrinks (leader `extractRequestsForBlock`). |
+| block-lifecycle timings | **starts** in `BlockWeaver` (via `Connections.metrics`): `onLeadStart` on entering `Leader.ProcessingReadyRequests`, `onReplayStart` on entering `Follower.ProcessingReadyRequests`. **Close**: `JointLedger.handleBlock` calls `onBlockProduced(blockNum, requests)` where the brief is produced (own when leading, a reproduction when following) — this closes lead/replay *and* opens the soft-consensus clock; `FastConsensusActor.completeCell` then calls `onBlockConfirmed(blockNum, isMajor, events)` (merged with the block counters), which closes soft-consensus. `PeerMetrics` matches a produced block to whichever start (lead vs replay) the local peer opened, so the close site needs no lead/replay flag. |
+| mempool size / leader mempool drain | `BlockWeaver.Leader.ProcessingReadyRequests` — `onLeaderMempoolDrain(extracted)` and `onMempoolSize(surviving)` right after the leader extracts its block from the mempool; `onMempoolSize` also on `storeRequest`. |
 | sequencer headroom | `RequestSequencer` — `onSequencerHeadroom(headroom)` at PreStart, after each admit/reject, and on `SoftConfirmedHighWater` (which frees headroom). |
 
 Because `completeCell` / `completeStack` are the *only* places a soft-confirmed block / hard-confirmed

--- a/src/main/scala/hydrozoa/app/Serve.scala
+++ b/src/main/scala/hydrozoa/app/Serve.scala
@@ -113,10 +113,17 @@ object Serve {
             // lifetime. In-memory only — counters reset on restart.
             metrics <- Resource.eval(
               IO.realTime.map(t =>
-                  PeerMetrics.create(
-                    t.toMillis,
-                    nodeConfig.headConfig.headPeerNums.toList.map(_.convert).toVector
-                  )
+                  // Track only remote head peers: this peer never sends requests to itself, so
+                  // its own `peerRequests` entry would be a constant zero (see PeerMetrics.create).
+                  val ownHeadNum = nodeConfig.ownPeerId match {
+                      case PeerId.Head(n) => Some(n.convert)
+                      case PeerId.Coil(_) => None
+                  }
+                  val remotePeerNums = nodeConfig.headConfig.headPeerNums.toList
+                      .map(_.convert)
+                      .filterNot(ownHeadNum.contains)
+                      .toVector
+                  PeerMetrics.create(t.toMillis, remotePeerNums)
               )
             )
             _ <- metrics.sampler().background

--- a/src/main/scala/hydrozoa/multisig/consensus/BlockWeaver.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/BlockWeaver.scala
@@ -670,6 +670,8 @@ object BlockWeaver {
                     _ <- realTimeQuantizedInstant(config.slotConfig)
                     extracted <- extractRequestsForBlock(config)
                     (requests, survivingMempool) = extracted
+                    // How many requests this lead pulled out of the mempool, and what's left behind.
+                    _ <- IO(connections.metrics.onLeaderMempoolDrain(requests.size))
                     _ <- IO(connections.metrics.onMempoolSize(survivingMempool.requests.size))
                     isBlockStarted <-
                         if requests.isEmpty

--- a/src/main/scala/hydrozoa/multisig/consensus/FastConsensusActor.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/FastConsensusActor.scala
@@ -268,10 +268,6 @@ class FastConsensusActor(
         f: ConsensusCell => Either[CollectingError, ConsensusCell]
     ): IO[Unit] = for {
         state <- stateRef.get
-        // First message for this block number spawns its cell — start the soft-consensus clock.
-        _ <- IO.unlessA(state.cells.contains(blockNum))(
-          IO(metrics.onCellSpawned((blockNum: Int).toLong))
-        )
         cell = state.cells.getOrElse(blockNum, ConsensusCell.fresh(blockNum))
         updated <- IO.fromEither(f(cell))
         _ <- stateRef.update(s => s.copy(cells = s.cells.updated(blockNum, updated)))
@@ -310,8 +306,13 @@ class FastConsensusActor(
         isMajorBlock = brief match
             case _: BlockBrief.Minor => false
             case _                   => true
-        _ <- IO(metrics.onBlockConfirmed(isMajorBlock, brief.requests.size))
-        _ <- IO(metrics.onCellConfirmed((confirmed.blockNum: Int).toLong))
+        _ <- IO(
+          metrics.onBlockConfirmed(
+            (confirmed.blockNum: Int).toLong,
+            isMajorBlock,
+            brief.requests.size
+          )
+        )
 
         // Persist the SoftConfirmation record (header + aggregated multisig) before fanning out
         // (CR4 write-before-send). `softConfirmed` derives as max(SoftConfirmation.key); we keep

--- a/src/main/scala/hydrozoa/multisig/metrics/PeerMetrics.scala
+++ b/src/main/scala/hydrozoa/multisig/metrics/PeerMetrics.scala
@@ -27,7 +27,7 @@ enum RejectionKind:
   *
   * Counters are not persisted: they reset on restart.
   */
-final class PeerMetrics private (startedAtMillis: Long, headPeerNums: Vector[Int]):
+final class PeerMetrics private (startedAtMillis: Long, remotePeerNums: Vector[Int]):
     import PeerMetrics.*
 
     // ---- local requests (written by RequestSequencer) ----
@@ -37,7 +37,7 @@ final class PeerMetrics private (startedAtMillis: Long, headPeerNums: Vector[Int
 
     // ---- peer requests, per remote head peer (written by the peer liaisons, multi-writer) ----
     private val peerRequests: Map[Int, LongAdder] =
-        headPeerNums.map(_ -> new LongAdder).toMap
+        remotePeerNums.map(_ -> new LongAdder).toMap
 
     // ---- blocks (written by FastConsensusActor) ----
     private val blocksMinor = new AtomicLong(0)
@@ -54,9 +54,10 @@ final class PeerMetrics private (startedAtMillis: Long, headPeerNums: Vector[Int
     private val stackBlocksMax = new AtomicLong(0)
 
     // ---- block-lifecycle timings ----
-    // Start clocks: blockNum -> startMillis. `leadStart`/`replayStart` (opened in BlockWeaver) are
-    // closed when the JointLedger produces the brief; `cellStart` (opened in FCA) at soft-confirmation.
-    // Written by one actor each, removed by one actor each — TrieMap keeps the cross-actor hand-off safe.
+    // Start clocks: blockNum -> startMillis. `leadStart`/`replayStart` (opened in BlockWeaver) close
+    // when the JointLedger produces the brief; `cellStart` opens at that same brief-produced moment
+    // and closes at soft-confirmation, so soft-consensus = brief produced -> soft-confirmed. Written
+    // by one actor each, removed by one actor each — TrieMap keeps the cross-actor hand-off safe.
     private val leadStart = TrieMap.empty[Long, Long]
     private val replayStart = TrieMap.empty[Long, Long]
     private val cellStart = TrieMap.empty[Long, Long]
@@ -64,12 +65,13 @@ final class PeerMetrics private (startedAtMillis: Long, headPeerNums: Vector[Int
     private val replayTiming = new TimingAccumulator(perRequest = true)
     private val softConsensusTiming = new TimingAccumulator(perRequest = false)
 
-    // ---- gauges (last value; BlockWeaver mempool depth, RequestSequencer backpressure headroom) ----
+    // ---- gauges (last value) ----
     private val mempool = new AtomicLong(0)
+    private val leaderMempoolDrain = new AtomicLong(0)
     private val seqHeadroom = new AtomicLong(0)
 
     // ---- derived rates (written only by the sampler fiber) ----
-    private val rolling = new AtomicReference[Rolling](Rolling.empty(headPeerNums))
+    private val rolling = new AtomicReference[Rolling](Rolling.empty(remotePeerNums))
 
     private def now(): Long = System.currentTimeMillis()
 
@@ -86,11 +88,16 @@ final class PeerMetrics private (startedAtMillis: Long, headPeerNums: Vector[Int
     def onPeerRequests(fromPeerNum: Int, n: Int): Unit =
         peerRequests.get(fromPeerNum).foreach(_.add(n.toLong))
 
-    /** Record a soft-confirmed block of the given type carrying `events` requests. */
-    def onBlockConfirmed(isMajor: Boolean, events: Int): Unit =
+    /** `blockNum` soft-confirmed as the given type carrying `events` requests: bump the block
+      * counters and close its soft-consensus clock (opened at [[onBlockProduced]]).
+      */
+    def onBlockConfirmed(blockNum: Long, isMajor: Boolean, events: Int): Unit =
         val _ = if isMajor then blocksMajor.incrementAndGet() else blocksMinor.incrementAndGet()
         blockEventsSum.addAndGet(events.toLong)
         updateMax(blockEventsMax, events.toLong)
+        cellStart
+            .remove(blockNum)
+            .foreach(start => softConsensusTiming.record(blockNum, now() - start, 0L))
 
     /** Record a hard-confirmed stack absorbing `blocksAbsorbed` blocks, at wall-clock `nowMillis`.
       */
@@ -111,7 +118,8 @@ final class PeerMetrics private (startedAtMillis: Long, headPeerNums: Vector[Int
 
     /** The JointLedger produced `blockNum`'s brief (this peer's own when leading, or a reproduction
       * when following): close whichever clock the local peer opened — `leadStart` if it led the
-      * block, else `replayStart` — recording the elapsed time and the block's request count.
+      * block, else `replayStart` — recording the elapsed time and the block's request count, and
+      * open the soft-consensus clock (closed at [[onBlockConfirmed]]).
       */
     def onBlockProduced(blockNum: Long, requests: Int): Unit =
         val end = now()
@@ -121,19 +129,14 @@ final class PeerMetrics private (startedAtMillis: Long, headPeerNums: Vector[Int
                 replayStart
                     .remove(blockNum)
                     .foreach(start => replayTiming.record(blockNum, end - start, requests.toLong))
-
-    /** FastConsensusActor spawned a consensus cell for `blockNum`: start its soft-consensus clock.
-      */
-    def onCellSpawned(blockNum: Long): Unit = startClock(cellStart, blockNum)
-
-    /** FastConsensusActor soft-confirmed `blockNum`: close its soft-consensus clock. */
-    def onCellConfirmed(blockNum: Long): Unit =
-        cellStart
-            .remove(blockNum)
-            .foreach(start => softConsensusTiming.record(blockNum, now() - start, 0L))
+        startClock(cellStart, blockNum)
 
     /** BlockWeaver's current mempool depth (requests received, not yet packed into a block). */
     def onMempoolSize(size: Int): Unit = mempool.set(size.toLong)
+
+    /** How many requests the leader just extracted from its mempool into the block it is starting.
+      */
+    def onLeaderMempoolDrain(n: Int): Unit = leaderMempoolDrain.set(n.toLong)
 
     /** How many more requests the RequestSequencer will admit right now before backpressure trips —
       * the free space in its window. (The window itself, `backpressureCoefficient *
@@ -162,7 +165,7 @@ final class PeerMetrics private (startedAtMillis: Long, headPeerNums: Vector[Int
           localRate = roll.localRate,
           localRejScreening = localRejScreening.get(),
           localRejBackpressure = localRejBackpressure.get(),
-          peerRequests = headPeerNums.map { p =>
+          peerRequests = remotePeerNums.map { p =>
               p -> CounterWithRate(
                 peerRequests(p).sum(),
                 roll.peerRates.getOrElse(p, RateView.zero)
@@ -194,6 +197,7 @@ final class PeerMetrics private (startedAtMillis: Long, headPeerNums: Vector[Int
             softConsensus = softConsensusTiming.snapshot
           ),
           mempoolSize = mempool.get(),
+          leaderMempoolDrain = leaderMempoolDrain.get(),
           sequencerHeadroom = seqHeadroom.get()
         )
 
@@ -203,7 +207,7 @@ final class PeerMetrics private (startedAtMillis: Long, headPeerNums: Vector[Int
       */
     def sampler(period: FiniteDuration = 1.second): IO[Unit] =
         val ewmaLocal = mkEwmas()
-        val ewmaPeer = headPeerNums.map(_ -> mkEwmas()).toMap
+        val ewmaPeer = remotePeerNums.map(_ -> mkEwmas()).toMap
         val ewmaBlocks = mkEwmas()
         val ewmaBlockReqs = mkEwmas()
 
@@ -222,11 +226,11 @@ final class PeerMetrics private (startedAtMillis: Long, headPeerNums: Vector[Int
                 val localInst = (curLocal - lastLocal) / dt
                 observe(ewmaLocal, localInst, dt)
 
-                val curPeer = headPeerNums.map(p => p -> peerRequests(p).sum()).toMap
-                val peerInst = headPeerNums.map { p =>
+                val curPeer = remotePeerNums.map(p => p -> peerRequests(p).sum()).toMap
+                val peerInst = remotePeerNums.map { p =>
                     p -> (curPeer(p) - lastPeer.getOrElse(p, 0L)) / dt
                 }.toMap
-                headPeerNums.foreach(p => observe(ewmaPeer(p), peerInst(p), dt))
+                remotePeerNums.foreach(p => observe(ewmaPeer(p), peerInst(p), dt))
 
                 val curBlocks = blocksMinor.get() + blocksMajor.get()
                 val blockInst = (curBlocks - lastBlocks) / dt
@@ -239,7 +243,8 @@ final class PeerMetrics private (startedAtMillis: Long, headPeerNums: Vector[Int
                 rolling.set(
                   Rolling(
                     localRate = rateOf(ewmaLocal, localInst),
-                    peerRates = headPeerNums.map(p => p -> rateOf(ewmaPeer(p), peerInst(p))).toMap,
+                    peerRates =
+                        remotePeerNums.map(p => p -> rateOf(ewmaPeer(p), peerInst(p))).toMap,
                     blockRate = rateOf(ewmaBlocks, blockInst),
                     blockRequestRate = rateOf(ewmaBlockReqs, blockReqInst)
                   )
@@ -248,7 +253,7 @@ final class PeerMetrics private (startedAtMillis: Long, headPeerNums: Vector[Int
             }
 
         IO.realTime.flatMap(t0 =>
-            loop(t0.toMillis, localAccepted.get(), headPeerNums.map(_ -> 0L).toMap, 0L, 0L)
+            loop(t0.toMillis, localAccepted.get(), remotePeerNums.map(_ -> 0L).toMap, 0L, 0L)
         )
 
 object PeerMetrics:
@@ -260,8 +265,12 @@ object PeerMetrics:
     /** How many slowest blocks each timing category keeps (with their block numbers). */
     private val TopN = 10
 
-    def create(nowMillis: Long, headPeerNums: Vector[Int]): PeerMetrics =
-        new PeerMetrics(nowMillis, headPeerNums)
+    /** Build a registry that tracks inbound requests from `remotePeerNums` — the head peers other
+      * than this one. Exclude the own peer number: a peer never sends requests to itself over the
+      * network, so its `peerRequests` entry would be a constant zero.
+      */
+    def create(nowMillis: Long, remotePeerNums: Vector[Int]): PeerMetrics =
+        new PeerMetrics(nowMillis, remotePeerNums)
 
     /** One timing category (lead / replay / soft-consensus). Written by exactly one actor and read
       * by the HTTP snapshot, so the running sum/count use plain atomics and the top-N list is
@@ -319,10 +328,10 @@ object PeerMetrics:
         blockRequestRate: RateView
     )
     private object Rolling:
-        def empty(headPeerNums: Vector[Int]): Rolling =
+        def empty(remotePeerNums: Vector[Int]): Rolling =
             Rolling(
               RateView.zero,
-              headPeerNums.map(_ -> RateView.zero).toMap,
+              remotePeerNums.map(_ -> RateView.zero).toMap,
               RateView.zero,
               RateView.zero
             )
@@ -384,5 +393,6 @@ final case class PeerStats(
     stacks: StackStats,
     blockTimings: BlockTimingSet,
     mempoolSize: Long,
+    leaderMempoolDrain: Long,
     sequencerHeadroom: Long
 )

--- a/src/main/scala/hydrozoa/multisig/metrics/PrometheusFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/metrics/PrometheusFormat.scala
@@ -130,6 +130,11 @@ object PrometheusFormat:
 
         gauge("hydrozoa_mempool_size", "Requests held in the BlockWeaver mempool.", s.mempoolSize)
         gauge(
+          "hydrozoa_leader_mempool_drain",
+          "Requests the last lead pulled from the mempool into its block.",
+          s.leaderMempoolDrain
+        )
+        gauge(
           "hydrozoa_sequencer_headroom",
           "Requests the sequencer will admit now before backpressure trips.",
           s.sequencerHeadroom

--- a/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
+++ b/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
@@ -246,6 +246,7 @@ object ApiDto {
         stacks: StackStatsView,
         blockTimings: BlockTimingSetView,
         mempoolSize: Long,
+        leaderMempoolDrain: Long,
         sequencerHeadroom: Long
     )
     given Codec[PeerStatsView] = deriveCodec
@@ -293,6 +294,7 @@ object ApiDto {
             softConsensus = timing(s.blockTimings.softConsensus)
           ),
           mempoolSize = s.mempoolSize,
+          leaderMempoolDrain = s.leaderMempoolDrain,
           sequencerHeadroom = s.sequencerHeadroom
         )
 

--- a/src/test/scala/hydrozoa/multisig/metrics/PeerMetricsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/metrics/PeerMetricsTest.scala
@@ -39,9 +39,9 @@ class PeerMetricsTest extends AnyFunSuite:
 
     test("block stats: minor/major counts, average and max events; empty is zero"):
         val m = fresh()
-        m.onBlockConfirmed(isMajor = false, events = 10)
-        m.onBlockConfirmed(isMajor = false, events = 20)
-        m.onBlockConfirmed(isMajor = true, events = 30)
+        m.onBlockConfirmed(blockNum = 1, isMajor = false, events = 10)
+        m.onBlockConfirmed(blockNum = 2, isMajor = false, events = 20)
+        m.onBlockConfirmed(blockNum = 3, isMajor = true, events = 30)
         val b = m.snapshot(0L).blocks
         assert(
           b.minor == 2 && b.major == 1 && b.maxEvents == 30 && b.avgEvents == 20.0 &&
@@ -73,11 +73,11 @@ class PeerMetricsTest extends AnyFunSuite:
         m.onBlockProduced(7, requests = 20)
         m.onReplayStart(6)
         m.onBlockProduced(6, requests = 3)
-        // A produced block with no start opened is ignored, not crashed.
+        // A produced block with no lead/replay start opened is ignored for those, not crashed.
         m.onBlockProduced(999, requests = 5)
-        // Soft-consensus is its own clock (cell spawned -> confirmed).
-        m.onCellSpawned(5)
-        m.onCellConfirmed(5)
+        // Soft-consensus opens at onBlockProduced (above) and closes at onBlockConfirmed.
+        m.onBlockConfirmed(blockNum = 5, isMajor = false, events = 10)
+        m.onLeaderMempoolDrain(64)
         m.onMempoolSize(42)
         m.onSequencerHeadroom(12)
         val s = m.snapshot(0L)
@@ -86,9 +86,10 @@ class PeerMetricsTest extends AnyFunSuite:
           bt.lead.count == 2 && bt.replay.count == 1 && bt.softConsensus.count == 1 &&
               bt.lead.top.map(_.blockNumber).toSet == Set(5L, 7L) &&
               bt.replay.top.map(_.blockNumber) == List(6L) &&
+              bt.softConsensus.top.map(_.blockNumber) == List(5L) &&
               bt.softConsensus.avgMillisPerRequest == 0.0 &&
-              s.mempoolSize == 42 && s.sequencerHeadroom == 12,
-          s"blockTimings=$bt mempool=${s.mempoolSize} headroom=${s.sequencerHeadroom}"
+              s.mempoolSize == 42 && s.leaderMempoolDrain == 64 && s.sequencerHeadroom == 12,
+          s"blockTimings=$bt mempool=${s.mempoolSize} taken=${s.leaderMempoolDrain} headroom=${s.sequencerHeadroom}"
         )
 
     test("sampler moves the EWMA load averages for local, block, and request rates after activity"):
@@ -97,10 +98,10 @@ class PeerMetricsTest extends AnyFunSuite:
                 m <- IO.realTime.map(t => PeerMetrics.create(t.toMillis, Vector(0, 1)))
                 fiber <- m.sampler(1.second).start
                 // one local request + one 2-event block per second for 5 seconds
-                _ <- (1 to 5).toList.traverse_ { _ =>
+                _ <- (1 to 5).toList.traverse_ { i =>
                     IO {
                         m.onLocalAccepted()
-                        m.onBlockConfirmed(isMajor = false, events = 2)
+                        m.onBlockConfirmed(blockNum = i.toLong, isMajor = false, events = 2)
                     } >> IO.sleep(1.second)
                 }
                 _ <- IO.sleep(1.second) // let the sampler observe the last tick

--- a/src/test/scala/hydrozoa/multisig/metrics/PrometheusFormatTest.scala
+++ b/src/test/scala/hydrozoa/multisig/metrics/PrometheusFormatTest.scala
@@ -43,6 +43,7 @@ class PrometheusFormatTest extends AnyFunSuite:
         )
       ),
       mempoolSize = 923,
+      leaderMempoolDrain = 900,
       sequencerHeadroom = 12
     )
 


### PR DESCRIPTION
Follow-ups on #615.

- **New gauge `leaderMempoolDrain`** — how many requests the last lead pulled out of its mempool into the block it started (`hydrozoa_leader_mempool_drain` / JSON `leaderMempoolDrain`). Recorded in `BlockWeaver.Leader.ProcessingReadyRequests`, alongside the surviving `mempoolSize`.
- **`onCellSpawned` → `onBlockProduced`** — same moment (brief produced), so the soft-consensus clock opens there (in the JointLedger) and closes at soft-confirm. Drops the redundant FCA `onCellSpawned` call.
- **Folded `onCellConfirmed` into `onBlockConfirmed`** — one handler `onBlockConfirmed(blockNum, isMajor, events)` bumps the block counters and closes the soft-consensus clock.
- **Exclude the own peer from `peerRequests`** — a peer never sends requests to itself, so its entry was a constant zero. `PeerMetrics` now tracks `remotePeerNums`, filtered at the single `Serve` call site.

Docs: `docs/spec/peer-stats-endpoint.md` + regenerated `docs/api/openapi.yaml`. Green: fmt/lint, PeerMetrics/PrometheusFormat/JointLedger/BlockWeaver/OpenApiSchema tests, and `just build-werror` (main + integration).