### PR TITLE
Let an opening L2 output carry an explicit evacuation key

### DIFF
--- a/src/main/scala/hydrozoa/bootstrap/Bootstrap.scala
+++ b/src/main/scala/hydrozoa/bootstrap/Bootstrap.scala
@@ -30,10 +30,15 @@ import hydrozoa.multisig.backend.cardano.{CardanoBackend, CardanoBackendBlockfro
 import hydrozoa.multisig.consensus.peer.HeadPeerNumber
 import hydrozoa.multisig.consensus.peer.HeadPeerNumber.given
 import hydrozoa.multisig.ledger.block.{Block, BlockBrief, BlockEffects, BlockHeader}
-import hydrozoa.multisig.ledger.eutxol2.toEvacuationMap
+import hydrozoa.multisig.ledger.eutxol2.toEvacuationKey
 import hydrozoa.multisig.ledger.eutxol2.tx.L2Genesis
+import hydrozoa.multisig.ledger.joint.EvacuationMapInstances.given
+import hydrozoa.multisig.ledger.joint.given
+import hydrozoa.multisig.ledger.joint.obligation.Payout
+import hydrozoa.multisig.ledger.joint.{EvacuationKey, EvacuationMap}
 import hydrozoa.multisig.ledger.l1.tx.RawTx
 import hydrozoa.multisig.ledger.l1.txseq.InitializationTxSeq
+import hydrozoa.rulebased.ledger.l1.script.plutus.RuleBasedTreasuryValidator.evacuationKeyToData
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import io.circe.syntax.*
 import io.circe.{Decoder, DecodingFailure, Encoder, Json, parser}
@@ -47,7 +52,7 @@ import scala.collection.immutable.SortedMap
 import scala.util.Try
 import scalus.cardano.address.{Address, ShelleyAddress}
 import scalus.cardano.ledger.TransactionOutput.Babbage
-import scalus.cardano.ledger.{Coin, EvaluatorMode, Hash32, PlutusScriptEvaluator, TransactionInput, TransactionOutput, Utxo, Utxos, Value}
+import scalus.cardano.ledger.{Coin, EvaluatorMode, Hash32, PlutusScriptEvaluator, TransactionInput, TransactionOutput, Utxo, Value}
 import scalus.cardano.txbuilder.TransactionBuilderStep.{Send, Spend}
 import scalus.cardano.txbuilder.{Change, TransactionBuilder}
 import scalus.crypto.ed25519.{SigningKey, VerificationKey}
@@ -195,7 +200,15 @@ object Bootstrap:
       * reference (the seed utxo's tx id + a per-entry index) once the seed is resolved. (A datum
       * field can be added here later; the opening distribution does not need one.)
       */
-    final case class L2Output(address: Address, value: Value) {
+    final case class L2Output(
+        address: Address,
+        value: Value,
+        // SUGAR-RUSH LOCAL PATCH (2026-08-19): optional explicit evacuation-map
+        // key, so the opening state can mirror an `any-remote` L2 ledger's
+        // genesis (keyed by account hash) instead of synthetic eutxo refs.
+        // Remove once build-head-config grows a real any-remote mode.
+        evacuationKey: Option[EvacuationKey] = None
+    ) {
         def toTransactionOutput: TransactionOutput =
             TransactionOutput.Babbage(address, value, None, None)
     }
@@ -208,7 +221,8 @@ object Bootstrap:
                     DecodingFailure(s"invalid bech32 address: ${e.getMessage}", c.history)
                 )
                 value <- c.downField("value").as[Value]
-            } yield L2Output(address, value)
+                evacuationKey <- c.downField("evacuationKey").as[Option[EvacuationKey]]
+            } yield L2Output(address, value, evacuationKey)
         }
 
         given Encoder[L2Output] = Encoder.instance { o =>
@@ -475,12 +489,29 @@ object Bootstrap:
         // seed's raw tx id would be unsafe: `(seedTxId, i)` could collide with a real on-chain output
         // of the seed's own transaction, or with the seed utxo itself.
         genesisTxId = L2Genesis.mkGenesisId(seedUtxo.input)
-        initialUtxos: Utxos = bootstrapConfig.initialL2State.zipWithIndex.map { case (out, i) =>
-            TransactionInput(genesisTxId, i) -> out.toTransactionOutput
-        }.toMap
-        evacMap <- IO.fromEither(
-          initialUtxos.toEvacuationMap(cardanoNetwork).left.map(e => RuntimeException(e.toString))
+        // SUGAR-RUSH LOCAL PATCH (2026-08-19): entries may carry an explicit
+        // `evacuationKey` (see L2Output); those keep it, the rest keep the
+        // synthetic eutxo-ref convention above. Obligation construction --
+        // including min-ada validation -- is unchanged.
+        evacEntries <- IO.fromEither(
+          bootstrapConfig.initialL2State.zipWithIndex
+              .traverse { case (out, i) =>
+                  Payout
+                      .Obligation(
+                        scalus.cardano.ledger.KeepRaw(out.toTransactionOutput),
+                        cardanoNetwork
+                      )
+                      .map { o =>
+                          val key = out.evacuationKey.getOrElse(
+                            TransactionInput(genesisTxId, i).toEvacuationKey
+                          )
+                          key -> o
+                      }
+              }
+              .left
+              .map(e => RuntimeException(e.toString))
         )
+        evacMap = EvacuationMap(scala.collection.immutable.TreeMap.from(evacEntries))
 
         initializationParameters = InitializationParameters(
           initialEvacuationMap = evacMap,

--- a/src/test/scala/hydrozoa/bootstrap/L2OutputEvacuationKeyTest.scala
+++ b/src/test/scala/hydrozoa/bootstrap/L2OutputEvacuationKeyTest.scala
@@ -1,0 +1,42 @@
+package hydrozoa.bootstrap
+
+import io.circe.parser.decode
+import org.scalatest.funsuite.AnyFunSuite
+
+/** [[Bootstrap.L2Output]]'s optional `evacuationKey`: the escape hatch that lets an opening L2
+  * output be keyed the way a remote ledger keys it, instead of by the synthetic eutxo reference the
+  * bootstrap derives from the seed utxo.
+  */
+class L2OutputEvacuationKeyTest extends AnyFunSuite:
+
+    /** A SugarRush fee-account key: a 28-byte account hash zero-padded to 32. */
+    private val remoteKeyHex =
+        "e04159fa6693834ddb3dd21a1ce289929a2a2f0f66d67b904e76f84400000000"
+
+    private val address =
+        "addr_test1vrsyzk06v6fcxnwm8hfp588z3xff5230pandv7usfem0s3qvscar4"
+
+    private def json(extra: String): String =
+        s"""{"address":"$address","value":{"coin":"10000000","assets":{}}$extra}"""
+
+    test("an entry carrying an evacuationKey decodes it") {
+        val out = decode[Bootstrap.L2Output](json(s""","evacuationKey":"$remoteKeyHex""""))
+            .fold(e => fail(s"decode failed: $e"), identity)
+        assert(out.evacuationKey.map(_.byteString.toHex).contains(remoteKeyHex))
+    }
+
+    test("an entry without one decodes to None, so the synthetic eutxo key is used") {
+        val out = decode[Bootstrap.L2Output](json(""))
+            .fold(e => fail(s"decode failed: $e"), identity)
+        assert(out.evacuationKey.isEmpty)
+    }
+
+    test("a malformed evacuationKey is rejected rather than silently ignored") {
+        assert(decode[Bootstrap.L2Output](json(""","evacuationKey":"not-hex"""")).isLeft)
+    }
+
+    test("the address and value still decode alongside an explicit key") {
+        val out = decode[Bootstrap.L2Output](json(s""","evacuationKey":"$remoteKeyHex""""))
+            .fold(e => fail(s"decode failed: $e"), identity)
+        assert(out.toTransactionOutput.value.coin.value == 10000000L)
+    }


### PR DESCRIPTION
Recovered from an uncommitted working tree on the demo box — **authored by @Pi-Lanningham**, committed here so it stops living one `git checkout` from oblivion. It is what the running demo head was actually built with.

## Why

`build-head-config` keys the opening evacuation map by a synthetic eutxo reference derived from the seed utxo. A remote L2 ledger keys its own map by **account hash** — Sugar Rush uses a 28-byte key hash zero-padded to 32. With no way to express that, an `any-remote` head commits an `initialEvacuationMap` its ledger never agrees with: different key space, silently.

This is not theoretical. It is why the demo head needed a hand-modified binary to build a bootable config, and — with cardano-hydrozoa#639 — a head built without it now refuses to start.

`L2Output` gains an optional `evacuationKey`. Entries that set it keep it; entries that don't keep the synthetic convention. Obligation construction, including the min-ada check, is untouched.

## Verified

On a branch carrying both this and #639, the competition bootstrap directory produces:

```
e04159fa…f84400000000 -> a200581d60e04159fa…f844011a00989680
digest: 66beaaaaa0c2c624db9b83eb21bde446580944d825bb6ac2ea5f76c5d4633d29
```

byte-identical to what `sugar-rush-ledger-server print-initial-evacuation-map` reports for the matching ledger config. Two independent implementations, same bytes.

## Review notes — this is a stopgap, and the code says so

The patch's own comment reads *"Remove once build-head-config grows a real any-remote mode."* Agreed, and worth recording why before it calcifies:

- **It duplicates derivable data.** For Sugar Rush the key and the address are the same account hash — note above that the map key's first 28 bytes and the output's address bytes coincide. Operators supply both halves of one fact with nothing checking they agree.
- **`L2Output` is the wrong home.** The type means "an output in the EUTXO L2 ledger". A remote ledger has accounts, not outputs.
- **It cannot express a destination datum.** Sugar Rush's `Destination` is `{address, datum: Option<Datum>}`, and `toTransactionOutput` hardcodes `datumOption = None`. The whitepaper's ledger-state page says that datum is what "enables treasury-owned sugar rush accounts, with trading authority temporarily delegated". Route such an account through `L2Output` and you get different CBOR, a different digest, and a head that won't boot — or, pre-#639, a committed map paying somewhere else. Today's fee account has no datum, so we're fine; it's a landmine, not a wall.

The durable fix is an `initial-evacuation-map.json` bootstrap input: the map verbatim in the head config's own encoding, exactly what the ledger already prints. No re-derivation, no redundant key, datums preserved because the CBOR is never decoded and rebuilt. That would also retire the `sed` workaround for `l2Ledger` that sugar-rush's `DEPLOYMENT.md` §3 currently documents.

Landing this now because the competition launch needs a bootable head config today.

## Tests

Four cases on the decoder: an explicit key is read, absence leaves the synthetic convention, a malformed key is rejected rather than dropped (circe ignores unknown fields, so a typo would otherwise pass unnoticed), and address/value still decode alongside a key.

`just fmt`, `just lint`, and `just build-werror` all clean. The original patch left `Utxos` unused and imports unsorted; both fixed.