### PR TITLE
Verify the L2 ledger's evacuation map on every boot

### DIFF
--- a/docs/spec/l2-ledger-command-coordination.md
+++ b/docs/spec/l2-ledger-command-coordination.md
@@ -209,6 +209,89 @@ remote co-anchored recovery — a crash-time re-drive of `[anchor+1, head]` agai
 *ahead* of the anchor — is out of scope here; the self-correlating wire (responses echo the number,
 client asserts + fail-stops) is the safe interim.
 
+### Startup is the zeroth recovery case
+
+**JL calls `restoreTo` on every boot, including a cold one**, where the anchor is command `0`. This
+is not a special case bolted on: an empty store means JL persisted no block, and blocks are numbered
+from 1, so a crash part-way through block 1 leaves the ledger at `tip > 0` with JL's saved index at
+`0`. `restoreTo(0)` is what the ordering argument above already prescribes there — it rolls the
+orphaned commands back and consensus re-drives them. Making it unconditional removes the only path
+on which JL adopts a ledger it never spoke to.
+
+`restoreTo(0)` returns the ledger to its **initial state**: the state the ledger built from its own
+configuration before any command, with the tip at `0` and the event log truncated to that boundary.
+
+### The evacuation map is verified against the ledger, not assumed
+
+The head config's `initialEvacuationMap` is the head's opening L2 state, and the initialization
+transaction commits to it on L1 (treasury value, plus its KZG in the treasury datum). The two are
+authored independently — the config by the bootstrap tooling, the state by the ledger itself — so a
+head can otherwise run for its whole life on an evacuation map the ledger never agreed to, and
+discover it only when falling back, at which point the committed payouts are unevacuable.
+
+So **every `Restored` reply carries the ledger's `evacuationMapHash`** at the restored command number
+([the digest](#the-evacuation-map-digest)), and JL checks it **at every anchor**:
+
+- **At a cold start** (`restoreTo(0)`) against the digest of its configured `initialEvacuationMap`.
+- **After a crash** against its own map at the fast anchor. JL does not keep that map directly — the
+  slow side stores it per block, and only at blocks whose map backs an on-chain KZG commitment — so
+  JL takes the highest stored map at or below the anchor (the config's initial map when no stack has
+  closed) and folds each remaining `BlockResult`'s `evacuationMapDiff` onto it. The slow side never
+  runs ahead of the fast one, so that base is always at or below the anchor.
+
+**A mismatch is fatal either way: the node refuses to boot.** It is not recoverable at runtime and
+not safe to run through — the on-chain commitment is already wrong, or the ledger is the wrong one.
+
+The operator gets the two sides to agree by generating the config from the ledger rather than by
+hand: the ledger prints its initial evacuation map in exactly the head config's encoding, and the
+bootstrap consumes that ([Initial evacuation map](#initial-evacuation-map)).
+
+## The evacuation map digest
+
+A digest over an evacuation map, defined so that both a Scala head and a Rust sidecar can compute it
+from bytes they already hold — no Plutus `Data` encoding and no BLS12-381. It is a **coordination
+check, not an on-chain commitment**; the on-chain commitment stays the KZG in the treasury datum.
+
+Each entry contributes the two byte strings that are already the wire form of an evacuation-map
+entry: the raw **evacuation key**, and the raw **CBOR of the entry's L1 transaction output** — the
+exact bytes, never a re-encoding. (The head keeps them verbatim in `Payout.Obligation`'s
+`KeepRaw[TransactionOutput]` precisely so this holds.)
+
+```
+evacuationMapHash(M) = blake2b_256(
+     "gummiworm-evacuation-map-v1"          -- domain tag, ASCII, no terminator
+  || uint32_be(entryCount(M))
+  || for each (key, output) of M, ascending by key:
+         uint32_be(len(key))    || key
+      || uint32_be(len(output)) || output
+)
+```
+
+- **Order** is ascending by the raw key bytes, compared **unsigned, byte by byte, shorter prefix
+  first**. Both sides' native map ordering already is this (scalus's `Ordering[ByteString]`, Rust's
+  `Ord` on byte slices), so both fold in iteration order without re-sorting.
+- **Length framing** is mandatory: keys are not fixed-width across backends (the EUTXO ledger keys by
+  CBOR of a `TransactionInput`, Sugar Rush by a 28-byte account key hash zero-padded to 32), so
+  unframed concatenation would be ambiguous.
+- **The empty map** hashes the domain tag and a zero count — a defined value, not a special case.
+- **Backends do not share a key space.** The digest proves the two sides hold the same map; it does
+  not make an EUTXO-keyed map meaningful to an account-keyed ledger. That is the point — this is the
+  check that catches exactly that substitution.
+
+## Initial evacuation map
+
+A ledger implementation **must** provide an out-of-band way to print the evacuation map of its
+initial state, in the head config's encoding for `initialEvacuationMap`:
+
+```json
+{ "<evacuationKeyHex>": "<transactionOutputCborHex>", ... }
+```
+
+It is computed from the ledger's own configuration, without touching a durable store, so an operator
+can produce it before the head exists. This file is the bootstrap input for a remote-ledger head —
+backend-agnostic, and already in final form: the bootstrap copies it into the head config rather than
+deriving anything from it.
+
 ## Wire protocol
 
 The command envelope wraps the coordination number around each command; the response is the
@@ -219,6 +302,21 @@ type GummiwormCommand =
   | { "RegisterDeposit":        { commandNumber: CommandNumber, command: RegisterDeposit } }
   | { "ApplyDepositDecisions":  { commandNumber: CommandNumber, command: ApplyDepositDecisions } }
   | { "ApplyTransaction":       { commandNumber: CommandNumber, command: ApplyTransaction } }
+```
+
+`restoreTo` rides the same socket as a separate un-numbered frame. Its tag is disjoint from every
+command tag, so the two never collide:
+
+```typescript
+type RestoreRequest =
+  | { "RestoreTo": { commandNumber: CommandNumber } }
+
+type RestoreResponse =
+  // Reconstructed as of the requested number. `tip` equals the request. `evacuationMapHash` is the
+  // digest of the ledger's evacuation map at that state — 32 bytes, hex.
+  | { "Restored":      { tip: CommandNumber, evacuationMapHash: string } }
+  // `requested` is the asked-for number, `tip` the ledger's current durable tip.
+  | { "RestoreFailed": { requested: CommandNumber, tip: CommandNumber, reason: string } }
 ```
 
 Delta from the spec (`/whitepaper/sugar-rush/commands`):

--- a/src/main/scala/hydrozoa/multisig/ledger/block/BlockResult.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/block/BlockResult.scala
@@ -86,7 +86,13 @@ object BlockResult:
         postDatedRefundTxs: List[RefundTx.PostDated],
         absorbedDeposits: List[DepositUtxo],
         competingFallbackTxTime: FallbackTxStartTime
-    )
+    ):
+
+        /** The block's evacuation diffs in application order, boundaries erased — as
+          * [[BlockResult.flatEvacuationDiffs]], but off the stored projection, so a caller folding
+          * the cumulative map on boot needs no brief.
+          */
+        def flatEvacuationDiffs: Seq[EvacuationDiff] = evacuationMapDiff.flatMap(_.diffs)
 
     /** Reassemble the full [[BlockResult]] at recovery from its persisted projection + the brief
       * read back from the `Block` journal.

--- a/src/main/scala/hydrozoa/multisig/ledger/eutxol2/EutxoL2Ledger.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/eutxol2/EutxoL2Ledger.scala
@@ -13,7 +13,7 @@ import hydrozoa.multisig.ledger.eutxol2.store.{L2Snapshot, L2Store}
 import hydrozoa.multisig.ledger.eutxol2.tx.{L2Genesis, L2Tx}
 import hydrozoa.multisig.ledger.event.RequestId
 import hydrozoa.multisig.ledger.joint.obligation.Payout
-import hydrozoa.multisig.ledger.joint.{EvacuationDiff, EvacuationKey, EvacuationMap, evacuationKeyOrdering}
+import hydrozoa.multisig.ledger.joint.{EvacuationDiff, EvacuationKey, EvacuationMap, EvacuationMapHash, evacuationKeyOrdering}
 import hydrozoa.multisig.ledger.l2.*
 import hydrozoa.multisig.ledger.l2.L2CommandNumber.increment
 import hydrozoa.multisig.ledger.l2.L2LedgerCommand.RegisterDeposit
@@ -381,7 +381,9 @@ case class EutxoL2Ledger private (
       * target beyond the recorded tip (a corruption tripwire — the co-anchoring ordering prevents
       * it).
       */
-    override def restoreTo(commandNumber: L2CommandNumber): EitherT[IO, RestoreError, Unit] =
+    override def restoreTo(
+        commandNumber: L2CommandNumber
+    ): EitherT[IO, RestoreError, EvacuationMapHash] =
         for {
             tip <- EitherT.right(store.getTip.map(_.getOrElse(L2CommandNumber.zero)))
             _ <- EitherT.cond[IO](
@@ -419,7 +421,18 @@ case class EutxoL2Ledger private (
                     .replace(frozenAt)
               )
             )
-        } yield ()
+            // The digest of the state we just restored to. For this backend the caller's check is
+            // a tautology at a cold start — the ledger seeds its own genesis from the same
+            // `initialEvacuationMap` the caller compares against — but it keeps one boot path for
+            // every backend, and it is a real check against a remote ledger that owns its state.
+            digest <- EitherT.fromEither[IO](
+              restored.activeUtxos
+                  .toEvacuationMap(config)
+                  .left
+                  .map(violation => RestoreError.OtherError(violation.toString))
+                  .map(_.digest)
+            )
+        } yield digest
 
     /** Rebuild a full [[EutxoL2Ledger.State]] from a persisted snapshot — `activeUtxos`,
       * `transientTokens`, `pendingDeposits`, and `commandNumber` come from the snapshot (§R2b).

--- a/src/main/scala/hydrozoa/multisig/ledger/joint/EvacuationMap.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/joint/EvacuationMap.scala
@@ -13,6 +13,8 @@ import hydrozoa.multisig.ledger.remote.RemoteL2LedgerCodecs.{payoutObligationDec
 import hydrozoa.rulebased.ledger.l1.script.plutus.RuleBasedTreasuryValidator.given
 import io.circe.*
 import io.circe.syntax.*
+import java.io.ByteArrayOutputStream
+import java.nio.charset.StandardCharsets.UTF_8
 import scala.collection.immutable.{SortedMap, TreeMap}
 import scala.util.Try
 import scalus.cardano.ledger.*
@@ -20,7 +22,7 @@ import scalus.cardano.onchain.plutus.prelude.List as SList
 import scalus.cardano.onchain.plutus.v2.TxOut
 import scalus.uplc.builtin.Builtins.{blake2b_224, serialiseData}
 import scalus.uplc.builtin.Data.toData
-import scalus.uplc.builtin.{ByteString, Data, ToData}
+import scalus.uplc.builtin.{ByteString, Data, ToData, platform}
 import scalus.|>
 import supranational.blst.Scalar
 
@@ -67,6 +69,45 @@ object EvacuationMapInstances:
             } yield ek
     }
 
+/** A digest of an [[EvacuationMap]], as defined in `docs/spec/l2-ledger-command-coordination.md`
+  * ("The evacuation map digest").
+  *
+  * A **coordination check, not an on-chain commitment**: the head commits to its evacuation map on
+  * L1 with [[EvacuationMap.kzgCommitment]], which needs BLS12-381 and the head's trusted setup.
+  * This digest exists so a remote L2 ledger and the head can cheaply agree that they hold the
+  * *same* map, and so is defined over bytes both already have — the raw evacuation key and the
+  * entry's raw CBOR output — with no Plutus `Data` encoding on either side.
+  *
+  * Sugar Rush computes it in `types/src/types/evacuation_map.rs`; the two are pinned to a shared
+  * golden, so a change to [[EvacuationMap.digest]] is a wire break.
+  */
+final case class EvacuationMapHash(byteString: ByteString) {
+    def toHex: String = byteString.toHex
+
+    override def toString: String = toHex
+}
+
+object EvacuationMapHash:
+
+    /** Mixed in before anything else so this digest can never collide with a hash of the same bytes
+      * taken for another purpose. ASCII, no terminator — the length framing that follows makes the
+      * boundary unambiguous.
+      */
+    val domainTag: Array[Byte] = "gummiworm-evacuation-map-v1".getBytes(UTF_8)
+
+    given Encoder[EvacuationMapHash] =
+        Encoder.encodeString.contramap(_.toHex)
+
+    given Decoder[EvacuationMapHash] =
+        Decoder.decodeString.emap(s =>
+            Try(ByteString.fromHex(s)).toEither.left
+                .map(_ => s"not a hex-encoded evacuation map hash: $s")
+                .flatMap(bs =>
+                    if bs.size == 32 then Right(EvacuationMapHash(bs))
+                    else Left(s"evacuation map hash must be 32 bytes, got ${bs.size}")
+                )
+        )
+
 final case class EvacuationMap(
     evacuationMap: TreeMap[EvacuationKey, Payout.Obligation]
 )(using Ordering[EvacuationKey], ToData[EvacuationKey])
@@ -96,6 +137,49 @@ final case class EvacuationMap(
     val outputsCooked: Iterable[TransactionOutput] = evacuationMap.values.map(_.utxo.value)
 
     lazy val kzgCommitment: KzgCommitment = KzgCommitment.calculateKzgCommitment(scalars)
+
+    /** The [[EvacuationMapHash]] of this map — see that type for what it is for.
+      *
+      * ```
+      * blake2b_256(
+      *      "gummiworm-evacuation-map-v1"
+      *   || uint32_be(entryCount)
+      *   || for each (key, output) ascending by key:
+      *          uint32_be(len(key))    || key
+      *       || uint32_be(len(output)) || output
+      * )
+      * ```
+      *
+      * Both fields are length-framed because evacuation keys are not fixed-width across L2 ledger
+      * backends — the EUTXO ledger keys by the CBOR of a `TransactionInput`, Sugar Rush by a
+      * 28-byte account key hash zero-padded to 32 — so an unframed concatenation would be
+      * ambiguous. The output contributes its **raw** CBOR, which is why [[Payout.Obligation]] holds
+      * a `KeepRaw`: a re-encoding could differ from the bytes the remote hashed.
+      *
+      * Folding in `evacuationMap`'s own iteration order is what the spec requires: scalus's
+      * `Ordering[ByteString]` compares unsigned, byte by byte, shorter prefix first, which is the
+      * same order Rust's `Ord` on byte slices gives the remote.
+      */
+    lazy val digest: EvacuationMapHash = {
+        val buffer = ByteArrayOutputStream()
+        def putLength(n: Int): Unit = {
+            buffer.write((n >>> 24) & 0xff)
+            buffer.write((n >>> 16) & 0xff)
+            buffer.write((n >>> 8) & 0xff)
+            buffer.write(n & 0xff)
+        }
+        def putFramed(bytes: Array[Byte]): Unit = {
+            putLength(bytes.length)
+            buffer.write(bytes)
+        }
+        buffer.write(EvacuationMapHash.domainTag)
+        putLength(evacuationMap.size)
+        evacuationMap.foreach { (key, obligation) =>
+            putFramed(key.byteString.bytes)
+            putFramed(obligation.utxo.raw)
+        }
+        EvacuationMapHash(platform.blake2b_256(ByteString.unsafeFromArray(buffer.toByteArray)))
+    }
 
     lazy val scalars: SList[Scalar] = {
         SList.from(

--- a/src/main/scala/hydrozoa/multisig/ledger/joint/JointLedger.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/joint/JointLedger.scala
@@ -1129,7 +1129,7 @@ object JointLedger {
             persistence: Persistence[IO],
             blockNum: BlockNumber,
             initialEvacuationMap: EvacuationMap
-        )(using CardanoNetwork.Section): IO[EvacuationMap] =
+        ): IO[EvacuationMap] =
             for {
                 mapMark <- Markers.recoverEvacuationMapMark(persistence.backend)
                 base <- mapMark.fold(IO.pure(BlockNumber.zero -> initialEvacuationMap))(mark =>

--- a/src/main/scala/hydrozoa/multisig/ledger/joint/JointLedger.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/joint/JointLedger.scala
@@ -32,7 +32,7 @@ import hydrozoa.multisig.ledger.l1.tx.RefundTx
 import hydrozoa.multisig.ledger.l1.txseq.DepositRefundTxSeq
 import hydrozoa.multisig.ledger.l1.utxo.DepositUtxo
 import hydrozoa.multisig.ledger.l2.L2CommandNumber.increment
-import hydrozoa.multisig.ledger.l2.{L2CommandNumber, L2Ledger, L2LedgerCommand, L2LedgerInteractionState, L2LedgerResponse}
+import hydrozoa.multisig.ledger.l2.{L2CommandNumber, L2Ledger, L2LedgerCommand, L2LedgerInteractionState, L2LedgerResponse, RestoreError}
 import hydrozoa.multisig.metrics.PeerMetrics
 import hydrozoa.multisig.persistence.recovery.ReplayCursors
 import hydrozoa.multisig.persistence.{DepositDecision, JournalKey, JournalValue, Markers, Persistence, RequestBlockEntry, StoreKey, WriteBatch}
@@ -194,13 +194,19 @@ final case class JointLedger(
         for {
             _ <- initializeConnections
             // On a non-empty store restore the passive `Done` and co-anchor the L2 ledger to the
-            // fast anchor. Cold start (empty store) leaves `State.initialize`. The
+            // fast anchor. A cold start (empty store) keeps `State.initialize` here, but still
+            // co-anchors the ledger at command zero and verifies its initial evacuation map. The
             // `[anchor + 1, head]` block tail is re-driven by BlockWeaver, not restored here. The
             // fast anchor is `fastBlockMark = max(BlockResult)` (§6), shared by head and coil peers:
             // on a head peer it coincides with `max(own SoftAck)` (both written in the same atomic
             // per-block batch); a coil peer authors no soft-ack and anchors on it directly.
             fastBlockMark <- Markers.recoverFastBlockMark(persistence.backend)
-            recovered <- State.recover(persistence, l2Ledger, fastBlockMark)
+            recovered <- State.recover(
+              persistence,
+              l2Ledger,
+              fastBlockMark,
+              config.initialEvacuationMap
+            )
             _ <- recovered match {
                 case Some(done) =>
                     state.set(done) >> tracer.traceWith(
@@ -1039,11 +1045,10 @@ object JointLedger {
         )
 
         /** Reconstruct the passive [[Done]] state after a crash and co-anchor the L2 ledger to the
-          * same `fastBlockMark = max(BlockResult)` boundary, or `None` for an empty store (no
-          * `BlockResult` yet — cold start). Shared by head and coil peers: on a head peer the fast
-          * anchor coincides with `max(own SoftAck)` (both written in the same atomic per-block
-          * batch), and a coil peer authors no soft-ack, so `max(BlockResult)` is its sole fast
-          * anchor.
+          * same `fastBlockMark = max(BlockResult)` boundary, or `None` for an empty store (a cold
+          * start). Shared by head and coil peers: on a head peer the fast anchor coincides with
+          * `max(own SoftAck)` (both written in the same atomic per-block batch), and a coil peer
+          * authors no soft-ack, so `max(BlockResult)` is its sole fast anchor.
           *
           * Beyond rebuilding `Done` from the store ([[recoverState]]), this reads the L2 command
           * number recorded for the `fastBlockMark` block and calls [[L2Ledger.restoreTo]] — the
@@ -1052,19 +1057,93 @@ object JointLedger {
           * `restoreTo`, so this path runs for all of them: the EUTXO reference ledger rewinds its
           * committed state locally, and a `RemoteL2Ledger` sends a `Restore` request so the remote
           * rewinds its own command-number tip.
+          *
+          * **A cold start is the zeroth recovery case, not a skipped one**: it restores to command
+          * zero. That is not a formality — blocks are numbered from 1, so a crash part-way through
+          * block 1 leaves the ledger at a tip above zero with nothing persisted here, and the
+          * orphaned commands must be rolled back before consensus re-drives them. It also makes the
+          * ledger's initial evacuation map verifiable, which is the point below.
+          *
+          * **The digest `restoreTo` returns is checked at every anchor, not only at a cold one.**
+          * At command zero it is the ledger's initial evacuation map, checked against the head
+          * config's `initialEvacuationMap`: the two are authored independently and the
+          * initialization transaction has already committed to the configured one on L1, so a
+          * mismatch means this node would run normally and produce unevacuable payouts at fallback.
+          * Past a cold start it is checked against [[evacuationMapAt]] — this side keeps the map on
+          * the slow side at stack boundaries, so reaching the fast anchor means folding the blocks
+          * between. Either way a mismatch raises [[RestoreError.EvacuationMapMismatch]] and the
+          * node does not start.
           */
         def recover(
             persistence: Persistence[IO],
             l2Ledger: L2Ledger[IO],
-            fastBlockMark: Option[BlockNumber]
+            fastBlockMark: Option[BlockNumber],
+            initialEvacuationMap: EvacuationMap
         )(using CardanoNetwork.Section): IO[Option[Done]] =
             fastBlockMark match
-                case None => IO.pure(None)
+                case None =>
+                    l2Ledger
+                        .restoreTo(L2CommandNumber.zero)
+                        .value
+                        .flatMap(IO.fromEither)
+                        .flatMap(actual =>
+                            IO.raiseUnless(actual == initialEvacuationMap.digest)(
+                              RestoreError.EvacuationMapMismatch(
+                                expected = initialEvacuationMap.digest,
+                                actual = actual
+                              )
+                            )
+                        )
+                        .as(None)
                 case Some(blockNum) =>
                     for {
                         done <- doneAt(persistence, blockNum)
-                        _ <- l2Ledger.restoreTo(done.commandNumber).value.flatMap(IO.fromEither)
+                        actual <- l2Ledger
+                            .restoreTo(done.commandNumber)
+                            .value
+                            .flatMap(IO.fromEither)
+                        expected <- evacuationMapAt(persistence, blockNum, initialEvacuationMap)
+                        _ <- IO.raiseUnless(actual == expected.digest)(
+                          RestoreError.EvacuationMapMismatch(
+                            expected = expected.digest,
+                            actual = actual
+                          )
+                        )
                     } yield Some(done)
+
+        /** This peer's cumulative evacuation map at `blockNum` — the fast anchor.
+          *
+          * The slow side stores the map only at blocks whose map backs an on-chain KZG commitment,
+          * and only once a stack closes, so there is usually no entry at the fast anchor itself.
+          * Rebuild it: take the highest stored map at or below the anchor as the base (or the head
+          * config's initial map when no stack has closed) and fold the `evacuationMapDiff` of every
+          * `BlockResult` from there to the anchor.
+          *
+          * `Markers.recoverEvacuationMapMark` is the base block, not a scan bounded by `blockNum`:
+          * the slow side never runs ahead of the fast one, so the highest stored map is always at
+          * or below the anchor. Every `BlockResult` in the folded range is present — the anchor is
+          * `max(BlockResult)` and the CF is contiguous — so a gap is store corruption and
+          * `getOrFail` throws.
+          */
+        private def evacuationMapAt(
+            persistence: Persistence[IO],
+            blockNum: BlockNumber,
+            initialEvacuationMap: EvacuationMap
+        )(using CardanoNetwork.Section): IO[EvacuationMap] =
+            for {
+                mapMark <- Markers.recoverEvacuationMapMark(persistence.backend)
+                base <- mapMark.fold(IO.pure(BlockNumber.zero -> initialEvacuationMap))(mark =>
+                    persistence.getOrFail(StoreKey.EvacuationMap(mark)).map(mark -> _)
+                )
+                (baseBlock, baseMap) = base
+                diffs <- ((baseBlock.increment: Int) to (blockNum: Int)).toList
+                    .map(BlockNumber.apply)
+                    .flatTraverse(num =>
+                        persistence
+                            .getOrFail(StoreKey.BlockResult(num))
+                            .map(_.flatEvacuationDiffs.toList)
+                    )
+            } yield EvacuationMap.applyDiffs(baseMap, diffs)
 
         /** The store-only half of [[recover]]: rebuild `Done(previousBlockHeader, deposits)` from
           * the `fastBlockMark` block's persisted brief + the deposits snapshot, with no L2 effect.

--- a/src/main/scala/hydrozoa/multisig/ledger/l2/L2Ledger.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/l2/L2Ledger.scala
@@ -4,7 +4,7 @@ import cats.Monad
 import cats.data.EitherT
 import hydrozoa.multisig.ledger.event.RequestId
 import hydrozoa.multisig.ledger.joint.obligation.Payout
-import hydrozoa.multisig.ledger.joint.{EvacuationDiff, EvacuationDiffGroup}
+import hydrozoa.multisig.ledger.joint.{EvacuationDiff, EvacuationDiffGroup, EvacuationMapHash}
 
 /** Why [[L2Ledger.restoreTo]] could not reconstruct the committed state. Extends `Throwable` so the
   * one fatal caller (`JointLedger.State.recover`, at boot) can raise it directly; it is still a
@@ -23,6 +23,23 @@ object RestoreError:
       * [[L2LedgerResponse.UnrecoverableError.OtherError]], the command-path counterpart.
       */
     final case class OtherError(message: String) extends RestoreError
+
+    /** The ledger's evacuation map at the restored command number is not the one this node holds.
+      *
+      * At a cold start that means the head config's `initialEvacuationMap` is not the map the L2
+      * ledger actually starts from — the head was built against a different ledger, or against a
+      * different configuration of this one. The initialization transaction has already committed to
+      * the configured map on L1, so this cannot be repaired at runtime and must not be run through:
+      * the head would work normally for its whole life and produce unevacuable payouts at fallback.
+      * See `docs/spec/l2-ledger-command-coordination.md`.
+      */
+    final case class EvacuationMapMismatch(
+        expected: EvacuationMapHash,
+        actual: EvacuationMapHash
+    ) extends RestoreError {
+        override def getMessage: String =
+            s"L2 ledger evacuation map digest $actual does not match the configured $expected"
+    }
 
 /** State changes accumulated via interaction with the L2 Ledger (i.e., as seen from the Joint
   * Ledger).
@@ -168,6 +185,11 @@ trait L2Ledger[F[_]] {
       *
       * Unlike the command path, this stays an [[EitherT]]: it is a boot-time reconstruction, not a
       * numbered command, so its failure is a [[RestoreError]] rather than one of the verdicts.
+      *
+      * Returns the [[EvacuationMapHash]] of the ledger's evacuation map at `commandNumber`, so the
+      * caller can check that both sides hold the same map. At a cold start (`commandNumber` zero)
+      * that is the check that the head config's `initialEvacuationMap` is the one this ledger
+      * actually starts from — see [[RestoreError.EvacuationMapMismatch]].
       */
-    def restoreTo(commandNumber: L2CommandNumber): EitherT[F, RestoreError, Unit]
+    def restoreTo(commandNumber: L2CommandNumber): EitherT[F, RestoreError, EvacuationMapHash]
 }

--- a/src/main/scala/hydrozoa/multisig/ledger/remote/RemoteL2Ledger.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/remote/RemoteL2Ledger.scala
@@ -7,6 +7,7 @@ import cats.effect.{Async, FiberIO, IO, Ref, Resource}
 import cats.syntax.all.*
 import hydrozoa.config.head.network.CardanoNetwork
 import hydrozoa.lib.logging.ContraTracer
+import hydrozoa.multisig.ledger.joint.EvacuationMapHash
 import hydrozoa.multisig.ledger.l2.{ApplyDepositDecisionsResponse, ApplyTransactionResponse, L2CommandNumber, L2Ledger, L2LedgerCommand, L2LedgerResponse, RegisterDepositResponse, RestoreError}
 import hydrozoa.multisig.ledger.remote.RemoteL2Ledger.{Conn, Request, RestoreResponse}
 import hydrozoa.multisig.ledger.remote.RemoteL2LedgerEvent.*
@@ -142,9 +143,11 @@ class RemoteL2Ledger private (
       * Bounded by [[restoreTimeout]], not the ordinary `requestTimeout`, and an expiry is **not**
       * retried — see that parameter for why.
       */
-    override def restoreTo(commandNumber: L2CommandNumber): EitherT[IO, RestoreError, Unit] =
+    override def restoreTo(
+        commandNumber: L2CommandNumber
+    ): EitherT[IO, RestoreError, EvacuationMapHash] =
         EitherT(sendRestoreRequest(Request.Restore(commandNumber)).map {
-            case _: RestoreResponse.Restored => Right(())
+            case r: RestoreResponse.Restored => Right(r.evacuationMapHash)
             case RestoreResponse.RestoreFailed(requested, tip, reason) =>
                 if requested.value > tip.value then
                     Left(RestoreError.CommandNumberTooHigh(requested, tip))
@@ -392,7 +395,12 @@ object RemoteL2Ledger {
     }
 
     object RestoreResponse {
-        final case class Restored(tip: L2CommandNumber) extends RestoreResponse {
+
+        /** `evacuationMapHash` is the remote's [[EvacuationMapHash]] at `tip` — the digest the
+          * caller checks its own evacuation map against.
+          */
+        final case class Restored(tip: L2CommandNumber, evacuationMapHash: EvacuationMapHash)
+            extends RestoreResponse {
             def commandNumber: L2CommandNumber = tip
         }
         final case class RestoreFailed(

--- a/src/main/scala/hydrozoa/multisig/ledger/remote/RemoteL2LedgerCodecs.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/remote/RemoteL2LedgerCodecs.scala
@@ -4,8 +4,8 @@ import hydrozoa.config.head.network.CardanoNetwork
 import hydrozoa.lib.cardano.scalus.codecs.json.Codecs.{keepRawTransactionOutputDecoder, keepRawTransactionOutputEncoder}
 import hydrozoa.multisig.ledger.block.BlockNumber
 import hydrozoa.multisig.ledger.event.RequestId
-import hydrozoa.multisig.ledger.joint.EvacuationDiff
 import hydrozoa.multisig.ledger.joint.obligation.Payout
+import hydrozoa.multisig.ledger.joint.{EvacuationDiff, EvacuationMapHash}
 import hydrozoa.multisig.ledger.l2.{Destination, L2CommandNumber, L2LedgerCommand, L2LedgerResponse}
 import io.circe.generic.semiauto.*
 import io.circe.syntax.*
@@ -216,10 +216,11 @@ object RemoteL2LedgerCodecs {
               )
               .flatMap {
                   case "Restored" =>
-                      c.downField("Restored")
-                          .downField("tip")
-                          .as[L2CommandNumber]
-                          .map(RestoreResponse.Restored.apply)
+                      val body = c.downField("Restored")
+                      for {
+                          tip <- body.downField("tip").as[L2CommandNumber]
+                          hash <- body.downField("evacuationMapHash").as[EvacuationMapHash]
+                      } yield RestoreResponse.Restored(tip, hash)
                   case "RestoreFailed" =>
                       val body = c.downField("RestoreFailed")
                       for {
@@ -236,8 +237,13 @@ object RemoteL2LedgerCodecs {
                       )
               },
       encodeA = {
-          case RestoreResponse.Restored(tip) =>
-              io.circe.Json.obj("Restored" -> io.circe.Json.obj("tip" -> tip.asJson))
+          case RestoreResponse.Restored(tip, evacuationMapHash) =>
+              io.circe.Json.obj(
+                "Restored" -> io.circe.Json.obj(
+                  "tip" -> tip.asJson,
+                  "evacuationMapHash" -> evacuationMapHash.asJson
+                )
+              )
           case RestoreResponse.RestoreFailed(requested, tip, reason) =>
               io.circe.Json.obj(
                 "RestoreFailed" -> io.circe.Json.obj(

--- a/src/main/scala/hydrozoa/multisig/persistence/Markers.scala
+++ b/src/main/scala/hydrozoa/multisig/persistence/Markers.scala
@@ -74,6 +74,18 @@ object Markers:
     def recoverFastBlockMark(backend: BackendStore[IO]): IO[Option[BlockNumber]] =
         backend.lastKey(Cf.BlockResult).map(_.map(decodeBlockNum))
 
+    /** The highest block at which a cumulative evacuation map is durably stored, or `None` when the
+      * slow side has closed no stack yet (the map is then the head config's initial one).
+      *
+      * `Cf.EvacuationMap` is written by `StackComposer` at stack close, only at blocks whose map
+      * backs an on-chain KZG commitment ([[hydrozoa.multisig.persistence.StoreKey.EvacuationMap]]),
+      * so it is sparse and lags [[recoverFastBlockMark]] — the slow side never runs ahead of the
+      * fast one. `JointLedger` reads it on boot as the base to fold the remaining blocks'
+      * `evacuationMapDiff`s onto, to reach the map at the fast anchor.
+      */
+    def recoverEvacuationMapMark(backend: BackendStore[IO]): IO[Option[BlockNumber]] =
+        backend.lastKey(Cf.EvacuationMap).map(_.map(decodeBlockNum))
+
     /** The slow-side anchor: `hardAcked = max(own HardAck.key)` — this peer's last own hard-ack
       * number, or `None` for an empty store. Works for both peer types: `own` is a [[PeerId]], so a
       * head peer reads its head `HardAck` CF and a coil peer reads its coil `HardAck` CF (the stack

--- a/src/test/scala/hydrozoa/multisig/ledger/joint/EvacuationMapDigestTest.scala
+++ b/src/test/scala/hydrozoa/multisig/ledger/joint/EvacuationMapDigestTest.scala
@@ -1,0 +1,61 @@
+package hydrozoa.multisig.ledger.joint
+
+import hydrozoa.config.head.network.CardanoNetwork
+import hydrozoa.config.node.MultiNodeConfig
+import hydrozoa.multisig.consensus.peer.HeadPeerNumber
+import io.circe.parser.decode
+import org.scalacheck.Gen
+import org.scalatest.funsuite.AnyFunSuite
+
+/** The cross-repo contract for [[EvacuationMap.digest]].
+  *
+  * Sugar Rush computes the same digest in `types/src/types/evacuation_map.rs`, and the head refuses
+  * to boot when its configured `initialEvacuationMap` disagrees with the ledger's — so these
+  * vectors are a wire pin, not a regression guard. A change here must land on both sides together.
+  */
+class EvacuationMapDigestTest extends AnyFunSuite:
+
+    private given CardanoNetwork.Section =
+        MultiNodeConfig.generateDefault
+            .map(_.nodeConfigs(HeadPeerNumber.zero))
+            .pureApply(Gen.Parameters.default, org.scalacheck.rng.Seed(0L))
+
+    /** Exactly the JSON `sugar-rush-ledger-server print-initial-evacuation-map` emits — the head
+      * config's `initialEvacuationMap` encoding, keyed by the evacuation key's hex, valued by the
+      * output's raw CBOR hex.
+      */
+    private val goldenJson: String =
+        """{
+          |  "ab00000000000000000000000000000000000000000000000000000000000000":
+          |    "a2005839000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000011a00989680"
+          |}""".stripMargin
+
+    /** The value `EvacuationMap::hash` produces for the same map in
+      * `types/src/types/evacuation_map.rs`'s `digest_golden`.
+      */
+    private val goldenDigest = "6a0bf68bee4d771bd969fce92285d7e3da0683d01e4c2c44310e5a162ba84995"
+
+    private def goldenMap: EvacuationMap =
+        decode[EvacuationMap](goldenJson).fold(e => fail(s"golden did not decode: $e"), identity)
+
+    test("a map printed by the remote ledger decodes into the head config's evacuation map") {
+        assert(goldenMap.size == 1)
+    }
+
+    test("digest matches the value Sugar Rush computes for the same map") {
+        assert(goldenMap.digest.toHex == goldenDigest)
+    }
+
+    test("the empty map has a defined digest, distinct from any populated one") {
+        assert(EvacuationMap.empty.digest != goldenMap.digest)
+    }
+
+    test("digest round-trips through its JSON codec") {
+        import io.circe.syntax.*
+        val digest = goldenMap.digest
+        assert(decode[EvacuationMapHash](digest.asJson.noSpaces) == Right(digest))
+    }
+
+    test("a digest of the wrong length is rejected rather than silently truncated") {
+        assert(decode[EvacuationMapHash](""""abcd"""").isLeft)
+    }

--- a/src/test/scala/hydrozoa/multisig/ledger/remote/RemoteL2LedgerCodecsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/ledger/remote/RemoteL2LedgerCodecsTest.scala
@@ -4,7 +4,7 @@ import hydrozoa.config.head.network.CardanoNetwork
 import hydrozoa.config.node.MultiNodeConfig
 import hydrozoa.multisig.consensus.peer.HeadPeerNumber
 import hydrozoa.multisig.ledger.event.RequestId
-import hydrozoa.multisig.ledger.joint.{EvacuationDiff, EvacuationKey}
+import hydrozoa.multisig.ledger.joint.{EvacuationDiff, EvacuationKey, EvacuationMapHash}
 import hydrozoa.multisig.ledger.l2.L2LedgerResponse.UnrecoverableError
 import hydrozoa.multisig.ledger.l2.{L2CommandNumber, L2LedgerResponse}
 import hydrozoa.multisig.ledger.remote.RemoteL2Ledger.{Request, RestoreResponse}
@@ -107,10 +107,12 @@ class RemoteL2LedgerCodecsTest extends AnyFunSuite:
     }
 
     test("Restored success encodes to the canonical SugarRush wire shape and round-trips") {
-        val response: RestoreResponse = RestoreResponse.Restored(L2CommandNumber(7L))
+        // The same vector SugarRush pins in `types/src/types/coordination/restore.rs`.
+        val hash = EvacuationMapHash(ByteString.fromArray(Array.fill[Byte](32)(0xab.toByte)))
+        val response: RestoreResponse = RestoreResponse.Restored(L2CommandNumber(7L), hash)
         val json = response.asJson.noSpaces
         assert(
-          json == """{"Restored":{"tip":7}}"""
+          json == """{"Restored":{"tip":7,"evacuationMapHash":"abababababababababababababababababababababababababababababababab"}}"""
               && io.circe.parser.decode[RestoreResponse](json) == Right(response)
         )
     }

--- a/src/test/scala/hydrozoa/multisig/persistence/recovery/RecoverSeamsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/persistence/recovery/RecoverSeamsTest.scala
@@ -22,7 +22,7 @@ import hydrozoa.multisig.ledger.joint.{EvacuationMap, JointLedger}
 import hydrozoa.multisig.ledger.l1.deposits.map.DepositsMap
 import hydrozoa.multisig.ledger.l1.tx.TxSignature
 import hydrozoa.multisig.ledger.l1.utxo.MultisigTreasuryUtxo
-import hydrozoa.multisig.ledger.l2.{L2CommandNumber, L2LedgerCommand}
+import hydrozoa.multisig.ledger.l2.{L2CommandNumber, L2LedgerCommand, RestoreError}
 import hydrozoa.multisig.ledger.stack.{PartitionEffects, Stack, StackBrief, StackEffects, StackNumber, StandaloneEvacuationCommitment}
 import hydrozoa.multisig.persistence.codec.TreasuryFixture
 import hydrozoa.multisig.persistence.{ArrivalStamp, Cf, InMemoryBackendStore, JournalKey, JournalValue, Markers, Persistence, PersistenceEventFormat, StoreKey, Timestamped}
@@ -79,7 +79,12 @@ class RecoverSeamsTest extends AnyFunSuite:
             for
                 store <- InMemoryL2Store.create
                 ledger <- EutxoL2Ledger(config, store)
-                viaRecover <- JointLedger.State.recover(p, ledger, None)
+                viaRecover <- JointLedger.State.recover(
+                  p,
+                  ledger,
+                  None,
+                  config.initialEvacuationMap
+                )
                 viaState <- JointLedger.State.recoverState(p, None)
             yield assert(viaRecover.isEmpty && viaState.isEmpty)
         }
@@ -119,7 +124,19 @@ class RecoverSeamsTest extends AnyFunSuite:
                 _ <- p.put(JournalKey.Block(BlockNumber(2)))(JournalValue(stamp, brief))
                 _ <- p.put(StoreKey.DepositMap)(DepositsMap.empty)
                 _ <- p.put(StoreKey.L2CommandNumber(BlockNumber(2)))(L2CommandNumber(2L))
-                done <- JointLedger.State.recover(p, ledger, Some(BlockNumber(2)))
+                // The fast anchor IS max(BlockResult), so the anchored blocks must be present:
+                // recover folds their evacuation diffs to reach the map at the anchor.
+                _ <- (1 to 2).toList.traverse_(n =>
+                    blockResult(n).flatMap(br =>
+                        p.put(StoreKey.BlockResult(BlockNumber(n)))(br.persisted)
+                    )
+                )
+                done <- JointLedger.State.recover(
+                  p,
+                  ledger,
+                  Some(BlockNumber(2)),
+                  config.initialEvacuationMap
+                )
                 anchored <- ledger.peekState.map(_.commandNumber)
             yield assert(done.isDefined && anchored == L2CommandNumber(2L))
         }
@@ -144,7 +161,19 @@ class RecoverSeamsTest extends AnyFunSuite:
                 _ <- p.put(JournalKey.Block(BlockNumber(2)))(JournalValue(stamp, brief))
                 _ <- p.put(StoreKey.DepositMap)(DepositsMap.empty)
                 _ <- p.put(StoreKey.L2CommandNumber(BlockNumber(2)))(L2CommandNumber(2L))
-                recovered <- JointLedger.State.recover(p, ledger, Some(BlockNumber(2)))
+                // The fast anchor IS max(BlockResult), so the anchored blocks must be present:
+                // recover folds their evacuation diffs to reach the map at the anchor.
+                _ <- (1 to 2).toList.traverse_(n =>
+                    blockResult(n).flatMap(br =>
+                        p.put(StoreKey.BlockResult(BlockNumber(n)))(br.persisted)
+                    )
+                )
+                recovered <- JointLedger.State.recover(
+                  p,
+                  ledger,
+                  Some(BlockNumber(2)),
+                  config.initialEvacuationMap
+                )
                 anchored <- ledger.peekState.map(_.commandNumber)
             yield assert(
               recovered.exists(d =>
@@ -406,6 +435,99 @@ class RecoverSeamsTest extends AnyFunSuite:
         }
     }
 
+    test(
+      "JointLedger.recover accepts a cold start whose L2 ledger holds the configured initial " +
+          "evacuation map"
+    ) {
+        withStore { p =>
+            for
+                store <- InMemoryL2Store.create
+                ledger <- EutxoL2Ledger(config, store)
+                r <- JointLedger.State
+                    .recover(p, ledger, None, config.initialEvacuationMap)
+                    .attempt
+            yield assert(r == Right(None))
+        }
+    }
+
+    test("JointLedger.recover refuses to boot when the L2 ledger holds a different initial map") {
+        withStore { p =>
+            for
+                store <- InMemoryL2Store.create
+                ledger <- EutxoL2Ledger(config, store)
+                // Stand in for the real failure: a head config built against a different ledger,
+                // or against a different configuration of this one. Dropping one entry is enough —
+                // the check is on the digest of the whole map.
+                divergent = EvacuationMap.from(config.initialEvacuationMap.drop(1))
+                r <- JointLedger.State.recover(p, ledger, None, divergent).attempt
+            yield assert(
+              r.swap.toOption.exists {
+                  case RestoreError.EvacuationMapMismatch(expected, actual) =>
+                      expected == divergent.digest && actual == config.initialEvacuationMap.digest
+                  case _ => false
+              }
+            )
+        }
+    }
+
+    test(
+      "JointLedger.recover verifies the evacuation map at the crash anchor, folding onto the "
+          + "last stored map"
+    ) {
+        withStore { p =>
+            for
+                store <- InMemoryL2Store.create
+                ledger <- EutxoL2Ledger(config, store)
+                _ <- (1 to 3).toList.traverse_(i =>
+                    ledger.applyDepositDecisions(L2CommandNumber(i.toLong), noop(i))
+                )
+                brief <- blockBrief(2)
+                _ <- p.put(JournalKey.Block(BlockNumber(2)))(JournalValue(stamp, brief))
+                _ <- p.put(StoreKey.DepositMap)(DepositsMap.empty)
+                _ <- p.put(StoreKey.L2CommandNumber(BlockNumber(2)))(L2CommandNumber(2L))
+                _ <- (1 to 2).toList.traverse_(n =>
+                    blockResult(n).flatMap(br =>
+                        p.put(StoreKey.BlockResult(BlockNumber(n)))(br.persisted)
+                    )
+                )
+                // A stack closed at block 1, so its stored map — not the config's initial one — is
+                // the base, and only block 2's diffs are folded on top.
+                _ <- p.put(StoreKey.EvacuationMap(BlockNumber(1)))(config.initialEvacuationMap)
+                r <- JointLedger.State
+                    .recover(p, ledger, Some(BlockNumber(2)), config.initialEvacuationMap)
+                    .attempt
+            yield assert(r.map(_.isDefined) == Right(true))
+        }
+    }
+
+    test("JointLedger.recover refuses to boot when the map at the crash anchor diverges") {
+        withStore { p =>
+            for
+                store <- InMemoryL2Store.create
+                ledger <- EutxoL2Ledger(config, store)
+                _ <- (1 to 3).toList.traverse_(i =>
+                    ledger.applyDepositDecisions(L2CommandNumber(i.toLong), noop(i))
+                )
+                brief <- blockBrief(2)
+                _ <- p.put(JournalKey.Block(BlockNumber(2)))(JournalValue(stamp, brief))
+                _ <- p.put(StoreKey.DepositMap)(DepositsMap.empty)
+                _ <- p.put(StoreKey.L2CommandNumber(BlockNumber(2)))(L2CommandNumber(2L))
+                _ <- (1 to 2).toList.traverse_(n =>
+                    blockResult(n).flatMap(br =>
+                        p.put(StoreKey.BlockResult(BlockNumber(n)))(br.persisted)
+                    )
+                )
+                // The stack-close base disagrees with what the ledger holds, and the blocks folded
+                // on top carry no diffs to reconcile it — so the anchor maps differ.
+                _ <- p.put(StoreKey.EvacuationMap(BlockNumber(1)))(EvacuationMap.empty)
+                r <- JointLedger.State
+                    .recover(p, ledger, Some(BlockNumber(2)), config.initialEvacuationMap)
+                    .attempt
+            yield assert(
+              r.swap.toOption.exists(_.isInstanceOf[RestoreError.EvacuationMapMismatch])
+            )
+        }
+    }
     test("JointLedger.recover throws when the fastBlockMark block's L2 command number is missing") {
         withStore { p =>
             for
@@ -415,7 +537,9 @@ class RecoverSeamsTest extends AnyFunSuite:
                 _ <- p.put(JournalKey.Block(BlockNumber(2)))(JournalValue(stamp, brief))
                 _ <- p.put(StoreKey.DepositMap)(DepositsMap.empty)
                 // L2CommandNumber intentionally not written
-                r <- JointLedger.State.recover(p, ledger, Some(BlockNumber(2))).attempt
+                r <- JointLedger.State
+                    .recover(p, ledger, Some(BlockNumber(2)), config.initialEvacuationMap)
+                    .attempt
             yield assert(r.swap.toOption.exists(_.isInstanceOf[IllegalStateException]))
         }
     }


### PR DESCRIPTION
The head config's `initialEvacuationMap` and the map the L2 ledger actually holds are authored independently, and nothing reconciled them. A head can run its whole life against a ledger that never agreed to the map its initialization transaction committed on L1, and find out only at fallback — when the committed payouts are already unevacuable.

For a remote ledger the two do not even share a key space: `Bootstrap` keys the map by the CBOR of a `TransactionInput`, Sugar Rush by a 28-byte account key hash zero-padded to 32. A head bootstrapped through `l2-cardano-eutxo.json` against a remote ledger can never agree, and nothing notices.

Pairs with **GummiwormLabs/sugar-rush-ledger#156** — the `Restored` frame changes on both sides, so they must land together.

## The digest

`EvacuationMap.digest` is blake2b-256 over the two byte strings each entry already puts on the wire: the raw evacuation key and the raw CBOR output, length-framed, folded in key order.

Deliberately not the KZG commitment (needs BLS12-381 and the head's trusted setup in Rust) and not `mkScalar` (needs a Plutus `Data` encoder for `TxOut` in Rust). It is a **coordination check, not an on-chain commitment** — the on-chain commitment stays the KZG in the treasury datum. The output contributes its raw CBOR, which is why `Payout.Obligation` holds a `KeepRaw`: a re-encoding could differ from the bytes the remote hashed.

Both repos independently produce `6a0bf68bee4d771bd969fce92285d7e3da0683d01e4c2c44310e5a162ba84995` for the same one-entry map, and `EvacuationMapDigestTest` decodes the exact JSON the ledger's `print-initial-evacuation-map` emits.

## The check

`restoreTo` now returns the digest at the restored command number, and `JointLedger.State.recover` checks it **at every anchor**. A mismatch raises `RestoreError.EvacuationMapMismatch` and the node does not start — it is not recoverable at runtime and not safe to run through.

**A cold start is now the zeroth recovery case, not a skipped one.** It restores to command zero. That is not a formality: blocks are numbered from 1, so a crash part-way through block 1 leaves the ledger at a tip above zero with nothing persisted here, and those orphaned commands must be rolled back before consensus re-drives them. Previously `recover` short-circuited on an empty store and the ledger was never spoken to.

**Past a cold start** the expected map is rebuilt by `evacuationMapAt`. The slow side stores the cumulative map per block, and only at blocks whose map backs an on-chain KZG commitment, so there is usually no entry at the fast anchor. It takes the highest stored map at or below the anchor (the config's initial map when no stack has closed) and folds the remaining `BlockResult`s' `evacuationMapDiff` onto it. The slow side never runs ahead of the fast one, so that base is always at or below the anchor.

## Notes for review

- Two `RecoverSeamsTest` fixtures seeded no `BlockResult` even though the fast anchor is by definition `max(BlockResult)`. They now seed the anchored blocks.
- The EUTXO backend's check is a tautology at a cold start — it seeds its own genesis from the same config map — but it keeps one boot path for every backend.
- `docs/spec/l2-ledger-command-coordination.md` carries the digest definition and the restore frames. The whitepaper's head-initialization article is updated separately in the writing room.

## Verification

`just fmt`, `just lint`, `just build-werror`, and a full `core/testOnly *` (351 passed, 0 failed). Note `sbt core/test` selects incrementally — it under-reports.