### PR TITLE
fix(config): validate built-in TxTiming presets via mk

### DIFF
--- a/src/main/scala/hydrozoa/config/head/multisig/timing/TxTiming.scala
+++ b/src/main/scala/hydrozoa/config/head/multisig/timing/TxTiming.scala
@@ -280,7 +280,7 @@ object TxTiming {
               "depositAbsorptionDuration must exceed minSettlementDuration + inactivityMarginDuration"
             )
 
-    def default(slotConfig: SlotConfig): TxTiming = TxTiming(
+    def default(slotConfig: SlotConfig): TxTiming = preset(
       MinSettlementDuration(12.hours.quantize(slotConfig)),
       InactivityMarginDuration(24.hours.quantize(slotConfig)),
       SilenceDuration(5.minutes.quantize(slotConfig)),
@@ -290,7 +290,7 @@ object TxTiming {
     )
 
     // TODO: move to integration
-    def yaci(slotConfig: SlotConfig): TxTiming = TxTiming(
+    def yaci(slotConfig: SlotConfig): TxTiming = preset(
       MinSettlementDuration(10.minutes.quantize(slotConfig)),
       InactivityMarginDuration(60.seconds.quantize(slotConfig)),
       SilenceDuration(10.minutes.quantize(slotConfig)),
@@ -299,7 +299,7 @@ object TxTiming {
       DepositAbsorptionDuration(12.minutes.quantize(slotConfig)),
     )
 
-    def demo(slotConfig: SlotConfig): TxTiming = TxTiming(
+    def demo(slotConfig: SlotConfig): TxTiming = preset(
       MinSettlementDuration(1.hour.quantize(slotConfig)),
       InactivityMarginDuration(2.hours.quantize(slotConfig)),
       SilenceDuration(2.minutes.quantize(slotConfig)),
@@ -309,7 +309,7 @@ object TxTiming {
     )
 
     // TODO: move to integration
-    def testnet(slotConfig: SlotConfig): TxTiming = TxTiming(
+    def testnet(slotConfig: SlotConfig): TxTiming = preset(
       MinSettlementDuration(1.hour.quantize(slotConfig)),
       InactivityMarginDuration(2.hours.quantize(slotConfig)),
       SilenceDuration(2.minutes.quantize(slotConfig)),
@@ -317,6 +317,30 @@ object TxTiming {
       DepositMaturityDuration(30.seconds.quantize(slotConfig)),
       DepositAbsorptionDuration(4.hours.quantize(slotConfig)),
     )
+
+    /** Build a built-in preset through the validating [[mk]] so it obeys the same invariant as a
+      * loaded config. A preset that violates it is a programming error, not recoverable input, so a
+      * `Left` is raised rather than threaded back to a caller.
+      */
+    private def preset(
+        minSettlementDuration: MinSettlementDuration,
+        inactivityMarginDuration: InactivityMarginDuration,
+        silenceDuration: SilenceDuration,
+        depositSubmissionDuration: DepositSubmissionDuration,
+        depositMaturityDuration: DepositMaturityDuration,
+        depositAbsorptionDuration: DepositAbsorptionDuration,
+    ): TxTiming =
+        mk(
+          minSettlementDuration,
+          inactivityMarginDuration,
+          silenceDuration,
+          depositSubmissionDuration,
+          depositMaturityDuration,
+          depositAbsorptionDuration
+        ).fold(
+          msg => throw IllegalArgumentException(s"invalid built-in TxTiming preset: $msg"),
+          identity
+        )
 
     /** The cardano liaison polling period must be at least this many times shorter than
       * [[depositMaturityDuration]]. Rationale: by the time a deposit reaches its absorption start

--- a/src/test/scala/hydrozoa/config/head/multisig/timing/TxTimingPresetsTest.scala
+++ b/src/test/scala/hydrozoa/config/head/multisig/timing/TxTimingPresetsTest.scala
@@ -1,0 +1,37 @@
+package hydrozoa.config.head.multisig.timing
+
+import hydrozoa.config.head.network.CardanoNetwork
+import org.scalatest.funsuite.AnyFunSuite
+
+class TxTimingPresetsTest extends AnyFunSuite:
+
+    private val slotConfig = CardanoNetwork.Preview.slotConfig
+
+    // Each built-in preset is routed through the validating `mk`, which requires
+    // depositAbsorptionDuration > minSettlementDuration + inactivityMarginDuration and throws
+    // otherwise. So merely constructing every preset is the assertion that they all satisfy it.
+    test("built-in TxTiming presets satisfy the depositAbsorptionDuration invariant"):
+        val presets = List(
+          TxTiming.default(slotConfig),
+          TxTiming.yaci(slotConfig),
+          TxTiming.demo(slotConfig),
+          TxTiming.testnet(slotConfig)
+        )
+        assert(presets.sizeIs == 4)
+
+    // A config whose absorption window is too small must be rejected, not silently built.
+    test(
+      "mk rejects depositAbsorptionDuration <= minSettlementDuration + inactivityMarginDuration"
+    ):
+        import TxTiming.Durations.*
+        import hydrozoa.lib.cardano.scalus.QuantizedTime.quantize
+        import scala.concurrent.duration.DurationInt
+        val bad = TxTiming.mk(
+          MinSettlementDuration(1.hour.quantize(slotConfig)),
+          InactivityMarginDuration(2.hours.quantize(slotConfig)),
+          SilenceDuration(2.minutes.quantize(slotConfig)),
+          DepositSubmissionDuration(2.minutes.quantize(slotConfig)),
+          DepositMaturityDuration(3.minutes.quantize(slotConfig)),
+          DepositAbsorptionDuration(3.hours.quantize(slotConfig)) // == 1h + 2h, not >
+        )
+        assert(bad.isLeft, s"expected Left, got $bad")


### PR DESCRIPTION
Follow-up to the earlier finding: the `depositAbsorptionDuration > minSettlementDuration + inactivityMarginDuration` invariant (max settlement-tx validity must fit inside the absorption window) was only enforced on the **JSON-decode path** (`txTimingDecoder` → `mk`). The built-in presets — `default` / `yaci` / `demo` / `testnet` — built `TxTiming` through the private case-class `apply`, bypassing the check.

**Change:** route every preset through a new private `preset` helper that calls `mk` and raises on a `Left` (a preset that violates the invariant is a programming error, not recoverable input). Single source of truth: the same `mk` both paths use.

**Test:** `TxTimingPresetsTest` — all four presets satisfy the invariant (construction is the assertion, since `preset` throws otherwise), and `mk` rejects a too-small absorption window (`Left`).

All four current presets already satisfy it (default 48h > 36h; yaci 12m > 11m; demo/testnet 4h > 3h), so no behavior change today — this locks it in going forward.

Green: fmt/lint, `TxTimingPresetsTest`, and `just build-werror` (main + integration).