### PR TITLE
Retire WalletModule.BloxBean; fix MainSmokeTest flakiness (runnable test config)

### DIFF
--- a/src/main/scala/hydrozoa/lib/cardano/wallet/WalletModule.scala
+++ b/src/main/scala/hydrozoa/lib/cardano/wallet/WalletModule.scala
@@ -1,53 +1,19 @@
 package hydrozoa.lib.cardano.wallet
 
-import com.bloxbean.cardano.client.crypto.Blake2bUtil
-import com.bloxbean.cardano.client.crypto.api.SigningProvider
-import com.bloxbean.cardano.client.crypto.bip32.key.{HdPrivateKey, HdPublicKey}
-import com.bloxbean.cardano.client.crypto.config.CryptoConfiguration
-import com.bloxbean.cardano.client.transaction.util.TransactionBytes
-import scala.language.implicitConversions
 import scalus.cardano.ledger.{Transaction, VKeyWitness}
 import scalus.crypto.ed25519.{SigningKey as ScalusSigningKey, VerificationKey as ScalusVerificationKey}
 import scalus.uplc.builtin.ByteString
 import scalus.uplc.builtin.JVMPlatformSpecific.signEd25519
 
-/*
-Cardano adopted BIP-32: Hierarchical Deterministic Wallets in the form of Ed25529-BIP32:
-https://github.com/input-output-hk/adrestia/raw/bdf00e4e7791d610d273d227be877bc6dd0dbcfb/user-guide/static/Ed25519_BIP.pdf
-
-Java implementation (copied to BB):
-https://github.com/semuxproject/semux-core/tree/master/src/main/java/org/semux/crypto/bip32
-
-bouncycastle/scalus: doesn't support Ed25529-BIP32, only vanilla Ed25529.
-
-BIP-32 overview:
-
-Seed (32 bytes)
-    ↓ (SHA-512 hash)
-Extended Key (64 bytes)
-    ↓
-[scalar (32) | prefix (32)] - both parts are used during signing, seed has some bits changed.
-
-
-Regular Verification Key (vk):
-  [public_key (32)] = 32 bytes
-    ↓
-Extended Verification Key (xvk):
-  [public_key (32) | chaincode (32)] = 64 bytes
-    ↓
-Extended Signing Key (xsk):
-  [private_key (64) | public_key (32) | chaincode (32)] = 128 bytes
-
-// For signature verification only first 32 bytes of xvk are used:
-val vkeyForVerification = extendedVkey.take(32)  // First 32 bytes
-
-The public key portion is identical whether it's:
- * Standalone (32 bytes)
- * Inside an extended verification key (first 32 of 64 bytes)
- * Inside an extended signing key (bytes 64-95 of 128 bytes)
-
- */
-
+/** A signing backend: the key types plus the Ed25519 signing primitives a
+  * [[hydrozoa.multisig.consensus.peer.PeerWallet]] builds on.
+  *
+  * Cardano verifies witnesses with vanilla Ed25519 over the tx-body hash (`tx.id`), and the only
+  * backend is [[WalletModule.Scalus]] — 32-byte vanilla Ed25519 keys that round-trip through the
+  * private-config JSON codec. (A former BloxBean / Ed25519-BIP32 backend was removed: its 128-byte
+  * extended signing keys cannot be expressed in the 32-byte codec, so serialized configs carried a
+  * dummy key and were not runnable.)
+  */
 trait WalletModule:
 
     type VerificationKey
@@ -67,46 +33,6 @@ trait WalletModule:
     ): IArray[Byte]
 
 object WalletModule {
-    // TODO: this may be moved to test
-    object BloxBean extends WalletModule:
-
-        protected val signingProvider: SigningProvider =
-            CryptoConfiguration.INSTANCE.getSigningProvider
-
-        override type VerificationKey = HdPublicKey
-        override type SigningKey = HdPrivateKey
-
-        override def exportVerificationKey(
-            verificationKey: VerificationKey
-        ): ScalusVerificationKey =
-            ScalusVerificationKey.unsafeFromByteString(
-              ByteString.fromArray(verificationKey.getKeyData)
-            )
-
-        override def signTx(
-            tx: Transaction,
-            verificationKey: VerificationKey,
-            signingKey: SigningKey
-        ): VKeyWitness =
-            // See BloxBean's TransactionSigner.class
-            val txBytes = TransactionBytes(tx.toCbor)
-            val txnBodyHash = Blake2bUtil.blake2bHash256(txBytes.getTxBodyBytes)
-            val signature = signingProvider.signExtended(txnBodyHash, signingKey.getKeyData)
-            VKeyWitness(
-              signature = ByteString.fromArray(signature),
-              vkey = ByteString.fromArray(verificationKey.getKeyData)
-            )
-
-        override def signMsg(
-            msg: IArray[Byte],
-            signingKey: SigningKey
-        ): IArray[Byte] =
-            val signature = signingProvider.signExtended(
-              IArray.genericWrapArray(msg).toArray,
-              signingKey.getKeyData
-            )
-            IArray.from(signature)
-
     object Scalus extends WalletModule:
         override type VerificationKey = ScalusVerificationKey
         override type SigningKey = ScalusSigningKey

--- a/src/test/scala/hydrozoa/app/MainSmokeTest.scala
+++ b/src/test/scala/hydrozoa/app/MainSmokeTest.scala
@@ -10,12 +10,13 @@ import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.backend.cardano.{CardanoBackendMock, MockState}
 import hydrozoa.multisig.consensus.peer.HeadPeerNumber
 import hydrozoa.multisig.server.HydrozoaHttpEvent
-import io.circe.Printer
 import io.circe.syntax.*
+import io.circe.{Json, Printer}
 import java.nio.file.Files
 import org.scalacheck.Gen
 import org.scalatest.funsuite.AnyFunSuite
 import scala.concurrent.duration.DurationInt
+import test.TestPeers
 
 /** End-to-end sanity check: generates a 1-peer sample config in memory, writes it to a temp dir
   * (the head peer's mesh `webSocketAddress` carries port 0 from the test fixture, and `httpPort` is
@@ -57,13 +58,29 @@ class MainSmokeTest extends AnyFunSuite:
 
         val printer = Printer.spaces2.copy(dropNullValues = true)
 
+        // The stock config encoders deliberately withhold signing keys (PeerWallet's encoder writes
+        // an all-zero placeholder), so a serialized private config boots a node that cannot sign —
+        // its stack-0 hard-ack self-verification then fails and terminates the actor system before
+        // the HTTP server binds. Splice peer 0's real signing key back in — the same key TestPeers
+        // derived for the generated config — so the on-disk config is actually runnable.
+        val (_, peerSigningKey) = TestPeers.deriveScalusKeypair(spec.seedPhrase.mnemonic, 0)
+        val runnablePrivateJson = peerPrivate.asJson.deepMerge(
+          Json.obj(
+            "ownPeerPrivate" -> Json.obj(
+              "ownHeadWallet" -> Json.obj(
+                "signingKey" -> Json.fromString(scodec.bits.ByteVector(peerSigningKey.bytes).toHex)
+              )
+            )
+          )
+        )
+
         val testIO = for {
             _ <- IO.blocking(
               Files.writeString(headPath, printer.print(mnc.headConfig.asJson))
             )
             _ <- IO.blocking(Files.createDirectories(privatePath.getParent))
             _ <- IO.blocking(
-              Files.writeString(privatePath, printer.print(peerPrivate.asJson))
+              Files.writeString(privatePath, printer.print(runnablePrivateJson))
             )
 
             mockBackend <- CardanoBackendMock.mockIO(

--- a/src/test/scala/test/TestPeers.scala
+++ b/src/test/scala/test/TestPeers.scala
@@ -239,7 +239,15 @@ object TestPeers:
       * node that cannot sign. No network input: the key is network-independent; only address
       * encoding downstream is network-specific.
       */
-    def deriveScalusWallet(mnemonic: String, ordinal: Int): PeerWallet = {
+    def deriveScalusWallet(mnemonic: String, ordinal: Int): PeerWallet =
+        val (vk, sk) = deriveScalusKeypair(mnemonic, ordinal)
+        PeerWallet.scalusWallet(vk, sk)
+
+    /** The raw keypair behind [[deriveScalusWallet]]. Exposed so a test that writes a peer's
+      * `private.json` can splice in the real signing key explicitly — the stock config encoders
+      * deliberately withhold it ([[PeerWallet.dummyPeerWalletEncoder]]).
+      */
+    def deriveScalusKeypair(mnemonic: String, ordinal: Int): (VerificationKey, SigningKey) = {
         val seed = MessageDigest
             .getInstance("SHA-256")
             .digest(s"$mnemonic#$ordinal".getBytes(StandardCharsets.UTF_8))
@@ -247,10 +255,7 @@ object TestPeers:
         val vk = VerificationKey.unsafeFromByteString(
           ByteString.fromArray(sk.generatePublicKey().getEncoded)
         )
-        PeerWallet.scalusWallet(
-          vk,
-          SigningKey.unsafeFromByteString(ByteString.fromArray(sk.getEncoded))
-        )
+        (vk, SigningKey.unsafeFromByteString(ByteString.fromArray(sk.getEncoded)))
     }
 
     def arbitrary: Gen[TestPeers] = for {

--- a/src/test/scala/test/TestPeers.scala
+++ b/src/test/scala/test/TestPeers.scala
@@ -2,9 +2,6 @@ package test
 
 import cats.data.Validated.{Invalid, Valid}
 import cats.data.{NonEmptyList, NonEmptyMap, ReaderT}
-import com.bloxbean.cardano.client.account.Account
-import com.bloxbean.cardano.client.common.model.Network as BloxbeanNetwork
-import com.bloxbean.cardano.client.crypto.cip1852.DerivationPath.createExternalAddressDerivationPathForAccount
 import hydrozoa.*
 import hydrozoa.config.head.coil.{CoilPeerData, CoilPeers}
 import hydrozoa.config.head.network.CardanoNetwork
@@ -12,9 +9,11 @@ import hydrozoa.config.head.network.CardanoNetworkGen.given_Arbitrary_CardanoNet
 import hydrozoa.config.head.peers.{HeadPeerData, HeadPeers}
 import hydrozoa.lib.cardano.scalus.VerificationKeyExtra.shelleyAddress
 import hydrozoa.lib.cardano.scalus.txbuilder.Transaction.attachVKeyWitnesses
-import hydrozoa.lib.cardano.wallet.WalletModule
 import hydrozoa.multisig.consensus.peer.{CoilPeerNumber, HeadPeerId, HeadPeerNumber, PeerWallet}
 import hydrozoa.multisig.ledger.l1.tx.EnrichedTx
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters
 import org.http4s.Uri
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Test.Parameters
@@ -24,7 +23,8 @@ import scala.collection.immutable.SortedMap
 import scala.collection.mutable
 import scalus.cardano.address.ShelleyAddress
 import scalus.cardano.ledger.{Transaction, VKeyWitness}
-import scalus.crypto.ed25519.VerificationKey
+import scalus.crypto.ed25519.{SigningKey, VerificationKey}
+import scalus.uplc.builtin.ByteString
 import scalus.|>
 
 type GenWithTestPeers[A] = ReaderT[Gen, TestPeers, A]
@@ -198,39 +198,13 @@ case class TestPeers private (
             case Some(value) => value
         }
 
-    private val accountCache: mutable.Map[TestPeerName, Account] = mutable.Map.empty
-        .withDefault(peer =>
-            Account.createFromMnemonic(
-              cardanoNetwork.asBloxbeanNetwork,
-              seedPhrase.mnemonic,
-              createExternalAddressDerivationPathForAccount(peer.ordinal)
-            )
-        )
-
-    private def bloxbeanAccountFor(peer: TestPeerName): Account = accountCache.useOrCreate(peer)
-
-    /** Caching the [[Account]] is not enough: Bloxbean re-runs the whole derivation on every key
-      * access (`getHdKeyPairFromDerivationPath` → `getRootKeyPairFromMnemonic` →
-      * `pbkdf2HmacSha512`), which dominates the suite's runtime once a generator reaches a peer's
-      * key per sample. The derived key and wallet are therefore cached in the companion, not here —
-      * see [[TestPeers.vkeyCache]] for why instance scope is not enough.
-      */
     private def vkeyFor(peer: TestPeerName): VerificationKey =
-        TestPeers.vkeyCache.getOrElseUpdate(
-          (seedPhrase.mnemonic, peer.ordinal),
-          VerificationKey.unsafeFromArray(bloxbeanAccountFor(peer).publicKeyBytes())
-        )
+        walletFor_(peer).exportVerificationKey
 
     private def walletFor_(peer: TestPeerName): PeerWallet =
         TestPeers.walletCache.getOrElseUpdate(
-          (seedPhrase.mnemonic, peer.ordinal), {
-              val hdKeyPair = bloxbeanAccountFor(peer).hdKeyPair()
-              PeerWallet(
-                WalletModule.BloxBean,
-                hdKeyPair.getPublicKey,
-                hdKeyPair.getPrivateKey
-              )
-          }
+          (seedPhrase.mnemonic, peer.ordinal),
+          TestPeers.deriveScalusWallet(seedPhrase.mnemonic, peer.ordinal)
         )
 
     // Stays instance-scoped: unlike the key it is derived from, an address *is* network-specific.
@@ -243,24 +217,41 @@ case class TestPeers private (
 
 object TestPeers:
 
-    /** Derived peer keys, shared across every [[TestPeers]] instance in the JVM.
+    /** Peer wallets, shared across every [[TestPeers]] instance in the JVM.
       *
       * It has to outlive the instance: `TestPeers.arbitrary` builds a fresh one per ScalaCheck
-      * sample, so an instance-scoped cache would still pay a full BIP32 derivation per peer per
-      * sample — the suite's dominant cost. Keyed by `(mnemonic, ordinal)` and **not** by network,
-      * because BIP32 derivation does not involve the network; only address encoding does, and that
-      * happens downstream of the key. `TestPeersTest` pins that. The key space is therefore tiny:
-      * the few seed phrases in use times at most `TestPeerName.maxPeers`.
+      * sample, so an instance-scoped cache would re-derive every peer's key per sample. Keyed by
+      * `(mnemonic, ordinal)` and **not** by network, because [[deriveScalusWallet]] does not
+      * involve the network; only address encoding does, and that happens downstream of the key.
+      * `TestPeersTest` pins that. The key space is therefore tiny: the few seed phrases in use
+      * times at most `TestPeerName.maxPeers`.
       *
-      * Concurrent by construction — suites run in parallel and share this map.
-      */
-    private val vkeyCache: TrieMap[(String, Int), VerificationKey] = TrieMap.empty
-
-    /** Peer wallets, shared for the same reason as [[vkeyCache]] and keyed identically: the HD key
-      * pair behind a wallet comes from the same network-independent derivation. Safe to share —
-      * [[PeerWallet]] is an immutable holder of a key pair whose methods are pure.
+      * Safe to share — [[PeerWallet]] is an immutable holder of a key pair whose methods are pure —
+      * and concurrent by construction, since suites run in parallel and share this map.
       */
     private val walletCache: TrieMap[(String, Int), PeerWallet] = TrieMap.empty
+
+    /** Deterministic vanilla Ed25519 wallet for a peer, a pure function of `(mnemonic, ordinal)`.
+      *
+      * Replaces the former BloxBean / Ed25519-BIP32 derivation. Vanilla 32-byte keys round-trip
+      * through the private-config JSON codec, so a config generated from these peers is actually
+      * runnable — BIP32 extended keys serialize lossily (a dummy all-zero signing key) and boot a
+      * node that cannot sign. No network input: the key is network-independent; only address
+      * encoding downstream is network-specific.
+      */
+    def deriveScalusWallet(mnemonic: String, ordinal: Int): PeerWallet = {
+        val seed = MessageDigest
+            .getInstance("SHA-256")
+            .digest(s"$mnemonic#$ordinal".getBytes(StandardCharsets.UTF_8))
+        val sk = Ed25519PrivateKeyParameters(seed, 0)
+        val vk = VerificationKey.unsafeFromByteString(
+          ByteString.fromArray(sk.generatePublicKey().getEncoded)
+        )
+        PeerWallet.scalusWallet(
+          vk,
+          SigningKey.unsafeFromByteString(ByteString.fromArray(sk.getEncoded))
+        )
+    }
 
     def arbitrary: Gen[TestPeers] = for {
         spec <- TestPeersSpec.generate()
@@ -365,11 +356,6 @@ object TestPeersSpec:
             peersNumberSpec <- PeersNumberSpec.generate()
         } yield TestPeersSpec(seedPhrase, network, peersNumberSpec)
 
-extension (self: CardanoNetwork)
-    def asBloxbeanNetwork: BloxbeanNetwork =
-
-        BloxbeanNetwork(self.cardanoInfo.network.networkId.toInt, self.protocolMagic)
-
 enum PeersNumberSpec:
     case Random
     case Range(mbMin: Option[Int] = None, mbMax: Option[Int] = None)
@@ -404,35 +390,20 @@ object TestPeersTest extends Properties("Test peers") {
           .flatMap(TestPeers.generate)
     )(testPeers => Prop.collect(testPeers)(Prop.passed))
 
-    /** [[TestPeers.vkeyCache]] and [[TestPeers.walletCache]] are keyed by `(mnemonic, ordinal)`
-      * with no network component, which is only sound because BIP32 derivation does not involve the
-      * network — only address encoding does, downstream of the key. Pin that: the same seed and
-      * ordinal must yield both the same verification key and an equivalently-signing wallet on any
-      * two networks.
+    /** [[TestPeers.walletCache]] is keyed by `(mnemonic, ordinal)` with no network component, which
+      * is only sound because [[TestPeers.deriveScalusWallet]] is a pure function of the seed and
+      * ordinal — no network, and no randomness. Pin that: the same seed and ordinal yield an
+      * equivalently-signing wallet every time.
       */
-    val _ = property("a peer's key and wallet do not depend on the network") = Prop.forAll(
-      Gen.oneOf(SeedPhrase.Yaci, SeedPhrase.Public),
-      arbitrary[CardanoNetwork],
-      arbitrary[CardanoNetwork],
-      Gen.choose(0, TestPeerName.maxPeers - 1)
-    ) { (seedPhrase, networkA, networkB, ordinal) =>
-        // Derive straight through Bloxbean rather than via TestPeers: going through the caches the
-        // property exists to justify would make it vacuously true.
-        def accountOn(network: CardanoNetwork): Account =
-            Account.createFromMnemonic(
-              network.asBloxbeanNetwork,
-              seedPhrase.mnemonic,
-              createExternalAddressDerivationPathForAccount(ordinal)
-            )
-        def walletOf(account: Account): PeerWallet =
-            val hdKeyPair = account.hdKeyPair()
-            PeerWallet(WalletModule.BloxBean, hdKeyPair.getPublicKey, hdKeyPair.getPrivateKey)
-
-        val accountA = accountOn(networkA)
-        val accountB = accountOn(networkB)
-        // PeerWallet's equality is extensional — same exported vkey *and* same signature over a
-        // fixed message — so this covers the signing key, not just the public one.
-        accountA.publicKeyBytes().toList == accountB.publicKeyBytes().toList &&
-        walletOf(accountA) == walletOf(accountB)
-    }
+    val _ = property("a peer's wallet is a deterministic function of (seed, ordinal)") =
+        Prop.forAll(
+          Gen.oneOf(SeedPhrase.Yaci, SeedPhrase.Public),
+          Gen.choose(0, TestPeerName.maxPeers - 1)
+        ) { (seedPhrase, ordinal) =>
+            // Derive straight, bypassing the cache the property exists to justify.
+            // PeerWallet's equality is extensional — same exported vkey *and* same signature over a
+            // fixed message — so this covers the signing key, not just the public one.
+            TestPeers.deriveScalusWallet(seedPhrase.mnemonic, ordinal) ==
+                TestPeers.deriveScalusWallet(seedPhrase.mnemonic, ordinal)
+        }
 }


### PR DESCRIPTION
## Summary

Retires the test-only `WalletModule.BloxBean` wallet backend in favor of deterministic vanilla Scalus keys, and fixes the long-standing `MainSmokeTest` flakiness that turned PRs red (details in #649).

## Why

`TestPeers` derived peer keys as BloxBean ed25519-BIP32 **extended** keys. Those 128-byte extended keys can't be expressed in the 32-byte vanilla-ed25519 codec, so serializing a peer's private config wrote a **dummy all-zero signing key** — the config was not runnable. `MainSmokeTest` boots a node from such a config, so the node signed its stack-0 hard-ack with the zero key, self-verification failed **every run**, and the actor system terminated — racing the HTTP bind the test asserts. The only random part was who won the race, hence the flakiness. (Full root-cause writeup: #649.)

## Changes

1. **`test: retire WalletModule.BloxBean`** — replace BloxBean/BIP32 derivation with a deterministic vanilla Ed25519 keypair per `(seed, ordinal)` and delete `WalletModule.BloxBean`. Vanilla 32-byte keys round-trip through the private-config JSON codec. Production already uses only `WalletModule.Scalus`, so this removes a test-only outlier.
2. **`test(MainSmokeTest): write peer 0's real signing key`** — the stock config encoders deliberately withhold signing keys (`PeerWallet`'s encoder writes a placeholder; real `private.json` files are produced by `GenerateKeyPair` splicing the key into a template). Mirror that: splice peer 0's real signing key into the written `private.json` via a new `TestPeers.deriveScalusKeypair`, so the on-disk config is runnable.

## Testing

- Full unit suite: 303 passed, 0 failed (10 canceled = Yaci-tagged); the changed key values broke no golden tests.
- `just precommit` (fmt/lint/nixfmt) and `just build-werror` pass.
- `MainSmokeTest` run repeatedly: reaches `ServerStarted` every time, with **no** `Hard-ack signature verification failed` logged (previously it fired on every run).

## Notes

- The Yaci integration tests are unaffected: they fund whatever address a peer yields via the devnet faucet (`DevKit.topup` → `/addresses/topup`), not BIP32-derived genesis addresses.
- The stock encoders' deliberate key-withholding is left unchanged; only the test splices the real key explicitly (as `GenerateKeyPair` does for real configs).

Closes #649.
