### PR TITLE
docs(review): fix stale restoreTo comment; TODO two #622 review nits

### DIFF
--- a/src/main/scala/hydrozoa/multisig/consensus/StackEffectsBuilder.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/StackEffectsBuilder.scala
@@ -371,6 +371,11 @@ object StackEffectsBuilder {
       * payouts`) backstops the shape — it catches absorbed deposits whose decisions group never
       * arrived, which no per-group check would demand.
       */
+    // TODO(#622-review): this folds `applyDiffsWithDelta` over every block's diffs to compute the
+    // deltas, but the `mkEffectsRegular` match arms then re-fold `applyDiffs` over those diffs to
+    // thread the running map — the map fold runs twice per partition. `applyDiffsWithDelta` already
+    // yields the updated map; have this return it (or the per-block maps) so the arms reuse it
+    // instead of re-folding, halving the per-partition fold on a large map.
     private def checkPartitionConservation(
         startMap: EvacuationMap,
         partition: StackPartition

--- a/src/main/scala/hydrozoa/multisig/ledger/joint/JointLedger.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/joint/JointLedger.scala
@@ -1029,9 +1029,10 @@ object JointLedger {
           * Beyond rebuilding `Done` from the store ([[recoverState]]), this reads the L2 command
           * number recorded for the `fastBlockMark` block and calls [[L2Ledger.restoreTo]] — the
           * only effect on the L2 ledger. The consensus → L2 mapping stays wholly on this side; only
-          * the recorded command number crosses, never an ack (§R2b). A `RemoteL2Ledger` owns its
-          * own recovery and leaves `restoreTo` unsupported, so this path is for the EUTXO reference
-          * ledger.
+          * the recorded command number crosses, never an ack (§R2b). Every L2 backend implements
+          * `restoreTo`, so this path runs for all of them: the EUTXO reference ledger rewinds its
+          * committed state locally, and a `RemoteL2Ledger` sends a `Restore` request so the remote
+          * rewinds its own command-number tip.
           */
         def recover(
             persistence: Persistence[IO],

--- a/src/main/scala/hydrozoa/rulebased/RuleBasedActor.scala
+++ b/src/main/scala/hydrozoa/rulebased/RuleBasedActor.scala
@@ -1128,6 +1128,10 @@ final case class RuleBasedActor(
     // evacuation regime then spawns but never polls, so funds never come back (custody-critical). A
     // fixed-cadence self-tick fires every `evacuationBotPollingPeriod` regardless of mailbox
     // activity, which is correct here because `handleTick` is a poll-then-retry safe to re-run.
+    // TODO(#622-review): this overwrites `tickFiber` without cancelling any fiber already there. If
+    // cats-actors ever re-runs `preStart` on a restart without `postStop` in between, the old tick
+    // fiber orphans (two poll loops, one uncancellable). Cancel the existing fiber before replacing
+    // it — or confirm cats-actors' restart path always runs `postStop` first, and note that here.
     private def startTickTimer: IO[Unit] =
         (IO.sleep(config.evacuationBotPollingPeriod) >> (context.self ! Tick)).foreverM.start
             .flatMap(fib => tickFiber.set(Some(fib)))


### PR DESCRIPTION
- JointLedger.State.recover: restoreTo is now implemented by every L2 backend (EUTXO rewinds locally, RemoteL2Ledger sends Restore), not "unsupported".
- RuleBasedActor.startTickTimer: TODO the fiber-overwrite-on-restart leak.
- StackEffectsBuilder.checkPartitionConservation: TODO the double map-fold.