### PR TITLE
fix(consensus): single-feeder the CoilRelay block and stack lanes (t3 hang)

### DIFF
--- a/src/main/scala/hydrozoa/multisig/consensus/CoilRelay.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/CoilRelay.scala
@@ -21,23 +21,32 @@ import hydrozoa.multisig.ledger.stack.StackBrief
   *
   * ==Who feeds it==
   *
-  * Every population artifact reaches this relay '''exactly once''', from whichever side owns it:
-  *   - '''Own production''' — the hub's own producers (`JointLedger` / `StackComposer` /
-  *     `FastConsensusActor` / `SlowConsensusActor` / `RequestSequencer` / `CoilAckSequencer`) each
-  *     send only their '''own''' output (own-led briefs, own acks/requests). Not a received-traffic
-  *     relay — just one extra broadcast target alongside the head mesh.
-  *   - '''Other heads' output''' — the hub's mesh [[PeerLiaisonHeadToHead]]s forward what they
-  *     receive from other head peers, including the block/stack briefs those heads lead.
+  * Every population artifact reaches this relay '''exactly once'''. The per-author artifacts
+  * (requests, soft-acks, hard-acks) are forwarded by whichever side owns them — the hub's own
+  * producers (`FastConsensusActor` / `SlowConsensusActor` / `RequestSequencer` /
+  * `CoilAckSequencer`) for its own output, the hub's mesh [[PeerLiaisonHeadToHead]]s for other
+  * heads' — and each lands on a '''per-author''' lane, so every such lane has exactly one feeder.
   *
-  * So a block/stack brief is relayed by the mesh liaison of the head that led it, or by the hub's
-  * own JL/SC if the hub led it — never both.
+  * The block and stack briefs are different: their lanes are '''contiguous''' and every brief —
+  * own-led AND remote-led — is fed by a '''single''' hub-local actor:
+  *   - blocks by [[JointLedger]], which applies every block serially in spine order (its own when
+  *     it leads, a reproduction when it follows);
+  *   - stacks by [[StackComposer]], which closes every stack serially in spine order (single-flight
+  *     on `previousStackHardConfirmed`).
+  * A remote-led brief reaches that single feeder through the mesh (`dispatch` → `BlockWeaver` →
+  * `JointLedger`, `dispatch` → `StackComposer`) and is relayed from there — never directly from the
+  * mesh liaison.
   *
   * ==Why no reordering is needed==
   *
-  * The block/stack lanes on each [[PeerLiaisonHubToCoil]] are '''contiguous''', so they must be fed
-  * in ascending spine order. They are — not because this relay sorts anything, but because of an
-  * end-to-end consensus invariant. The hub is a head peer, and a leader cannot produce artifact N+1
-  * until artifact N is confirmed by '''all''' head peers:
+  * A contiguous lane must be fed in ascending spine order. It is — because a single actor feeds
+  * each brief lane and emits from '''one''' fiber, so its `!` sends keep their order
+  * (`ActorCell.sendMessage` enqueues without suspending). The relay's FIFO mailbox and the
+  * contiguous outbox preserve that order downstream.
+  *
+  * That the feeder emits in spine order in the first place rests on an all-head confirmation
+  * invariant: a leader cannot produce brief N+1 until brief N is confirmed by '''all''' head peers,
+  * so the hub applies/closes N before N+1 exists:
   *   - Blocks: a leader seals block K only on `Block.SoftConfirmed(K-1)` ([[BlockWeaver]]
   *     `Leader.AwaitingConfirmation`), and soft-confirmation requires every head peer's ack
   *     ([[FastConsensusActor]]: a cell saturates iff `acks.keySet == headPeerVKeys`).
@@ -45,20 +54,21 @@ import hydrozoa.multisig.ledger.stack.StackBrief
   *     `tryProgress` gates on `previousStackHardConfirmed`), and hard-confirmation requires every
   *     head peer ([[SlowConsensusActor]]: `AllOf(head)` ∧ a coil quorum).
   *
-  * Since the hub is in every all-head quorum, it must have received (and acked) brief N before
-  * brief N+1 can be produced anywhere — so it always holds brief N before brief N+1 exists, and
-  * relays them in that order. This relay's FIFO mailbox and the contiguous outbox preserve it. The
-  * contiguous `LaneOutbound.append` is the backstop: if the invariant were ever violated it raises
+  * An earlier form of this proof argued only that the hub '''holds''' brief N before N+1 — true,
+  * but insufficient. With two feeders (mesh liaison for remote-led, own producer for own-led),
+  * held-at-the-node did not imply enqueued-at-the-relay: an own-led N+1 could overtake a remote-led
+  * N whose forwarding fiber was descheduled, raising `AppendOutOfOrder` (the t3 hang). The single
+  * feeder closes that gap — order at the node IS order at the relay. The contiguous
+  * `LaneOutbound.append` remains the backstop: if the invariant were ever violated it raises
   * `AppendOutOfOrder` (a loud crash, never silent corruption) rather than appending out of order.
   *
-  * '''Three invariants keep this true — don't break them:'''
-  *   1. Confirmation is '''all-head''' (soft: `acks.keySet == headPeerVKeys`; hard: `AllOf(head)`).
-  *      A `< nHead` threshold would let a hub be skipped and receive N+1 before N — then a reorder
-  *      buffer here would be required.
-  *   2. A leader gates the next artifact on the prior's confirmation (no pipelining past one).
-  *   3. Every brief fed here is one the hub itself received or produced (mesh liaison for
-  *      remote-led, own JL/SC for own-led) — don't add a feeder that forwards a brief the hub
-  *      hasn't itself seen.
+  * '''Invariants that keep this true — don't break them:'''
+  *   1. One feeder per brief lane: [[JointLedger]] for blocks, [[StackComposer]] for stacks, for
+  *      BOTH own-led and remote-led. Never forward a block/stack brief to this relay from the mesh
+  *      [[PeerLiaisonHeadToHead]] (or any second actor) — that reintroduces the race.
+  *   2. Confirmation is '''all-head''' (soft: `acks.keySet == headPeerVKeys`; hard: `AllOf(head)`),
+  *      and a leader gates the next brief on the prior's confirmation (no pipelining past one) — so
+  *      the single feeder observes briefs in spine order to begin with.
   */
 abstract class CoilRelay(
     pendingConnections: HeadMultisigRegimeManager.PendingConnections | CoilRelay.Connections

--- a/src/main/scala/hydrozoa/multisig/consensus/StackComposer.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/StackComposer.scala
@@ -191,9 +191,9 @@ final case class StackComposer(
 
     private def handleIncomingStackBrief(brief: StackBrief): IO[Unit] = for {
         _ <- state.update(_.withInboundLeaderBrief(brief))
-        // Stack briefs led by OTHER heads are relayed to CoilRelay by the hub's mesh liaisons, not
-        // here — so this actor relays only its OWN-led briefs (in tryCloseAsLeader). That keeps each
-        // brief relayed exactly once, in spine order.
+        // Relaying to CoilRelay happens when a stack actually closes (tryCloseAsLeader /
+        // tryCloseAsFollower), not on brief arrival — StackComposer is the single ordered feeder
+        // into the relay's stack lane. See tryCloseAsLeader.
         _ <- tryProgress
     } yield ()
 
@@ -256,9 +256,11 @@ final case class StackComposer(
                     // Broadcast brief directly to PeerLiaisons (briefs go DIRECT, not via
                     // SlowConsensusActor). Each peer's outbox has a stackBrief lane.
                     _ <- (conn.headPeerLiaisons ! brief).parallel
-                    // A hub relays its OWN-led stack brief to CoilRelay (§5.4) [doc-ref]; briefs led by other
-                    // heads are relayed by the hub's mesh liaisons, so each is relayed once, in spine
-                    // order. No-op off a hub.
+                    // Feed the hub's CoilRelay stack lane from StackComposer for every stack it
+                    // closes — own-led here, remote-led in tryCloseAsFollower. StackComposer closes
+                    // stacks serially in spine order (single-flight on previousStackHardConfirmed),
+                    // so it is the single ordered feeder into the relay's contiguous stack lane; a
+                    // hub relays each stack exactly once. No-op off a hub. (§5.4) [doc-ref]
                     _ <- conn.coilRelay.traverse_(_ ! brief)
                     // Hand the unsigned stack + own pre-signed hard-acks to SlowConsensusActor
                     // (which manages broadcast scheduling: round-1 / sole immediately, round-2
@@ -458,6 +460,9 @@ final case class StackComposer(
                                   handoff.ownAcks,
                                   withdrawalTracking
                                 )
+                                // Relay this reproduced stack brief to the hub's coil peers — the
+                                // follower half of the single-feeder rule (see tryCloseAsLeader).
+                                _ <- conn.coilRelay.traverse_(_ ! brief)
                                 _ <- conn.slowConsensusActor ! handoff
                                 _ <- state.update(
                                   _.afterClose(nextStackNum, slice, newTreasury, newMap)

--- a/src/main/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonHeadToHead.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonHeadToHead.scala
@@ -274,16 +274,17 @@ abstract class PeerLiaisonHeadToHead(
                 _ <- m.softAck.traverse_(conn.consensusActor ! _)
                 _ <- m.headHardAck.traverse_(conn.slowConsensusActor ! _)
                 _ <- m.hubHardAck.traverse_(hc => conn.slowConsensusActor ! hc.ack)
-                // On a hub, forward this remote head peer's whole production to CoilRelay so its
-                // coil peers hear the full population — including the block/stack briefs this remote
-                // leads. The mesh liaisons relay remote-led briefs; the hub's own JointLedger /
-                // StackComposer relay only their own-led briefs (see those sites), so every brief
-                // reaches CoilRelay exactly once. They arrive in spine order — CoilRelay needs no
-                // reordering; see its doc for the proof.
+                // On a hub, forward this remote head peer's per-author artifacts (requests, acks) to
+                // CoilRelay so its coil peers hear the full population. Block and stack briefs are
+                // deliberately NOT forwarded here: those relay lanes are contiguous and must have a
+                // single ordered feeder — the hub's own JointLedger (blocks) / StackComposer
+                // (stacks), which relay every brief, own-led and remote-led alike, in spine order.
+                // Forwarding briefs from here too put a second feeder on those lanes and raced its
+                // sends into the relay mailbox — the t3 AppendOutOfOrder hang (see CoilRelay's
+                // ordering note). The per-author lanes below are keyed by author, so each already
+                // has exactly one feeder and is safe.
                 _ <- conn.coilRelay.traverse_ { cr =>
-                    m.block.traverse_(cr ! _) >>
-                        m.stack.traverse_(cr ! _) >>
-                        m.requests.traverse_(cr ! _) >>
+                    m.requests.traverse_(cr ! _) >>
                         m.softAck.traverse_(cr ! _) >>
                         m.headHardAck.traverse_(cr ! _) >>
                         m.hubHardAck.traverse_(cr ! _)

--- a/src/main/scala/hydrozoa/multisig/ledger/joint/JointLedger.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/joint/JointLedger.scala
@@ -699,14 +699,21 @@ final case class JointLedger(
                     for {
                         _ <- persistOwnAckBundle(brief, softAck, blockResult)
 
-                        // Broadcast our OWN-led brief to the head mesh and (on a hub) to CoilRelay,
-                        // so coil peers get the blocks WE lead. Blocks led by OTHER heads reach
-                        // CoilRelay through the mesh liaisons instead, so each block is relayed
-                        // exactly once and arrives in spine order (see CoilRelay for the proof).
+                        // Broadcast our OWN-led brief to the head mesh — only blocks WE lead go
+                        // to the mesh.
                         _ <- IO.whenA(config.canLeadFast(brief.blockNum))(
-                          (conn.headPeerLiaisons ! brief).parallel >>
-                              conn.coilRelay.traverse_(_ ! brief)
+                          (conn.headPeerLiaisons ! brief).parallel
                         )
+
+                        // Feed the hub's CoilRelay block lane from JointLedger for EVERY block —
+                        // own-led and remote-led (reproduced) alike. JointLedger applies blocks
+                        // serially in spine order, so it is the single ordered feeder into the
+                        // relay's contiguous block lane, and a hub relays each block exactly once.
+                        // (No-op off a hub, where coilRelay is None.) Splitting this by leadership
+                        // — own-led here, remote-led via PeerLiaisonHeadToHead.dispatch — let the
+                        // two feeders' sends race into the relay mailbox, the t3 AppendOutOfOrder
+                        // hang (see CoilRelay's ordering note).
+                        _ <- conn.coilRelay.traverse_(_ ! brief)
 
                         _ <- conn.fastConsensusActor ! softAck
                     } yield ()

--- a/src/test/scala/hydrozoa/multisig/consensus/CoilRelayOrderingTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/CoilRelayOrderingTest.scala
@@ -1,0 +1,182 @@
+package hydrozoa.multisig.consensus
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import cats.syntax.all.*
+import com.suprnation.actor.Actor.{Actor, Receive}
+import com.suprnation.actor.ActorSystem
+import hydrozoa.config.head.multisig.timing.TxTiming.BlockTimes.{BlockCreationEndTime, BlockCreationStartTime}
+import hydrozoa.config.head.network.CardanoNetwork
+import hydrozoa.config.node.MultiNodeConfig
+import hydrozoa.lib.cardano.scalus.QuantizedTime.QuantizedInstant
+import hydrozoa.lib.cardano.scalus.QuantizedTime.QuantizedInstant.realTimeQuantizedInstant
+import hydrozoa.multisig.consensus.liaison.{LaneOutbound, LiaisonProtocol}
+import hydrozoa.multisig.ledger.block.{BlockBody, BlockBrief, BlockHeader, BlockNumber, BlockVersion}
+import org.scalacheck.{Prop, Properties}
+import scala.concurrent.duration.DurationInt
+import test.{SeedPhrase, TestPeers}
+
+/** Finding #38 — the hub→coil **block lane** is fed by two different actors, so its gap-free
+  * contiguous numbering rests on the relative scheduling of two fibers rather than on anything that
+  * enforces order.
+  *
+  * On head peer `h` with `nHeadPeers = 2`, leadership alternates every block
+  * ([[hydrozoa.multisig.consensus.peer.HeadPeerId.isLeader]] is
+  * `blockNum % nHeadPeers == peerNum`), so consecutive briefs always arrive at [[CoilRelay]] from
+  * *different* feeders:
+  *   - remote-led `N` — `PeerLiaisonHeadToHead.dispatch`, which forwards to the relay **last**,
+  *     after it has already handed the brief and the remote's soft-ack to consensus;
+  *   - own-led `N+1` — `JointLedger`, reached by exactly those two forwards.
+  *
+  * So everything needed to produce `N+1` is set in motion before `N` is forwarded, and if the
+  * dispatch fiber loses its worker in between, `N+1` is enqueued first. That is what killed head-0
+  * on the t3 at block 4922 (`last=Some(4920) attempted=4922 expected=Some(4921)`).
+  *
+  * Three properties pin the behaviour: with two feeders the own-led brief can overtake the
+  * remote-led one and raise the exact crash (`ownLedOvertakingRemoteLedRaisesTheT3Error`); the
+  * undisturbed interleaving is fine (`meshFirstIsFine`, which is why it survived 4921 blocks); and
+  * a single feeder is order-independent by construction (`singleFeederIsOrderIndependent`) — the
+  * shape of the fix now wired in [[JointLedger]] (blocks) and [[StackComposer]] (stacks).
+  */
+object CoilRelayOrderingTest extends Properties("CoilRelay block-lane ordering") {
+
+    private val network = CardanoNetwork.Preprod
+
+    private val headConfig = {
+        val headPeers = TestPeers.apply(SeedPhrase.Yaci, network, 2)
+        MultiNodeConfig.generateWith(headPeers)().sample.get.headConfig
+    }
+
+    private def brief(blockNum: Int, now: QuantizedInstant): BlockBrief.Next = {
+        val end = BlockCreationEndTime(now + 1.second)
+        val fallback = headConfig.txTiming.newFallbackStartTime(end)
+        BlockBrief.Minor(
+          BlockHeader.Minor(
+            blockNum = BlockNumber(blockNum),
+            blockVersion = BlockVersion.Full(0, 0),
+            startTime = BlockCreationStartTime(now),
+            endTime = end,
+            fallbackTxStartTime = fallback,
+            forcedMajorBlockWakeupTime = headConfig.txTiming.forcedMajorBlockWakeupTime(fallback),
+            mDepositDecisionWakeupTime = None
+          ),
+          BlockBody.Minor(requests = List.empty, depositsRejected = List.empty)
+        )
+    }
+
+    /** The real hub→coil block lane, built exactly as `PeerLiaisonHubToCoil` builds it (`:93`).
+      * `backfill` is unused here — nothing in this scenario reads below the outbox floor.
+      */
+    private def blockLane: LaneOutbound[BlockBrief.Next, BlockNumber] =
+        LaneOutbound.contiguous[BlockBrief.Next, BlockNumber](
+          _.blockNum,
+          BlockNumber(1),
+          _.increment,
+          backfill = (_, _) => IO.pure(Nil)
+        )
+
+    /** Stands in for `PeerLiaisonHubToCoil`, doing what its `appendArtifact` does for a block brief
+      * (`:244`) and nothing else.
+      */
+    private class LiaisonStub(
+        lane: LaneOutbound[BlockBrief.Next, BlockNumber],
+        raised: cats.effect.Ref[IO, Vector[Throwable]]
+    ) extends Actor[IO, LiaisonProtocol.HubToCoilRequest] {
+        override def receive: Receive[IO, LiaisonProtocol.HubToCoilRequest] = {
+            // Record and re-raise: the raise is the incident (it kills the actor system), and the
+            // record is how the harness observes it afterwards.
+            case b: BlockBrief.Next =>
+                lane.append(b).onError(t => raised.update(_ :+ t))
+            case _ => IO.unit
+        }
+    }
+
+    /** Which fiber reaches [[CoilRelay]] first with its brief. The remote-led brief `N` is
+      * forwarded by `PeerLiaisonHeadToHead.dispatch` as its *last* act; the own-led brief `N+1` is
+      * produced by `JointLedger`, which dispatch already unblocked two steps earlier. Nothing
+      * orders the two.
+      */
+    private enum Interleaving:
+        /** dispatch keeps its worker through the steps-5→7 window — the usual case. */
+        case MeshFirst
+
+        /** dispatch is descheduled in that window and the own-led brief overtakes it — the t3. */
+        case OwnLedFirst
+
+        /** The fix: one actor owns the lane, so it emits in spine order whoever is descheduled. */
+        case SingleFeeder
+
+    /** Drive a real [[CoilRelay]] and a real block lane with the given interleaving, and return
+      * whatever the lane raised. The lane resumes at the high-water the crash reports and the
+      * briefs are the ones it reports, so a reproduction is recognisable by its message.
+      */
+    private def run(interleaving: Interleaving): (Option[Throwable], List[Int]) = {
+        val io = for {
+            raised <- cats.effect.Ref[IO].of(Vector.empty[Throwable])
+            delivered <- cats.effect.Ref[IO].of(List.empty[Int])
+            _ <- ActorSystem[IO]("coil-relay-ordering-test").use { system =>
+                for {
+                    now <- realTimeQuantizedInstant(headConfig.slotConfig)
+                    lane = blockLane
+                    _ <- lane.seedHighWater(Some(BlockNumber(4920)))
+                    liaison <- system.actorOf(new LiaisonStub(lane, raised))
+                    relay <- system.actorOf(
+                      CoilRelay(CoilRelay.Connections(coilPeerLiaisons = List(liaison)))
+                    )
+                    _ <- IO.sleep(50.millis) // let CoilRelay.PreStart resolve its connections
+                    remoteLed = relay ! brief(4921, now)
+                    ownLed = relay ! brief(4922, now)
+                    _ <- interleaving match {
+                        case Interleaving.MeshFirst =>
+                            remoteLed >> IO.sleep(50.millis) >> ownLed
+                        case Interleaving.OwnLedFirst =>
+                            ownLed >> IO.sleep(50.millis) >> remoteLed
+                        // One feeder, so its own sends are ordered by `!` and the lane cannot
+                        // see a gap no matter which fiber was descheduled.
+                        case Interleaving.SingleFeeder =>
+                            remoteLed >> ownLed
+                    }
+                    _ <- IO.sleep(200.millis)
+                    // Presence-of-effect: the briefs the lane will actually serve a coil
+                    // peer, in order. The block lane's `maxPerReply` is 1, so pull twice.
+                    served <- List(4921, 4922).traverse(n =>
+                        lane.reply(BlockNumber(n)).attempt.map {
+                            case Right(LaneOutbound.Items(items)) =>
+                                items.map(_.blockNum.convert.toInt)
+                            case _ => Nil
+                        }
+                    )
+                    _ <- delivered.set(served.flatten)
+                } yield ()
+            }.attempt // the raise emergency-stops the actor system; that is the incident
+            errs <- raised.get
+            n <- delivered.get
+        } yield (errs.headOption, n)
+        io.unsafeRunSync()
+    }
+
+    private def isTheCrash(t: Throwable): Boolean = t match {
+        case LaneOutbound.AppendOutOfOrder("Some(4920)", "4922", "Some(4921)") => true
+        case _                                                                 => false
+    }
+
+    /** The t3: the own-led brief overtakes the remote-led one and the lane raises the exact error
+      * head-0 died on.
+      */
+    val _ = property("ownLedOvertakingRemoteLedRaisesTheT3Error") = Prop {
+        val (raised, delivered) = run(Interleaving.OwnLedFirst)
+        raised.exists(isTheCrash) && delivered != List(4921, 4922)
+    }
+
+    /** The same two feeders, same code, undisturbed — which is why it survived 4921 blocks. */
+    val _ = property("meshFirstIsFine") = Prop {
+        val (raised, delivered) = run(Interleaving.MeshFirst)
+        raised.isEmpty && delivered == List(4921, 4922)
+    }
+
+    /** The fix: a single feeder is order-independent by construction. */
+    val _ = property("singleFeederIsOrderIndependent") = Prop {
+        val (raised, delivered) = run(Interleaving.SingleFeeder)
+        raised.isEmpty && delivered == List(4921, 4922)
+    }
+}


### PR DESCRIPTION
## The t3 hang

On 2026-08-17 head-0 fail-stopped on an EC2 t3.2xlarge (~210k requests in) with:

```
LaneOutbound$AppendOutOfOrder: append out of order: last=Some(4920) attempted=4922 expected=Some(4921)
```

The supervisor's failure handling then threw a secondary `NoSuchElementException: None.get` at
`ActorCell.finishTerminate`, escalating a restartable actor failure into an `ActorSystem`
**emergency stop** and burying the cause. `GET /ready` kept returning `active` throughout.

## Root cause — two feeders on one contiguous lane

The hub→coil **block lane** (`LaneOutbound.contiguous`) must be fed in ascending spine order, but
it had **two feeders**:

- own-led brief `N+1` → forwarded by **`JointLedger`**;
- remote-led brief `N` → forwarded by **`PeerLiaisonHeadToHead.dispatch`** (its *last* step, after
  it has already handed the brief and the remote's soft-ack to consensus).

With two head peers, leadership alternates every block, so consecutive briefs always arrive from
**different fibers** — and nothing orders one feeder's send against the other's. Once `dispatch`
hands block `N` and the remote's soft-ack to consensus, head-0 has everything it needs to
soft-confirm `N`, lead `N+1`, and enqueue `N+1` at the relay via `JointLedger` — *before* `dispatch`
reaches its own relay-forward. If the `dispatch` fiber is descheduled in that ~3-IO-step window
(likely under the load/APC-sweep conditions on the t3, never on dev), `N+1` wins the race and the
contiguous lane raises. The `CoilRelay` doc carried a proof that briefs arrive in order, but it
argued about what the node *holds*, not what is *enqueued at the relay* — that is the gap.

The **stack lane** has the identical split (`StackComposer` own-led vs `dispatch` remote-led),
latent only because stacks advance far more slowly than blocks.

## Fix — one feeder per aggregate lane

- **`JointLedger`** relays **every** block (own-led and reproduced remote-led). It applies blocks
  serially in spine order, so it is a natural single serialization point. The block forward is
  dropped from `dispatch`.
- **`StackComposer`** relays **every** stack (`tryCloseAsLeader` + `tryCloseAsFollower`). It closes
  stacks serially (single-flight on `previousStackHardConfirmed`). The stack forward is dropped from
  `dispatch`.
- The mesh still forwards the **per-author** artifacts (requests/soft-acks/hard-acks) — those lanes
  are keyed by author and already have exactly one feeder each, so they were never at risk.
- `CoilRelay`'s ordering proof is corrected to argue enqueue-order via the single feeder.

A single feeder emits from one fiber, and `!` (`ActorCell.sendMessage`) enqueues without
suspending, so its sends keep their order regardless of scheduling.

## Testing

`CoilRelayOrderingTest` drives a **real** `CoilRelay` + contiguous block lane seeded at the crash's
high-water through three interleavings:

| property | interleaving | result |
|---|---|---|
| `ownLedOvertakingRemoteLedRaisesTheT3Error` | own-led 4922 before remote-led 4921 | raises the exact error (+ the `None.get` escalation) |
| `meshFirstIsFine` | undisturbed | clean |
| `singleFeederIsOrderIndependent` | one feeder | clean |

Also green: `CoilLiaisonTest`, `BlockWeaverTest`, `JointLedgerTest`, `StackComposer` suites; `Test`
+ `integration/Test` compile under `-Werror`.

## Out of scope (flagged separately by the analysis)

- The cats-actors `finishTerminate → parent → None.get` escalation that turned a restartable failure
  into a whole-system stop and hid the cause — an upstream library defect.
- `/ready` continuing to report `active` after the actor system has stopped — a dead node looks
  healthy to an orchestrator.
