### PR TITLE
chore(release): 0.1.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -377,7 +377,7 @@ inThisBuild(
   List(
     // Release version — drives the Docker image tag, `hydrozoa.BuildInfo.version`, and `GET
     // /version`. Bump here for a release (see RELEASE.md), then tag `v<version>`.
-    version := "0.1.5",
+    version := "0.1.6",
     scalaVersion := "3.3.7",
     semanticdbEnabled := true,
     semanticdbVersion := scalafixSemanticdb.revision

--- a/docs/user-guide/DEPLOYMENT.md
+++ b/docs/user-guide/DEPLOYMENT.md
@@ -110,9 +110,9 @@ workspace from it:
 
 ```bash
 mkdir myhead && cd myhead
-docker pull ghcr.io/cardano-hydrozoa/hydrozoa:0.1.5
+docker pull ghcr.io/cardano-hydrozoa/hydrozoa:0.1.6
 docker run --rm -v "$PWD:/work" -w /work --user root \
-  ghcr.io/cardano-hydrozoa/hydrozoa:0.1.5 scaffold .
+  ghcr.io/cardano-hydrozoa/hydrozoa:0.1.6 scaffold .
 # writes docker-compose.yml, hydrozoa.sh, template/peer-private.template.json.local
 ```
 
@@ -123,13 +123,13 @@ under it. Then load the CLI alias and check you are on the version you expect:
 source ./hydrozoa.sh   # sets the `hydrozoa` alias + HYDROZOA_HOME (this folder, an absolute path)
 
 hydrozoa version       # verify the image you are running
-#   hydrozoa 0.1.5
-#   git:   v0.1.5
+#   hydrozoa 0.1.6
+#   git:   v0.1.6
 #   built: 2026-07-28 14:00:37.834-0600
 ```
 
-(The `git:` line is `git describe` provenance; a published image built from the `v0.1.5` tag reads a
-clean `v0.1.5`. A locally built image between releases shows the distance from the newest tag, e.g.
+(The `git:` line is `git describe` provenance; a published image built from the `v0.1.6` tag reads a
+clean `v0.1.6`. A locally built image between releases shows the distance from the newest tag, e.g.
 `v0.1.0-10-gaa9d7c69`.)
 
 Need a version that isn't in the registry? Build it from this repo — see §3.
@@ -152,12 +152,12 @@ just integration-fast  # multi-peer integration subset
 Two ways to use your build:
 
 **A local Docker image** — the same image as the published one, from your sources. It is tagged
-both `cardano-hydrozoa/hydrozoa:0.1.5` and `ghcr.io/cardano-hydrozoa/hydrozoa:0.1.5`, so it matches
+both `cardano-hydrozoa/hydrozoa:0.1.6` and `ghcr.io/cardano-hydrozoa/hydrozoa:0.1.6`, so it matches
 `docker compose`'s default image name — the scaffolded head (§5) picks it up with no `HYDROZOA_IMAGE`
 override:
 
 ```bash
-just docker-image      # -> cardano-hydrozoa/hydrozoa:0.1.5 + ghcr.io/… (base eclipse-temurin:25-jre)
+just docker-image      # -> cardano-hydrozoa/hydrozoa:0.1.6 + ghcr.io/… (base eclipse-temurin:25-jre)
 ```
 
 **Locally-compiled code (development)** — `just stage` builds the `hydrozoa` launcher from the
@@ -361,8 +361,8 @@ At this point every node has its two files, and the composition (§5) mounts
 - Config mounts resolve against `.` — the head directory the compose file was scaffolded into — so
   running compose from there mounts that dir's shared `head-config.json` plus each node's
   `head-N/private.json` or `coil-N/private.json`. The image defaults to the published
-  `ghcr.io/cardano-hydrozoa/hydrozoa:0.1.5` (pulled on first run); set `${HYDROZOA_IMAGE}` to use
-  another, e.g. a locally built `cardano-hydrozoa/hydrozoa:0.1.5`.
+  `ghcr.io/cardano-hydrozoa/hydrozoa:0.1.6` (pulled on first run); set `${HYDROZOA_IMAGE}` to use
+  another, e.g. a locally built `cardano-hydrozoa/hydrozoa:0.1.6`.
 
 Caveats:
 - **State is ephemeral.** No data volumes are mounted (only read-only config bind mounts), so both
@@ -386,7 +386,7 @@ Default — pull the published image and run the scaffolded head:
 
 ```bash
 cd "$HYDROZOA_HOME"            # the scaffolded head dir (default head/demo)
-docker compose up -d          # pulls ghcr.io/cardano-hydrozoa/hydrozoa:0.1.5 on first run
+docker compose up -d          # pulls ghcr.io/cardano-hydrozoa/hydrozoa:0.1.6 on first run
 ```
 
 Stack 0 initializes once both head peers + any `coilQuorum` coil peers are signing.
@@ -411,11 +411,11 @@ The `(0,0)` entry under `happyPathEffects` is the initialization tx — open its
 network's explorer to check it out. Every following happy-path effect (settlements, the
 finalization) appears in the same section as the head progresses.
 
-**Another image** — `HYDROZOA_IMAGE` (default `ghcr.io/cardano-hydrozoa/hydrozoa:0.1.5`), e.g. a
+**Another image** — `HYDROZOA_IMAGE` (default `ghcr.io/cardano-hydrozoa/hydrozoa:0.1.6`), e.g. a
 locally built one (§3):
 
 ```bash
-HYDROZOA_IMAGE=cardano-hydrozoa/hydrozoa:0.1.5 docker compose up -d
+HYDROZOA_IMAGE=cardano-hydrozoa/hydrozoa:0.1.6 docker compose up -d
 ```
 
 **Another head** — each head directory carries its own `docker-compose.yml`, so switch heads by

--- a/src/main/resources/scaffold/docker-compose.yml
+++ b/src/main/resources/scaffold/docker-compose.yml
@@ -20,7 +20,7 @@ networks:
       com.docker.network.driver.mtu: 1400
 
 x-hydrozoa: &hydrozoa
-  image: ${HYDROZOA_IMAGE:-ghcr.io/cardano-hydrozoa/hydrozoa:${HYDROZOA_VERSION:-0.1.5}}
+  image: ${HYDROZOA_IMAGE:-ghcr.io/cardano-hydrozoa/hydrozoa:${HYDROZOA_VERSION:-0.1.6}}
   # root: the image's non-root user cannot write the RocksDB stores / logs under the /opt/docker
   # workdir. State is ephemeral here (no volumes) — restarting re-initializes a fresh head (§5b).
   user: root

--- a/src/main/resources/scaffold/hydrozoa.sh
+++ b/src/main/resources/scaffold/hydrozoa.sh
@@ -13,7 +13,7 @@
 # scaffolded workspace — resolved to an absolute path, so the alias mounts correctly no matter which
 # directory you run it from. Override HYDROZOA_HOME (to an absolute path) or HYDROZOA_VERSION before
 # sourcing, or edit the defaults below.
-: "${HYDROZOA_VERSION:=0.1.5}"   # published image tag (ghcr.io/cardano-hydrozoa/hydrozoa)
+: "${HYDROZOA_VERSION:=0.1.6}"   # published image tag (ghcr.io/cardano-hydrozoa/hydrozoa)
 : "${HYDROZOA_HOME:=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)}"   # head directory (absolute)
 export HYDROZOA_VERSION HYDROZOA_HOME
 


### PR DESCRIPTION
Version bump for the **0.1.6** release. Merge this (no need to wait on checks), then a `v0.1.6` tag builds and publishes the image (`:0.1.6`, `:0.1`, `:latest`).

## Version sites bumped (0.1.5 → 0.1.6)
- `build.sbt` release version (drives the image tag, `BuildInfo.version`, `GET /version`)
- `src/main/resources/scaffold/hydrozoa.sh` — `HYDROZOA_VERSION` default
- `src/main/resources/scaffold/docker-compose.yml` — default image tag
- `docs/user-guide/DEPLOYMENT.md` — pull/run examples

## Reference UTxOs
On-chain scripts and Scalus (`1.0.0`) are **unchanged** since 0.1.5, so the baked `scaffold/ref-utxos/` stay valid — no redeploy (RELEASE.md step 2 no-op).

## Notable changes since 0.1.5
- **Metrics / backpressure:** `backpressureCoefficient` (scales sequencer window *and* mesh pull ceiling) + block-lifecycle timing stats; new `leaderMempoolDrain` gauge; folded cell handlers; own peer excluded from `peerRequests`; lead/replay clocks closed in the JointLedger.
- **Transport:** configurable WS idle timeout + always-on keep-alive pings.
- **Rule-based:** stop `PollResults` forward after rule-based handoff; `TreasuryUnresolvedButNoVotes` → recoverable; tally gated on voting deadline; evacuation candidate-map fixes.
- **Tests/CI:** RBR MBT hardening on Scalus 1.0.0 (Yaci suites, withdrawals/L2 paths, scenario-summary tracer).