### PR TITLE
Wrap the remaining synchronous Blockfrost calls in `IO.blocking`

### DIFF
--- a/src/main/scala/hydrozoa/multisig/backend/cardano/CardanoBackendBlockfrost.scala
+++ b/src/main/scala/hydrozoa/multisig/backend/cardano/CardanoBackendBlockfrost.scala
@@ -153,11 +153,19 @@ class CardanoBackendBlockfrost private (
             }
     }
 
+    /** `IO.blocking`, here and at every other `backendService` call site: those calls are
+      * synchronous okhttp, so the thread that enters one stays there for the whole HTTPS round
+      * trip. On a compute worker the runtime cannot see that and does not start a replacement, so
+      * the pool runs a thread short until the call returns.
+      *
+      * This one is the worst of them — one round trip per page, on the CardanoLiaison poll path
+      * that runs for the life of the head.
+      */
     private def paginate[A](
         apiCall: Int => Result[java.util.List[A]],
         mbStopPred: Option[A => Boolean] = None
     ): IO[Either[CardanoBackend.Error, List[A]]] =
-        IO {
+        IO.blocking {
             val elems: mutable.Buffer[A] = mutable.Buffer.empty
             var page: Int = 1
 
@@ -352,10 +360,12 @@ class CardanoBackendBlockfrost private (
         (utxoId, output)
     }
 
+    /** `IO.blocking`: a synchronous Blockfrost round trip — see [[paginate]] for why that matters.
+      */
     override def isTxKnown(
         txHash: TransactionHash
     ): IO[Either[CardanoBackend.Error, Boolean]] =
-        IO {
+        IO.blocking {
             val result = backendService.getTransactionService.getTransaction(txHash.toHex)
             if result.isSuccessful then {
                 Right(true)
@@ -633,8 +643,11 @@ class CardanoBackendBlockfrost private (
             )
         )
 
+    /** `IO.blocking`: a synchronous Blockfrost round trip — see [[paginate]] for why that matters.
+      * This one is on the L1 effect path, so a stalled worker here delays settlement itself.
+      */
     override def submitTx(etx: EnrichedTx[?]): IO[Either[CardanoBackend.Error, Unit]] =
-        IO {
+        IO.blocking {
             val result = backendService.getTransactionService.submitTransaction(etx.tx.toCbor)
             if result.isSuccessful
             then Right(())


### PR DESCRIPTION
One commit off `main`, one file, +6/−3 lines of code plus a comment explaining the hazard.

## What was wrong

`CardanoBackendBlockfrost` makes four calls out to Blockfrost. Exactly one of them — `rawTxUtxoInputs` — was wrapped in `IO.blocking`. The other three ran as plain `IO { … }`:

- `paginate`, behind both `utxosAt`, on the `CardanoLiaison` poll that runs every `cardanoLiaisonPollingPeriod` for the life of the head — and it makes one blocking round trip **per page**, in a `while` loop;
- `isTxKnown`;
- `submitTx`, i.e. every L1 effect submission.

All three go through `backendService`, which is synchronous okhttp: the thread that enters stays there for the whole HTTPS round trip, tens to hundreds of milliseconds. On a cats-effect compute worker the runtime cannot see that and does not start a replacement, so the pool runs a thread short for the duration. On a two-vCPU node that is half the compute pool.

The one call that was already correct is the tell: `rawTxUtxoInputs` is the one written by hand with `HttpRequest` rather than routed through `backendService`, so it was the one where the blocking was visible at the call site.

## Verification

Found and confirmed with BlockHound against a six-peer head under load, in a run that also exercised deposits and a finalization.

Filtering detections to those whose stack touches the Blockfrost backend and splitting by the thread name recorded at detection time: **5 violations on true cats-effect worker threads before, 0 after** — the same 68 records either way, but afterwards every one is on an `io-compute-blocker` thread, which is the runtime saying it knows about the block and has ceded the worker. The peer's total detections fell from 296 469 to 11 385 against more requests.

One methodology note for anyone repeating this: BlockHound decides whether a thread is non-blocking **once per thread and caches it**, and cats-effect does not swap threads when a worker cedes into blocking mode — it renames the same `Thread` to `io-compute-blocker-N`. So a worker judged non-blocking keeps that verdict for life and every correctly-wrapped `IO.blocking` it later makes is still reported. Excluding blocker threads inside the predicate does not work, because the rename happens after the predicate has run. The thread name recorded *with* each detection is the only reliable discriminator.

## Scope, and one thing this does not claim

This is a correctness fix for how the effect is described to the runtime, not a throughput change, and I am not claiming a measured latency improvement from it.

An undeclared blocking call removes one of N workers for its whole duration, which made this a candidate explanation for the `hotPath.apply max = 14.7 s` outliers that no CPU or GC measurement accounted for on a two-vCPU box. That remains a lead rather than an established cause — the BlockHound evidence shows the calls were misdeclared and are now correct, not that a specific outlier was caused by them.

## Provenance

Extracted from `loadtest/prod-box-tuning`, where it has been sitting unpushed since 2026-08-17 alongside performance work that is not ready. The commit is unchanged apart from the code comment, which was trimmed to the hazard and no longer cites a working note that is not in this repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)