### PR TITLE
feat(consensus): coil peers replay deposit existence from the leader brief

### DIFF
--- a/src/main/scala/hydrozoa/config/node/NodeConfig.scala
+++ b/src/main/scala/hydrozoa/config/node/NodeConfig.scala
@@ -17,6 +17,7 @@ import hydrozoa.config.node.operation.multisig.NodeOperationMultisigConfig
 import hydrozoa.config.node.owninfo.{OwnCoilPeerPrivate, OwnHeadPeerPrivate}
 import hydrozoa.lib.logging.Slf4jTracer
 import hydrozoa.multisig.backend.cardano.{CardanoBackend, CardanoBackendBlockfrost, CardanoBackendEventFormat}
+import hydrozoa.multisig.consensus.peer.PeerId.isCoil
 import hydrozoa.multisig.consensus.peer.PeerWallet
 import io.circe.{parser, *}
 import java.nio.file.{Files, Path}
@@ -27,16 +28,18 @@ final case class NodeConfig private (
 ) extends NodeConfig.Section {
     override transparent inline def nodeConfig: NodeConfig = this
 
-    // Safety invariant: a peer's CardanoLiaison must poll at least
-    // `cardanoLiaisonPollingPeriodSafetyFactor` times within `depositMaturityDuration`,
-    // so that by the time a deposit is mature every peer has observed it on L1. Otherwise
-    // the leader (which has seen the deposit) and a follower (which hasn't yet) will disagree
-    // on whether to absorb or refund, breaking consensus.
+    // Safety invariant (head peers only): a head peer's CardanoLiaison must poll at least
+    // `cardanoLiaisonPollingPeriodSafetyFactor` times within `depositMaturityDuration`, so that
+    // by the time a deposit is mature every head peer has observed it on L1. Otherwise the leader
+    // (which has seen the deposit) and a head follower (which hasn't yet) disagree on whether to
+    // absorb or refund, breaking consensus. Coil peers are exempt: they classify deposit existence
+    // from the head peers' soft-confirmed view rather than their own polls (see
+    // DepositsMap.Existence), so their poll cadence is unconstrained and can be set far slower.
     private val pollingPeriod =
         nodePrivateConfig.nodeOperationMultisigConfig.cardanoLiaisonPollingPeriod
     private val maxPollingPeriod = headConfig.maxCardanoLiaisonPollingPeriod
     require(
-      pollingPeriod <= maxPollingPeriod,
+      nodePrivateConfig.ownPeerId.isCoil || pollingPeriod <= maxPollingPeriod,
       s"cardanoLiaisonPollingPeriod ($pollingPeriod) exceeds the maximum allowed for this " +
           s"head's depositMaturityDuration (${headConfig.depositMaturityDuration}): " +
           s"$maxPollingPeriod (= depositMaturityDuration / " +

--- a/src/main/scala/hydrozoa/multisig/consensus/peer/PeerId.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/peer/PeerId.scala
@@ -43,4 +43,15 @@ object PeerId {
             case Head(n) => (n.convert << 1) | 1
             case Coil(n) => n.convert << 1
         }
+
+        /** Whether this peer is a coil peer. Coil peers never lead and follow the head peers'
+          * soft-confirmed view of L1 rather than their own fresh polls.
+          */
+        def isCoil: Boolean = self match {
+            case _: Coil => true
+            case _: Head => false
+        }
+
+        /** Whether this peer is a head peer. */
+        def isHead: Boolean = !self.isCoil
 }

--- a/src/main/scala/hydrozoa/multisig/ledger/joint/JointLedger.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/joint/JointLedger.scala
@@ -443,12 +443,23 @@ final case class JointLedger(
     ): IO[Unit] = {
         import args.*
         unsafeGetProducing.flatMap { p =>
+            // Coil peers classify deposit existence from the head peers' soft-confirmed view
+            // (the reference brief) rather than a fresh L1 poll. A coil below the settlement
+            // quorum can lag behind an already-submitted settlement that has spent the absorbed
+            // deposits; a fresh poll would then report them gone and diverge from the leader.
+            // Head peers (and any leader-mode producer) always poll — see DepositsMap.Existence.
+            val existence = referenceBlockBrief match {
+                case Some(ref) if config.ownPeerId.isCoil =>
+                    DepositsMap.Existence.FromLeaderView(ref.depositsRejected.toSet)
+                case _ =>
+                    DepositsMap.Existence.FromPoll(pollResults)
+            }
             for {
                 partition <- p.deposits.partition(dmTracer)(
                   blockCreationEndTime = blockCreationEndTime,
                   settlementTxEndTime =
                       config.txTiming.newSettlementEndTime(p.competingFallbackTxTime),
-                  pollResults = pollResults
+                  existence = existence
                 )
                 split = partition.split(maxDepositsAbsorbedPerBlock)
                 _ <- tracer.traceWith(

--- a/src/main/scala/hydrozoa/multisig/ledger/l1/deposits/map/DepositsMap.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/l1/deposits/map/DepositsMap.scala
@@ -79,14 +79,14 @@ final case class DepositsMap private[map] (
     def partition[F[_]: Monad](tracer: ContraTracer[F, DepositsMapEvent])(
         blockCreationEndTime: BlockCreationEndTime,
         settlementTxEndTime: SettlementTxEndTime,
-        pollResults: PollResults
+        existence: DepositsMap.Existence
     ): F[DepositsMap.Partition] =
         for {
             _ <- tracer.traceWith(
               DepositsMapEvent.PartitionStarted(
                 blockCreationEndTime,
                 settlementTxEndTime,
-                pollResults
+                existence
               )
             )
             result <- treeMap.toList.foldM(Partition.empty) { case (outerAcc, (_, depositQueue)) =>
@@ -102,7 +102,7 @@ final case class DepositsMap private[map] (
                           settlementTxEndTime,
                           entry.depositUtxo.absorptionEndTime
                         )
-                    val isExistent = pollResults.utxos.contains(entry.depositUtxo.toUtxo.input)
+                    val isExistent = existence.isExistent(entry)
                     // A deposit whose absorption window closes before the settlement tx's
                     // validity ends can never be safely absorbed, so it must be rejected even
                     // if it has not matured yet — `isExpired` takes precedence over `isImmature`.
@@ -128,6 +128,35 @@ object DepositsMap {
         requestId: RequestId,
         depositUtxo: DepositUtxo
     )
+
+    /** How [[DepositsMap.partition]] decides whether a mature, unexpired deposit still exists on L1
+      * — the only classification input that differs between peer roles. All other checks (immature
+      * / expired / the absorption cap) are role-independent.
+      *
+      *   - [[FromPoll]] — the peer's own fresh L1 poll. The head-peer path: head peers hold
+      *     settlement keys, so a settlement can never spend an absorbed deposit without their
+      *     signature; their fresh poll therefore always reflects the pre-settlement L1 and they
+      *     verify existence independently.
+      *   - [[FromLeaderView]] — replay the soft-confirmed leader's verdict carried by the block
+      *     brief. The coil-peer path: a coil below the settlement quorum can lag behind an
+      *     already-submitted settlement that has spent the absorbed deposits, so a fresh poll would
+      *     spuriously report them gone. Instead the coil trusts the head peers' unanimous view — a
+      *     deposit is existent iff the leader did **not** reject it (`depositsRejected`). This
+      *     handles every compartment: absorbed and eligible-but-cap-unabsorbed deposits are both
+      *     absent from `depositsRejected` (existent), while leader-rejected ones are present
+      *     (non-existent); immature/expired deposits never reach this check.
+      */
+    enum Existence {
+        case FromPoll(pollResults: PollResults)
+        case FromLeaderView(rejectedRequestIds: Set[RequestId])
+
+        def isExistent(entry: Entry): Boolean = this match {
+            case FromPoll(pollResults) =>
+                pollResults.utxos.contains(entry.depositUtxo.toUtxo.input)
+            case FromLeaderView(rejectedRequestIds) =>
+                !rejectedRequestIds.contains(entry.requestId)
+        }
+    }
 
     final case class Partition private[map] (
         expired: DepositsMap,

--- a/src/main/scala/hydrozoa/multisig/ledger/l1/deposits/map/DepositsMapEvent.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/l1/deposits/map/DepositsMapEvent.scala
@@ -1,8 +1,7 @@
 package hydrozoa.multisig.ledger.l1.deposits.map
 
 import hydrozoa.config.head.multisig.timing.TxTiming.BlockTimes.{BlockCreationEndTime, SettlementTxEndTime}
-import hydrozoa.multisig.consensus.pollresults.PollResults
-import hydrozoa.multisig.ledger.l1.deposits.map.DepositsMap.{Entry, Partition}
+import hydrozoa.multisig.ledger.l1.deposits.map.DepositsMap.{Entry, Existence, Partition}
 
 sealed trait DepositsMapEvent
 
@@ -11,7 +10,7 @@ object DepositsMapEvent:
     final case class PartitionStarted(
         blockCreationEndTime: BlockCreationEndTime,
         settlementTxEndTime: SettlementTxEndTime,
-        pollResults: PollResults
+        existence: Existence
     ) extends DepositsMapEvent
 
     final case class EntryClassified(

--- a/src/main/scala/hydrozoa/multisig/ledger/l1/deposits/map/DepositsMapEventFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/l1/deposits/map/DepositsMapEventFormat.scala
@@ -2,6 +2,7 @@ package hydrozoa.multisig.ledger.l1.deposits.map
 
 import hydrozoa.lib.cardano.scalus.codecs.json.Codecs.given
 import hydrozoa.lib.logging.LogEvent
+import hydrozoa.multisig.ledger.l1.deposits.map.DepositsMap.Existence
 import hydrozoa.multisig.ledger.l1.deposits.map.DepositsMap.Partition.Compartment
 import hydrozoa.multisig.ledger.l1.deposits.map.DepositsMapEvent.*
 import io.circe.syntax.*
@@ -13,12 +14,16 @@ object DepositsMapEventFormat:
         val ev = LogEvent.From(Map.empty, "DepositsMap")
         import ev.*
         e match
-            case PartitionStarted(bce, ste, pr) =>
+            case PartitionStarted(bce, ste, existence) =>
+                val existenceDesc = existence match
+                    case Existence.FromPoll(pr) => s"poll: ${pr.utxos.asJson}"
+                    case Existence.FromLeaderView(rejected) =>
+                        s"leader view, rejected requests: ${rejected.map(_.asI64).toList.sorted}"
                 debug(
                   "[partition]" +
                       s"\n\t blockCreationEndTime: $bce" +
                       s"\n\t settlementTxEndTime: $ste" +
-                      s"\n\t pollResults: ${pr.utxos.asJson}"
+                      s"\n\t existence: $existenceDesc"
                 )
             case EntryClassified(entry, compartment) =>
                 val desc = compartment match

--- a/src/test/scala/hydrozoa/multisig/ledger/l1/tx/DepositsMapExistenceTest.scala
+++ b/src/test/scala/hydrozoa/multisig/ledger/l1/tx/DepositsMapExistenceTest.scala
@@ -1,0 +1,84 @@
+package hydrozoa.multisig.ledger.l1.tx
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import hydrozoa.config.head.multisig.timing.TxTiming.BlockTimes.{BlockCreationEndTime, FallbackTxStartTime, SettlementTxEndTime}
+import hydrozoa.config.node.{MultiNodeConfig, NodeConfig}
+import hydrozoa.lib.logging.ContraTracer
+import hydrozoa.multisig.consensus.peer.HeadPeerNumber
+import hydrozoa.multisig.consensus.pollresults.PollResults
+import hydrozoa.multisig.ledger.event.RequestId
+import hydrozoa.multisig.ledger.l1.deposits.map.{DepositsMap, DepositsMapEvent}
+import org.scalacheck.Prop.propBoolean
+import org.scalacheck.{Gen, Prop, Properties}
+import scalus.cardano.ledger.*
+import test.*
+
+/** The coil-follower deposit-existence oracle (`DepositsMap.Existence`).
+  *
+  * A coil peer below the settlement quorum can fall behind a settlement that has already been
+  * submitted to L1, spending the absorbed deposits. Its fresh L1 poll would then report those
+  * deposits gone, land them in `NotInPollResults`, and produce a brief that mismatches the leader's
+  * — the consensus failure observed in production. `Existence.FromLeaderView` replays the head
+  * peers' soft-confirmed verdict instead: a deposit is existent iff the leader did not reject it.
+  */
+object DepositsMapExistenceTest extends Properties("DepositsMap existence oracle") {
+
+    private val tracer: ContraTracer[IO, DepositsMapEvent] =
+        ContraTracer[IO, DepositsMapEvent](_ => IO.unit)
+
+    /** Partition a single-entry map with the deposit deliberately mature and unexpired at the given
+      * block/settlement times, so the outcome turns solely on the existence oracle.
+      */
+    private def classify(
+        config: NodeConfig,
+        entry: DepositsMap.Entry,
+        existence: DepositsMap.Existence
+    ): DepositsMap.Partition = {
+        val du = entry.depositUtxo
+        // bce == absorptionStartTime => not immature; ste = start - silence <= absorptionEndTime
+        // => not expired. The deposit therefore reaches the existence check.
+        val bce = BlockCreationEndTime(du.absorptionStartTime)
+        val ste: SettlementTxEndTime =
+            config.txTiming.newSettlementEndTime(FallbackTxStartTime(du.absorptionStartTime))
+        DepositsMap.empty
+            .append(entry)
+            .partition(tracer)(bce, ste, existence)
+            .unsafeRunSync()
+    }
+
+    private val genEnv: Gen[(NodeConfig, DepositsMap.Entry)] =
+        for {
+            mnc <- MultiNodeConfig.generate(TestPeersSpec.default)()
+            config = mnc.nodeConfigs(HeadPeerNumber.zero)
+            du <- genDepositUtxo(
+              config,
+              Some(config.headMultisigAddress),
+              Gen.const(Value.ada(10))
+            )()
+        } yield (config, DepositsMap.Entry(RequestId(0, 1L), du))
+
+    val _ = property(
+      "fresh poll rejects a deposit a submitted settlement already spent (bug repro)"
+    ) = Prop.forAll(genEnv) { case (config, entry) =>
+        val p = classify(config, entry, DepositsMap.Existence.FromPoll(PollResults.empty))
+        (p.notInPollResults.requestIds == List(entry.requestId)) :| "landed in NotInPollResults" &&
+        p.eligible.requestIds.isEmpty :| "not eligible"
+    }
+
+    val _ = property("coil leader-view absorbs the same deposit despite the empty poll") =
+        Prop.forAll(genEnv) { case (config, entry) =>
+            val p = classify(config, entry, DepositsMap.Existence.FromLeaderView(Set.empty))
+            (p.eligible.requestIds == List(entry.requestId)) :| "eligible" &&
+            p.notInPollResults.requestIds.isEmpty :| "not rejected"
+        }
+
+    val _ = property(
+      "coil leader-view replays the leader's rejection of a truly non-existent deposit"
+    ) = Prop.forAll(genEnv) { case (config, entry) =>
+        val p =
+            classify(config, entry, DepositsMap.Existence.FromLeaderView(Set(entry.requestId)))
+        (p.notInPollResults.requestIds == List(entry.requestId)) :| "rejected as non-existent" &&
+        p.eligible.requestIds.isEmpty :| "not eligible"
+    }
+}


### PR DESCRIPTION
## Problem

A coil peer below the settlement quorum can fall behind. Consider Alpha as the sole head
peer with coil peers Alice + Bob at coil quorum 1/2. If Bob is on a slow/badly-tuned machine,
it lags on request processing. By the time Bob reproduces major block *N* (with its deposit
decisions), Alpha + Alice have already hard-confirmed *N* and submitted the multisigned
settlement tx to L1 — which **spends the deposits that block absorbed**.

When Bob then reproduces block *N*, its fresh L1 poll reports those deposits gone, lands them
in `NotInPollResults`, and produces a brief whose `depositsRejected` mismatches the leader's.
`JointLedger` panics on the brief mismatch and the slow coil is stranded — it refuses to catch up.
This is the consensus failure we saw on the demo server.

## Fix

Head peers hold settlement keys, so a settlement can never spend an absorbed deposit without their
signature — their fresh poll is always consistent and they must keep verifying existence
independently. A coil peer *is* below the settlement threshold, so it can be raced past a
settlement; it should instead trust the head peers' unanimous, soft-confirmed view carried by the
block brief.

Replace the single `pollResults` argument of `DepositsMap.partition` with a `DepositsMap.Existence`
oracle:

- **`FromPoll`** — the peer's own fresh L1 poll. Head peers, and any leader-mode producer.
- **`FromLeaderView`** — replay the leader's verdict from the reference brief. Coil followers.
  A deposit is existent **iff the leader did not reject it** (`depositsRejected`).

Keyed on `RequestId` (what the brief actually pins), this is correct for every compartment and
**keeps all other checks intact** (immature / expired / the absorption cap):

- absorbed → not in `depositsRejected` → existent ✓
- eligible-but-cap-unabsorbed (surviving) → not in `depositsRejected` → existent ✓ (this is why
  the oracle keys off *rejected*, not *absorbed* — keying off absorbed would wrongly reject
  cap-limited deposits)
- leader-rejected-as-nonexistent → in `depositsRejected` → non-existent ✓
- immature / expired → decided by their own timing short-circuits, never reach this check ✓

`JointLedger.completeBlockRegular` selects `FromLeaderView` only for a **coil peer in follower
mode**; every other case still polls.

Since coil peers no longer decide existence from their own polls, the
`cardanoLiaisonPollingPeriod` safety cap (which exists precisely to keep a head follower's poll
recent enough to agree with the leader) no longer binds them — `NodeConfig` now exempts coils, so
a coil can be configured to poll far slower (e.g. 10-20 min).

## Commits

1. `feat(peer)` — `PeerId.isCoil/isHead` predicates.
2. `feat(consensus)` — the `DepositsMap.Existence` oracle, `JointLedger` wiring, and a property
   test suite (`DepositsMapExistenceTest`) that reproduces the fresh-poll rejection and proves the
   leader-view oracle absorbs the same deposit / replays a genuine rejection.
3. `feat(config)` — exempt coil peers from the poll-period safety cap.

## Testing

- `DepositsMapExistenceTest` — 3 properties, 100 cases each, green.
- Full `Test / compile` + `integration / Test / compile` clean under `-Werror` (`CI=true`).

## Why key off `depositsRejected`, not `depositsAbsorbed`?

The oracle only decides `Eligible` vs `NotInPollResults`, and only for mature, unexpired deposits
(the other compartments come from role-independent timing checks a follower recomputes from the
brief's times). To match the leader's partition, the follower must reproduce the leader's existence
*verdict* — the one thing its stale poll gets wrong.

The brief pins decisions as `depositsAbsorbed` / `depositsRejected` (`= notInPollResults ∪ expired`).
A leader-eligible deposit that doesn't fit under the per-block cap *survives* and appears in **neither**
list, so the leader's full "existent" set isn't recoverable from the brief — but its non-existent set
is. Existence is the complement:

```
isExistent(entry) = !rejectedRequestIds.contains(entry.requestId)
```

- absorbed → not rejected → existent → `Eligible` ✓
- surviving (cap-limited) → not rejected → existent → `Eligible` ✓
- non-existent → rejected → `NotInPollResults` ✓

`depositsAbsorbed` would collapse "existent" into "absorbed this block": when the cap bites, surviving
deposits get marked non-existent → land in the follower's `depositsRejected` but not the leader's →
the same brief mismatch we're fixing. Expired entries in `depositsRejected` are harmless — they
short-circuit into `Expired` before the existence check and are rejected either way.
