### PR TITLE
test(e2e): Docker crash-recovery scenario — SIGKILL a head peer and restart it

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -291,7 +291,8 @@ lazy val integration: Project = (project in file("integration"))
                      "hydrozoa.integration.yaci.YaciMultiPeerProbe",
                      "hydrozoa.integration.rbr.mbt.RbrMbtPropertiesYaci",
                      "hydrozoa.integration.rbr.mbt.RbrMbtPropertiesPublic",
-                     "hydrozoa.integration.e2e.DockerSmokeTest"
+                     "hydrozoa.integration.e2e.DockerSmokeTest",
+                     "hydrozoa.integration.e2e.DockerRecoveryTest"
                    )
                  )
                )),

--- a/docs/spec/integration-stages.md
+++ b/docs/spec/integration-stages.md
@@ -274,9 +274,13 @@ The default 2-peer run takes seconds; 10-peer WS runs at `commits=500` take a fe
 
 ---
 
-## E2E: Docker smoke-test on the shipped topology (CI-excluded)
+## E2E: Docker suites on the shipped topology (CI-excluded)
 
-`integration/src/test/scala/hydrozoa/integration/e2e/DockerSmokeTest.scala` is a black-box level outside the `ModelBasedSuite` framework. It stands up the `docker-compose.yml` that `hydrozoa scaffold` writes — **2 head + 4 coil peers** — on a local **Yaci** devnet, forms a head through the packaged image and the real WS mesh + Ember HTTP API, submits an L2 transaction to head-0 over HTTP, and asserts it reaches both head peers' L2 ledgers. It's the one test that covers the documented deployment path end to end (`docker compose`, the image, real sockets, the custom-network config flow); the stages only reach `HydrozoaRoutes` in-process.
+`integration/src/test/scala/hydrozoa/integration/e2e/` is a black-box level outside the `ModelBasedSuite` framework. `DockerHeadSuite` owns the bring-up — everything up to "every head peer reports `/ready`" — and each concrete suite supplies the scenario that runs against the formed head: `DockerSmokeTest` (L2 propagation) and `DockerRecoveryTest` (crash and recovery). Bringing a head up costs minutes, which is why the two share it.
+
+### DockerSmokeTest — L2 propagation
+
+It stands up the `docker-compose.yml` that `hydrozoa scaffold` writes — **2 head + 4 coil peers** — on a local **Yaci** devnet, forms a head through the packaged image and the real WS mesh + Ember HTTP API, submits an L2 transaction to head-0 over HTTP, and asserts it reaches both head peers' L2 ledgers. It's the one test that covers the documented deployment path end to end (`docker compose`, the image, real sockets, the custom-network config flow); the stages only reach `HydrozoaRoutes` in-process.
 
 - **Shipped topology, not a lookalike.** It runs `keygen-fleet 2 4 2` against the scaffolded `docker-compose.yml` + `docker-compose.yaci.yml` overlay — the pair docs/user-guide/DEPLOYMENT.md hands an operator — so a failure is a failure of the documented path. The peer count lives in two places (the `keygen-fleet` args and the compose services); keep them in sync.
 - **Only head peers are asserted on.** Coil peers run no `HydrozoaServer`, but they are load-bearing — the head can't initialize without `coilQuorum` of them signing — so a broken coil surfaces as a `/ready` timeout, not a silent pass.
@@ -286,6 +290,19 @@ The default 2-peer run takes seconds; 10-peer WS runs at `commits=500` take a fe
 
 ```bash
 just integration-e2e-docker   # builds the image, stages the launcher, runs the suite
+```
+
+### DockerRecoveryTest — a head peer crashes and comes back
+
+Same deployment, run through the loss of a head peer. After a baseline L2 transaction confirms, the test SIGKILLs head-1 (`docker compose kill` — no SIGTERM, no flush, and the daemon treats it as a manual stop so `restart: on-failure` doesn't resurrect it), submits another transaction while the peer is gone, then `docker compose start`s the same container on the same named volume and asserts the head comes back whole: head-1 reaches `/ready` again, its recovered L2 view still carries the pre-crash transaction, the transaction submitted during the outage confirms on every head peer, and a fresh one confirms after that.
+
+- **head-1 is the peer that matters.** The head multisig is *every* head peer plus a coil quorum, so losing one of two head peers is the outage that stops consensus; a coil peer's loss is absorbed by the 2-of-4 quorum. head-1 also publishes the HTTP API, so its recovered state is read directly rather than inferred.
+- **Its own compose project** (`hydrozoa-e2e-recovery`), so the peers' named volumes are namespaced away from a smoke run's — the run must start from empty stores, since what a peer reads back from its store is the point.
+- **It does not assert that head-0's L2 view stays empty during the outage.** A peer's ledger commits a block when the block is *produced*, and only the next block waits on soft-confirmation ([`fast-consensus.md`](fast-consensus.md)), so a surviving leader may legitimately have applied one more block before stalling. Convergence across peers is the property the suite checks instead.
+- It is the black-box counterpart to the crash-restart coverage [`persistence-and-crash-recovery.md`](persistence-and-crash-recovery.md) §9 lists as not yet built: a whole-node reboot end to end, rather than a single actor's recovery contract.
+
+```bash
+just integration-e2e-docker-recovery
 ```
 
 ---
@@ -303,6 +320,7 @@ just integration-e2e-docker   # builds the image, stages the launcher, runs the 
 | L2 ledger correctness under reordering                                         | Stage 4   |
 | L1-side fee / validity-interval / treasury-rotation regression                  | Stage 1 (Yaci/Blockfrost) |
 | Black-box propagation across the packaged image + `docker compose` + HTTP API   | E2E (Docker, CI-excluded) |
+| Whole-node crash + restart against a real store and a real mesh                 | E2E (Docker recovery, CI-excluded) |
 
 A scenario that needs **both** real L1 and slow-cycle multi-peer consensus does not yet have a home — that's the "stage 4 against Yaci" path. The harness already supports the swap (`CardanoBackend[IO]` is the only L1 dependency); only `propEffectsLanded`'s `(attempts, sleep)` budget needs widening.
 

--- a/docs/spec/persistence-and-crash-recovery.md
+++ b/docs/spec/persistence-and-crash-recovery.md
@@ -1831,9 +1831,13 @@ three liaisons' outbox recover ([§6](#6-per-actor-recovery-contracts)).
   in-flight slow-side cell completes as replayed/live `HubHardAck` entries arrive —
   assert hard-confirmation still reaches `AllOf(head) ∧ coilQuorum`.
 
-**Testing strategy.** The automated coverage of these scenarios is not yet built: the
-model-based integration suites (stage1 / stage4) do not yet carry a **crash-restart
-action** that kills and reconstructs a peer from its store mid-run, and the
+**Testing strategy.** One black-box scenario is covered end to end:
+`DockerRecoveryTest` (see [`integration-stages.md`](integration-stages.md)) SIGKILLs a
+head peer of the shipped Docker deployment, keeps submitting while it is gone, restarts
+the container on its own volume, and asserts the head re-converges — a whole-node reboot
+against a real store and a real mesh. The rest is not yet built: the model-based
+integration suites (stage1 / stage4) do not yet carry a **crash-restart action** that
+kills and reconstructs a peer from its store mid-run, and the
 **observational-equivalence property** (*for any crash point, recovered committed state
 is observationally equivalent to the no-crash run*) is not yet asserted. The design of
 that coverage: a crash-restart action for **head, coil, and hub** peers asserting the
@@ -1859,7 +1863,9 @@ back, vote, and evacuate, and its write side is fully persisted. Outstanding bey
   loading them once on the rule-based handover ([§5.7](#57-the-recovery-priority-ladder-graceful-degradation))
   is not yet wired (`rulebased/persistence/Persistence.scala` is a stub).
 - **The crash-restart integration action and the observational-equivalence property test
-  are not yet built** ([§9](#9-failure-scenarios-recovery-handles)).
+  are not yet built** ([§9](#9-failure-scenarios-recovery-handles)). The black-box
+  `DockerRecoveryTest` covers a whole-node reboot, but not per-actor crash windows or
+  the equivalence property.
 
 ---
 

--- a/integration/src/test/scala/hydrozoa/integration/e2e/DockerHeadSuite.scala
+++ b/integration/src/test/scala/hydrozoa/integration/e2e/DockerHeadSuite.scala
@@ -545,7 +545,10 @@ object DockerHeadSuite:
     private val MeshBlockfrostUrl = "http://yaci:8080/api/v1"
 
     private val TopupAda = 100_000L // ADA to head-0 on the devnet
-    private val SendAda = 2L // ADA moved head-0 → head-1 on L2
+    // ADA moved head-0 → head-1 per L2 send. `keygen-fleet` opens each head peer with 5 ADA
+    // (the `l2-cardano-eutxo.json` it writes), and a scenario may send several times off the same
+    // change chain, so this has to leave every change output above min-ADA to the last send.
+    private val SendAda = 1L
     private val RecentTxWindow = 50 // entries pulled from each peer's /transactions feed
 
     // Placeholder Blockfrost key for the keyless devnet — value is ignored (see `cli`).

--- a/integration/src/test/scala/hydrozoa/integration/e2e/DockerHeadSuite.scala
+++ b/integration/src/test/scala/hydrozoa/integration/e2e/DockerHeadSuite.scala
@@ -29,14 +29,18 @@ import scalus.cardano.address.ShelleyAddress
 import scalus.cardano.ledger.Value
 import scalus.uplc.builtin.ByteString
 
-/** Stand up a whole head in containers on a local Yaci devnet, form it, submit an L2 transaction to
-  * head-0 over HTTP, and assert it reaches every head peer's L2 ledger. Unlike the in-process
-  * `MultiPeerHeadHarness`, this drives the shipped artifacts black-box: the packaged image, `docker
-  * compose`, the mesh, the HTTP API, and L2 consensus across distinct node identities.
+/** Stand up a whole head in containers on a local Yaci devnet and form it, then hand the formed
+  * head to a subclass's [[scenario]]. Unlike the in-process `MultiPeerHeadHarness`, this drives the
+  * shipped artifacts black-box: the packaged image, `docker compose`, the mesh, the HTTP API, and
+  * L2 consensus across distinct node identities.
   *
-  * Subclass it with a [[DockerTopology]] — that is the only thing that varies. See
-  * [[DockerSmokeTest]] for the deployment we ship, and the E2E section of
-  * `docs/spec/integration-stages.md` for where this level sits among the others.
+  * Bringing a head up costs minutes, so everything up to "every head peer reports `/ready`" lives
+  * here and every subclass shares it; what varies is the [[DockerTopology]] it runs on and the
+  * [[scenario]] it then asserts. Subclasses also inherit the L2 traffic helpers ([[sendAda]],
+  * [[awaitPropagation]]) and the container controls ([[killPeer]], [[startPeer]]). See
+  * [[DockerSmokeTest]] for L2 propagation on the deployment we ship, [[DockerRecoveryTest]] for
+  * killing a head peer and recovering it, and the E2E section of `docs/spec/integration-stages.md`
+  * for where this level sits among the others.
   *
   * '''Only head peers are observable.''' `runCoilNode` starts no `HydrozoaServer`, so the HTTP
   * assertions cover head peers alone. Coil peers are still load-bearing: the head cannot initialize
@@ -62,14 +66,14 @@ import scalus.uplc.builtin.ByteString
   *   6. `deploy-scripts-and-g2-setup` — deploy the treasury/dispute validators (+ G2 ladder);
   *   7. `build-head-config` — resolve the ref UTxOs into the shared head config;
   *   8. `docker compose up` — every peer;
-  *   9. wait for `/ready`, submit an L2 tx to head-0, poll the head peers until convergence.
+  *   9. wait for `/ready` on every head peer — after which the subclass's [[scenario]] runs.
   *
   * URL split (the containers and the host reach the same devnet at different addresses): the peers
   * reach it in-mesh at `http://yaci:8080` (written into each `private.json` via the template's
   * `blockfrostApiUrl`), while the host-side generation steps reach it at the devnet's host-mapped
   * port (`localhost:18080`) via `--blockfrost-url`.
   */
-abstract class DockerHeadSuite(topology: DockerTopology) extends AnyFunSuite:
+abstract class DockerHeadSuite(topology: DockerTopology, scenarioName: String) extends AnyFunSuite:
 
     import DockerHeadSuite.*
 
@@ -88,9 +92,13 @@ abstract class DockerHeadSuite(topology: DockerTopology) extends AnyFunSuite:
     private val peerServices: List[String] =
         headPeerIndices.map(i => s"head-$i") ++ (0 until CoilCount).map(i => s"coil-$i").toList
 
-    test(
-      s"a head forms on the ${topology.name} topology and an L2 tx reaches every head peer"
-    ) {
+    /** What this suite asserts once the head has formed and every head peer reports `/ready`. The
+      * workspace is the one [[formHead]] scaffolded, so a scenario can read the generated configs
+      * and drive `docker compose` against the running project.
+      */
+    protected def scenario(home: Path, client: Client[IO]): IO[Unit]
+
+    test(s"a head forms on the ${topology.name} topology and $scenarioName") {
         // Prerequisites the `just integration-e2e-docker` recipe guarantees; cancel (not fail) when
         // a stray `testOnly *` reaches this excluded suite without them.
         if !commandSucceeds(Seq("docker", "--version")) then
@@ -109,7 +117,7 @@ abstract class DockerHeadSuite(topology: DockerTopology) extends AnyFunSuite:
     private def program: IO[Unit] =
         makeHome.flatMap { home =>
             EmberClientBuilder.default[IO].build.use { client =>
-                runScenario(home, client)
+                (formHead(home, client) *> scenario(home, client))
                     .onError(e =>
                         log(s"scenario failed: ${e.getMessage} — configs kept at $home") *>
                             dumpLogs(home).attempt.void
@@ -119,7 +127,10 @@ abstract class DockerHeadSuite(topology: DockerTopology) extends AnyFunSuite:
             }
         }
 
-    private def runScenario(home: Path, client: Client[IO]): IO[Unit] =
+    /** Steps 1-9 of the deployment flow: scaffold the workspace, bring the devnet up, generate the
+      * fleet, deploy the scripts, start every peer, and wait for the head to open on L1.
+      */
+    private def formHead(home: Path, client: Client[IO]): IO[Unit] =
         for {
             _ <- log(s"home=$home image=$image compose=${composeFiles(home).mkString(" + ")}")
             _ <- writePrivateTemplate(home)
@@ -186,49 +197,50 @@ abstract class DockerHeadSuite(topology: DockerTopology) extends AnyFunSuite:
             _ <- pollUntil("the head peers to become ready", ReadyTimeout, 5.seconds)(
               allReady(client)
             )
-
-            _ <- submitAndAssertPropagation(home, client)
-            _ <- log("propagation confirmed on both head peers ✓")
         } yield ()
 
-    /** Build the same zero-fee L2 tx `submit-l2-tx` would (spend head-0's opening output, send
-      * [[SendAda]] to head-1), submit it to head-0, then poll both head peers until the resulting
-      * utxo and feed entry appear on each. Loads head-0's wallet/headId/network offline, plus
-      * head-1's wallet for the destination address.
+    // ---- L2 traffic --------------------------------------------------------------------------
+
+    /** Load the two ends of the suite's L2 traffic from the generated workspace: head-0's offline
+      * demo config (wallet, head id, network) and head-1's wallet, whose address every [[sendAda]]
+      * pays. Both read files, so they survive a peer being down.
       */
-    private def submitAndAssertPropagation(home: Path, client: Client[IO]): IO[Unit] =
+    protected def loadL2Wallets(home: Path): IO[L2Wallets] =
         for {
-            demo0 <- DemoConfig.loadOffline(headConfigPath(home), privatePath(home, "head-0"))
-            head1Wallet <- DemoConfig.readWallet(privatePath(home, "head-1"))
-            _ <- runSubmit(demo0, head1Wallet, client)
-        } yield ()
+            sender <- DemoConfig.loadOffline(headConfigPath(home), privatePath(home, "head-0"))
+            recipient <- DemoConfig.readWallet(privatePath(home, "head-1"))
+        } yield L2Wallets(sender, recipient)
 
-    private def runSubmit(
-        demo0: DemoConfig.L2Demo,
-        head1Wallet: PeerWallet,
-        client: Client[IO]
-    ): IO[Unit] =
-        given CardanoNetwork.Section = demo0.cardanoNetwork
-        val head0Address = demo0.wallet.exportVerificationKey.shelleyAddress()
-        val head1Address = head1Wallet.exportVerificationKey.shelleyAddress()
+    /** Build the same zero-fee L2 tx `submit-l2-tx` would — spend head-0's largest L2 output, send
+      * [[SendAda]] to head-1, keep the change — sign it, and submit it to head-0. Returns as soon
+      * as head-0 has assigned a request id; landing it on every peer is [[awaitPropagation]]'s job,
+      * so a scenario can submit while consensus cannot progress.
+      *
+      * The input is re-read from head-0's live utxo set on every call, so repeated sends chain off
+      * the previous one's change.
+      */
+    protected def sendAda(wallets: L2Wallets, client: Client[IO]): IO[SentTransaction] =
+        given CardanoNetwork.Section = wallets.sender.cardanoNetwork
+        val head0Address = wallets.sender.wallet.exportVerificationKey.shelleyAddress()
+        val head1Address = wallets.recipient.exportVerificationKey.shelleyAddress()
         for {
             head0Bech32 <- IO.fromOption(head0Address.toBech32.toOption)(
               RuntimeException("head-0 address is not bech32-renderable")
             )
 
             parsed <- EutxoL2QueryClient.http(client, headUri(0)).utxos(head0Address)
-            selected <- IO.fromOption(parsed.headOption)(
-              RuntimeException(s"head-0 has no opening L2 utxo at $head0Bech32")
+            selected <- IO.fromOption(parsed.maxByOption(_._2.value.coin.value))(
+              RuntimeException(s"head-0 has no spendable L2 utxo at $head0Bech32")
             )
             (input, output) = selected
 
             tx <- IO.fromEither(
               SubmitL2Transaction
-                  .buildTx(demo0.headId, input, output, head1Address, Value.ada(SendAda))
+                  .buildTx(wallets.sender.headId, input, output, head1Address, Value.ada(SendAda))
                   .left
                   .map(e => RuntimeException(s"could not build the L2 tx: $e"))
             )
-            signed = demo0.wallet.signTx(tx)
+            signed = wallets.sender.wallet.signTx(tx)
             txIdHex = signed.id.toHex
             _ <- log(s"submitting L2 tx $txIdHex ($SendAda ADA head-0 → head-1) to head-0…")
             requestId <- SubmissionClient
@@ -238,24 +250,40 @@ abstract class DockerHeadSuite(topology: DockerTopology) extends AnyFunSuite:
                     TransactionRequestBody(ByteString.fromArray(signed.toCbor))
                   )
                 )
-            expectedRequest = mkRequestIdView(requestId)
+        } yield SentTransaction(txIdHex, mkRequestIdView(requestId), head1Address)
 
-            _ <- log("polling both head peers for the propagated utxo…")
-            _ <- pollUntil(s"utxo $txIdHex at head-1 on every peer", ConvergeTimeout, 3.seconds)(
-              allPeersShowUtxo(client, head1Address, txIdHex)
-            )
+    /** Poll every head peer until `sent` shows up in both of its L2 views — the utxo it paid to
+      * head-1 and the entry in its `/transactions` feed — or [[ConvergeTimeout]] elapses.
+      */
+    protected def awaitPropagation(client: Client[IO], sent: SentTransaction): IO[Unit] =
+        for {
+            _ <- log(s"polling every head peer for L2 tx ${sent.txIdHex}…")
+            _ <- pollUntil(
+              s"utxo ${sent.txIdHex} at head-1 on every peer",
+              ConvergeTimeout,
+              3.seconds
+            )(allPeersShowUtxo(client, sent.destination, sent.txIdHex))
             _ <- pollUntil("our tx in every peer's /transactions feed", ConvergeTimeout, 3.seconds)(
-              allPeersShowTransaction(client, expectedRequest)
+              allPeersShowTransaction(client, sent.request)
             )
         } yield ()
 
     // ---- HTTP probes -------------------------------------------------------------------------
 
     /** `GET /ready` returns 200 on every HTTP-observable peer (head initialized and active). */
-    private def allReady(client: Client[IO]): IO[Boolean] =
+    protected def allReady(client: Client[IO]): IO[Boolean] =
         headPeerIndices
             .traverse(i => client.get(headUri(i) / "ready")(r => IO.pure(r.status.code == 200)))
             .map(_.forall(identity))
+
+    /** Whether head peer `peer` answers `GET /health` at all — false while its container is down,
+      * so a scenario can tell "killed" from "still serving".
+      */
+    protected def peerResponds(client: Client[IO], peer: Int): IO[Boolean] =
+        client
+            .get(headUri(peer) / "health")(r => IO.pure(r.status.code == 200))
+            .attempt
+            .map(_.getOrElse(false))
 
     /** Every head peer's `GET /l2/cardano-eutxo/utxos/{head-1}` lists a utxo minted by our tx. */
     private def allPeersShowUtxo(
@@ -293,6 +321,45 @@ abstract class DockerHeadSuite(topology: DockerTopology) extends AnyFunSuite:
             ()
         }
 
+    // ---- container controls ------------------------------------------------------------------
+
+    /** SIGKILL `service`'s container — an abrupt crash, with no SIGTERM and no chance to flush, so
+      * what the peer left in its RocksDB store is what a real crash would have left.
+      *
+      * `docker compose kill` is a manual stop as far as the daemon is concerned, so the compose
+      * file's `restart: on-failure` policy does *not* resurrect the container and the peer stays
+      * down until [[startPeer]].
+      */
+    protected def killPeer(home: Path, service: String): IO[Unit] =
+        compose(home, "kill", service)
+
+    /** Start `service`'s existing container again. This is a restart, not a re-creation: the same
+      * container comes back on the same named volume, so the peer boots off the store its crash
+      * left behind.
+      */
+    protected def startPeer(home: Path, service: String): IO[Unit] =
+        compose(home, "start", service)
+
+    /** `service`'s container exit code, as the daemon recorded it — 137 (128 + SIGKILL) after a
+      * [[killPeer]], which is how a scenario confirms the peer really died rather than exiting on
+      * its own.
+      */
+    protected def peerExitCode(home: Path, service: String): IO[Int] =
+        for {
+            id <- composeCapture(home, "ps", "-a", "-q", service).flatMap(out =>
+                IO.fromOption(lastNonBlankLine(out))(
+                  RuntimeException(s"docker compose ps found no container for $service")
+                )
+            )
+            raw <- captureProcess(
+              Seq("docker", "inspect", "-f", "{{.State.ExitCode}}", id),
+              extraEnv = Seq.empty
+            )
+            code <- IO.fromOption(lastNonBlankLine(raw).flatMap(_.toIntOption))(
+              RuntimeException(s"could not read $service's exit code from: $raw")
+            )
+        } yield code
+
     // ---- process orchestration ---------------------------------------------------------------
 
     /** Run `scripts/yaci-devnet.sh`, the same entry point the deployment guide documents.
@@ -322,6 +389,10 @@ abstract class DockerHeadSuite(topology: DockerTopology) extends AnyFunSuite:
 
     private def compose(home: Path, args: String*): IO[Unit] =
         runProcess(composeCmd(home, args*), cwd = None, extraEnv = composeEnv(home))
+
+    /** [[compose]], but returning the command's stdout instead of only echoing it. */
+    private def composeCapture(home: Path, args: String*): IO[String] =
+        captureProcess(composeCmd(home, args*), composeEnv(home))
 
     /** The head directory's scaffolded `docker-compose.yml` plus the Yaci overlay — the same pair,
       * in the same order, that the deployment guide tells an operator to run, so this suite
@@ -377,6 +448,22 @@ abstract class DockerHeadSuite(topology: DockerTopology) extends AnyFunSuite:
                 )
         }
 
+    /** [[runProcess]] that returns stdout. Stderr still goes to the console, so a failing command
+      * reports itself the same way.
+      */
+    private def captureProcess(cmd: Seq[String], extraEnv: Seq[(String, String)]): IO[String] =
+        IO.blocking {
+            val captured = new StringBuilder
+            val logger = ProcessLogger(
+              line => { val _ = captured.append(line).append('\n') },
+              line => println(s"$Tag $line")
+            )
+            val code = Process(cmd, None, extraEnv*).!(logger)
+            if code != 0 then
+                throw RuntimeException(s"command failed (exit $code): ${cmd.mkString(" ")}")
+            captured.toString
+        }
+
     private def runProcessLenient(cmd: Seq[String], extraEnv: Seq[(String, String)]): IO[Unit] =
         IO.blocking {
             val code =
@@ -389,7 +476,7 @@ abstract class DockerHeadSuite(topology: DockerTopology) extends AnyFunSuite:
     /** Repeat `check` until it returns true, or raise after `timeout`. Exceptions (a peer not up
       * yet, a connection refused) count as "not ready" and are retried until the deadline.
       */
-    private def pollUntil(what: String, timeout: FiniteDuration, interval: FiniteDuration)(
+    protected def pollUntil(what: String, timeout: FiniteDuration, interval: FiniteDuration)(
         check: IO[Boolean]
     ): IO[Unit] =
         IO.monotonic.flatMap { start =>
@@ -413,7 +500,11 @@ abstract class DockerHeadSuite(topology: DockerTopology) extends AnyFunSuite:
             loop
         }
 
-    private def log(msg: String): IO[Unit] = IO.println(s"$Tag $msg")
+    /** Fail the scenario unless `condition` holds, with `message` as the reason. */
+    protected def ensure(condition: Boolean, message: String): IO[Unit] =
+        IO.raiseUnless(condition)(RuntimeException(message))
+
+    protected def log(msg: String): IO[Unit] = IO.println(s"$Tag $msg")
 
     private def makeHome: IO[Path] = IO.blocking(Files.createTempDirectory("hydrozoa-e2e"))
 
@@ -430,6 +521,22 @@ abstract class DockerHeadSuite(topology: DockerTopology) extends AnyFunSuite:
 end DockerHeadSuite
 
 object DockerHeadSuite:
+
+    /** The two ends of the L2 traffic a scenario sends: head-0, whose offline demo config carries
+      * the wallet, head id, and network needed to build and sign, and head-1's wallet, whose
+      * address every [[DockerHeadSuite.sendAda]] pays.
+      */
+    private[e2e] final case class L2Wallets(sender: DemoConfig.L2Demo, recipient: PeerWallet)
+
+    /** An L2 transaction a scenario submitted, and everything needed to recognize it afterwards: in
+      * a peer's utxo set (a `txIdHex` output at `destination`) and in its `/transactions` feed (the
+      * `request` head-0 assigned it).
+      */
+    private[e2e] final case class SentTransaction(
+        txIdHex: String,
+        request: RequestIdView,
+        destination: ShelleyAddress
+    )
 
     /** The devnet's host-mapped Blockfrost port (`docker-compose.yaci.yml`). */
     private val HostBlockfrostUrl = "http://localhost:18080/api/v1"

--- a/integration/src/test/scala/hydrozoa/integration/e2e/DockerRecoveryTest.scala
+++ b/integration/src/test/scala/hydrozoa/integration/e2e/DockerRecoveryTest.scala
@@ -1,0 +1,133 @@
+package hydrozoa.integration.e2e
+
+import cats.effect.IO
+import java.nio.file.Path
+import org.http4s.client.Client
+import scala.concurrent.duration.*
+
+/** The Docker crash-recovery test: [[DockerHeadSuite]] on the shipped topology, run through the
+  * loss of a head peer. Once the head is formed and an L2 transaction has confirmed, the test
+  * SIGKILLs head-1, keeps using the head while it is gone, then starts the same container again on
+  * the same named volume and asserts the head comes back whole.
+  *
+  * '''Why head-1.''' The head multisig is *every* head peer plus a coil quorum, so losing one of
+  * two head peers is the outage that actually stops consensus — a coil peer's loss is absorbed by
+  * the 2-of-4 quorum. head-1 is also HTTP-observable, so its recovered L2 state can be read
+  * directly rather than inferred.
+  *
+  * '''Why `kill` and not `stop`.''' `docker compose kill` sends SIGKILL: no SIGTERM, no shutdown
+  * hook, no flush — the store the peer boots from is the one an abrupt crash left. The daemon
+  * treats it as a manual stop, so the compose file's `restart: on-failure` does not resurrect the
+  * container behind the test's back.
+  *
+  * What the run asserts, in order:
+  *   1. head-1 really died — exit 137 (128 + SIGKILL) and no answer on `/health`;
+  *   2. head-0 keeps serving through the outage, and still accepts a submission;
+  *   3. head-1 reaches `/ready` again after a plain restart, off its own store;
+  *   4. the pre-crash transaction is still in head-1's recovered L2 view — nothing was lost;
+  *   5. the transaction submitted *during* the outage confirms on every head peer — the backlog
+  *      drained rather than being dropped;
+  *   6. a fresh transaction submitted after recovery confirms too — the head is live again, not
+  *      wedged in a state that merely looks healthy.
+  *
+  * '''What it deliberately does not assert.''' That head-0's own L2 view stays empty during the
+  * outage. A peer's ledger commits a block when the block is *produced*, and only the next block
+  * waits on soft-confirmation (`docs/spec/fast-consensus.md`), so a surviving leader may
+  * legitimately have applied one more block before stalling. Convergence across peers is the
+  * property this suite can check without pinning that internal.
+  *
+  * This is the black-box counterpart to the crash-restart coverage
+  * `docs/spec/persistence-and-crash-recovery.md` §9 lists as not yet built: it exercises a whole
+  * node reboot end to end rather than a single actor's recovery contract.
+  *
+  * Heavy and CI-excluded; run it with `just integration-e2e-docker-recovery`.
+  */
+class DockerRecoveryTest
+    extends DockerHeadSuite(
+      DockerTopology.shippedRecovery,
+      "a SIGKILLed head peer recovers and consensus resumes"
+    ):
+
+    import DockerRecoveryTest.*
+
+    override protected def scenario(home: Path, client: Client[IO]): IO[Unit] =
+        for {
+            wallets <- loadL2Wallets(home)
+
+            // A confirmed transaction first, so the peer we are about to kill has L2 state that a
+            // botched recovery would visibly lose.
+            beforeCrash <- sendAda(wallets, client)
+            _ <- awaitPropagation(client, beforeCrash)
+            _ <- log(s"baseline tx ${beforeCrash.txIdHex} confirmed on every head peer ✓")
+
+            _ <- log(s"SIGKILLing $Victim…")
+            _ <- killPeer(home, Victim)
+            exit <- peerExitCode(home, Victim)
+            _ <- ensure(
+              exit == SigkillExit,
+              s"$Victim exited $exit, not $SigkillExit — it was not killed by SIGKILL"
+            )
+            _ <- pollUntil(s"$Victim to stop answering", DownTimeout, 2.seconds)(
+              peerResponds(client, VictimIndex).map(!_)
+            )
+            _ <- log(s"$Victim is down (exit $exit) ✓")
+
+            // The head runs on one head peer for a while: long enough that the outage is a real
+            // one, with a submitted request waiting on the peer that is gone.
+            duringOutage <- sendAda(wallets, client)
+            _ <- log(s"submitted ${duringOutage.txIdHex} during the outage; dwelling $OutageDwell…")
+            _ <- IO.sleep(OutageDwell)
+            survivorUp <- peerResponds(client, SurvivorIndex)
+            _ <- ensure(survivorUp, "head-0 stopped serving while head-1 was down")
+            victimUp <- peerResponds(client, VictimIndex)
+            _ <- ensure(!victimUp, s"$Victim answered while it was supposed to be down")
+
+            // The restart: same container, same volume, so the peer boots off the store its crash
+            // left behind.
+            _ <- log(s"restarting $Victim…")
+            _ <- startPeer(home, Victim)
+            _ <- pollUntil("every head peer to be ready again", RecoverTimeout, 5.seconds)(
+              allReady(client)
+            )
+            _ <- log(s"$Victim is ready again ✓")
+
+            _ <- awaitPropagation(client, beforeCrash)
+            _ <- log("the pre-crash tx is still in the recovered L2 view ✓")
+
+            _ <- awaitPropagation(client, duringOutage)
+            _ <- log("the tx submitted during the outage confirmed on every head peer ✓")
+
+            afterRecovery <- sendAda(wallets, client)
+            _ <- awaitPropagation(client, afterRecovery)
+            _ <- log("a fresh tx confirmed after recovery — the head is live again ✓")
+        } yield ()
+
+end DockerRecoveryTest
+
+object DockerRecoveryTest:
+
+    /** The head peer the run kills. Losing one of the two head peers stops consensus, because the
+      * head multisig needs every head peer.
+      */
+    private val Victim = "head-1"
+    private val VictimIndex = 1
+
+    /** The head peer that stays up, keeps serving the HTTP API, and takes the outage submission. */
+    private val SurvivorIndex = 0
+
+    /** A container killed by SIGKILL exits 128 + 9. */
+    private val SigkillExit = 137
+
+    /** How long the head runs with a head peer missing before the restart — long enough for the
+      * outage submission to be genuinely stuck rather than merely in flight.
+      */
+    private val OutageDwell = 30.seconds
+
+    private val DownTimeout = 1.minute
+
+    /** Real-wall-clock budget for the restarted peer: it replays its journals and rejoins the mesh
+      * before `/ready` flips back.
+      */
+    private val RecoverTimeout = 5.minutes
+
+end DockerRecoveryTest

--- a/integration/src/test/scala/hydrozoa/integration/e2e/DockerSmokeTest.scala
+++ b/integration/src/test/scala/hydrozoa/integration/e2e/DockerSmokeTest.scala
@@ -1,11 +1,30 @@
 package hydrozoa.integration.e2e
 
+import cats.effect.IO
+import java.nio.file.Path
+import org.http4s.client.Client
+
 /** The Docker smoke-test: [[DockerHeadSuite]] run against the topology we actually ship — 2 head
   * peers and 4 coil peers, `keygen-fleet 2 4 2`, the scaffolded `docker-compose.yml` plus the
   * devnet overlay. A failure here is a failure of the procedure in docs/user-guide/DEPLOYMENT.md,
   * not of a test-only lookalike.
   *
+  * The scenario is the baseline one: a single L2 transaction submitted to head-0 must reach every
+  * head peer's L2 ledger. [[DockerRecoveryTest]] runs the same deployment through a crash.
+  *
   * Heavy and CI-excluded; run it with `just integration-e2e-docker`. See [[DockerHeadSuite]] for
-  * what the run does and `docs/spec/integration-stages.md` for where it sits among the test levels.
+  * what the bring-up does and `docs/spec/integration-stages.md` for where this sits among the test
+  * levels.
   */
-class DockerSmokeTest extends DockerHeadSuite(DockerTopology.shipped)
+class DockerSmokeTest
+    extends DockerHeadSuite(DockerTopology.shipped, "an L2 tx reaches every head peer"):
+
+    override protected def scenario(home: Path, client: Client[IO]): IO[Unit] =
+        for {
+            wallets <- loadL2Wallets(home)
+            sent <- sendAda(wallets, client)
+            _ <- awaitPropagation(client, sent)
+            _ <- log("propagation confirmed on every head peer ✓")
+        } yield ()
+
+end DockerSmokeTest

--- a/integration/src/test/scala/hydrozoa/integration/e2e/DockerTopology.scala
+++ b/integration/src/test/scala/hydrozoa/integration/e2e/DockerTopology.scala
@@ -57,4 +57,14 @@ object DockerTopology {
       tag = "[smoke]",
       composeOverlayNames = List("docker-compose.yaci.yml")
     )
+
+    /** [[shipped]] again, under its own compose project. The project namespaces the peers' named
+      * volumes, so a recovery run always starts from empty stores rather than resuming whatever a
+      * smoke run left behind — which matters here, because the point of the run is what a peer
+      * reads back from its own store.
+      */
+    val shippedRecovery: DockerTopology = shipped.copy(
+      project = "hydrozoa-e2e-recovery",
+      tag = "[recovery]"
+    )
 }

--- a/justfile
+++ b/justfile
@@ -104,6 +104,14 @@ integration-e2e-docker:
   trap 'just notify "integration-e2e-docker"' EXIT
   HYDROZOA_INCLUDE_HEAVY_TESTS=1 sbt "Docker/publishLocal; stage; integration/testOnly hydrozoa.integration.e2e.DockerSmokeTest"
 
+# Heavy Docker crash-recovery test on the same shipped topology: forms the head, SIGKILLs head-1,
+# keeps submitting, then restarts it on its own store and asserts the head comes back whole. Needs
+# a running Docker; longer than the smoke test. See docs/spec/integration-stages.md.
+integration-e2e-docker-recovery:
+  #!/usr/bin/env bash
+  trap 'just notify "integration-e2e-docker-recovery"' EXIT
+  HYDROZOA_INCLUDE_HEAVY_TESTS=1 sbt "Docker/publishLocal; stage; integration/testOnly hydrozoa.integration.e2e.DockerRecoveryTest"
+
 # Recompile and export the on-chain script blueprint to src/main/resources/hydrozoa/scripts/plutus.json.
 export:
   #!/usr/bin/env bash


### PR DESCRIPTION
Stacked on #570 — it builds on `DockerHeadSuite`, which lands there. Retarget to `main` once #570 merges.

## What this adds

`DockerRecoveryTest`: the shipped 2 head + 4 coil Docker deployment, run through the loss of a head peer, driven entirely from inside the test.

1. baseline L2 tx confirms on both head peers;
2. `docker compose kill head-1` — SIGKILL, asserted via **exit 137**, then `/health` stops answering;
3. an L2 tx is submitted to head-0 **during** the outage, then a 30s dwell;
4. `docker compose start head-1` — same container, same named volume, so the peer boots off the store its crash left;
5. asserts head-1 reaches `/ready` again, its recovered L2 view still carries the pre-crash tx, the outage tx converges on every head peer, and a fresh tx confirms after that.

`kill` rather than `stop` is deliberate: SIGKILL leaves the store an abrupt crash would leave, and the daemon treats it as a manual stop, so the compose file's `restart: on-failure` does not resurrect the container behind the test's back.

To make room for it, `DockerHeadSuite` is split: it owns the bring-up (scaffold → devnet → keygen → deploy → `compose up` → `/ready`, which costs minutes) and declares an abstract `scenario`. `DockerSmokeTest` keeps its behaviour, now written out as its scenario.

## Verification

Run end to end against Docker + a local Yaci devnet, on this branch rebased onto current `main`:

```
[recovery] baseline tx cc67c4e7… confirmed on every head peer ✓
[recovery] SIGKILLing head-1…
[recovery] head-1 is down (exit 137) ✓
[recovery] restarting head-1…
[recovery] head-1 is ready again ✓
[recovery] the pre-crash tx is still in the recovered L2 view ✓
[recovery] the tx submitted during the outage confirmed on every head peer ✓
[recovery] a fresh tx confirmed after recovery — the head is live again ✓
Tests: succeeded 1, failed 0
```

Worth recording how it got here: on the pre-rebase base the restart killed the peer outright — `BlockWeaver` opened at block 1 against a non-empty store, landed in `Leader.AwaitingConfirmation`, and `panicUnexpectedRequest` took the actor system down. `920a36f8` ("fix(recovery): give BlockWeaver its base state, read in its own PreStart") fixes exactly that, and this suite is now a passing guard over it.

`compile`, `Test/compile`, `integration/Test/compile`, `just fmt-check`, `just lint-check`, `just nixfmt-check` all pass.

## Not asserted, deliberately

That head-0's L2 view stays empty during the outage. A peer's ledger commits a block when the block is *produced*, and only the next block waits on soft-confirmation (`fast-consensus.md`), so a surviving leader may legitimately have applied one more before stalling. Convergence across peers is the property the suite can check without pinning that internal.

## Notes

- The per-send amount is 1 ADA: `keygen-fleet` opens each head peer with 5 ADA on L2 and this scenario sends three times off the same change chain, which 2 ADA a send cannot fund. The smoke test sends once, so it never met that limit.
- Runs under its own compose project (`hydrozoa-e2e-recovery`) so the peers' named volumes are namespaced away from a smoke run's — the run must start from empty stores, since what a peer reads back from its store is the point.
- CI-excluded by FQN in `build.sbt` alongside `DockerSmokeTest`; run it with `just integration-e2e-docker-recovery`.
- Docs: `integration-stages.md` gains the suite; `persistence-and-crash-recovery.md` §9's testing-status note now records that the whole-node reboot scenario is covered, with per-actor crash windows and the observational-equivalence property still outstanding.