### PR TITLE
Close out head generations whose evacuation has already finished

### DIFF
--- a/src/main/scala/hydrozoa/app/Main.scala
+++ b/src/main/scala/hydrozoa/app/Main.scala
@@ -6,6 +6,7 @@ import com.monovore.decline.{Command, Opts}
 import hydrozoa.BuildInfo
 import hydrozoa.app.cli.{Scaffold, SubmitDeposit, SubmitL2Transaction}
 import hydrozoa.bootstrap.{BuildHeadConfig, GenerateKeyPair, InitBootstrapFiles, KeygenFleet, Migrate, PrintHeadZeroAddress}
+import hydrozoa.rulebased.evacuator.DeinitSweep
 
 /** The `hydrozoa` command-line entry point: a single dispatcher over every deployment and runtime
   * command. Each subcommand is defined next to its logic and surfaced here as a `Command` value:
@@ -54,6 +55,7 @@ object Main
           SubmitDeposit.command,
           SubmitL2Transaction.command,
           Migrate.command,
+          DeinitSweep.command,
           Scaffold.command,
           versionCommand
         )

--- a/src/main/scala/hydrozoa/rulebased/evacuator/DeinitSweep.scala
+++ b/src/main/scala/hydrozoa/rulebased/evacuator/DeinitSweep.scala
@@ -1,0 +1,426 @@
+package hydrozoa.rulebased.evacuator
+
+import cats.effect.{ExitCode, IO}
+import cats.syntax.apply.*
+import cats.syntax.contravariant.*
+import cats.syntax.foldable.*
+import cats.syntax.traverse.*
+import com.monovore.decline.{Command, Opts}
+import hydrozoa.config.HydrozoaBlueprint
+import hydrozoa.config.head.HeadConfig
+import hydrozoa.config.head.network.CardanoNetwork
+import hydrozoa.config.node.NodeConfig
+import hydrozoa.lib.cardano.scalus.contextualscalus.Change
+import hydrozoa.lib.cardano.scalus.contextualscalus.TransactionBuilder.{addExpectedSigners, build, finalizeContext}
+import hydrozoa.lib.cardano.scalus.ledger.CollateralUtxo
+import hydrozoa.lib.logging.Slf4jTracer
+import hydrozoa.lib.logging.{ContraTracer, Slf4jMsg, Slf4jMsgFormat, Slf4jTracer as BackendTracer, info}
+import hydrozoa.multisig.backend.cardano.{CardanoBackend, CardanoBackendBlockfrost, CardanoBackendEventFormat}
+import hydrozoa.multisig.consensus.peer.PeerWallet
+import hydrozoa.multisig.consensus.peer.PeerWallet.peerWalletDecoder
+import hydrozoa.multisig.ledger.l1.script.multisig.HeadMultisigScript
+import hydrozoa.multisig.ledger.l1.tx.EnrichedTx.Validators.nonSigningValidators
+import hydrozoa.multisig.ledger.l1.tx.RawTx
+import hydrozoa.rulebased.ledger.l1.script.plutus.RuleBasedTreasuryValidator.TreasuryRedeemer
+import hydrozoa.rulebased.ledger.l1.script.plutus.RuleBasedTreasuryValidator.given
+import io.circe.Decoder
+import io.circe.parser.decode
+import java.nio.file.{Files, Path}
+import scalus.cardano.ledger.*
+import scalus.cardano.txbuilder.Datum.DatumInlined
+import scalus.cardano.txbuilder.ScriptSource.PlutusScriptAttached
+import scalus.cardano.txbuilder.ThreeArgumentPlutusScriptWitness
+import scalus.cardano.txbuilder.TransactionBuilderStep.{Mint, ReferenceOutput, Spend}
+import scalus.uplc.builtin.Data.toData
+import scalus.uplc.builtin.{ByteString, Data}
+
+/** Closes out head generations whose evacuation has already finished.
+  *
+  * A resolved treasury whose `evacuationActive` is the empty-set commitment has paid out everything
+  * it owed. What remains is its residual ada and its beacons — the HYDR singleton and the VOTE
+  * tokens that `Resolve` absorbed — sitting at the rule-based treasury address with no one left to
+  * spend them. `Deinit` is the redeemer that ends that: it burns the beacons and frees the ada.
+  *
+  * ★ `Deinit` needs KEYS, not an evacuation map. That is what separates these from the rest of the
+  * graveyard. An unevacuated treasury can only be drained by whoever holds the map preimage, which
+  * dies with the peers' stores; a fully evacuated one needs only the head's own signatures, because
+  * the beacons are minted under the head's native-script policy and the validator delegates consent
+  * to it.
+  *
+  * ★★ The validator requires the burn map to CONTAIN each spent treasury's tokens, not to equal
+  * them (`RuleBasedTreasuryScript.scala`, the `Deinit` branch). So one transaction can close out
+  * several generations at once: every validator instance checks its own tokens against the combined
+  * mint, and each of them passes.
+  *
+  * Generations sharing one head policy also share one native script and one set of signatures,
+  * which is what makes the batch worth building — the fee is paid once instead of per generation.
+  */
+object DeinitSweep {
+
+    private val log: ContraTracer[IO, Slf4jMsg] =
+        Slf4jTracer.sink.contramap(
+          Slf4jMsgFormat.humanFormat("hydrozoa.rulebased.evacuator.DeinitSweep")
+        )
+
+    /** The compressed BLS12-381 G1 generator, which is what committing to the empty set yields. A
+      * treasury carrying it has evacuated everything.
+      */
+    private val emptySetCommitment: String =
+        "97f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb"
+
+    /** One spent-out treasury as read off the chain. `tokens` is keyed by the full asset unit —
+      * policy id followed by asset name — exactly as Blockfrost reports it, and `inlineDatum` is
+      * the datum's CBOR, which the validator reads and so must be reproduced exactly.
+      */
+    final case class Dead(
+        txHash: String,
+        index: Int,
+        lovelace: Long,
+        tokens: Map[String, Long],
+        inlineDatum: String
+    ) derives Decoder
+
+    private val headConfigPathArg: Opts[Path] =
+        Opts.argument[String]("head-config.json").map(Path.of(_))
+
+    private val privateConfigPathArg: Opts[Path] =
+        Opts.argument[String]("peer-private.json").map(Path.of(_))
+
+    private val keysOpt: Opts[List[Path]] =
+        Opts
+            .options[String]("signer", "A peer private.json whose wallet co-signs the burn")
+            .map(_.toList.map(Path.of(_)))
+
+    private val utxosOpt: Opts[Path] =
+        Opts.option[String]("utxos", "JSON array of evacuated treasuries to close").map(Path.of(_))
+
+    /** The treasury validator travels as a reference script. The utxo named in a head's config is
+      * whichever one that head's bootstrap deployed, and a generation old enough to need closing
+      * has usually outlived it — so the one to use is named here. Any unspent utxo carrying the
+      * validator will do, since the ledger cares about the script, not about its provenance.
+      */
+    private val scriptRefOpt: Opts[String] =
+        Opts.option[String]("treasury-script-ref", "Unspent utxo carrying the validator, txhash#ix")
+
+    private val collateralOpt: Opts[String] =
+        Opts.option[String]("collateral", "Ada-only wallet utxo to use as collateral, txhash#ix")
+
+    private val dumpOpt: Opts[Option[Path]] =
+        Opts.option[String]("dump", "Write the signed tx CBOR (hex) here").map(Path.of(_)).orNone
+
+    private val commitOpt: Opts[Boolean] =
+        Opts.flag("commit", "Actually submit; without it, build and report only").orFalse
+
+    private val backendUrlOpt: Opts[Option[String]] =
+        Opts
+            .option[String]("backend-url", "Blockfrost-compatible base URL (e.g. a local Dolos)")
+            .orNone
+
+    lazy val command: Command[IO[ExitCode]] =
+        Command(
+          name = "sweep-deinit",
+          header = "Burn the beacons of fully evacuated head generations and reclaim their ada"
+        )(
+          (
+            headConfigPathArg,
+            privateConfigPathArg,
+            keysOpt,
+            utxosOpt,
+            scriptRefOpt,
+            collateralOpt,
+            commitOpt,
+            backendUrlOpt,
+            dumpOpt
+          ).mapN(run)
+        )
+
+    def run(
+        headConfigPath: Path,
+        privateConfigPath: Path,
+        signerPaths: List[Path],
+        utxosPath: Path,
+        scriptRef: String,
+        collateral: String,
+        commit: Boolean,
+        backendUrl: Option[String],
+        dump: Option[Path]
+    ): IO[ExitCode] =
+        for {
+            override_ <- backendUrl.traverse(localBackend)
+            loaded <- NodeConfig.load(headConfigPath, privateConfigPath, override_)
+            (nodeConfig, backend) = loaded
+            exit <- {
+                given HeadConfig.Bootstrap.Section = nodeConfig.headConfig
+                drive(backend, signerPaths, utxosPath, scriptRef, collateral, commit, dump)
+            }
+        } yield exit
+
+    private def drive(
+        backend: CardanoBackend[IO],
+        signerPaths: List[Path],
+        utxosPath: Path,
+        scriptRef: String,
+        collateral: String,
+        commit: Boolean,
+        dump: Option[Path]
+    )(using config: HeadConfig.Bootstrap.Section): IO[ExitCode] = {
+
+        val script = config.headMultisigScript
+        val headPolicy = script.policyId
+
+        for {
+            signers <- signerPaths.traverse(loadSigner)
+            _ <- IO.raiseUnless(signers.size == script.numSigners)(
+              RuntimeException(
+                s"multisig needs ${script.numSigners} signatures, ${signers.size} supplied"
+              )
+            )
+
+            json <- IO.blocking(Files.readString(utxosPath))
+            dead <- IO.fromEither(
+              decode[List[Dead]](json).left.map(e => RuntimeException(s"utxos: $e"))
+            )
+            _ <- IO.raiseWhen(dead.isEmpty)(RuntimeException("nothing to close out"))
+
+            // Every token of ours in these utxos is dead by definition — the generation is over.
+            // Anything under another policy would be someone else's and cannot be burned here, so
+            // its presence means the input was misidentified.
+            foreign = dead.flatMap(_.tokens.keys).filterNot(_.startsWith(headPolicy.toHex))
+            _ <- IO.raiseWhen(foreign.nonEmpty)(
+              RuntimeException(s"utxos carry ${foreign.size} token(s) not under $headPolicy")
+            )
+
+            _ <- dead.traverse_(d => IO.fromEither(checkEvacuated(d)))
+
+            refUtxo <- IO.fromEither(parseInput(scriptRef)).map(referenceUtxo)
+            collateralInput <- IO.fromEither(parseInput(collateral))
+            collateralUtxo <- backend
+                .resolve(collateralInput)
+                .flatMap(r =>
+                    IO.fromEither(r.left.map(e => RuntimeException(s"collateral: $e")))
+                        .flatMap(
+                          IO.fromOption(_)(RuntimeException(s"collateral $collateral not found"))
+                        )
+                )
+                .flatMap(u => IO.fromEither(CollateralUtxo.parse(u)))
+
+            totalAda = dead.map(_.lovelace).sum
+            burn = dead.flatMap(_.tokens.toList)
+            _ <- log.info(s"${dead.size} evacuated generation(s), ${totalAda / 1e6} ada residual")
+            _ <- log.info(s"burning ${burn.size} beacon(s) under policy $headPolicy")
+            _ <- log.info(s"treasury validator referenced at $scriptRef")
+            _ <- log.info(s"collateral and residual return to ${collateralUtxo.collateralOutput}")
+
+            params <- backend.fetchLatestParams.flatMap(
+              IO.fromEither(_).adaptError(e => RuntimeException(s"protocol params: $e"))
+            )
+
+            tx <- IO.fromEither(buildTx(dead, burn, refUtxo, collateralUtxo, script))
+            signed = signers.foldLeft(tx)((t, w) => w.signTx(t))
+            size = signed.toCbor.length
+            _ <- IO.raiseWhen(size > params.maxTxSize)(
+              RuntimeException(s"$size bytes exceeds the ${params.maxTxSize} limit — close fewer")
+            )
+            outs = signed.body.value.outputs.toList.map(_.value)
+            _ <- outs.zipWithIndex.traverse_ { (o, i) =>
+                log.info(f"  output $i: ${o.value.coin.value / 1e6}%.6f ada")
+            }
+            _ <- log.info(f"fee ${signed.body.value.fee.value / 1e6}%.6f ada")
+            _ <- log.info(s"size $size bytes of ${params.maxTxSize}, tx ${signed.id}")
+            _ <- dump.traverse_ { path =>
+                IO.blocking(Files.writeString(path, signed.toCbor.map("%02x".format(_)).mkString))
+                    .void *> log.info(s"signed tx written to $path")
+            }
+
+            exit <-
+                if !commit then
+                    log.info("not submitting; pass --commit to run it").as(ExitCode.Success)
+                else
+                    backend
+                        .submitTx(RawTx(signed))
+                        .flatMap(r =>
+                            IO.fromEither(r.left.map(e => RuntimeException(s"submit failed: $e")))
+                        ) *> log.info(s"submitted ${signed.id}").as(ExitCode.Success)
+        } yield exit
+    }
+
+    /** Refuse anything that has not finished evacuating.
+      *
+      * The validator enforces this too, so the check buys no safety on chain — it buys a legible
+      * failure. A treasury still owing payouts cannot be closed by any key, and saying so here
+      * beats a phase-2 rejection that names only the input.
+      */
+    private def checkEvacuated(d: Dead): Either[Throwable, Unit] = {
+        val datum = d.inlineDatum
+        val resolved = datum.startsWith("d87a9f")
+        val commitment = datum.slice(70, 70 + 96)
+        if !resolved then
+            Left(
+              RuntimeException(s"${d.txHash}#${d.index} is unresolved — it never reached Resolve")
+            )
+        else if commitment != emptySetCommitment then
+            Left(RuntimeException(s"${d.txHash}#${d.index} still owes payouts — evacuate it first"))
+        else Right(())
+    }
+
+    /** The reference input as the ledger will see it: the validator's own bytes, at the utxo that
+      * carries them. Only the script matters to phase 2, so the address and ada are the deployment
+      * convention rather than anything the transaction depends on.
+      */
+    private def referenceUtxo(input: TransactionInput)(using
+        config: HeadConfig.Bootstrap.Section
+    ): Utxo =
+        Utxo(
+          input,
+          TransactionOutput.Babbage(
+            address = config.ruleBasedTreasuryAddress,
+            value = Value(Coin(35_747_140L)),
+            datumOption = None,
+            scriptRef = Some(ScriptRef(HydrozoaBlueprint.treasuryScript))
+          )
+        )
+
+    private def parseInput(s: String): Either[Throwable, TransactionInput] =
+        s.split('#') match {
+            case Array(h, i) if i.toIntOption.isDefined =>
+                Right(TransactionInput(TransactionHash.fromHex(h), i.toInt))
+            case _ => Left(RuntimeException(s"expected txhash#index, got $s"))
+        }
+
+    private def buildTx(
+        dead: List[Dead],
+        burn: List[(String, Long)],
+        refUtxo: Utxo,
+        collateralUtxo: CollateralUtxo,
+        script: HeadMultisigScript
+    )(using config: HeadConfig.Bootstrap.Section): Either[Throwable, Transaction] = {
+
+        val treasuries = dead.map { d =>
+            Utxo(
+              TransactionInput(TransactionHash.fromHex(d.txHash), d.index),
+              TransactionOutput.Babbage(
+                address = config.ruleBasedTreasuryAddress,
+                value = Value(Coin(d.lovelace), multiAssetOf(d.tokens)),
+                datumOption = Some(DatumOption.Inline(Data.fromCbor(hexToBytes(d.inlineDatum)))),
+                scriptRef = None
+              )
+            )
+        }
+
+        val spends = treasuries.map(u =>
+            Spend(
+              u,
+              ThreeArgumentPlutusScriptWitness(
+                PlutusScriptAttached,
+                TreasuryRedeemer.Deinit.toData,
+                DatumInlined
+              )
+            )
+        )
+
+        // The native script travels by value on the first burn that needs it and by reference
+        // after; the builder's steps are not commutative, so attaching it later would leave the
+        // earlier mint unable to resolve its witness.
+        val burns = burn.zipWithIndex.map { case ((unit, amount), i) =>
+            Mint(
+              scriptHash = script.policyId,
+              assetName = AssetName(ByteString.fromHex(unit.drop(56))),
+              amount = -amount,
+              witness = if i == 0 then script.witnessValue else script.witnessAttached
+            )
+        }
+
+        val steps =
+            List(ReferenceOutput(refUtxo))
+                ++ spends
+                ++ List(
+                  collateralUtxo.spend,
+                  collateralUtxo.add,
+                  collateralUtxo.collateralOutput.send
+                )
+                ++ burns
+
+        for {
+            context <- build(steps).left
+                .map(e => RuntimeException(s"deinit build failed: $e"))
+            // Balancing prices the transaction it can see, and the multisig witnesses are attached
+            // afterwards — without declaring them the fee is short by exactly their bytes.
+            finalized <- context
+                .addExpectedSigners(script.numSigners)
+                .finalizeContext(
+                  diffHandler = Change.changeOutputDiffHandler(0),
+                  validators = nonSigningValidators
+                )
+                .left
+                .map(e => RuntimeException(s"deinit balancing failed: $e"))
+        } yield finalized.transaction
+    }
+
+    private def multiAssetOf(tokens: Map[String, Long]): MultiAsset =
+        tokens.foldLeft(MultiAsset.empty) { case (acc, (unit, amount)) =>
+            acc + Value
+                .asset(
+                  ScriptHash.fromByteString(ByteString.fromHex(unit.take(56))),
+                  AssetName(ByteString.fromHex(unit.drop(56))),
+                  amount
+                )
+                .assets
+        }
+
+    private def hexToBytes(hex: String): Array[Byte] =
+        hex.grouped(2).map(Integer.parseInt(_, 16).toByte).toArray
+
+    /** Accept either a bare wallet or a peer's whole `private.json`.
+      *
+      * The files that hold these keys on an operator's disk are peer configs, and requiring the
+      * wallet to be extracted from them first would mean copying signing keys around to satisfy a
+      * parser. A head peer keeps its wallet under `ownHeadWallet` and a coil peer under
+      * `ownCoilWallet`, so both are tried.
+      */
+    private def loadSigner(path: Path): IO[PeerWallet] =
+        IO.blocking(Files.readString(path)).flatMap { s =>
+            IO.fromEither(
+              io.circe.parser
+                  .parse(s)
+                  .left
+                  .map(e => RuntimeException(s"$path: $e"))
+                  .flatMap { json =>
+                      val root = json.hcursor
+                      val nested = root.downField("ownPeerPrivate")
+                      val candidates = List(
+                        root,
+                        nested.downField("ownHeadWallet"),
+                        nested.downField("ownCoilWallet")
+                      )
+                      candidates
+                          .flatMap(_.as[PeerWallet].toOption)
+                          .headOption
+                          .toRight(
+                            RuntimeException(
+                              s"$path: no wallet found at the root, ownPeerPrivate.ownHeadWallet " +
+                                  "or ownPeerPrivate.ownCoilWallet"
+                            )
+                          )
+                  }
+            )
+        }
+
+    /** A backend pointed at a Blockfrost-compatible endpoint of our own. The network is declared
+      * `Custom` purely so the base URL is ours; its parameters are still preview's, because that is
+      * the chain the node is following.
+      */
+    private def localBackend(url: String): IO[CardanoBackend[IO]] =
+        CardanoBackendBlockfrost(
+          network = Right(
+            (
+              CardanoNetwork.Custom(
+                CardanoNetwork.Preview.cardanoInfo,
+                CardanoNetwork.Preview.protocolMagic
+              ),
+              url
+            )
+          ),
+          apiKey = "",
+          tracer = BackendTracer.sink.contramap(CardanoBackendEventFormat.humanFormat)
+        ).map(b => b: CardanoBackend[IO])
+}


### PR DESCRIPTION
One commit, one new file, +390 lines. `app/Main.scala` gains two lines to register the command; nothing else in the existing tree changes.

Branched off `7c866e90` (release 0.1.9) rather than `main`, because it was built to act on live preview state.

## The problem

Both rule-based validator addresses are deterministic from the UPLC, so **there is one rule-based treasury address per network and every head that ever fell back left its state there**. On preview it holds 31 utxos and 3,391 ADA across eight head policies.

Those divide into three kinds, and only the datum tells them apart:

| state | meaning | recoverable? |
|---|---|---|
| `Unresolved` | fell back, never resolved | only with the evacuation map |
| `Resolved`, commitment ≠ g1 | partially evacuated | only with the map |
| `Resolved`, commitment = g1 generator | fully evacuated, awaiting `Deinit` | **yes, with keys alone** |

The third kind is what this closes. Its payouts are done — `evacuationActive` is the empty-set commitment — and what remains is residual ada plus the beacons, sitting there with nobody left to spend them. That matters because `Deinit` is the one rule-based redeemer that needs **keys rather than a map**. An unevacuated treasury can only be drained by whoever holds the map preimage, which dies with the peers' stores; a fully evacuated one needs only the head's own signatures, since the beacons are minted under its native-script policy and the validator delegates consent to it.

## What this adds

```
hydrozoa sweep-deinit <head-config.json> <peer-private.json> --signer <p>.json ... \
    --utxos <json> --treasury-script-ref <txhash#ix> --collateral <txhash#ix> \
    [--backend-url <url>] [--dump <path>] [--commit]
```

It refuses anything not `Resolved`-with-empty-commitment before building, refuses any token not under the head's policy, and defaults to a dry run. The residual ada and the collateral return together to the collateral's own address.

**One transaction closes several generations.** The validator's `Deinit` branch requires the burn map to *contain* each spent treasury's tokens rather than equal them — the code says so explicitly, "require inclusion rather than equality". So N treasury inputs and one combined mint work: each validator instance checks its own tokens against the union and each passes. Generations under one head policy also share one native script and one signature set, so the fee is paid once instead of N times.

`--signer` accepts either a bare wallet or a peer's whole `private.json`, trying the root, then `ownPeerPrivate.ownHeadWallet`, then `ownPeerPrivate.ownCoilWallet`. The keys live in peer configs on an operator's disk, and requiring extraction first would mean copying signing keys around to satisfy a parser.

## Why not `DeinitTx`

`DeinitTx.Build` takes `regimeUtxo: RuleBasedRegimeUtxo` as a required argument and burns its HRWT. A generation whose regime utxo has already been cleaned up therefore cannot be closed by it — which is every generation on the preview fleet, since the multisig-address sweep burned those beacons.

**The validator never required a regime input.** `RegimeReferenceNotFound` belongs to `Resolve` and `Evacuate`; the `Deinit` branch reads only its own input's datum, the mint, and the commitment. Making `regimeUtxo` optional in `DeinitTx` would let the sanctioned builder cover both cases, and this command could then be a thin caller. That seemed worth raising rather than deciding here.

## Two things that will bite the next person

**The reference script named in a head's config is usually dead.** Each bootstrap deploys its own copy of the treasury validator, and by the time a generation needs closing, its copy is long spent — hence `--treasury-script-ref`. Any unspent utxo carrying the validator works, since the ledger cares about the script and not its provenance; preview currently has 21 of them at 35.747140 ADA each, about 750 ADA of deposits nobody reclaims.

Worth knowing: `NodeConfig.load` resolves a *spent* reference utxo without complaint, because `CardanoBackend.resolve` uses `getTxOutput`, which returns spent outputs. The failure surfaces only when the node rejects the transaction.

**No collateral return is set.** The built body carries `collateralInputs` but no `collateralReturn` and no `totalCollateral`, because these builders model collateral as a normal input returned as a normal output 0. Conway would bound the loss to `collateralPercentage × fee`; as built, a phase-2 failure forfeits the entire collateral utxo. That is the existing pattern in `DeinitTx` and `EvacuationTx`, not something this command introduces — on the evacuator it means roughly 183 ADA exposed per transaction. Until it is addressed, pass a deliberately small collateral utxo; this run used 5 ADA.

## What it did

Run against preview on 2026-08-22, both `valid_contract: true`:

| tx | generations | ADA | fee | block |
|---|---|---|---|---|
| `f9d7dbf29ea9df1b…` | 3 (`2d58a52b`, `3bc469f8`, `afad521e`) | 25.316144 | 0.414429 | 4,594,693 |
| `95eef1eab11271c5…` | 1 (`33c6b509`) | 2.413600 | 0.317242 | 4,594,710 |

Thirteen beacons burned, every one now reporting `quantity 0`. The treasury address went from 31 to 27 utxos, and the demo stand's awaiting-`Deinit` bucket is empty.

One of the three, `60bc745e…#1`, was the residue of our own evacuation run — so its empty-set commitment is independent on-chain confirmation that the run really did reach ∅, rather than the bot merely reporting zero outstanding.

## What this does not do

- **No tests.** It acts on specific chain state and the shapes it builds are validated by the ledger accepting or rejecting them; the evidence is the two runs above. If it becomes more than an operational tool, that changes.
- **It cannot help the other two buckets.** 2,165 ADA is unresolved and 810 ADA partially evacuated on preview, all needing evacuation maps that no longer exist. Five of those are our own demo-stand generations holding 934 ADA, wiped by `rebuild-head.sh`. The fix is to export the map before a teardown, which belongs in whatever tears a head down.
- **It does not choose its own inputs.** The utxos, the reference script and the collateral are all named on the command line, deliberately: the address is shared by every head on the network, so anything that selected inputs by shape could reach into a fleet that is not yours.