### PR TITLE
feat(bootstrap): give head peers a screener uri and keep it off coils

### DIFF
--- a/docs/spec/l2-isomorphism.md
+++ b/docs/spec/l2-isomorphism.md
@@ -231,6 +231,8 @@ divergence, not a spec change.
   assigned; a rejection surfaces to the user, while a transport failure fails open (the request
   proceeds unscreened — the remote ledger still checks authoritatively at submission). Without the
   URI, remote screening remains a passthrough.
+  Screening is head-only: it runs in `RequestSequencer`, which coil peers do not have, so
+  `keygen-fleet` writes `remoteScreenerUri` into head private configs and omits it from coils'.
 - **`l2Ledger` and `identityIsomorphism` are pinned by the bootstrap tooling** to `cardano-eutxo`
   and `false` (`bootstrap/Bootstrap.scala`, `mkSharedHeadConfig`); surfacing them as bootstrap
   config fields is pending.

--- a/docs/user-guide/DEPLOYMENT.md
+++ b/docs/user-guide/DEPLOYMENT.md
@@ -201,6 +201,8 @@ period), `nodeOperationMultisigConfig` (rate limits, Cardano polling period),
 `blockfrostApiKey`, `adminUsername`, `adminPassword`, `httpHost`, `httpPort`. `remoteLedgerUri` is
 **optional and unused for the EUTXO ledger** — it is read only on the `any-remote` path, so an
 EUTXO node may omit it.
+`remoteScreenerUri` is read on the same path and only by a head peer, whose `RequestSequencer`
+screens each request before assigning it a RequestId; `keygen-fleet` omits it from coil configs.
 
 ### Generating a head's configuration
 

--- a/src/main/resources/scaffold/peer-private.template.json
+++ b/src/main/resources/scaffold/peer-private.template.json
@@ -19,6 +19,7 @@
   },
   "blockfrostApiKey": "preview00000000000000000000000000000000",
   "remoteLedgerUri": "ws://127.0.0.1:3001/ws",
+  "remoteScreenerUri": "http://127.0.0.1:3003",
   "adminUsername": "admin",
   "adminPassword": "welcome",
   "httpHost": "0.0.0.0",

--- a/src/main/scala/hydrozoa/bootstrap/Bootstrap.scala
+++ b/src/main/scala/hydrozoa/bootstrap/Bootstrap.scala
@@ -814,7 +814,12 @@ object GenerateKeyPair:
         }
     } yield ()
 
-    /** Pure template edit shared with tests. */
+    /** Pure template edit shared with tests.
+      *
+      * A coil peer drops `remoteScreenerUri`: screening runs in the RequestSequencer, which only
+      * head peers have, so the field would sit in a coil's config describing an endpoint it never
+      * calls.
+      */
     private[bootstrap] def fillPrivateConfig(
         template: Json,
         role: Role,
@@ -831,10 +836,13 @@ object GenerateKeyPair:
         }
         for {
             obj <- template.asObject.toRight("template is not a JSON object")
-        } yield Json.fromJsonObject(
-          obj
-              .add("ownPeerPrivate", Json.obj(walletField -> mkWallet(vKeyHex, sKeyHex)))
-        )
+            withWallet = obj
+                .add("ownPeerPrivate", Json.obj(walletField -> mkWallet(vKeyHex, sKeyHex)))
+            filled = role match {
+                case Role.Head => withWallet
+                case Role.Coil => withWallet.remove("remoteScreenerUri")
+            }
+        } yield Json.fromJsonObject(filled)
     }
 
     private def mkHex(bytes: Array[Byte]): String = bytes.map("%02x".format(_)).mkString

--- a/src/test/scala/hydrozoa/bootstrap/GenerateKeyPairOutputsTest.scala
+++ b/src/test/scala/hydrozoa/bootstrap/GenerateKeyPairOutputsTest.scala
@@ -112,6 +112,24 @@ class GenerateKeyPairOutputsTest extends AnyFunSuite {
         }
     }
 
+    test("the screener uri survives a head fill and is dropped from a coil's") {
+        val head = GenerateKeyPair
+            .fillPrivateConfig(template, Role.Head, hex('1'), hex('a'))
+            .fold(e => fail(s"fill failed: $e"), identity)
+        val coil = GenerateKeyPair
+            .fillPrivateConfig(template, Role.Coil, hex('3'), hex('a'))
+            .fold(e => fail(s"fill failed: $e"), identity)
+
+        // The template has to carry it, or the head check passes vacuously.
+        val inTemplate = template.hcursor.downField("remoteScreenerUri").succeeded
+        val inHead = head.hcursor.downField("remoteScreenerUri").succeeded
+        val inCoil = coil.hcursor.downField("remoteScreenerUri").succeeded
+        // Only that field goes: the coil keeps its own ledger uri.
+        val coilKeepsLedgerUri = coil.hcursor.downField("remoteLedgerUri").succeeded
+
+        assert(inTemplate && inHead && !inCoil && coilKeepsLedgerUri)
+    }
+
     test("a coil-filled template decodes into an OwnCoilPeerPrivate identity") {
         given HeadPeers = headPeers
         given CoilPeers = coilPeers


### PR DESCRIPTION
A generated head peer had no `remoteScreenerUri`, so every `any-remote` head fell back to
`RemoteL2Screener.passthrough` — requests reached a RequestId unscreened and were caught only at
submission. The scaffold template now carries the field, and `keygen-fleet` keeps it off coils.

## Head-only, and why

Screening runs in `RequestSequencer`, which head peers alone construct — `Serve.scala:497` raises
`"RequestSequencer required on head peers"`, and a coil peer runs no user-facing HTTP server at all
(`Serve.scala:406`), so it never has a request to screen. A `remoteScreenerUri` in a coil's private
config would name an endpoint nothing calls: dead config that reads as live, which is the shape of
mistake that already cost us a debugging session when a coil's `remoteLedgerUri` pointed at the
wrong port.

So `fillPrivateConfig` removes the key for `Role.Coil`. One template, both roles, no manual edit
after generation.

## The value

`http://127.0.0.1:3003`, matching the screener's own `config.default.json`. It is a **base** URI —
`RemoteL2Screener` appends `/screen/tx` and `/screen/deposit` itself — and **HTTP**, not the ws the
ledger uses.

## Tests

`GenerateKeyPairOutputsTest` pins both directions: the field survives a head fill and is gone from a
coil's, while the coil keeps its `remoteLedgerUri`. It also asserts the template carries the field,
so the head case cannot pass vacuously if the template ever loses it.

Verified with a full `core/testOnly *` (364 passed) and `build-werror` from a **deleted** classes
directory — zinc will otherwise reuse a non-`-Werror` compile and report a false pass.

## Docs

`docs/spec/l2-isomorphism.md` already described `remoteScreenerUri` but not that it is head-only;
`DEPLOYMENT.md`'s private-config field list did not mention it. Both updated. The whitepaper does not
cover the screener, so nothing to change there.