### PR TITLE
chore(release): 0.1.7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -403,7 +403,7 @@ inThisBuild(
   List(
     // Release version — drives the Docker image tag, `hydrozoa.BuildInfo.version`, and `GET
     // /version`. Bump here for a release (see RELEASE.md), then tag `v<version>`.
-    version := "0.1.6",
+    version := "0.1.7",
     scalaVersion := "3.3.7",
     semanticdbEnabled := true,
     semanticdbVersion := scalafixSemanticdb.revision

--- a/docs/user-guide/DEPLOYMENT.md
+++ b/docs/user-guide/DEPLOYMENT.md
@@ -124,13 +124,13 @@ under it. Then load the CLI alias and check you are on the version you expect:
 source ./hydrozoa.sh   # sets the `hydrozoa` alias + HYDROZOA_HOME (this folder, an absolute path)
 
 hydrozoa version       # verify the image you are running
-#   hydrozoa 0.1.6
-#   git:   v0.1.6
+#   hydrozoa 0.1.7
+#   git:   v0.1.7
 #   built: 2026-07-28 14:00:37.834-0600
 ```
 
-(The `git:` line is `git describe` provenance; a published image built from the `v0.1.6` tag reads a
-clean `v0.1.6`. A locally built image between releases shows the distance from the newest tag, e.g.
+(The `git:` line is `git describe` provenance; a published image built from the `v0.1.7` tag reads a
+clean `v0.1.7`. A locally built image between releases shows the distance from the newest tag, e.g.
 `v0.1.0-10-gaa9d7c69`.)
 
 Need a version that isn't in the registry? Build it from this repo — see §3.
@@ -418,8 +418,8 @@ finalization) appears in the same section as the head progresses.
 build (§3) is already tagged `…:latest`, so it is picked up without either:
 
 ```bash
-HYDROZOA_VERSION=0.1.6 just head-up                          # a specific published release
-HYDROZOA_IMAGE=cardano-hydrozoa/hydrozoa:0.1.6 just head-up  # a specific/other image name
+HYDROZOA_VERSION=0.1.7 just head-up                          # a specific published release
+HYDROZOA_IMAGE=cardano-hydrozoa/hydrozoa:0.1.7 just head-up  # a specific/other image name
 ```
 
 **Another head** — each head directory carries its own `docker-compose.yml`, so switch heads by

--- a/src/main/resources/scaffold/hydrozoa.sh
+++ b/src/main/resources/scaffold/hydrozoa.sh
@@ -13,7 +13,7 @@
 # scaffolded workspace — resolved to an absolute path, so the alias mounts correctly no matter which
 # directory you run it from. Override HYDROZOA_HOME (to an absolute path) or HYDROZOA_VERSION before
 # sourcing, or edit the defaults below.
-: "${HYDROZOA_VERSION:=0.1.6}"   # published image tag (ghcr.io/cardano-hydrozoa/hydrozoa)
+: "${HYDROZOA_VERSION:=0.1.7}"   # published image tag (ghcr.io/cardano-hydrozoa/hydrozoa)
 : "${HYDROZOA_HOME:=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)}"   # head directory (absolute)
 export HYDROZOA_VERSION HYDROZOA_HOME
 


### PR DESCRIPTION
Cut **0.1.7**. Version-bump only — no code changes.

## Bumped
- `build.sbt` — `version := "0.1.7"` (drives the image tag, `BuildInfo.version`, `GET /version`)
- `src/main/resources/scaffold/hydrozoa.sh` — `HYDROZOA_VERSION` default
- `docs/user-guide/DEPLOYMENT.md` — pull/run examples

## Deliberately skipped
- `scaffold/docker-compose.yml` — now defaults to `:latest`, so no per-release pin to bump (RELEASE.md step 1 is slightly stale here).
- Reference-script UTxOs — Scalus and the compiled `cardanoOnchain` scripts are **unchanged** since 0.1.6 (the only rulebased-L1 diffs are the `Throwable`→`RuntimeException` re-rooting sweep + a VoteTx error-message tweak — no UPLC change), so per RELEASE.md step 2 the baked refs stay valid. No redeploy.

## After merge
Tag `v0.1.7` on the merged commit and push it — `release.yml` publishes `:0.1.7`, `:0.1`, and `:latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)