### PR TITLE
Cap deposit absorption by deposits, not by absorption-start slots

### DIFF
--- a/src/main/scala/hydrozoa/multisig/ledger/l1/deposits/map/DepositsMap.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/l1/deposits/map/DepositsMap.scala
@@ -173,8 +173,56 @@ object DepositsMap {
                 case Compartment.Immature => copy(immature = immature.append(x))
             }
 
+        /** Take the first `n` eligible '''deposits''' for absorption, in absorption-start order and
+          * then queue order, leaving the rest unabsorbed.
+          *
+          * `n` counts deposits, not map keys. The map is two-layer — one queue per absorption start
+          * time, and that time is slot-quantized, so any deposits maturing in the same second share
+          * a key — which means a key-boundary split cannot express the bound at all: a single key
+          * may hold more than `n` deposits on its own. The cut therefore falls '''inside''' a queue
+          * whenever the budget runs out mid-key. Queue order is the request-stream subsequence, so
+          * cutting there absorbs the earliest requests of that second and leaves the later ones for
+          * the next block.
+          *
+          * Bounded by `n`, not by the size of the map: keys are walked in ascending order only
+          * until the budget is spent, `sizeIs` stops measuring an oversized queue as soon as it is
+          * known not to fit, and the unabsorbed tail is taken as a range rather than traversed.
+          */
         def split(n: Int): Split = {
-            val (tmAbsorbed, tmUnabsorbed) = eligible.treeMap.splitAt(n)
+            // The first key whose queue does not fit whole in the remaining budget, with the room
+            // left for it; `None` if every eligible deposit fits.
+            @annotation.tailrec
+            def boundary(
+                remaining: Iterator[(DepositAbsorptionStartTime, Queue[Entry])],
+                taken: Int
+            ): Option[(DepositAbsorptionStartTime, Int)] =
+                if !remaining.hasNext then None
+                else {
+                    val (startTime, queue) = remaining.next()
+                    val room = n - taken
+                    // `sizeIs` short-circuits: it stops counting once the queue is known to be
+                    // longer than `room`, so an enormous same-second queue is never measured.
+                    if queue.sizeIs > room then Some((startTime, room))
+                    else boundary(remaining, taken + queue.size)
+                }
+
+            val (tmAbsorbed, tmUnabsorbed) =
+                boundary(eligible.treeMap.iterator, 0) match {
+                    case None =>
+                        (eligible.treeMap, TreeMap.empty[DepositAbsorptionStartTime, Queue[Entry]])
+                    case Some((startTime, room)) =>
+                        val (headOfQueue, tailOfQueue) = eligible.treeMap(startTime).splitAt(room)
+                        val before = eligible.treeMap.rangeUntil(startTime)
+                        val fromHere = eligible.treeMap.rangeFrom(startTime)
+                        // `room < queue.size` by construction, so the tail is never empty and the
+                        // boundary key always survives; the head is empty only when the budget ran
+                        // out exactly on the previous key.
+                        (
+                          if headOfQueue.isEmpty then before
+                          else before.updated(startTime, headOfQueue),
+                          fromHere.updated(startTime, tailOfQueue)
+                        )
+                }
             val absorbed = DepositsMap(tmAbsorbed)
             val unabsorbed = DepositsMap(tmUnabsorbed)
             Split(

--- a/src/test/scala/hydrozoa/multisig/ledger/l1/deposits/map/DepositsMapSplitTest.scala
+++ b/src/test/scala/hydrozoa/multisig/ledger/l1/deposits/map/DepositsMapSplitTest.scala
@@ -1,0 +1,150 @@
+package hydrozoa.multisig.ledger.l1.deposits.map
+
+import hydrozoa.config.head.multisig.timing.TxTiming.RequestTimes.DepositAbsorptionStartTime
+import hydrozoa.config.node.{MultiNodeConfig, NodeConfig}
+import hydrozoa.multisig.consensus.peer.HeadPeerNumber
+import hydrozoa.multisig.ledger.event.RequestId
+import hydrozoa.multisig.ledger.l1.tx.genDepositUtxo
+import hydrozoa.multisig.ledger.l1.utxo.DepositUtxo
+import org.scalacheck.Prop.propBoolean
+import org.scalacheck.rng.Seed
+import org.scalacheck.{Gen, Prop, Properties}
+import scala.collection.immutable.Queue
+import scalus.cardano.ledger.Value
+
+/** `DepositsMap.Partition.split` — the absorption cap.
+  *
+  * The cap counts '''deposits''', because that is what the settlement tx builder checks it against
+  * (`SettlementTx`: `depositsToSpend.length <= maxDepositsAbsorbedPerBlock`). The map is two-layer,
+  * one queue per absorption start time, and that time is slot-quantized — so deposits maturing in
+  * the same second share a key, and a split that takes the first `n` '''keys''' takes more than `n`
+  * deposits. That is the production failure these tests pin: *"Too many deposits were included. You
+  * passed 133, but we can have at most 100"*, raised in `tryCloseAsLeader`, which wedges the head
+  * at that block on every restart.
+  *
+  * The bug was invisible under light load: with one deposit per second, keys and deposits are the
+  * same number.
+  */
+object DepositsMapSplitTest extends Properties("DepositsMap.split") {
+
+    private val config: NodeConfig =
+        MultiNodeConfig.generateDefault
+            .map(_.nodeConfigs(HeadPeerNumber.zero))
+            .pureApply(Gen.Parameters.default, Seed(0L))
+
+    /** `k` deposit utxos with pairwise distinct absorption start times, ascending.
+      *
+      * Split cares only about an entry's identity and its slot, so the fixtures below reuse one
+      * utxo per slot under fresh request ids rather than generating a utxo per deposit — which also
+      * keeps a 250-deposit slot cheap to build.
+      */
+    private def slotBases(k: Int): List[DepositUtxo] = {
+        val one =
+            genDepositUtxo(config, Some(config.headMultisigAddress), Gen.const(Value.ada(10)))()
+        val candidates =
+            Gen.listOfN(k * 4, one).pureApply(Gen.Parameters.default, Seed(1L))
+        val distinct = candidates
+            .distinctBy(_.absorptionStartTime.instant)
+            .sortBy(_.absorptionStartTime.instant)
+        require(
+          distinct.length >= k,
+          s"fixture needs $k distinct absorption start times, generator produced ${distinct.length}"
+        )
+        distinct.take(k)
+    }
+
+    /** An eligible map whose i-th slot holds `sizes(i)` deposits. */
+    private def eligibleWith(sizes: List[Int]): DepositsMap =
+        sizes.zip(slotBases(sizes.length)).zipWithIndex.foldLeft(DepositsMap.empty) {
+            case (m, ((count, base), slot)) =>
+                val entries = Queue.from(
+                  (0 until count)
+                      .map(i => DepositsMap.Entry(RequestId(0, (slot * 10_000 + i).toLong), base))
+                )
+                m.append((base.absorptionStartTime: DepositAbsorptionStartTime, entries))
+        }
+
+    private def splitOf(sizes: List[Int], n: Int): DepositsMap.Split =
+        DepositsMap
+            .Partition(
+              expired = DepositsMap.empty,
+              eligible = eligibleWith(sizes),
+              immature = DepositsMap.empty,
+              notInPollResults = DepositsMap.empty
+            )
+            .split(n)
+
+    // ----- regressions -------------------------------------------------------------------
+
+    /** The reported failure, to the number. 33 slots of two deposits and 67 of one: 100 slots, 133
+      * deposits. The negative control is the second conjunct — the old key-based split really does
+      * hand 133 deposits to a builder that accepts at most 100.
+      */
+    val _ = property("100 slots holding 133 deposits absorb exactly 100 (bug repro)") = {
+        val sizes = List.fill(33)(2) ++ List.fill(67)(1)
+        val eligible = eligibleWith(sizes)
+        val absorbed = splitOf(sizes, 100).absorbed.requestIds.length
+        val byKeyAsBefore = DepositsMap(eligible.treeMap.splitAt(100)._1).requestIds.length
+        (eligible.requestIds.length == 133) :| "fixture holds 133 deposits" &&
+        (absorbed == 100) :| s"absorbed $absorbed, expected 100" &&
+        (byKeyAsBefore == 133) :| "negative control: the key-based split overruns to 133"
+    }
+
+    /** A single second can hold more deposits than the whole cap, so no key-boundary split can
+      * express the bound — the cut has to fall inside the queue.
+      */
+    val _ = property("one slot larger than the cap is split inside its queue") = {
+        val s = splitOf(List(250), 100)
+        (s.absorbed.requestIds.length == 100) :| "absorbed 100" &&
+        (s.unabsorbed.requestIds.length == 150) :| "unabsorbed 150" &&
+        (s.absorbed.treeMap.keySet == s.unabsorbed.treeMap.keySet) :|
+            "the boundary slot appears in both halves"
+    }
+
+    /** The budget running out exactly on a slot boundary leaves that slot wholly unabsorbed — the
+      * empty-head case of the cut.
+      */
+    val _ = property("a budget landing on a slot boundary absorbs no part of the next slot") = {
+        val s = splitOf(List(60, 40, 25), 100)
+        (s.absorbed.requestIds.length == 100) :| "absorbed 100" &&
+        (s.absorbed.treeMap.size == 2) :| "only the two full slots" &&
+        (s.unabsorbed.requestIds.length == 25) :| "the third slot survives whole"
+    }
+
+    val _ = property("everything below the cap is absorbed") = {
+        val s = splitOf(List(3, 4), 100)
+        (s.absorbed.requestIds.length == 7) :| "all seven absorbed" &&
+        s.unabsorbed.requestIds.isEmpty :| "nothing left over"
+    }
+
+    // ----- properties --------------------------------------------------------------------
+
+    private val genSizes: Gen[List[Int]] =
+        Gen.choose(1, 12).flatMap(k => Gen.listOfN(k, Gen.choose(1, 20)))
+
+    val _ = property("absorbs exactly the budget, or everything if there is less") =
+        Prop.forAll(genSizes, Gen.choose(1, 60)) { (sizes, n) =>
+            val s = splitOf(sizes, n)
+            s.absorbed.requestIds.length == math.min(n, eligibleWith(sizes).requestIds.length)
+        }
+
+    /** The semantics the cap rides on: splitting only decides *where* the eligible stream is cut,
+      * never reorders or drops any part of it.
+      */
+    val _ = property("absorbed then unabsorbed reconstructs the eligible stream in order") =
+        Prop.forAll(genSizes, Gen.choose(1, 60)) { (sizes, n) =>
+            val s = splitOf(sizes, n)
+            s.absorbed.requestIds ++ s.unabsorbed.requestIds == eligibleWith(sizes).requestIds
+        }
+
+    val _ = property("every absorbed slot is at or before every unabsorbed slot") =
+        Prop.forAll(genSizes, Gen.choose(1, 60)) { (sizes, n) =>
+            val s = splitOf(sizes, n)
+            val lastAbsorbed = s.absorbed.treeMap.keys.maxOption.map(_.instant)
+            val firstUnabsorbed = s.unabsorbed.treeMap.keys.minOption.map(_.instant)
+            (lastAbsorbed, firstUnabsorbed) match {
+                case (Some(a), Some(b)) => !a.isAfter(b)
+                case _                  => true
+            }
+        }
+}


### PR DESCRIPTION
One commit off `main`: `DepositsMap.scala` +50/−1, plus a new `DepositsMapSplitTest`. Fixes the production failure

```
Settlement tx error: Too many deposits were included. You passed 133, but we can have at most 100.
```

## What was wrong

`Partition.split(n)` took the first `n` entries of `eligible.treeMap` — but that map is two-layer, one queue per absorption start time, so it took `n` **slots**. `Decisions.absorbed` then flattens those queues, and the settlement tx builder checks the flattened count against the same parameter:

```scala
depositsToSpend.length <= config.maxDepositsAbsorbedPerBlock
```

One parameter, two units. Absorption start times are slot-quantized, so any deposits maturing in the same second share a key — 100 slots held 133 deposits.

It is invisible under light load: at one deposit per second, keys and deposits are the same number. It needs both more than `n` eligible deposits and at least two sharing a second, which is why it took a real deposit run to surface.

## Blast radius

The raise is inside `mkEffectsRegular`, reached from `tryCloseAsLeader`, so the stack leader dies at that block and dies again at the same block on every restart — the head is wedged with funds committed. Rotating the leader does not help: `tryCloseAsFollower` builds the same effects through the same `mkStackUnsigned`.

## The fix

Split on deposits. A single slot may hold more than `n` deposits on its own, so no key-boundary split can express the bound at all — the cut falls **inside** a queue when the budget runs out mid-slot. Queue order is the request-stream subsequence, so that absorbs the earliest requests of that second and leaves the later ones for the next block.

The walk is bounded by `n` rather than by the map: keys are visited only until the budget is spent, `sizeIs` stops measuring an oversized queue as soon as it is known not to fit, and the unabsorbed tail is taken as a range rather than traversed. So it does not flatten the eligible set in order to count it — the cost is O(cap), independent of how many deposits are waiting.

## Tests

Nothing exercised `split` at all before; the only `DepositsMap` test covers existence classification.

Four regressions — the 133-from-100 repro (with the old key-based result asserted inside the test as a standing control), a single slot larger than the cap, a budget landing exactly on a slot boundary, and everything below the cap. Three properties — absorbs exactly `min(budget, eligible)`; `absorbed ++ unabsorbed` reconstructs the eligible stream in order; absorbed slots precede unabsorbed ones.

Negative control: against the pre-fix split the repro reports `absorbed 133, expected 100` and three of the seven fail.

## Note for reviewers

Two follow-ups deliberately left out of this PR:

- the Stage-1 model's `absorb` body is still commented out (`fix(stage1 model): no absorption on fast-only path`), so the model-based suite does not model the cap. Its own note — "restore once the slow cycle wires absorption back in" — is still outstanding, and had it been live this bug had a divergence oracle: it modelled the cap over a **flat** sorted list, which is the correct semantics;
- `maxDepositsAbsorbedPerBlock` now genuinely means deposits per block. The name was `maxDepositsPerSettlementTx` until `65b9f456`, which described the unit correctly; renaming it is not part of this change.