### PR TITLE
chore(release): 0.1.8

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,14 +16,22 @@ the image with `sbt Docker/stage` and pushes it to ghcr. No manual `docker push`
    a few deployment files that do *not* read `build.sbt`, so bump them in lockstep:
 
    - `src/main/resources/scaffold/hydrozoa.sh` — `HYDROZOA_VERSION` default
-   - `src/main/resources/scaffold/docker-compose.yml` — the default
-     `${HYDROZOA_IMAGE:-ghcr.io/cardano-hydrozoa/hydrozoa:X.Y.Z}`
-   - `docs/user-guide/DEPLOYMENT.md` — the `…/hydrozoa:X.Y.Z` pull/run examples
+   - `docs/user-guide/DEPLOYMENT.md` — the `hydrozoa version` sample output, the `git describe`
+     paragraph beneath it, and the `HYDROZOA_VERSION=` / `HYDROZOA_IMAGE=` run examples
 
-   Catch stragglers with `grep -rn "hydrozoa:<previous-version>"` (and the bare previous version in
-   `scaffold/hydrozoa.sh`). Not bumped: `HydrozoaRoutes.apiVersion` + `docs/openapi*.yaml` (the API-contract
-   version, separate from the release version). Commit the bump on `main` (via PR; `main` is
-   protected).
+   `scaffold/docker-compose.yml` needs **no** edit: its image default is
+   `${HYDROZOA_IMAGE:-ghcr.io/cardano-hydrozoa/hydrozoa:${HYDROZOA_VERSION:-latest}}`, so it follows
+   `hydrozoa.sh` rather than pinning a version of its own.
+
+   Catch stragglers by grepping the bare previous version, not just the image ref — it also appears
+   as `version := "X.Y.Z"` and in prose:
+
+   ```bash
+   grep -rn "0\.1\.7" --include=* . | grep -vE "^\./(target|\.git|head)/"
+   ```
+
+   Not bumped: `HydrozoaRoutes.apiVersion` + `docs/openapi*.yaml` (the API-contract version,
+   separate from the release version). Commit the bump on `main` (via PR; `main` is protected).
 
 2. **Check the baked-in reference-script UTxOs are current.** The image ships per-network default
    reference UTxOs at `src/main/resources/scaffold/ref-utxos/` (Preview and Preprod): the treasury +

--- a/build.sbt
+++ b/build.sbt
@@ -403,7 +403,7 @@ inThisBuild(
   List(
     // Release version — drives the Docker image tag, `hydrozoa.BuildInfo.version`, and `GET
     // /version`. Bump here for a release (see RELEASE.md), then tag `v<version>`.
-    version := "0.1.7",
+    version := "0.1.8",
     scalaVersion := "3.3.7",
     semanticdbEnabled := true,
     semanticdbVersion := scalafixSemanticdb.revision

--- a/docs/user-guide/DEPLOYMENT.md
+++ b/docs/user-guide/DEPLOYMENT.md
@@ -124,13 +124,13 @@ under it. Then load the CLI alias and check you are on the version you expect:
 source ./hydrozoa.sh   # sets the `hydrozoa` alias + HYDROZOA_HOME (this folder, an absolute path)
 
 hydrozoa version       # verify the image you are running
-#   hydrozoa 0.1.7
-#   git:   v0.1.7
+#   hydrozoa 0.1.8
+#   git:   v0.1.8
 #   built: 2026-07-28 14:00:37.834-0600
 ```
 
-(The `git:` line is `git describe` provenance; a published image built from the `v0.1.7` tag reads a
-clean `v0.1.7`. A locally built image between releases shows the distance from the newest tag, e.g.
+(The `git:` line is `git describe` provenance; a published image built from the `v0.1.8` tag reads a
+clean `v0.1.8`. A locally built image between releases shows the distance from the newest tag, e.g.
 `v0.1.0-10-gaa9d7c69`.)
 
 Need a version that isn't in the registry? Build it from this repo — see §3.
@@ -418,8 +418,8 @@ finalization) appears in the same section as the head progresses.
 build (§3) is already tagged `…:latest`, so it is picked up without either:
 
 ```bash
-HYDROZOA_VERSION=0.1.7 just head-up                          # a specific published release
-HYDROZOA_IMAGE=cardano-hydrozoa/hydrozoa:0.1.7 just head-up  # a specific/other image name
+HYDROZOA_VERSION=0.1.8 just head-up                          # a specific published release
+HYDROZOA_IMAGE=cardano-hydrozoa/hydrozoa:0.1.8 just head-up  # a specific/other image name
 ```
 
 **Another head** — each head directory carries its own `docker-compose.yml`, so switch heads by

--- a/src/main/resources/scaffold/hydrozoa.sh
+++ b/src/main/resources/scaffold/hydrozoa.sh
@@ -13,7 +13,7 @@
 # scaffolded workspace — resolved to an absolute path, so the alias mounts correctly no matter which
 # directory you run it from. Override HYDROZOA_HOME (to an absolute path) or HYDROZOA_VERSION before
 # sourcing, or edit the defaults below.
-: "${HYDROZOA_VERSION:=0.1.7}"   # published image tag (ghcr.io/cardano-hydrozoa/hydrozoa)
+: "${HYDROZOA_VERSION:=0.1.8}"   # published image tag (ghcr.io/cardano-hydrozoa/hydrozoa)
 : "${HYDROZOA_HOME:=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)}"   # head directory (absolute)
 export HYDROZOA_VERSION HYDROZOA_HOME
 


### PR DESCRIPTION
Version bump for **0.1.8**, per [RELEASE.md](../blob/main/RELEASE.md) step 1. Merge this, then tag `v0.1.8` on the merge commit to publish.

18 commits since `v0.1.7`, including #638–#646.

## Bumped

| file | what |
|---|---|
| `build.sbt` | `version := "0.1.8"` — drives the image tag, `BuildInfo.version`, `GET /version` |
| `src/main/resources/scaffold/hydrozoa.sh` | `HYDROZOA_VERSION` default |
| `docs/user-guide/DEPLOYMENT.md` | `hydrozoa version` sample output, the `git describe` paragraph, and the two run examples |

Verified `core/version` now reports `0.1.8`, and no test pins a version string.

## RELEASE.md corrections

Two things in the guide were wrong, found by following it:

- It told you to bump `scaffold/docker-compose.yml`. That file no longer pins a version — its default is `${HYDROZOA_IMAGE:-ghcr.io/cardano-hydrozoa/hydrozoa:${HYDROZOA_VERSION:-latest}}`, so it follows `hydrozoa.sh`. Removed, with a note saying why.
- The suggested straggler check was `grep -rn "hydrozoa:<previous-version>"`, which **misses** both `version := "0.1.7"` in `build.sbt` and the prose occurrences in DEPLOYMENT.md. Replaced with a grep for the bare version.

## Step 2 — reference UTxOs: nothing to do

The baked `scaffold/ref-utxos/` defaults stay valid. Nothing since `v0.1.7` touched `cardano-onchain/`, the validator sources, or `plutus.json`, and Scalus was not bumped — the only `build.sbt` change was the ScalaTest framework fix (#646). So the compiled UPLC is unchanged and no redeploy is needed.

## Step 3 — shipped logger levels reviewed

`logback-docker.xml` is `root=warn` with `hydrozoa`, `RuleBasedActor`, `CardanoLiaison`, `RemoteL2Ledger`, `HeadMultisigRegimeManager`, `CoilMultisigRegimeManager` at `info`, and `com.bloxbean` / `scalus` / `CardanoBackend` at `warn`. Unchanged from 0.1.7 apart from #638's crash-recovery narration, which is deliberate.

## Tests

`just build-werror` clean; `core/testOnly *` → 350 passed, 1 failed. The failure is `MainSmokeTest`, a pre-existing flake unrelated to this change — it fails roughly 2 runs in 3 on unmodified `main` (`BadSignature` in hard-ack verification), which I measured separately.

Also worth noting #646 is working: test results now print once per run instead of twice.

## Not included

**#643 (Pi's `evacuationKey`) is still open.** Without it, an image built from this tag cannot produce a bootable `any-remote` head config — `build-head-config` silently ignores the field. If 0.1.8 is meant to be the competition-launch image, merge #643 first and I will rebase this bump on top.