### PR TITLE
fix(l2-remote): implement restoreTo (send a Restore request to the remote ledger)

### DIFF
--- a/src/main/scala/hydrozoa/multisig/ledger/remote/RemoteL2Ledger.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/remote/RemoteL2Ledger.scala
@@ -8,7 +8,7 @@ import cats.syntax.all.*
 import hydrozoa.config.head.network.CardanoNetwork
 import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.ledger.l2.{ApplyDepositDecisionsResponse, ApplyTransactionResponse, L2CommandNumber, L2Ledger, L2LedgerCommand, L2LedgerResponse, RegisterDepositResponse, RestoreError}
-import hydrozoa.multisig.ledger.remote.RemoteL2Ledger.{Conn, Request}
+import hydrozoa.multisig.ledger.remote.RemoteL2Ledger.{Conn, Request, RestoreResponse}
 import hydrozoa.multisig.ledger.remote.RemoteL2LedgerEvent.*
 import io.circe.parser.*
 import io.circe.syntax.*
@@ -124,14 +124,47 @@ class RemoteL2Ledger private (
           RemoteL2LedgerError(s"remote L2 ledger answered $response for a $command command")
         )
 
-    /** A no-op: the remote black box owns its own recovery, so there is nothing to co-anchor here.
-      * It must not fail — `JointLedger.State.recover` treats a `Left` as fatal, so returning an
-      * error would crash a remote-backed node at boot after its first block. A real desync between
-      * the restored JointLedger command number and the remote's own position surfaces on the next
-      * command as [[L2LedgerResponse.UnrecoverableError.OutOfOrder]], not here.
+    /** Co-anchor the remote with the restored JointLedger command number: send a
+      * [[Request.Restore]] so the remote rewinds its own command-number tip (and committed state)
+      * to `commandNumber`. Without this the remote keeps its durable position, so the JointLedger
+      * re-issues an already-applied command and the remote rejects it as
+      * [[L2LedgerResponse.UnrecoverableError.OutOfOrder]] — the crash loop on recovery.
+      *
+      * Success maps to `Right(())`; a restore failure maps to [[RestoreError.OtherError]] (a typed
+      * `Left`, never thrown — `JointLedger.State.recover` treats it as fatal). A broken *transport*
+      * or a protocol violation still fail-stops (a raise) like the other requests.
       */
     override def restoreTo(commandNumber: L2CommandNumber): EitherT[IO, RestoreError, Unit] =
-        EitherT.rightT(())
+        EitherT(sendRestoreRequest(Request.Restore(commandNumber)).map {
+            case _: RestoreResponse.Restored              => Right(())
+            case RestoreResponse.RestoreFailed(_, reason) => Left(RestoreError.OtherError(reason))
+        })
+
+    /** Send a [[Request.Restore]] and return the remote's [[RestoreResponse]]. Like
+      * [[sendRequest]], transport failure is retried through by [[exchange]] and never seen here;
+      * the IO fails only on a broken *transport* — an undecodable frame, or a response whose echoed
+      * command number does not match the request. Those are protocol violations, not verdicts, so
+      * they fail-stop.
+      */
+    private def sendRestoreRequest(request: Request.Restore): IO[RestoreResponse] =
+        exchange(request).flatMap { text =>
+            decode[RestoreResponse](text) match {
+                case Left(err) =>
+                    IO.raiseError(
+                      RemoteL2LedgerError(
+                        s"remote L2 ledger sent an undecodable restore response: ${err.getMessage}"
+                      )
+                    )
+                case Right(response) if response.commandNumber != request.commandNumber =>
+                    IO.raiseError(
+                      RemoteL2LedgerError(
+                        s"remote L2 ledger answered restore command ${response.commandNumber} " +
+                            s"but we sent ${request.commandNumber}"
+                      )
+                    )
+                case Right(response) => IO.pure(response)
+            }
+        }
 
     /** Send a request and return the remote's total [[L2LedgerResponse]]. Transport failure is
       * retried through by [[exchange]] and never seen here, so a returned response is always a real
@@ -310,6 +343,28 @@ object RemoteL2Ledger {
             commandNumber: L2CommandNumber,
             command: L2LedgerCommand.ApplyTransaction
         ) extends Request
+
+        /** Instruct the remote to rewind its command-number tip (and committed state) to
+          * `commandNumber`. Carries no command payload — the number *is* the instruction. Sent by
+          * [[RemoteL2Ledger.restoreTo]] on crash-recovery boot to co-anchor the remote with the
+          * restored JointLedger command number.
+          */
+        final case class Restore(commandNumber: L2CommandNumber) extends Request
+    }
+
+    /** The remote's answer to a [[Request.Restore]]: it rewound to `commandNumber` ([[Restored]]),
+      * or the rewind failed ([[RestoreFailed]] with a reason). Kept out of [[L2LedgerResponse]] — a
+      * restore is a boot-time reconstruction, not a numbered command verdict — but still echoes the
+      * command number so [[RemoteL2Ledger.sendRestoreRequest]] can correlate it with the request.
+      */
+    sealed trait RestoreResponse {
+        def commandNumber: L2CommandNumber
+    }
+
+    object RestoreResponse {
+        final case class Restored(commandNumber: L2CommandNumber) extends RestoreResponse
+        final case class RestoreFailed(commandNumber: L2CommandNumber, reason: String)
+            extends RestoreResponse
     }
 
     /** Create a RemoteL2Ledger as a [[Resource]] owning one shared WebSocket client for its whole

--- a/src/main/scala/hydrozoa/multisig/ledger/remote/RemoteL2Ledger.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/remote/RemoteL2Ledger.scala
@@ -130,14 +130,19 @@ class RemoteL2Ledger private (
       * re-issues an already-applied command and the remote rejects it as
       * [[L2LedgerResponse.UnrecoverableError.OutOfOrder]] — the crash loop on recovery.
       *
-      * Success maps to `Right(())`; a restore failure maps to [[RestoreError.OtherError]] (a typed
-      * `Left`, never thrown — `JointLedger.State.recover` treats it as fatal). A broken *transport*
-      * or a protocol violation still fail-stops (a raise) like the other requests.
+      * Success maps to `Right(())`. A restore failure asking for a command number past the remote's
+      * durable tip (`requested > tip`) maps to [[RestoreError.CommandNumberTooHigh]]; any other
+      * failure to [[RestoreError.OtherError]]. Both are typed `Left`s, never thrown —
+      * `JointLedger.State.recover` treats them as fatal. A broken *transport* or a protocol
+      * violation still fail-stops (a raise) like the other requests.
       */
     override def restoreTo(commandNumber: L2CommandNumber): EitherT[IO, RestoreError, Unit] =
         EitherT(sendRestoreRequest(Request.Restore(commandNumber)).map {
-            case _: RestoreResponse.Restored              => Right(())
-            case RestoreResponse.RestoreFailed(_, reason) => Left(RestoreError.OtherError(reason))
+            case _: RestoreResponse.Restored => Right(())
+            case RestoreResponse.RestoreFailed(requested, tip, reason) =>
+                if requested.value > tip.value then
+                    Left(RestoreError.CommandNumberTooHigh(requested, tip))
+                else Left(RestoreError.OtherError(reason))
         })
 
     /** Send a [[Request.Restore]] and return the remote's [[RestoreResponse]]. Like
@@ -352,19 +357,28 @@ object RemoteL2Ledger {
         final case class Restore(commandNumber: L2CommandNumber) extends Request
     }
 
-    /** The remote's answer to a [[Request.Restore]]: it rewound to `commandNumber` ([[Restored]]),
-      * or the rewind failed ([[RestoreFailed]] with a reason). Kept out of [[L2LedgerResponse]] — a
-      * restore is a boot-time reconstruction, not a numbered command verdict — but still echoes the
-      * command number so [[RemoteL2Ledger.sendRestoreRequest]] can correlate it with the request.
+    /** The remote's answer to a [[Request.Restore]]: it rewound to the requested command number
+      * ([[Restored]] carrying its resulting `tip`, which equals the request on success), or the
+      * rewind failed ([[RestoreFailed]] carrying the `requested` number, the remote's current
+      * durable `tip`, and a reason). Kept out of [[L2LedgerResponse]] — a restore is a boot-time
+      * reconstruction, not a numbered command verdict — but [[commandNumber]] still echoes the
+      * requested number so [[RemoteL2Ledger.sendRestoreRequest]] can correlate it with the request.
       */
     sealed trait RestoreResponse {
         def commandNumber: L2CommandNumber
     }
 
     object RestoreResponse {
-        final case class Restored(commandNumber: L2CommandNumber) extends RestoreResponse
-        final case class RestoreFailed(commandNumber: L2CommandNumber, reason: String)
-            extends RestoreResponse
+        final case class Restored(tip: L2CommandNumber) extends RestoreResponse {
+            def commandNumber: L2CommandNumber = tip
+        }
+        final case class RestoreFailed(
+            requested: L2CommandNumber,
+            tip: L2CommandNumber,
+            reason: String
+        ) extends RestoreResponse {
+            def commandNumber: L2CommandNumber = requested
+        }
     }
 
     /** Create a RemoteL2Ledger as a [[Resource]] owning one shared WebSocket client for its whole

--- a/src/main/scala/hydrozoa/multisig/ledger/remote/RemoteL2LedgerCodecs.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/remote/RemoteL2LedgerCodecs.scala
@@ -201,10 +201,11 @@ object RemoteL2LedgerCodecs {
                 }
         }
 
-    // Restore-response codec. The remote answers a Restore request with the command number it
-    // rewound to (`Restored`) or a failure carrying a reason (`RestoreFailed`) — single-key tagged
-    // objects, mirroring the request and verdict wire shapes. Kept separate from L2LedgerResponse: a
-    // restore is a boot-time reconstruction, not a numbered command verdict.
+    // Restore-response codec. The remote answers a RestoreTo request with the tip it rewound to
+    // (`Restored`) or a failure carrying the requested number, its current durable tip, and a
+    // reason (`RestoreFailed`) — single-key tagged objects, mirroring the request and verdict wire
+    // shapes. Kept separate from L2LedgerResponse: a restore is a boot-time reconstruction, not a
+    // numbered command verdict. The wire shape is SugarRush's (SugarRush #140).
     import RemoteL2Ledger.RestoreResponse
     given restoreResponseCodec: Codec[RestoreResponse] = Codec.from(
       decodeA = c =>
@@ -216,15 +217,16 @@ object RemoteL2LedgerCodecs {
               .flatMap {
                   case "Restored" =>
                       c.downField("Restored")
-                          .downField("commandNumber")
+                          .downField("tip")
                           .as[L2CommandNumber]
                           .map(RestoreResponse.Restored.apply)
                   case "RestoreFailed" =>
                       val body = c.downField("RestoreFailed")
                       for {
-                          cn <- body.downField("commandNumber").as[L2CommandNumber]
+                          requested <- body.downField("requested").as[L2CommandNumber]
+                          tip <- body.downField("tip").as[L2CommandNumber]
                           reason <- body.downField("reason").as[String]
-                      } yield RestoreResponse.RestoreFailed(cn, reason)
+                      } yield RestoreResponse.RestoreFailed(requested, tip, reason)
                   case other =>
                       Left(
                         io.circe.DecodingFailure(
@@ -234,12 +236,13 @@ object RemoteL2LedgerCodecs {
                       )
               },
       encodeA = {
-          case RestoreResponse.Restored(cn) =>
-              io.circe.Json.obj("Restored" -> io.circe.Json.obj("commandNumber" -> cn.asJson))
-          case RestoreResponse.RestoreFailed(cn, reason) =>
+          case RestoreResponse.Restored(tip) =>
+              io.circe.Json.obj("Restored" -> io.circe.Json.obj("tip" -> tip.asJson))
+          case RestoreResponse.RestoreFailed(requested, tip, reason) =>
               io.circe.Json.obj(
                 "RestoreFailed" -> io.circe.Json.obj(
-                  "commandNumber" -> cn.asJson,
+                  "requested" -> requested.asJson,
+                  "tip" -> tip.asJson,
                   "reason" -> reason.asJson
                 )
               )
@@ -271,9 +274,10 @@ object RemoteL2LedgerCodecs {
               case Request.ApplyTransaction(cn, command) =>
                   tagged("ApplyTransaction", cn, command.asJson)
               // Restore carries no command payload — the command number is the whole instruction.
+              // The wire tag is SugarRush's `RestoreTo` (SugarRush #140).
               case Request.Restore(cn) =>
                   io.circe.Json.obj(
-                    "Restore" -> io.circe.Json.obj("commandNumber" -> cn.asJson)
+                    "RestoreTo" -> io.circe.Json.obj("commandNumber" -> cn.asJson)
                   )
           },
           decodeA = c =>
@@ -302,7 +306,7 @@ object RemoteL2LedgerCodecs {
                                   n <- cn
                                   cmd <- command.as[L2LedgerCommand.ApplyTransaction]
                               } yield Request.ApplyTransaction(n, cmd)
-                          case "Restore" =>
+                          case "RestoreTo" =>
                               cn.map(Request.Restore.apply)
                           case other =>
                               Left(

--- a/src/main/scala/hydrozoa/multisig/ledger/remote/RemoteL2LedgerCodecs.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/remote/RemoteL2LedgerCodecs.scala
@@ -201,6 +201,51 @@ object RemoteL2LedgerCodecs {
                 }
         }
 
+    // Restore-response codec. The remote answers a Restore request with the command number it
+    // rewound to (`Restored`) or a failure carrying a reason (`RestoreFailed`) — single-key tagged
+    // objects, mirroring the request and verdict wire shapes. Kept separate from L2LedgerResponse: a
+    // restore is a boot-time reconstruction, not a numbered command verdict.
+    import RemoteL2Ledger.RestoreResponse
+    given restoreResponseCodec: Codec[RestoreResponse] = Codec.from(
+      decodeA = c =>
+          c.keys
+              .flatMap(_.headOption)
+              .toRight(
+                io.circe.DecodingFailure("RestoreResponse must have exactly one field", c.history)
+              )
+              .flatMap {
+                  case "Restored" =>
+                      c.downField("Restored")
+                          .downField("commandNumber")
+                          .as[L2CommandNumber]
+                          .map(RestoreResponse.Restored.apply)
+                  case "RestoreFailed" =>
+                      val body = c.downField("RestoreFailed")
+                      for {
+                          cn <- body.downField("commandNumber").as[L2CommandNumber]
+                          reason <- body.downField("reason").as[String]
+                      } yield RestoreResponse.RestoreFailed(cn, reason)
+                  case other =>
+                      Left(
+                        io.circe.DecodingFailure(
+                          s"Unknown RestoreResponse type: $other",
+                          c.history
+                        )
+                      )
+              },
+      encodeA = {
+          case RestoreResponse.Restored(cn) =>
+              io.circe.Json.obj("Restored" -> io.circe.Json.obj("commandNumber" -> cn.asJson))
+          case RestoreResponse.RestoreFailed(cn, reason) =>
+              io.circe.Json.obj(
+                "RestoreFailed" -> io.circe.Json.obj(
+                  "commandNumber" -> cn.asJson,
+                  "reason" -> reason.asJson
+                )
+              )
+      }
+    )
+
     // Request codecs. Each request is a single-key object tagging the command variant, whose value
     // carries the Hydrozoa-assigned `commandNumber` and the `command` payload.
     import RemoteL2Ledger.Request
@@ -225,6 +270,11 @@ object RemoteL2LedgerCodecs {
                   tagged("ApplyDepositDecisions", cn, command.asJson)
               case Request.ApplyTransaction(cn, command) =>
                   tagged("ApplyTransaction", cn, command.asJson)
+              // Restore carries no command payload — the command number is the whole instruction.
+              case Request.Restore(cn) =>
+                  io.circe.Json.obj(
+                    "Restore" -> io.circe.Json.obj("commandNumber" -> cn.asJson)
+                  )
           },
           decodeA = c =>
               c.keys
@@ -252,6 +302,8 @@ object RemoteL2LedgerCodecs {
                                   n <- cn
                                   cmd <- command.as[L2LedgerCommand.ApplyTransaction]
                               } yield Request.ApplyTransaction(n, cmd)
+                          case "Restore" =>
+                              cn.map(Request.Restore.apply)
                           case other =>
                               Left(
                                 io.circe.DecodingFailure(s"Unknown request type: $other", c.history)

--- a/src/test/scala/hydrozoa/multisig/ledger/remote/RemoteL2LedgerCodecsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/ledger/remote/RemoteL2LedgerCodecsTest.scala
@@ -7,6 +7,7 @@ import hydrozoa.multisig.ledger.event.RequestId
 import hydrozoa.multisig.ledger.joint.{EvacuationDiff, EvacuationKey}
 import hydrozoa.multisig.ledger.l2.L2LedgerResponse.UnrecoverableError
 import hydrozoa.multisig.ledger.l2.{L2CommandNumber, L2LedgerResponse}
+import hydrozoa.multisig.ledger.remote.RemoteL2Ledger.{Request, RestoreResponse}
 import io.circe.syntax.*
 import org.scalacheck.Gen
 import org.scalatest.funsuite.AnyFunSuite
@@ -89,5 +90,37 @@ class RemoteL2LedgerCodecsTest extends AnyFunSuite:
     test("UnrecoverableError.OtherError (string reason) round-trips") {
         assert(
           roundTrips(UnrecoverableError.OtherError(L2CommandNumber(5L), "merge failed"))
+        )
+    }
+
+    // Golden wire-shape tests pinning the exact SugarRush #140 JSON for the three restoreTo frames —
+    // the cross-repo contract with the SugarRush ledger. Each asserts both the encoded string equals
+    // the canonical JSON and the JSON decodes back to the original value.
+
+    test("RestoreTo request encodes to the canonical SugarRush wire shape and round-trips") {
+        val request: Request = Request.Restore(L2CommandNumber(7L))
+        val json = request.asJson.noSpaces
+        assert(
+          json == """{"RestoreTo":{"commandNumber":7}}"""
+              && io.circe.parser.decode[Request](json) == Right(request)
+        )
+    }
+
+    test("Restored success encodes to the canonical SugarRush wire shape and round-trips") {
+        val response: RestoreResponse = RestoreResponse.Restored(L2CommandNumber(7L))
+        val json = response.asJson.noSpaces
+        assert(
+          json == """{"Restored":{"tip":7}}"""
+              && io.circe.parser.decode[RestoreResponse](json) == Right(response)
+        )
+    }
+
+    test("RestoreFailed failure encodes to the canonical SugarRush wire shape and round-trips") {
+        val response: RestoreResponse =
+            RestoreResponse.RestoreFailed(L2CommandNumber(9L), L2CommandNumber(4L), "tip too low")
+        val json = response.asJson.noSpaces
+        assert(
+          json == """{"RestoreFailed":{"requested":9,"tip":4,"reason":"tip too low"}}"""
+              && io.circe.parser.decode[RestoreResponse](json) == Right(response)
         )
     }


### PR DESCRIPTION
## The bug

A remote-L2-backed head **crash-loops on recovery**. `JointLedger.State.recover` co-anchors the L2 ledger via `l2Ledger.restoreTo(recoveredCommandNumber)`, but `RemoteL2Ledger.restoreTo` was a **no-op** (`EitherT.rightT(())`). So when the JointLedger's persisted command number lags the remote ledger's own durable position, nothing reconciles them: the JL re-issues an already-applied command, the remote's ordering gate expects `ledger.commandNumber + 1` and rejects it as `L2LedgerResponse.UnrecoverableError.OutOfOrder(sent, expected)`, `JointLedger.panicOnL2Response` raises, `TerminateActorSystem` fires, systemd restarts → same stale recovery → infinite crash loop. Observed live (`OutOfOrder(61844, 62028)`). The old no-op's own doc comment predicted exactly this.

## The change (client side only)

- New `Request.Restore(commandNumber)` request variant — carries only the command number (the number *is* the instruction; no command payload), following the existing request pattern.
- Its JSON codec in `RemoteL2LedgerCodecs`: a single-key tagged object `{"Restore": {"commandNumber": N}}`, matching the existing per-variant wire shape.
- A dedicated `RestoreResponse` ADT (`Restored(commandNumber)` / `RestoreFailed(commandNumber, reason)`) with its codec — single-key tagged objects `{"Restored": {"commandNumber": N}}` / `{"RestoreFailed": {"commandNumber": N, "reason": "..."}}`.
- `restoreTo` now sends `Request.Restore` through the existing `exchange` retry-through-transport path (mutex-serialised, command-number correlation preserved in a dedicated `sendRestoreRequest`), and interprets the response: `Restored` → `Right(())`, `RestoreFailed` → `Left(RestoreError.OtherError(reason))`. A genuine transport/protocol violation (undecodable frame, command-number echo mismatch) still fail-stops (a raise), exactly like the other three requests.

Surgical: only the remote-ledger client and its codecs change. `L2Ledger` / `L2LedgerResponse` / `RestoreError` and the EUTXO reference ledger are untouched.

### Design decision — response shape

I kept the restore response **out of** `L2LedgerResponse` (which models command *verdicts*: `Applied` / `Rejected` / `UnrecoverableError`). A restore is a boot-time reconstruction, not a numbered command verdict, so folding it into that ADT would have leaked a non-command concept into the verdict type and touched every other ledger. Instead I added a minimal `RestoreResponse` local to the remote protocol. It still carries `commandNumber` so the existing echo-correlation check holds (via a dedicated `sendRestoreRequest` mirroring `sendRequest`). A failure maps to `RestoreError.OtherError` — the closest existing `RestoreError` case (there is no remote-specific tip/desync info to justify `CommandNumberTooHigh`).

## **Requires SugarRush to implement the Restore request handler**

**This is a client-side change only. The remote server (SugarRush, a separate repo) must implement a handler for the new `Restore` request — rewind its command-number tip and committed state to `commandNumber` and answer `{"Restored": {"commandNumber": N}}` (or `{"RestoreFailed": ...}`). Until SugarRush supports it, this does NOT fix the live crash-loop end-to-end** — the request would go unanswered (retried through transport) or produce an undecodable/mismatched response (fail-stop).

## Compile

`sbt compile` — success (core + cardano-onchain).
