### PR TITLE
chore(logging): narrate crash-recovery at info in the docker config

### DIFF
--- a/src/main/resources/logback-docker.xml
+++ b/src/main/resources/logback-docker.xml
@@ -33,6 +33,18 @@
          they are doing — `hydrozoa evacuate` runs both. -->
     <logger name="RuleBasedActor" level="info"/>
     <logger name="CardanoLiaison" level="info"/>
+    <!-- Crash-recovery narration. These routes log under their own top-level names, so under root=warn
+         the boot timeline is invisible: a warm restart that stalls waiting on the remote L2 ledger's
+         restore (it rebuilds its whole log first) shows nothing until it errors. Route them at info so
+         the connect/restore lifecycle (RemoteL2Ledger: Connecting / Connected) and the actor boot
+         (regime managers: Starting / Watching multisig actors) narrate. These fire at boot and on
+         regime transitions, not per block, so info stays bounded to the recovery window — the async
+         appender also sheds info first under load, so a steady-state burst can't be pinned by these.
+         The per-command RemoteL2Ledger Sending / Received stay at debug (below info), so ordinary L2
+         traffic does not flood. -->
+    <logger name="RemoteL2Ledger" level="info"/>
+    <logger name="HeadMultisigRegimeManager" level="info"/>
+    <logger name="CoilMultisigRegimeManager" level="info"/>
     <logger name="com.bloxbean" level="warn"/>
     <logger name="scalus" level="warn"/>
     <logger name="CardanoBackend" level="warn"/>


### PR DESCRIPTION
## Problem

The shipped `logback-docker.xml` runs `root=warn`. `RemoteL2Ledger` and the regime managers log under their own top-level logger names, so under root=warn their info-level lifecycle events are invisible. A **warm restart that stalls waiting on the remote L2 ledger's restore** (the ledger rebuilds its whole log before answering, up to the 10-min `restoreTimeout`) therefore shows **nothing** in `docker logs` until it finally errors — exactly the incident we just debugged, where the node looked dead with no clue why.

## Change

Config-only — no code log levels touched. Add three `info` loggers to `logback-docker.xml`:

- `RemoteL2Ledger` → `Connecting` / `Connected` (the L2 restore link)
- `HeadMultisigRegimeManager` / `CoilMultisigRegimeManager` → `Starting` / `Watching multisig actors`

A warm restart now narrates: `Starting multisig actors → Connecting to WebSocket → Successfully connected → Watching multisig actors → node started → Starting HTTP server`. A restore stall shows `Connected` then the eventual `RestoreTimedOut` (error) instead of silence.

## Scoping

- These routes fire at **boot / regime transitions, not per block**, so info stays bounded to the recovery window (and the async appender sheds info first under load, so they can't pin it in steady state).
- **Left out on purpose:** `JointLedger` / `StackComposer` / `Persistence`. Recovery events live there too, but those are per-block hot paths where info is *not* time-bounded — it would flood steady state.
- Per-command `RemoteL2Ledger` `Sending` / `Received` stay at debug, so ordinary L2 traffic does not flood (the restore request/response bodies remain hidden — surfacing those would need a code change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)