### PR TITLE
perf(persistence): tune RocksDB to absorb settlement write bursts

### DIFF
--- a/src/main/scala/hydrozoa/multisig/persistence/rocksdb/RocksDbBackendStore.scala
+++ b/src/main/scala/hydrozoa/multisig/persistence/rocksdb/RocksDbBackendStore.scala
@@ -6,7 +6,7 @@ import hydrozoa.multisig.persistence.*
 import hydrozoa.multisig.persistence.PersistenceEvent.{OpenRocksDbReady, OpenRocksDbStart}
 import java.nio.file.{Files, Path}
 import java.util.ArrayList as JArrayList
-import org.rocksdb.{ColumnFamilyDescriptor, ColumnFamilyHandle, ColumnFamilyOptions, DBOptions, ReadOptions, RocksDB, WriteBatch as RWriteBatch, WriteOptions}
+import org.rocksdb.{ColumnFamilyDescriptor, ColumnFamilyHandle, ColumnFamilyOptions, DBOptions, ReadOptions, RocksDB, Statistics, WriteBatch as RWriteBatch, WriteOptions}
 import scala.jdk.CollectionConverters.*
 
 /** RocksDB-backed [[BackendStore]] implementation.
@@ -108,12 +108,9 @@ object RocksDbBackendStore:
                 RocksDB.loadLibrary()
                 Files.createDirectories(path)
             })
-            cfOpts <- autoCloseable(new ColumnFamilyOptions())
-            dbOpts <- autoCloseable(
-              new DBOptions()
-                  .setCreateIfMissing(true)
-                  .setCreateMissingColumnFamilies(true)
-            )
+            cfOpts <- autoCloseable(tunedColumnFamilyOptions())
+            stats <- autoCloseable(new Statistics())
+            dbOpts <- autoCloseable(tunedDbOptions(stats))
             writeOptions <- autoCloseable(new WriteOptions())
             readOptions <- autoCloseable(new ReadOptions())
             opened <- openDb(path, dbOpts, cfOpts, cfs)
@@ -178,6 +175,52 @@ object RocksDbBackendStore:
     /** Stable on-disk name for a CF — `Cf.name` in UTF-8 (per-author satellites embed the author).
       */
     private def cfNameBytes(cf: Cf): Array[Byte] = cf.name.getBytes("UTF-8")
+
+    /** Per-column-family options tuned to absorb write bursts without stalling.
+      *
+      * All CFs (admission's Request lane plus every settlement lane) share this one options object,
+      * and they share a single write path. Under a settlement burst the stock defaults stall the
+      * whole DB — either on a full memtable (`maxWriteBufferNumber = 2`) or on the L0-file count
+      * (`level0StopWritesTrigger = 36`) — which blocks the RequestSequencer's per-request persist and
+      * shows up as multi-second admission latency. We have large disk headroom, so we widen both
+      * limits: more (and larger) memtables to soak up bursts while flushes drain, and much higher L0
+      * slowdown/stop triggers so compaction backlog throttles writes far later. Every value is
+      * overridable by env for no-recompile A/B tuning; the defaults are the tuned values (set the env
+      * vars back to 67108864 / 2 / 4 / 20 / 36 to reproduce stock behaviour).
+      */
+    private def tunedColumnFamilyOptions(): ColumnFamilyOptions =
+        new ColumnFamilyOptions()
+            .setWriteBufferSize(envLong("HYDROZOA_ROCKSDB_WRITE_BUFFER_BYTES", 128L * 1024 * 1024))
+            .setMaxWriteBufferNumber(envInt("HYDROZOA_ROCKSDB_MAX_WRITE_BUFFERS", 6))
+            .setMinWriteBufferNumberToMerge(envInt("HYDROZOA_ROCKSDB_MIN_MERGE", 1))
+            .setLevel0FileNumCompactionTrigger(envInt("HYDROZOA_ROCKSDB_L0_COMPACTION", 8))
+            .setLevel0SlowdownWritesTrigger(envInt("HYDROZOA_ROCKSDB_L0_SLOWDOWN", 40))
+            .setLevel0StopWritesTrigger(envInt("HYDROZOA_ROCKSDB_L0_STOP", 80))
+
+    /** Whole-DB options: size the background flush/compaction pool so it keeps up with the widened
+      * memtable/L0 budget above (a 32-thread box; stock `maxBackgroundJobs` is 2), spread large
+      * compactions across subcompactions, and range-sync in ~1 MB chunks so the OS writes dirty pages
+      * back incrementally instead of dumping a large buffer at once (smooths the latency tail even
+      * with `sync=false`). `stats` + a 30 s stats-dump make the DB's `LOG` record cumulative
+      * stall-micros and per-level compaction so we can confirm the stalls are actually gone.
+      */
+    private def tunedDbOptions(stats: Statistics): DBOptions =
+        new DBOptions()
+            .setCreateIfMissing(true)
+            .setCreateMissingColumnFamilies(true)
+            .setIncreaseParallelism(envInt("HYDROZOA_ROCKSDB_BG_JOBS", 8))
+            .setMaxBackgroundJobs(envInt("HYDROZOA_ROCKSDB_BG_JOBS", 8))
+            .setMaxSubcompactions(envInt("HYDROZOA_ROCKSDB_SUBCOMPACTIONS", 4))
+            .setBytesPerSync(envLong("HYDROZOA_ROCKSDB_BYTES_PER_SYNC", 1L * 1024 * 1024))
+            .setWalBytesPerSync(envLong("HYDROZOA_ROCKSDB_WAL_BYTES_PER_SYNC", 1L * 1024 * 1024))
+            .setStatistics(stats)
+            .setStatsDumpPeriodSec(envInt("HYDROZOA_ROCKSDB_STATS_DUMP_SEC", 30))
+
+    private def envInt(name: String, default: Int): Int =
+        sys.env.get(name).flatMap(_.toIntOption).getOrElse(default)
+
+    private def envLong(name: String, default: Long): Long =
+        sys.env.get(name).flatMap(_.toLongOption).getOrElse(default)
 
     private def autoCloseable[A <: AutoCloseable](a: => A): Resource[IO, A] =
         Resource.fromAutoCloseable(IO.blocking(a))


### PR DESCRIPTION
## What

Tune the node's RocksDB backend (`RocksDbBackendStore.open()`) so a settlement
burst no longer write-stalls the store: larger write buffers, higher L0
compaction triggers, a bigger background flush/compaction pool, and range-sync
on the WAL. Also enables RocksDB `Statistics` so stalls and compaction pressure
are observable.

Every knob is overridable via `HYDROZOA_ROCKSDB_*` environment variables; the
new defaults simply raise the library defaults enough to swallow the burst.

## Why

The node persists everything through a single RocksDB — request admission,
soft/hard confirmations, and settlement all write to column families that share
one WAL. A major block writes several CFs as one atomic batch, and that burst
can stall the DB (memtable-full / L0 backpressure). Because request admission
persists through the *same* store before it returns a requestId, a settlement
stall backs up directly into admission latency.

Tuning the write path to absorb the burst keeps admission responsive during
settlement without touching the storage format or the single-DB cross-CF
atomicity the recovery model relies on.

## Scope / safety

- Pure tuning: no schema, format, or write-ordering change; cross-CF atomic
  batches are untouched.
- Defaults are conservative and fully `HYDROZOA_ROCKSDB_*`-overridable, so an
  operator can retune per machine (a small prod box will want different values
  than a 32-thread dev box).
- This is the "tune the one DB" step. If a higher-TPS ceiling later demands it,
  group-committing the admission persist or splitting the request lane into its
  own DB remain open options — deliberately out of scope here.

## Testing

`sbt Test/compile` clean on top of current `main` (incl. #619). Rebased onto
`main` with no conflicts (touches only `RocksDbBackendStore.scala`, disjoint
from the mempool work in #619).