### PR TITLE
ci(release): publish linux/arm64 alongside amd64, and link the image from the notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
   publish-image:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write # edit the release notes to link the image
       packages: write # push to ghcr.io
     steps:
       - uses: actions/checkout@v4
@@ -24,6 +24,19 @@ jobs:
       - name: Stage the Docker build context
         # Native-packager writes the Dockerfile + app under target/docker/stage (no daemon needed).
         run: nix develop --command sbt Docker/stage
+
+      # The staged context is JVM bytecode plus a Dockerfile whose only RUN steps
+      # are chmod and useradd, and both native dependencies (blst-java,
+      # rocksdbjni) ship linux/aarch64 objects inside the same jars. So arm64
+      # needs no separate build -- only a runtime that can execute those two
+      # trivial RUN steps, which QEMU covers cheaply for 168 files.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
@@ -43,9 +56,43 @@ jobs:
             type=raw,value=latest
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: target/docker/stage
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      # The release itself is written by hand (GitHub's generated changelog), and
+      # it never said where the image is. Append that once the digest is known.
+      # Idempotent: re-running the workflow for a tag will not append twice.
+      - name: Link the image from the release notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ github.ref_name }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          if ! gh release view "$VERSION" >/dev/null 2>&1; then
+            echo "no release for $VERSION yet — skipping (create it, then re-run to link)"
+            exit 0
+          fi
+          body=$(gh release view "$VERSION" --json body -q .body)
+          if printf '%s' "$body" | grep -q '^## Container image'; then
+            echo "release notes already link the image — nothing to do"
+            exit 0
+          fi
+          v="${VERSION#v}"
+          printf '%s\n\n%s\n' "$body" "## Container image
+
+\`\`\`
+docker pull ghcr.io/cardano-hydrozoa/hydrozoa:${v}
+\`\`\`
+
+Also tagged \`${v%.*}\` and \`latest\`. Platforms: \`linux/amd64\`, \`linux/arm64\`.
+
+Digest: \`${DIGEST}\`" > /tmp/body.md
+          gh release edit "$VERSION" --notes-file /tmp/body.md
+          echo "linked ghcr.io/cardano-hydrozoa/hydrozoa:${v} from the $VERSION release notes"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -93,8 +93,14 @@ the image with `sbt Docker/stage` and pushes it to ghcr. No manual `docker push`
    git push origin vX.Y.Z
    ```
 
-6. **Watch the release workflow** (Actions → Release). It publishes three tags:
-   `ghcr.io/cardano-hydrozoa/hydrozoa:X.Y.Z`, `:X.Y`, and `:latest`.
+6. **Watch the release workflow** (Actions → Release). It publishes three tags —
+   `ghcr.io/cardano-hydrozoa/hydrozoa:X.Y.Z`, `:X.Y`, and `:latest` — each a multi-arch manifest,
+   and then appends a **Container image** section to the GitHub release notes with the pull command
+   and the digest.
+
+   That last step needs the release to exist. Create it (from the tag, with the generated changelog)
+   before or shortly after pushing the tag; if the workflow runs first it logs that it skipped, and
+   re-running it links the image. It never appends twice.
 
 7. **Verify** the published image:
 
@@ -125,8 +131,11 @@ the image with `sbt Docker/stage` and pushes it to ghcr. No manual `docker push`
   — without it `git describe` only considers annotated tags and falls back to an older one. The
   release version proper is the `hydrozoa X.Y.Z` line (from `build.sbt`), so this is provenance
   detail, not a mismatch.
-- **Architecture.** The image is currently linux/amd64 only. Multi-arch (adding linux/arm64 via
-  buildx) is a future improvement — it needs the native deps (blst-java, rocksdbjni) verified on
-  arm64 first.
+- **Architecture.** The image is a multi-arch manifest covering **linux/amd64** and
+  **linux/arm64**. No separate build is needed for arm64: the staged context is JVM bytecode, the
+  base image (`eclipse-temurin:25-jre`) is multi-arch, and both native dependencies ship aarch64
+  objects inside the same jars — `blst-java` as `supranational/blst/Linux/aarch64/libblst.so`,
+  `rocksdbjni` as `librocksdbjni-linux-aarch64.so`. The generated Dockerfile's only `RUN` steps are
+  `chmod` and `useradd` over 168 files, so QEMU emulation costs seconds rather than a rebuild.
 - **No pre-release automation.** Only `v*` tags publish. Ordinary `main` pushes and PRs run checks
   only (`.github/workflows/ci.yml`).


### PR DESCRIPTION
An operator running a node in Kubernetes on arm64 has nothing to pull today — the published image is a **single amd64 manifest**:

```
$ docker manifest inspect ghcr.io/cardano-hydrozoa/hydrozoa:0.1.8
mediaType: application/vnd.docker.distribution.manifest.v2+json
manifests: none (single manifest)
```

## arm64 needs no separate build

`RELEASE.md` warned that multi-arch "needs the native deps (blst-java, rocksdbjni) verified on arm64 first". That turns out to be stale — I checked both jars:

```
blst-java 0.3.2    supranational/blst/Linux/aarch64/libblst.so
rocksdbjni 9.7.3   librocksdbjni-linux-aarch64.so  (+ -musl)
```

Both ship aarch64 objects in the same artifact. Add that the staged context is JVM bytecode, `eclipse-temurin:25-jre` is multi-arch (`linux/arm64/v8` present), and the generated Dockerfile's only `RUN` steps are `chmod` and `useradd` over **168 files** — so QEMU covers arm64 in seconds rather than needing a native runner or a rebuild.

Hence just `platforms: linux/amd64,linux/arm64` plus QEMU/buildx setup.

## Verified

Built the arm64 image locally from the staged context:

- manifest reports `linux/arm64`
- `/opt/java/openjdk/bin/java` inside is **`ELF 64-bit LSB pie executable, ARM aarch64`**

**Not** verified: that it runs. This host registers no `binfmt_misc`, so `docker run --platform linux/arm64` fails with `exec format error` — a host limitation, not an image defect. First real runtime proof will be CI or an arm64 machine, and it's worth someone doing `docker run … version` on real hardware before we tell an operator to depend on it.

## Linking the image from the release notes

Releases are written by hand from GitHub's generated changelog and have never said where the image is — v0.1.8's notes are changelog-only. A final step now appends, once the digest is known:

```markdown
## Container image

    docker pull ghcr.io/cardano-hydrozoa/hydrozoa:0.1.9

Also tagged `0.1` and `latest`. Platforms: `linux/amd64`, `linux/arm64`.

Digest: `sha256:…`
```

- **Idempotent** — greps for the heading, so re-running the workflow won't append twice.
- **Tolerates either order** — if the release doesn't exist when the tag lands, it logs that it skipped; create the release and re-run to link.
- Needed `contents: write` on the job, which was `contents: read`.

I dry-ran the body-building shell locally; `${v%.*}` correctly yields `0.1` from `0.1.9`.

`RELEASE.md` updated: the architecture note now describes reality, and step 6 covers the notes step and its ordering caveat.