### PR TITLE
test(recovery): deterministic crash-injection harness + single-peer restart primitive

### DIFF
--- a/integration/src/test/scala/hydrozoa/integration/harness/CrashRestartTest.scala
+++ b/integration/src/test/scala/hydrozoa/integration/harness/CrashRestartTest.scala
@@ -1,0 +1,161 @@
+package hydrozoa.integration.harness
+
+import cats.effect.IO
+import cats.effect.testkit.TestControl
+import cats.effect.unsafe.implicits.global
+import hydrozoa.integration.stage4.Stage4Suite
+import hydrozoa.lib.logging.ContraTracer
+import hydrozoa.multisig.consensus.peer.{HeadPeerNumber, PeerId}
+import hydrozoa.multisig.persistence.Markers
+import org.scalacheck.Gen
+import org.scalacheck.rng.Seed
+import org.scalatest.funsuite.AnyFunSuite
+import scala.concurrent.duration.*
+
+/** End-to-end proof for the deterministic crash-recovery mechanism (see
+  * `.scratch/crash-after-write-n-scope.md`): crash one head peer at a chosen durable write during
+  * bring-up, restart it against its own store, and assert it recovers and rejoins the running head.
+  *
+  * This is the single hand-written case that proves the harness plumbing — [[CrashingPersistence]]
+  * (the injection seam), `MultiPeerHeadHarness.Hooks.wrapPersistence`, and
+  * `MultiPeerHeadHarness.restartHeadPeer` (stop the subtree, re-spawn against the same store + L2
+  * ledger, re-attach). The exhaustive `N × variant × victim-role` sweep and the ScalaCheck breadth
+  * layer build on it. It runs entirely on the cats-effect `TestControl` virtual clock (Direct
+  * transport, in-memory stores), so it is deterministic and fast.
+  *
+  * It directly guards the two recovery bugs fixed on `fix/recovery-crash-restart`: without the
+  * stack-0-close-bundle fix the restart fatally terminates (out-of-bounds on the own-hard-ack
+  * lane), and without the Puller cold-cursor fix the restarted peer loops rejecting and never
+  * rejoins — so the head could not hard-confirm past the crash.
+  */
+class CrashRestartTest extends AnyFunSuite {
+
+    test("a head peer crashed mid-init recovers from its store and rejoins the running head") {
+        val victim = HeadPeerNumber(1)
+        // An early durable write during head-1's bring-up. Small enough to fire well within the
+        // crash-wait budget below; the exact op it lands on is deterministic under TestControl.
+        val crashAtWrite = 3
+        // Virtual time granted after the restart for recovery + stack-0 hard-confirmation.
+        val recoveryWindow = 30.seconds
+
+        // A deterministic 2-head + 2-coil head (coil quorum 2) on the TestControl clock.
+        val state = Stage4Suite
+            .genInitialState(nPeers = 2, nCoilPeers = 2)
+            .pureApply(Gen.Parameters.default, Seed(0L))
+
+        val inputs = MultiPeerHeadHarness.Inputs(
+          config = MultiPeerHeadHarness.Config(
+            label = "crash-restart",
+            backendMode = MultiPeerHeadHarness.StorageBackend.Mode.InMemory,
+            transportMode = MultiPeerHeadHarness.Transport.Mode.Direct,
+          ),
+          multiNodeConfig = state.params.multiNodeConfig,
+          coilNodeConfigs = state.params.coilNodeConfigs,
+          preinitPeerUtxosL1 = state.preinitPeerUtxosL1,
+          takeoffTime = state.takeoffTime,
+          startEpochMs = state.currentModelTime.getEpochSecond * 1000L,
+        )
+
+        val program =
+            for
+                crashSignal <- IO.deferred[Unit]
+                writeCounter <- IO.ref(0)
+                hooks = MultiPeerHeadHarness.Hooks[Unit](
+                  tracer = ContraTracer.nullTracer[IO, MultiPeerHeadHarness.Event],
+                  handle = (_, _) => IO.unit,
+                  // Wrap only the victim's persistence: crash it at the N-th durable write.
+                  wrapPersistence = (peerId, persistence) =>
+                      if peerId == PeerId.Head(victim) then
+                          CrashingPersistence.wrap(
+                            persistence,
+                            writeCounter,
+                            Some(
+                              CrashingPersistence.Plan(
+                                crashAtWrite,
+                                CrashVariant.After,
+                                crashSignal,
+                              )
+                            ),
+                          )
+                      else persistence,
+                )
+                outcome <- MultiPeerHeadHarness.resource(inputs, hooks).use { harness =>
+                    for
+                        // Wait until head-1 actually crashes at write N — bounded so a mis-chosen N
+                        // fails fast rather than spinning the virtual clock forever.
+                        _ <- crashSignal.get.timeoutTo(
+                          3.minutes,
+                          IO.raiseError(
+                            new AssertionError(s"head $victim never reached write $crashAtWrite")
+                          ),
+                        )
+                        // Stop head-1's subtree and re-spawn it against the SAME store + L2 ledger;
+                        // recovery runs inline on boot and it re-attaches to the running head.
+                        restarted <- harness.restartHeadPeer(victim)
+                        _ <- IO.sleep(recoveryWindow)
+                        errors <- harness.sutErrors.get
+                        headConfirmed <- Markers.recoverHardConfirmed(
+                          harness.peers(HeadPeerNumber(0)).backendStore
+                        )
+                        victimOwnAcks <- Markers.recoverHardAcked(
+                          restarted.backendStore,
+                          PeerId.Head(victim),
+                        )
+                    yield (errors, headConfirmed, victimOwnAcks)
+                }
+            yield outcome
+
+        // Drive the virtual clock like ModelBasedSuite does (NOT TestControl.executeEmbed, which
+        // spins forever on the per-actor 1 s ping loops): tick eligible fibers, and when none is
+        // eligible advance to the next timer, until the inner program (including resource teardown)
+        // has produced its result.
+        def tickUntilAdvancing[A](tc: TestControl[A]): IO[Unit] =
+            tc.tickOne.flatMap {
+                case true => tickUntilAdvancing(tc)
+                case false =>
+                    tc.results.flatMap {
+                        case Some(_) => IO.unit
+                        case None =>
+                            tc.nextInterval.flatMap { next =>
+                                if next > Duration.Zero then
+                                    tc.advance(next) >> tickUntilAdvancing(tc)
+                                else
+                                    IO.raiseError(
+                                      new RuntimeException(
+                                        "TestControl deadlock: no eligible fibers, no timer"
+                                      )
+                                    )
+                            }
+                    }
+            }
+
+        val (errors, headConfirmed, victimOwnAcks) =
+            TestControl
+                .execute(program)
+                .flatMap(tc =>
+                    tickUntilAdvancing(tc) >> tc.results.flatMap {
+                        case Some(cats.effect.Outcome.Succeeded(value)) => IO.pure(value)
+                        case Some(cats.effect.Outcome.Errored(e))       => IO.raiseError(e)
+                        case Some(cats.effect.Outcome.Canceled()) =>
+                            IO.raiseError(new RuntimeException("inner program canceled"))
+                        case None =>
+                            IO.raiseError(new RuntimeException("inner program did not terminate"))
+                    }
+                )
+                .unsafeRunSync()
+
+        // Collect all failures so one assertion reports the full picture.
+        val problems = List(
+          Option.when(errors.nonEmpty)(s"uncaught actor errors after restart: $errors"),
+          // The head hard-confirmed a stack AFTER head-1 was crashed mid-init — only possible if
+          // head-1 recovered and rejoined (hard-confirmation needs every head peer's signature).
+          Option.when(headConfirmed.isEmpty)(
+            "head did not hard-confirm any stack after the restart"
+          ),
+          // head-1's own hard-acks are durable post-recovery (the stack-0-close-bundle fix), so its
+          // own-hard-ack marker is restored rather than empty.
+          Option.when(victimOwnAcks.isEmpty)("recovered head-1 has no own hard-acks"),
+        ).flatten
+        assert(problems.isEmpty, problems.mkString("; "))
+    }
+}

--- a/integration/src/test/scala/hydrozoa/integration/harness/CrashingPersistence.scala
+++ b/integration/src/test/scala/hydrozoa/integration/harness/CrashingPersistence.scala
@@ -1,0 +1,84 @@
+package hydrozoa.integration.harness
+
+import cats.effect.{Deferred, IO, Ref}
+import hydrozoa.multisig.persistence.{ArrivalStamp, BackendStore, Persistence, StoreKey, WriteBatch}
+import java.time.Instant
+
+/** Which side of a durable write the injected crash lands on. */
+enum CrashVariant:
+    /** Crash before the op's write reaches the backend — nothing persisted (the sender re-derives /
+      * the user resubmits).
+      */
+    case Before
+
+    /** Let the op's write land, then crash before the handler's next step (advance cursor / send /
+      * dispatch) — the CR4 / CR8 durability-barrier point.
+      */
+    case After
+
+/** A [[Persistence]] decorator for deterministic crash-recovery testing: it counts the wrapped
+  * peer's durable mutations and, at a chosen count, simulates a process death at that exact point.
+  *
+  * All durable writes in the node funnel through `put` / `delete` / `write` (`Persistence`
+  * §Persistence.scala), so a single decorator over one peer's `Persistence` observes every durable
+  * op that peer makes — including each `PeerLiaison*.persistInbound` (the CR8 write-before-advance
+  * point) and every consensus-actor write — with no changes to the actors or the backend. Under the
+  * stage4 `TestControl` clock the op order is deterministic, so "the N-th write" is reproducible.
+  *
+  * The crash is modelled as: at the N-th durable op, complete a [[Plan.signal]] and then block the
+  * op forever ([[IO.never]]). The fixture races the signal and tears the peer's actor subtree down,
+  * so the handler never advances, sends, or dispatches past the crash point. On
+  * [[CrashVariant.After]] the op's write lands first; on [[CrashVariant.Before]] it does not.
+  */
+object CrashingPersistence:
+
+    /** A crash plan: fire at the `at`-th durable op (1-based) with `variant` deciding whether that
+      * op's write lands first. `signal` is completed when the crash point is reached — the fixture
+      * awaits it, then stops the peer's actor subtree and rebuilds it against the same store.
+      */
+    final case class Plan(at: Int, variant: CrashVariant, signal: Deferred[IO, Unit])
+
+    /** Wrap `inner`, sharing `counter` across all of this peer's durable ops. `plan = None` is an
+      * ordinary pass-through (used for the post-restart instance, which must not crash again).
+      */
+    def wrap(
+        inner: Persistence[IO],
+        counter: Ref[IO, Int],
+        plan: Option[Plan],
+    ): Persistence[IO] =
+        new Persistence[IO]:
+            // Count only durable mutations; reads never advance the counter.
+            private def guarded(op: IO[Unit]): IO[Unit] =
+                plan match
+                    case None => op
+                    case Some(Plan(at, variant, signal)) =>
+                        counter.updateAndGet(_ + 1).flatMap { n =>
+                            if n != at then op
+                            else
+                                variant match
+                                    case CrashVariant.Before => crash(signal)
+                                    case CrashVariant.After  => op >> crash(signal)
+                        }
+
+            // Signal the crash point, then block forever — the fixture stops this peer's actors,
+            // cancelling the blocked op, so nothing past the crash point runs.
+            private def crash(signal: Deferred[IO, Unit]): IO[Unit] =
+                signal.complete(()).attempt >> IO.never
+
+            def put(key: StoreKey)(value: key.Value): IO[Unit] = guarded(inner.put(key)(value))
+
+            def delete(key: StoreKey): IO[Unit] = guarded(inner.delete(key))
+
+            def write(batch: WriteBatch): IO[Unit] = guarded(inner.write(batch))
+
+            def get(key: StoreKey): IO[Option[key.Value]] = inner.get(key)
+
+            def getOrFail(key: StoreKey): IO[key.Value] = inner.getOrFail(key)
+
+            def arrivalStamp: IO[ArrivalStamp] = inner.arrivalStamp
+
+            def zeroTimes: IO[Map[Int, Long]] = inner.zeroTimes
+
+            def wallClockOf(stamp: ArrivalStamp): IO[Instant] = inner.wallClockOf(stamp)
+
+            def backend: BackendStore[IO] = inner.backend

--- a/integration/src/test/scala/hydrozoa/integration/harness/CrashingPersistence.scala
+++ b/integration/src/test/scala/hydrozoa/integration/harness/CrashingPersistence.scala
@@ -25,10 +25,15 @@ enum CrashVariant:
   * point) and every consensus-actor write — with no changes to the actors or the backend. Under the
   * stage4 `TestControl` clock the op order is deterministic, so "the N-th write" is reproducible.
   *
-  * The crash is modelled as: at the N-th durable op, complete a [[Plan.signal]] and then block the
-  * op forever ([[IO.never]]). The fixture races the signal and tears the peer's actor subtree down,
-  * so the handler never advances, sends, or dispatches past the crash point. On
-  * [[CrashVariant.After]] the op's write lands first; on [[CrashVariant.Before]] it does not.
+  * The crash is modelled as: at the N-th durable op, complete a [[Plan.signal]] and return normally
+  * WITHOUT blocking — the fixture races the signal and tears the peer's actor subtree down.
+  * Blocking the op (e.g. `IO.never`) would stall the actor's mailbox loop so `stop`'s `Terminate`
+  * could never be processed, hanging system shutdown; so the peer keeps running for a deterministic
+  * few ops after the signal until the fixture stops it. That is sound because everything past the
+  * crash point is IN-MEMORY state that a restart discards anyway — the durable store reflects
+  * exactly what landed: on [[CrashVariant.After]] the op's write is included, on
+  * [[CrashVariant.Before]] it is skipped (the handler continues with un-persisted state that the
+  * restart throws away).
   */
 object CrashingPersistence:
 
@@ -47,7 +52,10 @@ object CrashingPersistence:
         plan: Option[Plan],
     ): Persistence[IO] =
         new Persistence[IO]:
-            // Count only durable mutations; reads never advance the counter.
+            // Count only durable mutations; reads never advance the counter. At the crash point,
+            // signal WITHOUT blocking — on Before the op is skipped, on After it runs first; the
+            // fixture then tears the peer down (blocking here would stall the mailbox so `stop`
+            // could never be processed).
             private def guarded(op: IO[Unit]): IO[Unit] =
                 plan match
                     case None => op
@@ -56,14 +64,9 @@ object CrashingPersistence:
                             if n != at then op
                             else
                                 variant match
-                                    case CrashVariant.Before => crash(signal)
-                                    case CrashVariant.After  => op >> crash(signal)
+                                    case CrashVariant.Before => signal.complete(()).void
+                                    case CrashVariant.After  => op >> signal.complete(()).void
                         }
-
-            // Signal the crash point, then block forever — the fixture stops this peer's actors,
-            // cancelling the blocked op, so nothing past the crash point runs.
-            private def crash(signal: Deferred[IO, Unit]): IO[Unit] =
-                signal.complete(()).attempt >> IO.never
 
             def put(key: StoreKey)(value: key.Value): IO[Unit] = guarded(inner.put(key)(value))
 

--- a/integration/src/test/scala/hydrozoa/integration/harness/MultiPeerHeadHarness.scala
+++ b/integration/src/test/scala/hydrozoa/integration/harness/MultiPeerHeadHarness.scala
@@ -595,6 +595,10 @@ object MultiPeerHeadHarness:
         handle: (PeerId, HeadMultisigRegimeManager.Connections) => IO[H],
         // Wrap the shared mock backend per peer (e.g. FirewalledCardanoBackend). Identity default.
         wrapBackend: (PeerId, L1Backend[IO]) => L1Backend[IO] = (_, b) => b,
+        // Wrap a peer's typed persistence before it reaches the regime manager — the injection
+        // seam for crash-recovery testing (e.g. CrashingPersistence, which fails at the N-th durable
+        // write). Identity default. See docs/spec/persistence-and-crash-recovery.md.
+        wrapPersistence: (PeerId, Persistence[IO]) => Persistence[IO] = (_, p) => p,
     )
 
     /** Per-head-peer artifacts exposed to callers: resolved connections, persistence backend, the
@@ -676,6 +680,7 @@ object MultiPeerHeadHarness:
                           backendMode,
                           transports.headNetworks(peerNum),
                           hooks.tracer.contramap(Event.Head(peerNum, _)),
+                          hooks.wrapPersistence(PeerId.Head(peerNum), _),
                         )
                         .map(peerNum -> _)
                 )
@@ -1345,6 +1350,8 @@ object MultiPeerHeadHarness:
             backendMode: StorageBackend.Mode,
             network: Transport.HeadNetwork,
             callerTracer: ContraTracer[IO, HeadRegimeManagerEvent],
+            // Wrap this peer's persistence before it reaches the regime manager (crash injection).
+            wrapPersistence: Persistence[IO] => Persistence[IO] = identity,
         ): Resource[IO, Peer] =
             val nodeConfig = multiNodeConfig.nodeConfigs(peerNum)
             val persistenceTracer = Slf4jTracer.sink.contramap(PersistenceEventFormat.humanFormat)
@@ -1365,10 +1372,11 @@ object MultiPeerHeadHarness:
                 )
                 .flatMap { backendStore =>
                     for
-                        persistence <- Resource.eval {
+                        rawPersistence <- Resource.eval {
                             given CardanoNetwork.Section = nodeConfig
                             Persistence.fromBackend(backendStore, persistenceTracer)
                         }
+                        persistence = wrapPersistence(rawPersistence)
                         l2Ledger <- Resource.eval(InMemoryL2Store.ledger(nodeConfig))
                         metrics = PeerMetrics.create(
                           0L,

--- a/integration/src/test/scala/hydrozoa/integration/harness/MultiPeerHeadHarness.scala
+++ b/integration/src/test/scala/hydrozoa/integration/harness/MultiPeerHeadHarness.scala
@@ -4,6 +4,7 @@ import cats.data.ReaderT
 import cats.effect.{IO, Ref, Resource}
 import cats.implicits.*
 import com.comcast.ip4s.{Port, host}
+import com.suprnation.actor.ActorRef.NoSendActorRef
 import com.suprnation.actor.event.Error as ActorError
 import com.suprnation.actor.{ActorContext, ActorSystem}
 import hydrozoa.config.head.coil.CoilPeers
@@ -29,6 +30,7 @@ import hydrozoa.multisig.consensus.{CardanoLiaison, RequestSequencer}
 import hydrozoa.multisig.ledger.block.BlockVersion.Major.given_Conversion_Major_Int
 import hydrozoa.multisig.ledger.eutxol2.EutxoL2Screener
 import hydrozoa.multisig.ledger.eutxol2.store.InMemoryL2Store
+import hydrozoa.multisig.ledger.l2.L2Ledger
 import hydrozoa.multisig.ledger.l1.tx.{EnrichedTx, SettlementTx}
 import hydrozoa.multisig.metrics.PeerMetrics
 import hydrozoa.multisig.persistence.rocksdb.RocksDbBackendStore
@@ -630,6 +632,11 @@ object MultiPeerHeadHarness:
         peers: Map[HeadPeerNumber, Peer[H]],
         coils: Map[CoilPeerNumber, Coil[H]],
         sutErrors: Ref[IO, List[String]],
+        // Crash-restart one head peer: stop its actor subtree, then re-spawn it against the SAME
+        // durable store + L2 ledger (recovery runs on boot) and re-attach it to the running head.
+        // Returns the peer's fresh handle (new connections + SubmissionClient). Direct transport
+        // only. The initial `peers` map entry goes stale after a restart — use the returned handle.
+        restartHeadPeer: HeadPeerNumber => IO[Peer[H]],
     )
 
     /** Build a fully-wired multi-peer head + coil followers. The returned resource owns everything;
@@ -722,14 +729,24 @@ object MultiPeerHeadHarness:
             )
             sutErrors <- Resource.eval(Ref[IO].of(List.empty[String]))
             _ <- ErrorDrainer.start(system, sutErrors)
-            _ <- Ticks.startForHeads(
-              peerConnections,
-              peerNum =>
-                  multiNodeConfig
-                      .nodeConfigs(peerNum)
-                      .nodeOperationMultisigConfig
-                      .cardanoLiaisonPollingPeriod,
-            )
+            headPollingPeriodOf = (peerNum: HeadPeerNumber) =>
+                multiNodeConfig
+                    .nodeConfigs(peerNum)
+                    .nodeOperationMultisigConfig
+                    .cardanoLiaisonPollingPeriod
+            // Per-peer CL tick fibers, tracked (as cancel actions) so a crash-restart can cancel the
+            // victim's old tick — which would otherwise keep poking its stopped CardanoLiaison, a
+            // dead-letter flood — and start a fresh one. All are cancelled on release.
+            headTicks <- Resource.make(
+              Ref[IO].of(Map.empty[HeadPeerNumber, IO[Unit]]).flatTap { ref =>
+                  peerConnections.toList.traverse_ { case (peerNum, conns) =>
+                      Ticks
+                          .tickLoop(headPollingPeriodOf(peerNum), conns)
+                          .start
+                          .flatMap(fib => ref.update(_.updated(peerNum, fib.cancel)))
+                  }
+              }
+            )(_.get.flatMap(_.values.toList.traverse_(identity)))
             _ <- Ticks.startForCoils(
               coilConnections,
               coilNum =>
@@ -763,6 +780,53 @@ object MultiPeerHeadHarness:
                   }
               }
             )
+            // Crash-restart bookkeeping: the current per-peer runtime (updated on each restart),
+            // an actor-name generation counter, and the restart-started tick fibers (cancelled on
+            // release; the initial bulk ticks are owned by Ticks.startForHeads above).
+            peerRuntime <- Resource.eval(Ref[IO].of(peerMrms))
+            restartGen <- Resource.eval(Ref[IO].of(0))
+            restartHeadPeer = { (peerNum: HeadPeerNumber) =>
+                for
+                    old <- peerRuntime.get.map(_(peerNum))
+                    // Stop the old subtree, then re-spawn against the SAME store + L2 ledger; the
+                    // rebuilt network re-registers in the shared registry so the mesh re-attaches.
+                    _ <- old.ref.stop
+                    gen <- restartGen.updateAndGet(_ + 1)
+                    network <- transports.rebuildHeadNetwork(peerNum)
+                    spawned <- Mrm
+                        .spawnPeer(
+                          s"hmrm-$peerNum-r$gen",
+                          peerNum,
+                          system,
+                          cardanoBackend,
+                          multiNodeConfig,
+                          network,
+                          hooks.tracer.contramap(Event.Head(peerNum, _)),
+                          old.backendStore,
+                          old.l2Ledger,
+                          identity,
+                        )
+                        .allocated
+                        .map(_._1)
+                    (mrm, ref) = spawned
+                    conns <- mrm.connectionsDeferred.get
+                    // Cancel the victim's previous tick (its CardanoLiaison is now stopped), then
+                    // start a fresh tick against the new connections.
+                    _ <- headTicks.get.flatMap(_.getOrElse(peerNum, IO.unit))
+                    tickFib <- Ticks.tickLoop(headPollingPeriodOf(peerNum), conns).start
+                    _ <- headTicks.update(_.updated(peerNum, tickFib.cancel))
+                    submissionClient <- Http.mkPeerSubmissionClient(peerNum, conns, multiNodeConfig)
+                    h <- hooks.handle(PeerId.Head(peerNum), conns)
+                    _ <- peerRuntime.update(
+                      _.updated(peerNum, Mrm.Peer(mrm, ref, old.backendStore, old.l2Ledger))
+                    )
+                yield Peer(
+                  connections = conns,
+                  backendStore = old.backendStore,
+                  submissionClient = submissionClient,
+                  handle = h,
+                )
+            }
         yield Harness(
           transportMode = transportMode,
           multiNodeConfig = multiNodeConfig,
@@ -772,6 +836,7 @@ object MultiPeerHeadHarness:
           peers = peerEntries.toMap,
           coils = coilEntries.toMap,
           sutErrors = sutErrors,
+          restartHeadPeer = restartHeadPeer,
         )
 
     // ===================================
@@ -1060,6 +1125,10 @@ object MultiPeerHeadHarness:
             headNetworks: Map[HeadPeerNumber, HeadNetwork],
             coilUplinks: Map[CoilPeerNumber, ContextFn[CoilTransport]],
             bringUpNetwork: Resource[IO, Unit],
+            // Rebuild ONE head peer's transport bundle for a crash-restart, re-registering it in the
+            // shared registry so the other peers' next sends resolve to the new transport (Direct
+            // only; unsupported under WS, which disables the TestControl clock anyway).
+            rebuildHeadNetwork: HeadPeerNumber => IO[HeadNetwork],
         )
 
         /** Per-peer transport bundle: the head-mesh transport and an optional hub-side hub-coil
@@ -1140,7 +1209,19 @@ object MultiPeerHeadHarness:
                             .map(t => coilNum -> ((_: ContextArg) => t: CoilTransport))
                     }
                     .map(_.toMap)
-            yield Setup(headNetworks, coilUplinks, Resource.unit)
+            yield Setup(
+              headNetworks,
+              coilUplinks,
+              Resource.unit,
+              rebuildHeadNetwork = peerNum =>
+                  directHeadNetwork(
+                    peerNum,
+                    multiNodeConfig,
+                    inProcessRegistry,
+                    hubCoilRegistry
+                  ).allocated
+                      .map(_._1),
+            )
 
         /** WebSocket (real-clock) bring-up: split into a creation phase (this method) and a
           * deferred [[Setup.bringUpNetwork]] phase. The creation phase allocates the shared
@@ -1190,7 +1271,17 @@ object MultiPeerHeadHarness:
                   headParts,
                   coilTransports,
                 )
-            yield Setup(headNetworks, coilUplinks, bringUp)
+            yield Setup(
+              headNetworks,
+              coilUplinks,
+              bringUp,
+              rebuildHeadNetwork = _ =>
+                  IO.raiseError(
+                    new UnsupportedOperationException(
+                      "peer crash-restart is unsupported under WebSocket transport"
+                    )
+                  ),
+            )
 
         /** Per-peer parts produced in WS Phase 1: the transport bundle exposed to the MRM, the
           * concrete mesh transport needed by Phase 2's dialer starter, and the route builders Phase
@@ -1333,7 +1424,13 @@ object MultiPeerHeadHarness:
     object Mrm:
         case class Peer(
             mrm: HeadMultisigRegimeManager,
+            // The regime-manager actor root; `.stop` cascade-stops the whole child subtree (the
+            // crash primitive). Held so a crash-restart can tear this instance down.
+            ref: NoSendActorRef[IO],
             backendStore: BackendStore[IO],
+            // Reused across a crash-restart (holds the L2 log/snapshots the recovering JointLedger
+            // co-anchors to via restoreTo), so it must survive the actor teardown.
+            l2Ledger: L2Ledger[IO],
         )
 
         case class Coil(
@@ -1355,10 +1452,6 @@ object MultiPeerHeadHarness:
         ): Resource[IO, Peer] =
             val nodeConfig = multiNodeConfig.nodeConfigs(peerNum)
             val persistenceTracer = Slf4jTracer.sink.contramap(PersistenceEventFormat.humanFormat)
-            val peerFactory: Resource[IO, Transport.ContextFn[PeerTransport]] =
-                Resource.pure((_: Transport.ContextArg) => network.peerTransport)
-            val hubFactory: Option[Resource[IO, Transport.ContextFn[HubTransport]]] =
-                network.hubTransport.map(h => Resource.pure((_: Transport.ContextArg) => h))
             StorageBackend
                 .openPerPeer(
                   peerNum,
@@ -1372,30 +1465,74 @@ object MultiPeerHeadHarness:
                 )
                 .flatMap { backendStore =>
                     for
-                        rawPersistence <- Resource.eval {
-                            given CardanoNetwork.Section = nodeConfig
-                            Persistence.fromBackend(backendStore, persistenceTracer)
-                        }
-                        persistence = wrapPersistence(rawPersistence)
                         l2Ledger <- Resource.eval(InMemoryL2Store.ledger(nodeConfig))
-                        metrics = PeerMetrics.create(
-                          0L,
-                          nodeConfig.headConfig.headPeerNums.toList.map(_.convert).toVector
-                        )
-                        mrm <- HeadMultisigRegimeManager.resource(
-                          nodeConfig,
+                        spawned <- spawnPeer(
+                          s"hmrm-$peerNum",
+                          peerNum,
+                          system,
                           cardanoBackend,
-                          l2Ledger,
-                          EutxoL2Screener(nodeConfig),
-                          persistence,
-                          metrics,
+                          multiNodeConfig,
+                          network,
                           callerTracer,
-                          peerFactory,
-                          hubFactory,
+                          backendStore,
+                          l2Ledger,
+                          wrapPersistence,
                         )
-                        _ <- Resource.eval(system.actorOf(mrm, s"hmrm-$peerNum"))
-                    yield Peer(mrm, backendStore)
+                        (mrm, ref) = spawned
+                    yield Peer(mrm, ref, backendStore, l2Ledger)
                 }
+
+        /** Spawn (or, on a crash-restart, re-spawn) a head peer's regime-manager actor over an
+          * ALREADY-OPEN store + L2 ledger. Re-invokable: a restart reuses the same `backendStore`
+          * and `l2Ledger` (so the durable consensus journal and the L2 log survive the "crash"),
+          * builds a fresh `Persistence` (bumping the arrival-stamp generation), and boots the HMRM
+          * — whose `preStartLocal` runs `ReplayActor.replay` inline. `actorName` must be unique per
+          * spawn (a restart uses a fresh suffix). The returned `NoSendActorRef` `.stop`s the whole
+          * child subtree — the crash primitive. The Resource finalizer is trivial (the actor is
+          * stopped via `.stop` / system shutdown, not the Resource), so a restart may `.allocated`
+          * it and discard the finalizer.
+          */
+        def spawnPeer(
+            actorName: String,
+            peerNum: HeadPeerNumber,
+            system: ActorSystem[IO],
+            cardanoBackend: L1Backend[IO],
+            multiNodeConfig: MultiNodeConfig,
+            network: Transport.HeadNetwork,
+            callerTracer: ContraTracer[IO, HeadRegimeManagerEvent],
+            backendStore: BackendStore[IO],
+            l2Ledger: L2Ledger[IO],
+            wrapPersistence: Persistence[IO] => Persistence[IO],
+        ): Resource[IO, (HeadMultisigRegimeManager, NoSendActorRef[IO])] =
+            val nodeConfig = multiNodeConfig.nodeConfigs(peerNum)
+            val persistenceTracer = Slf4jTracer.sink.contramap(PersistenceEventFormat.humanFormat)
+            val peerFactory: Resource[IO, Transport.ContextFn[PeerTransport]] =
+                Resource.pure((_: Transport.ContextArg) => network.peerTransport)
+            val hubFactory: Option[Resource[IO, Transport.ContextFn[HubTransport]]] =
+                network.hubTransport.map(h => Resource.pure((_: Transport.ContextArg) => h))
+            for
+                rawPersistence <- Resource.eval {
+                    given CardanoNetwork.Section = nodeConfig
+                    Persistence.fromBackend(backendStore, persistenceTracer)
+                }
+                persistence = wrapPersistence(rawPersistence)
+                metrics = PeerMetrics.create(
+                  0L,
+                  nodeConfig.headConfig.headPeerNums.toList.map(_.convert).toVector
+                )
+                mrm <- HeadMultisigRegimeManager.resource(
+                  nodeConfig,
+                  cardanoBackend,
+                  l2Ledger,
+                  EutxoL2Screener(nodeConfig),
+                  persistence,
+                  metrics,
+                  callerTracer,
+                  peerFactory,
+                  hubFactory,
+                )
+                ref <- Resource.eval(system.actorOf(mrm, actorName))
+            yield (mrm, ref: NoSendActorRef[IO])
 
         def buildCoil(
             coilConfig: NodeConfig,
@@ -1533,7 +1670,10 @@ object MultiPeerHeadHarness:
                 startedFiber(tickLoop(pollingPeriodOf(coilNum), conns))
             }
 
-        private def tickLoop(
+        // Non-private so a crash-restart can start a fresh tick for the rebuilt peer's new
+        // connections (the restarted peer's old tick keeps poking its now-stopped CardanoLiaison —
+        // harmless dead letters).
+        def tickLoop(
             pollingPeriod: FiniteDuration,
             conns: HeadMultisigRegimeManager.Connections,
         ): IO[Nothing] =


### PR DESCRIPTION
Adds the deterministic crash-recovery test infrastructure that the recovery fixes in #623 were built
against — the test that would have caught both of those bugs by construction, and the foundation for
the exhaustive crash-point sweep to come.

Builds on `main` (the two recovery fixes + the stage4 oracle count from #623 are already merged);
this PR is purely the test harness, so the diff is the 3 files below.

## What it adds

- **`CrashingPersistence`** — a `Persistence` decorator (injection seam). It counts a peer's durable
  ops (`put`/`delete`/`write`; reads don't count) and, at a chosen count, signals a crash. All durable
  writes funnel through the one seam, so it observes every durable op that peer makes — including each
  `PeerLiaison*.persistInbound` — with no changes to the actors or the backend. Under the stage4
  `TestControl` clock the op order is deterministic, so "the N-th write" is reproducible.
  Signal-and-continue model (not `IO.never`): blocking the op would stall the actor mailbox so
  `stop`'s `Terminate` could never be processed, hanging system shutdown.

- **`MultiPeerHeadHarness.restartHeadPeer(n)`** — stop one head peer's actor subtree (retained
  `NoSendActorRef`) and re-spawn it against the **same** durable consensus store **and** L2 ledger
  (recovery runs inline on boot), re-registering its Direct transport in the shared registry so the
  mesh re-attaches. Splits `buildPeer` into store-open + a re-invokable `spawnPeer`, adds a
  `wrapPersistence` hook (mirroring `wrapBackend`) as the injection point, and makes the CL ticks
  per-peer cancelable so a restart's victim doesn't leak a dead-lettering tick. Additive; no behaviour
  change with the identity defaults.

- **`CrashRestartTest`** — the end-to-end proof: crash head-1 mid-init at write N, restart it from its
  store, and assert the head hard-confirms past the crash and head-1 has its own hard-acks, with no
  actor errors. Runs entirely on the `TestControl` virtual clock (Direct transport, in-memory stores),
  driven by a `tickUntilAdvancing` loop (not `executeEmbed`, which spins on the per-actor ping loops).

## Scope / testing

3 files, integration test-only (+429/-33). `CrashRestartTest` passes; compiles + lint/fmt clean.

## Follow-up (not in this PR)

The exhaustive `N x {before,after} x victim-role` sweep, a pairwise-link-crash scenario (single-peer
crash can't exercise the liaison cold-to-cold reconnect), and a ScalaCheck breadth layer.