### PR TITLE
Two fixes a long-running head needs: a thread-unsafe hex cache, and a Restore bound that a growing log outlives

### DIFF
--- a/src/main/scala/hydrozoa/lib/cardano/cip116/JsonCodecs.scala
+++ b/src/main/scala/hydrozoa/lib/cardano/cip116/JsonCodecs.scala
@@ -102,7 +102,7 @@ object JsonCodecs {
 
             // AssetName codec (as plain value, not key)
             given assetNameValueEncoder: Encoder[AssetName] =
-                Encoder.encodeString.contramap(assetName => assetName.bytes.toHex)
+                Encoder.encodeString.contramap(assetName => ByteVector(assetName.bytes.bytes).toHex)
 
             given assetNameValueDecoder: Decoder[AssetName] =
                 Decoder.decodeString.map(s => AssetName.fromHex(s))
@@ -129,7 +129,7 @@ object JsonCodecs {
 
             // Encode/decode byte arrays as lowercase hex strings
             given byteStringEncoder: Encoder[ByteString] =
-                Encoder.encodeString.contramap(_.toHex)
+                Encoder.encodeString.contramap(bs => ByteVector(bs.bytes).toHex)
 
             given byteStringDecoder: Decoder[ByteString] =
                 Decoder.decodeString.emapTry { hexStr =>
@@ -147,7 +147,7 @@ object JsonCodecs {
 
             // Policy ID Codec
             given policyIdKeyEncoder: KeyEncoder[PolicyId] =
-                KeyEncoder.encodeKeyString.contramap(policyId => policyId.toHex)
+                KeyEncoder.encodeKeyString.contramap(policyId => ByteVector(policyId.bytes).toHex)
 
             // Script hash must be exactly 56 hex characters long
             given policyIdKeyDecoder: KeyDecoder[PolicyId] =
@@ -155,7 +155,9 @@ object JsonCodecs {
 
             // Asset Name Codec
             given assetNameKeyEncoder: KeyEncoder[AssetName] =
-                KeyEncoder.encodeKeyString.contramap(assetName => assetName.bytes.toHex)
+                KeyEncoder.encodeKeyString.contramap(assetName =>
+                    ByteVector(assetName.bytes.bytes).toHex
+                )
 
             // Asset name must be exactly 64 hexits
             given assetNameKeyDecoder: KeyDecoder[AssetName] =
@@ -224,7 +226,7 @@ object JsonCodecs {
             implicit val transactionInputEncoder: Encoder[TransactionInput] =
                 (ti: TransactionInput) =>
                     io.circe.Json.obj(
-                      "transaction_id" -> ti.transactionId.toHex.asJson,
+                      "transaction_id" -> ByteVector(ti.transactionId.bytes).toHex.asJson,
                       // N.B.: CIP-0116 defines this a UInt32; scalus defines it as signed.
                       "index" -> ti.index.toInt.asJson
                     )

--- a/src/main/scala/hydrozoa/multisig/ledger/remote/RemoteL2Ledger.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/remote/RemoteL2Ledger.scala
@@ -443,7 +443,15 @@ object RemoteL2Ledger {
         config: Config,
         tracer: ContraTracer[IO, RemoteL2LedgerEvent],
         requestTimeout: FiniteDuration = 5.seconds,
-        restoreTimeout: FiniteDuration = 10.minutes,
+        // A remote ledger answers a Restore by replaying its **whole** event log — there is no
+        // snapshot — so this bound has to exceed a full rebuild, and a rebuild grows linearly with
+        // the head's lifetime. Measured 2026-08-20 on the production box: ~8 minutes over ~42M
+        // events, growing ~2-3 minutes per day at that traffic. The old 10-minute default was
+        // therefore about two minutes from expiring, and an expiry here is terminal: `restoreTo`
+        // is deliberately not retried (a retry restarts the rebuild), and every boot calls it, so
+        // the node simply fails to start. Raised to leave room while the log keeps growing;
+        // the real fix is a ledger snapshot, which makes the rebuild bounded instead of linear.
+        restoreTimeout: FiniteDuration = 60.minutes,
         initialBackoff: FiniteDuration = 1.second,
         maxBackoff: FiniteDuration = 30.seconds,
     ): Resource[IO, RemoteL2Ledger] =


### PR DESCRIPTION
Two independent commits off `main`, two files, +16/−6. Both were found on the production box and both
bite a head that has been up for a while — one at load, one at the next restart.

## 1. Encoding a `ByteString` races on scalus's hex cache

`ByteString.toHex` is a `@threadUnsafe lazy val` (scalus 1.0.0, `ByteString.scala:45`): an
unsynchronised, non-volatile cache. That annotation is scalus telling us there is no publication
guarantee — a thread that reads the field while another is writing it can observe `null`.

We do exactly that. One `UserRequestWithId` is fanned out to the peer liaisons and the coil relay at
once, so several actors encode the same `ByteString` on different threads of a work-stealing pool.
The loser reads `null`, `Json.fromString` throws an NPE, the encoding actor dies, and consensus goes
with it: block production stops while admission stays up and sheds everything arriving. Roughly one
saturated run in five.

The fix computes the hex through scodec's `ByteVector`, which is thread-local, at the cost of one
allocation per encode. That is the pattern the encoders in this file that were already correct
follow.

**Five sites, not one.** The crash was observed at the `ByteString` encoder, but every site in
`JsonCodecs.scala` that reached the cache is converted: the `ByteString` encoder, both `AssetName`
encoders, the `PolicyId` key encoder, and `TransactionInput`'s transaction id. Whether a fan-out can
reach a given one *today* is not the criterion — the annotation makes them all unsafe, and the fix is
the same shape and the same cost at each.

Revertable to `_.toHex` if the annotation is ever dropped upstream.

## 2. `restoreTimeout` was about two minutes from expiring in production

A remote ledger answers a `Restore` by replaying its **whole** event log — there is no snapshot — so
the bound has to exceed a full rebuild, and a rebuild grows linearly with how long the head has been
running.

Measured on the production box, 2026-08-20: **~8 minutes over ~42M events, growing 2–3 minutes per
day** at that traffic. The default was 10 minutes.

An expiry here is terminal, not slow: `restoreTo` is deliberately not retried (`retryOnTimeout =
false`, because a retry restarts the rebuild from the beginning), and every boot calls it. So the
node does not recover late — it fails to start, and stays failed, with the margin shrinking every day
the head stays up.

Raised to 60 minutes. That is a stopgap sized to leave room while the log keeps growing, not a
principled value; the real fix is a ledger snapshot, which makes the rebuild bounded instead of
linear. The comment at the call site records the measurement so the next person to look has the
growth rate rather than a bare number.

## Scope

Neither change alters a wire or storage format, and neither is a throughput change. Both are commits
extracted from `loadtest/prod-box-tuning`, where they were sitting alongside performance work that is
not ready to merge.

## Verification

Full core suite green on this branch (351 tests, 0 failures), matching a control run on `main`.
`sbt fmtCheckAll` and `sbt lintCheckAll` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)