### PR TITLE
Make the RegisterDeposit wire codec explicitly encode-only

### DIFF
--- a/src/main/scala/hydrozoa/multisig/ledger/l2/L2LedgerCommand.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/l2/L2LedgerCommand.scala
@@ -103,14 +103,12 @@ object L2LedgerCommand {
                     )
         }
 
-        // FIXME (from Peter, after relocating from `RemoteL2LedgerCodecs`):
-        // How does this round-trip? Derived decoder with custom encoder??
-        given depositRegistrationDecoder: io.circe.Decoder[L2LedgerCommand.RegisterDeposit] = {
-            import hydrozoa.lib.cardano.cip116.JsonCodecs.CIP0116.Conway.{valueEncoder as _, valueDecoder as _, coinDecoder as _, coinEncoder as _, given}
-            import hydrozoa.multisig.ledger.remote.RemoteL2LedgerCodecs.{given_Decoder_Value, given_Decoder_Coin}
-            import RequestId.i64.given // L2-ledger / SugarRush wire form (i64), not the default object
-            io.circe.generic.semiauto.deriveDecoder
-        }
+        // Deliberately encode-only: Hydrozoa only ever *sends* a RegisterDeposit (the remote
+        // ledger decodes it with its own types). A decoder could not invert the encoder anyway —
+        // `Destination` is encoded as a lossy `{address, datum}` object while its circe decoder
+        // reads a CBOR-hex string. The one path that needs an exact RegisterDeposit round-trip,
+        // the EUTXO ledger's durable command log, re-derives symmetric store-local codecs
+        // (`eutxol2.store.L2StoreCodecs`) instead of using this wire form.
     }
 
     final case class ApplyDepositDecisions(

--- a/src/main/scala/hydrozoa/multisig/ledger/remote/RemoteL2LedgerCodecs.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/remote/RemoteL2LedgerCodecs.scala
@@ -291,11 +291,17 @@ object RemoteL2LedgerCodecs {
                       val cn = body.downField("commandNumber").as[L2CommandNumber]
                       val command = body.downField("command")
                       tag match {
+                          // RegisterDeposit is encode-only on this wire: Hydrozoa sends it, the
+                          // remote ledger decodes it with its own types, and the Scala decoder
+                          // could not invert the lossy Destination encoding (see
+                          // L2LedgerCommand.RegisterDeposit).
                           case "RegisterDeposit" =>
-                              for {
-                                  n <- cn
-                                  cmd <- command.as[L2LedgerCommand.RegisterDeposit]
-                              } yield Request.RegisterDeposit(n, cmd)
+                              Left(
+                                io.circe.DecodingFailure(
+                                  "RegisterDeposit is encode-only on the remote-ledger wire",
+                                  c.history
+                                )
+                              )
                           case "ApplyDepositDecisions" =>
                               for {
                                   n <- cn


### PR DESCRIPTION
Stacked on #633 (review/merge that first).

Resolves the long-standing `FIXME` on `depositRegistrationDecoder` ("How does this round-trip? Derived decoder with custom encoder??"). The answer was: it doesn't, and never did.

## The asymmetry

`Destination`'s two circe codecs are not inverses: the encoder emits a lossy `{"address": <bech32>, "datum": null}` object (a `Some(datum)` is silently dropped), while the decoder reads a CBOR-hex **string**. The derived `RegisterDeposit` decoder summoned the latter, so `decode(encode(_))` failed with a `DecodingFailure` at `refundDestination` for every deposit.

## Why deletion is safe

- On the remote-ledger wire, `RegisterDeposit` is send-only: Hydrozoa encodes it, the remote ledger decodes it with its own types (pinned by the cross-repo goldens in #633).
- The one production path needing an exact `RegisterDeposit` round-trip — the EUTXO ledger's durable command log (`RocksDbL2Store`) — already re-derives symmetric store-local codecs in `L2StoreCodecs`, whose doc comment cites this exact FIXME as the reason.
- The only decode call site was `requestCodec`'s `RegisterDeposit` branch, reachable by nothing in production; it now returns an explicit `DecodingFailure("RegisterDeposit is encode-only on the remote-ledger wire")` so the contract's direction is stated in code.

## Testing

`just build-werror` clean; remote + eutxol2 store suites green (30 tests — the store suite is what proves the durable-log round-trip path is unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)