### PR TITLE
chore(release): 0.1.9

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,14 +85,19 @@ jobs:
             exit 0
           fi
           v="${VERSION#v}"
-          printf '%s\n\n%s\n' "$body" "## Container image
-
-\`\`\`
-docker pull ghcr.io/cardano-hydrozoa/hydrozoa:${v}
-\`\`\`
-
-Also tagged \`${v%.*}\` and \`latest\`. Platforms: \`linux/amd64\`, \`linux/arm64\`.
-
-Digest: \`${DIGEST}\`" > /tmp/body.md
+          # Every line stays inside the `run:` block scalar — a line at column 0
+          # would end the scalar and leave the workflow file unparseable. The
+          # fences and the code spans are literal backticks, so each printf
+          # format string is single-quoted.
+          fence='```'
+          {
+            printf '%s\n\n' "$body"
+            printf '## Container image\n\n'
+            printf '%s\n' "$fence"
+            printf 'docker pull ghcr.io/cardano-hydrozoa/hydrozoa:%s\n' "$v"
+            printf '%s\n\n' "$fence"
+            printf 'Also tagged `%s` and `latest`. Platforms: `linux/amd64`, `linux/arm64`.\n\n' "${v%.*}"
+            printf 'Digest: `%s`\n' "$DIGEST"
+          } > /tmp/body.md
           gh release edit "$VERSION" --notes-file /tmp/body.md
           echo "linked ghcr.io/cardano-hydrozoa/hydrozoa:${v} from the $VERSION release notes"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -27,7 +27,7 @@ the image with `sbt Docker/stage` and pushes it to ghcr. No manual `docker push`
    as `version := "X.Y.Z"` and in prose:
 
    ```bash
-   grep -rn "0\.1\.7" --include=* . | grep -vE "^\./(target|\.git|head)/"
+   grep -rn "0\.1\.8" --include=* . | grep -vE "^\./(target|\.git|head)/"
    ```
 
    Not bumped: `HydrozoaRoutes.apiVersion` + `docs/openapi*.yaml` (the API-contract version,

--- a/build.sbt
+++ b/build.sbt
@@ -472,7 +472,7 @@ inThisBuild(
   List(
     // Release version — drives the Docker image tag, `hydrozoa.BuildInfo.version`, and `GET
     // /version`. Bump here for a release (see RELEASE.md), then tag `v<version>`.
-    version := "0.1.8",
+    version := "0.1.9",
     scalaVersion := "3.3.7",
     semanticdbEnabled := true,
     semanticdbVersion := scalafixSemanticdb.revision

--- a/docs/user-guide/DEPLOYMENT.md
+++ b/docs/user-guide/DEPLOYMENT.md
@@ -124,13 +124,13 @@ under it. Then load the CLI alias and check you are on the version you expect:
 source ./hydrozoa.sh   # sets the `hydrozoa` alias + HYDROZOA_HOME (this folder, an absolute path)
 
 hydrozoa version       # verify the image you are running
-#   hydrozoa 0.1.8
-#   git:   v0.1.8
+#   hydrozoa 0.1.9
+#   git:   v0.1.9
 #   built: 2026-07-28 14:00:37.834-0600
 ```
 
-(The `git:` line is `git describe` provenance; a published image built from the `v0.1.8` tag reads a
-clean `v0.1.8`. A locally built image between releases shows the distance from the newest tag, e.g.
+(The `git:` line is `git describe` provenance; a published image built from the `v0.1.9` tag reads a
+clean `v0.1.9`. A locally built image between releases shows the distance from the newest tag, e.g.
 `v0.1.0-10-gaa9d7c69`.)
 
 Need a version that isn't in the registry? Build it from this repo — see §3.
@@ -420,8 +420,8 @@ finalization) appears in the same section as the head progresses.
 build (§3) is already tagged `…:latest`, so it is picked up without either:
 
 ```bash
-HYDROZOA_VERSION=0.1.8 just head-up                          # a specific published release
-HYDROZOA_IMAGE=cardano-hydrozoa/hydrozoa:0.1.8 just head-up  # a specific/other image name
+HYDROZOA_VERSION=0.1.9 just head-up                          # a specific published release
+HYDROZOA_IMAGE=cardano-hydrozoa/hydrozoa:0.1.9 just head-up  # a specific/other image name
 ```
 
 **Another head** — each head directory carries its own `docker-compose.yml`, so switch heads by

--- a/src/main/resources/scaffold/hydrozoa.sh
+++ b/src/main/resources/scaffold/hydrozoa.sh
@@ -13,7 +13,7 @@
 # scaffolded workspace — resolved to an absolute path, so the alias mounts correctly no matter which
 # directory you run it from. Override HYDROZOA_HOME (to an absolute path) or HYDROZOA_VERSION before
 # sourcing, or edit the defaults below.
-: "${HYDROZOA_VERSION:=0.1.8}"   # published image tag (ghcr.io/cardano-hydrozoa/hydrozoa)
+: "${HYDROZOA_VERSION:=0.1.9}"   # published image tag (ghcr.io/cardano-hydrozoa/hydrozoa)
 : "${HYDROZOA_HOME:=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)}"   # head directory (absolute)
 export HYDROZOA_VERSION HYDROZOA_HOME
 


### PR DESCRIPTION
Cuts 0.1.9 from `main` (`ead2086a`).

**Blocker fixed first.** `release.yml` has not parsed since #654: the image-linking step built the
appended notes section as a multi-line shell string whose continuation lines sat at column 0, which
terminates the `run:` block scalar. Every push since has logged a 0s "workflow file issue" failure,
and a `v0.1.9` tag would have published nothing. The section is now built with indented `printf`
calls; `yq` parses all three workflows.

**Bump.** `build.sbt` `version`, plus the two files that pin the image tag by hand —
`scaffold/hydrozoa.sh`'s `HYDROZOA_VERSION` default and DEPLOYMENT.md's version/run examples.
RELEASE.md's straggler grep now names 0.1.8.

RELEASE.md steps 2 and 3 need no action: no `cardano-onchain/` or `plutus.json` change since
v0.1.8 and Scalus is still 1.0.0, so the baked reference UTxOs stay valid; `logback-docker.xml` is
unchanged.

### What's in 0.1.9
- crash fixes: scalus's thread-unsafe hex cache, a `Restore` bound a growing log outlived, and a
  node crash that passed as a clean start
- real RocksDB / consensus defaults, and a protobuf request journal
- remote deposit + L2 transaction screening via the ledger's `/screen` endpoints
- a head-only screener uri in bootstrap
- multi-arch (`linux/arm64`) release images