### PR TITLE
perf(mempool): index arrival order by seq for O(log n) removal

### DIFF
--- a/src/main/scala/hydrozoa/multisig/consensus/BlockWeaver.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/BlockWeaver.scala
@@ -220,7 +220,7 @@ object BlockWeaver {
             def storeRequest(request: UserRequestWithId): IO[Mempool] =
                 mempool.addRequest(request) match {
                     case Some(newMempool) =>
-                        IO(connections.metrics.onMempoolSize(newMempool.requests.size))
+                        IO(connections.metrics.onMempoolSize(newMempool.size))
                             .as(newMempool)
                     case None =>
                         IO.raiseError(
@@ -672,7 +672,7 @@ object BlockWeaver {
                     (requests, survivingMempool) = extracted
                     // How many requests this lead pulled out of the mempool, and what's left behind.
                     _ <- IO(connections.metrics.onLeaderMempoolDrain(requests.size))
-                    _ <- IO(connections.metrics.onMempoolSize(survivingMempool.requests.size))
+                    _ <- IO(connections.metrics.onMempoolSize(survivingMempool.size))
                     isBlockStarted <-
                         if requests.isEmpty
                         then IO.pure(NotStarted)

--- a/src/main/scala/hydrozoa/multisig/consensus/mempool/Mempool.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/mempool/Mempool.scala
@@ -4,41 +4,49 @@ import hydrozoa.multisig.consensus.UserRequestWithId
 import hydrozoa.multisig.consensus.peer.HeadPeerNumber
 import hydrozoa.multisig.ledger.event.RequestId
 import scala.annotation.tailrec
+import scala.collection.immutable.TreeMap
 
-/** Simple immutable mempool implementation. Duplicate ledger request IDs are NOT allowed and a
-  * runtime exception is thrown since this should never happen. Other components, particularly the
-  * peer liaison is in charge or maintaining the integrity of the stream of messages.
+/** Simple immutable mempool. Duplicate ledger request IDs are NOT allowed; a duplicate add returns
+  * `None`. Other components — particularly the peer liaison — keep the incoming stream of messages
+  * consistent.
   *
-  * @param requests
-  *   map to store requests
-  * @param arrivalOrder
-  *   vector to store order of request ids
+  * Arrival order is indexed by a monotonic sequence number rather than a `Vector`, so removing an
+  * arbitrary request (the follower replay path, one id at a time) is `O(log n)` instead of the
+  * `O(n)` a `Vector.filterNot` would cost. `bySeq` iterates in arrival order; `seqOf` maps a
+  * request id to its arrival slot for dedup and removal.
+  *
+  * @param bySeq
+  *   requests keyed by arrival sequence number, so iteration is in arrival order
+  * @param seqOf
+  *   the arrival sequence number of each live request id
+  * @param nextSeq
+  *   the sequence number the next arrival will take (monotonic, never reused)
   */
-final case class Mempool(
-    requests: Map[RequestId, UserRequestWithId] = Map.empty,
-    arrivalOrder: Vector[RequestId] = Vector.empty
+final case class Mempool private (
+    bySeq: TreeMap[Long, UserRequestWithId],
+    seqOf: Map[RequestId, Long],
+    nextSeq: Long
 ) {
 
-    def isEmpty: Boolean = requests.isEmpty
+    def isEmpty: Boolean = seqOf.isEmpty
 
-    /** Add a request to the mempool
+    /** The number of live requests. */
+    def size: Int = seqOf.size
+
+    /** Add a request to the mempool.
       *
       * @param request
       *   a request to add
       * @return
-      *   an updated mempool
-      * @throws IllegalArgumentException
-      *   if a duplicate is detected
+      *   the updated mempool, or `None` if a request with the same id is already present
       */
-    def addRequest(
-        request: UserRequestWithId
-    ): Option[Mempool] = {
+    def addRequest(request: UserRequestWithId): Option[Mempool] = {
         val requestId = request.requestId
-
-        Option.when(!requests.contains(requestId))(
+        Option.when(!seqOf.contains(requestId))(
           copy(
-            requests = requests + (requestId -> request),
-            arrivalOrder = arrivalOrder :+ requestId
+            bySeq = bySeq.updated(nextSeq, request),
+            seqOf = seqOf.updated(requestId, nextSeq),
+            nextSeq = nextSeq + 1
           )
         )
     }
@@ -47,7 +55,8 @@ final case class Mempool(
       * @param requestId
       *   the request's ID
       */
-    def getRequest(requestId: RequestId): Option[UserRequestWithId] = requests.get(requestId)
+    def getRequest(requestId: RequestId): Option[UserRequestWithId] =
+        seqOf.get(requestId).map(bySeq)
 
     /** Given a list of request IDs, extract the corresponding requests from the mempool until a
       * request ID is encountered that is missing from the mempool.
@@ -94,35 +103,11 @@ final case class Mempool(
             }
     }
 
-    private def extractRequest(requestId: RequestId): Option[(Mempool, UserRequestWithId)] = {
-        val mRequestWithId = requests.get(requestId)
-        mRequestWithId.map(request => {
-            val newMempool = copy(
-              requests = requests - requestId,
-              arrivalOrder = arrivalOrder.filterNot(_ == requestId)
-            )
-            (newMempool, request)
-        })
-    }
-
-    /** Retrieve all mempool requests by order of arrival.
-      * @throws RuntimeException
-      *   If the mempool's [[arrivalOrder]] vector contains a request ID that is missing from its
-      *   [[requests]] map, violating the mempool's invariant property.
-      */
-    def extractRequestsInOrder: List[UserRequestWithId] =
-        arrivalOrder.iterator
-            .map(requestId => {
-                requests.getOrElse(
-                  requestId, {
-                      throw RuntimeException(
-                        s"Panic: the mempool's `arrivalOrder` vector has a request ID (${requestId.asI64}) that" +
-                            " is missing from the mempool's `requests` map."
-                      )
-                  }
-                )
-            })
-            .toList
+    private def extractRequest(requestId: RequestId): Option[(Mempool, UserRequestWithId)] =
+        seqOf.get(requestId).map { seq =>
+            val request = bySeq(seq)
+            (copy(bySeq = bySeq - seq, seqOf = seqOf - requestId), request)
+        }
 
     /** Extract up to `limit` requests for block production, preferring those authored by
       * `preferredPeer` so a leader's own users are not starved when the mempool is full (fairness).
@@ -137,29 +122,20 @@ final case class Mempool(
         preferredPeer: HeadPeerNumber,
         limit: Int
     ): (List[UserRequestWithId], Mempool) = {
-        val ordered: Vector[UserRequestWithId] = arrivalOrder.map(id =>
-            requests.getOrElse(
-              id,
-              throw RuntimeException(
-                s"Panic: the mempool's `arrivalOrder` vector has a request ID (${id.asI64}) that" +
-                    " is missing from the mempool's `requests` map."
-              )
-            )
-        )
-        // `partition` is stable, so each side keeps its arrival order; own requests lead.
-        val (own, others) = ordered.partition(_.requestId.peerNum == preferredPeer)
-        val chosen = (own ++ others).take(limit).toList
-        val chosenIds = chosen.iterator.map(_.requestId).toSet
+        // `bySeq.toVector` is (seq, request) in arrival order; `partition` is stable, so each side
+        // keeps that order and own requests lead.
+        val (own, others) = bySeq.toVector.partition(_._2.requestId.peerNum == preferredPeer)
+        val chosen = (own ++ others).take(limit)
         val survivingMempool = copy(
-          requests = requests -- chosenIds,
-          arrivalOrder = arrivalOrder.filterNot(chosenIds.contains)
+          bySeq = bySeq -- chosen.iterator.map(_._1),
+          seqOf = seqOf -- chosen.iterator.map(_._2.requestId)
         )
-        (chosen, survivingMempool)
+        (chosen.map(_._2).toList, survivingMempool)
     }
 }
 
 object Mempool {
-    val empty: Mempool = Mempool()
+    val empty: Mempool = Mempool(TreeMap.empty, Map.empty, 0L)
 
     enum Extraction:
         def extractedRequests: List[UserRequestWithId]

--- a/src/test/scala/hydrozoa/multisig/consensus/mempool/MempoolTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/mempool/MempoolTest.scala
@@ -1,0 +1,118 @@
+package hydrozoa.multisig.consensus.mempool
+
+import hydrozoa.multisig.consensus.UserRequest.TransactionRequest
+import hydrozoa.multisig.consensus.UserRequestBody.TransactionRequestBody
+import hydrozoa.multisig.consensus.UserRequestWithId
+import hydrozoa.multisig.consensus.peer.HeadPeerNumber
+import hydrozoa.multisig.ledger.event.RequestId
+import org.scalacheck.Prop.{forAll, propBoolean}
+import org.scalacheck.{Gen, Properties}
+import scalus.uplc.builtin.ByteString
+
+/** Properties for [[Mempool]]. The dummy request content is irrelevant — only the request id (peer
+  * number + arrival slot) drives every behaviour under test: dedup, arrival-order preservation, the
+  * leader's own-preference-under-cap extraction, and the follower's stop-at-first-missing replay.
+  */
+object MempoolTest extends Properties("Mempool") {
+
+    private val poolPeers = 0 to 4
+    private val poolNums = 0L to 19L
+    // A peer that never appears in a generated mempool, for "prefer an absent peer" (⇒ pure arrival
+    // order) and "extract a missing id" cases.
+    private val absentPeer = HeadPeerNumber(7)
+    private val missingId = RequestId(7, 0)
+
+    private def req(id: RequestId): UserRequestWithId =
+        UserRequestWithId(TransactionRequest(TransactionRequestBody(ByteString.empty)), id)
+
+    private val idPool: Vector[RequestId] =
+        (for { p <- poolPeers; n <- poolNums } yield RequestId(p, n)).toVector
+
+    /** A list of requests with distinct ids, in a random arrival order. */
+    private val genRequests: Gen[List[UserRequestWithId]] =
+        for {
+            n <- Gen.choose(0, idPool.size)
+            ids <- Gen.pick(n, idPool)
+        } yield ids.iterator.map(req).toList
+
+    private def build(rs: List[UserRequestWithId]): Mempool =
+        rs.foldLeft(Mempool.empty)((m, r) => m.addRequest(r).getOrElse(m))
+
+    /** The surviving requests, in arrival order (extract-all preferring an absent peer). */
+    private def inOrder(m: Mempool): List[UserRequestWithId] =
+        m.extractInOrderPreferring(absentPeer, Int.MaxValue)._1
+
+    val _ = property("addRequest dedups by id and counts live requests") = forAll(genRequests) {
+        rs =>
+            val m = build(rs)
+            val dupRejected = rs.forall(r => m.addRequest(r).isEmpty)
+            (m.size == rs.size) :| s"size ${m.size} != ${rs.size}" &&
+            dupRejected :| "a duplicate id was accepted"
+    }
+
+    val _ = property("getRequest finds present ids and misses absent ones") = forAll(genRequests) {
+        rs =>
+            val m = build(rs)
+            rs.forall(r => m.getRequest(r.requestId).contains(r)) &&
+            m.getRequest(missingId).isEmpty
+    }
+
+    val _ = property(
+      "extractInOrderPreferring with a big limit and absent peer returns arrival order"
+    ) = forAll(genRequests) { rs =>
+        val m = build(rs)
+        val (chosen, surviving) = m.extractInOrderPreferring(absentPeer, rs.size)
+        (chosen == rs) :| s"chosen $chosen != $rs" &&
+        surviving.isEmpty :| "surviving not empty"
+    }
+
+    val _ = property(
+      "extractInOrderPreferring leads own requests then others, each in arrival order, capped at limit"
+    ) = forAll(genRequests, Gen.choose(0, 4), Gen.choose(0, 30)) { (rs, peer, limit) =>
+        val preferred = HeadPeerNumber(peer)
+        val m = build(rs)
+        val (chosen, surviving) = m.extractInOrderPreferring(preferred, limit)
+
+        val own = rs.filter(_.requestId.peerNum == preferred)
+        val others = rs.filterNot(_.requestId.peerNum == preferred)
+        val expected = (own ++ others).take(limit)
+
+        (chosen == expected) :| s"chosen $chosen != expected $expected" &&
+        // The surviving mempool keeps the remainder in arrival order (nothing lost or reordered).
+        (inOrder(surviving) == rs.filterNot(expected.contains)) :| "surviving order wrong"
+    }
+
+    val _ = property(
+      "extractRequestsWhile is Complete when every id is present, in the requested order"
+    ) = forAll(genRequests) { rs =>
+        val m = build(rs)
+        forAll(Gen.choose(0, rs.size).flatMap(k => Gen.pick(k, rs))) { picked =>
+            val ids = picked.iterator.map(_.requestId).toList
+            m.extractRequestsWhile(ids) match {
+                case Mempool.Extraction.Complete(extracted, surviving) =>
+                    (extracted.map(_.requestId) == ids) :| "extracted order != requested" &&
+                    (surviving.size == rs.size - ids.size) :| "surviving size wrong" &&
+                    (inOrder(surviving) == rs.filterNot(r => ids.contains(r.requestId))) :|
+                        "surviving order wrong"
+                case other => false :| s"expected Complete, got $other"
+            }
+        }
+    }
+
+    val _ = property("extractRequestsWhile is Incomplete and stops at the first missing id") =
+        forAll(genRequests) { rs =>
+            val m = build(rs)
+            forAll(Gen.choose(0, rs.size).flatMap(k => Gen.pick(k, rs))) { prefixPick =>
+                val prefixIds = prefixPick.iterator.map(_.requestId).toList
+                // A present tail after the missing id must be ignored (extraction stops at missing).
+                val ids = prefixIds ::: missingId :: rs.map(_.requestId)
+                m.extractRequestsWhile(ids) match {
+                    case Mempool.Extraction.Incomplete(extracted, surviving, awaiting) =>
+                        (awaiting == missingId) :| s"awaiting $awaiting != $missingId" &&
+                        (extracted.map(_.requestId) == prefixIds) :| "extracted != prefix" &&
+                        (surviving.size == rs.size - prefixIds.size) :| "surviving size wrong"
+                    case other => false :| s"expected Incomplete, got $other"
+                }
+            }
+        }
+}


### PR DESCRIPTION
## Problem
The BlockWeaver mempool stored a request map alongside `arrivalOrder: Vector[RequestId]`. Removing one request did `arrivalOrder.filterNot(_ == id)` — **O(n)** — and the **follower replay** path (`extractRequestsWhile`) removes ids one at a time, so reproducing a k-request block on every follower, every block, was **O(k·n)** on the hot consensus path.

(The leader path `extractInOrderPreferring` was already a single O(n) pass, so it wasn't the bottleneck.)

## Change
Replace the vector with:
- `bySeq: TreeMap[Long, UserRequestWithId]` — requests keyed by a monotonic arrival sequence, so iteration stays in arrival order;
- `seqOf: Map[RequestId, Long]` — id → arrival slot, for dedup and removal;
- `nextSeq: Long`.

Single-request removal is now **O(log n)** (follower path **O(k log n)**). Iteration order is unchanged, so **behavior is identical** — `extractInOrderPreferring` still leads the leader's own requests, then others, each in arrival order (FIFO), capped at `limit`. Also drops the dead `extractRequestsInOrder` and exposes `size` (callers used `.requests.size`).

## Tests
`Mempool` had **no** tests. Added `MempoolTest` (ScalaCheck):
- `addRequest` dedups by id + `size`;
- `getRequest` present/absent;
- arrival-order round-trip;
- own-preference then others, each in arrival order, capped at `limit`, remainder preserved;
- follower `Complete` (requested order) and `Incomplete` (stops at first missing id).

Green: `MempoolTest`, `BlockWeaverTest`, `JointLedgerTest`, fmt/lint, and `just build-werror` (main + integration).