### PR TITLE
fix(build): stop registering ScalaTest twice, which ran every suite twice

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -364,10 +364,10 @@ addCommandAlias(
   ";cardanoOnchain/scalafixAll --check ;petri/scalafixAll --check ;core/scalafixAll --check ;integration/scalafixAll --check ;benchmark/scalafixAll --check"
 )
 
-// Test dependencies.
-// NB (sbt 2): bare (not `ThisBuild /`) for the same reason as `scalacOptions` above — otherwise the
-// framework is registered once per subproject (4×) in the shared ThisBuild scope.
-testFrameworks += new TestFramework("org.scalatest.tools.Framework")
+// No `testFrameworks` entry for ScalaTest: sbt's default list already carries it, as
+// `TestFramework(org.scalatest.tools.Framework, org.scalatest.tools.ScalaTestFramework)`. Adding it
+// again registers a *second* framework that resolves to the same runner, and sbt then runs every
+// suite once per entry — twice.
 
 // Tests are wall-clock/sleep-bound (real System timestamps in the cats-actors), so run more
 // suites concurrently than CPU cores to overlap the waits. sbt's default caps concurrency at the


### PR DESCRIPTION
## The problem

sbt's default `testFrameworks` already carries ScalaTest:

```
* TestFramework(org.scalatest.tools.Framework, org.scalatest.tools.ScalaTestFramework)   <- sbt default
* TestFramework(org.scalatest.tools.Framework)                                           <- build.sbt
```

The second entry resolves to the same runner, and sbt runs every suite **once per framework entry**. So every ScalaTest suite in this build — root and `integration`, locally and in CI — has been executing twice.

It is visible in any test run as two independent run summaries from one invocation:

```
[info] Run completed in 7 seconds, 895 milliseconds.
[info] Total number of tests run: 33
[info] Run completed in 7 seconds, 902 milliseconds.
[info] Total number of tests run: 33
```

Two `Runner`s, each running the full set once — not one `Runner` counting 66.

## Where it came from

`git log -L` on the line:

| commit | change |
|---|---|
| `1c8dd80c` | added `ThisBuild / testFrameworks += … munit.Framework` |
| `0db52788` "Feat: migrate all tests to ScalaTest" | swapped it to `org.scalatest.tools.Framework` — the duplication starts here |
| `ca5b0ce5` "chore(build): migrate to sbt 2.0.1" | dropped `ThisBuild /`, cutting a 4x registration to 2x |

The last commit noticed the symptom (its comment explains the `ThisBuild /` removal) but not the cause, so the redundant entry survived. This PR removes it and leaves a note in its place so it does not come back a third time.

## The fix

Delete the line. ScalaTest is still picked up by sbt's built-in entry.

## Verification

- `show testFrameworks` now lists exactly one ScalaTest entry.
- `sbt test` on this branch: **336 tests, all passed**, one run summary.
- `just precommit` (scalafix check, scalafmt check, nixfmt check) passes.

Effect: roughly halves ScalaTest execution work in CI and locally. (No wall-clock before/after here — sbt 2's task caching makes a same-session comparison unreliable — but the work is exactly halved by construction.)

Nothing else is touched; this is one line of `build.sbt`.