### PR TITLE
fix(backend): suspend the Blockfrost call in resolve

### DIFF
--- a/src/main/scala/hydrozoa/multisig/backend/cardano/CardanoBackendBlockfrost.scala
+++ b/src/main/scala/hydrozoa/multisig/backend/cardano/CardanoBackendBlockfrost.scala
@@ -64,12 +64,19 @@ class CardanoBackendBlockfrost private (
     private val transactionService = backendService.getTransactionService
     private val assetService = backendService.getAssetService
 
+    /** `IO.blocking`: a synchronous Blockfrost round trip — see [[paginate]] for why that matters.
+      * The call also has to be suspended rather than passed to `EitherT.fromEither`, whose argument
+      * is strict: evaluating it eagerly would run the request when `resolve` is called instead of
+      * when the returned `IO` is run.
+      */
     override def resolve(input: Input): IO[Either[Error, Option[ledger.Utxo]]] =
         (for {
-            res <- EitherT.fromEither[IO](
-              Try(
-                utxoService.getTxOutput(input.transactionId.toHex, input.index)
-              ).toEither.left.map(e => Error.ErrorResolving(input, e.getMessage))
+            res <- EitherT(
+              IO.blocking(
+                Try(
+                  utxoService.getTxOutput(input.transactionId.toHex, input.index)
+                ).toEither.left.map(e => Error.ErrorResolving(input, e.getMessage))
+              )
             )
             mbUtxo <- res match {
                 // Resolution "successful", but no utxo found


### PR DESCRIPTION
`resolve` passed its Blockfrost call to `EitherT.fromEither[IO]`, whose argument is **strict**:

```scala
res <- EitherT.fromEither[IO](
  Try(
    backendService.getUtxoService.getTxOutput(input.transactionId.toHex, input.index)
  ).toEither.left.map(e => Error.ErrorResolving(input, e.getMessage))
)
```

The `Try` is evaluated when `resolve(input)` is *called*, before the returned `IO` runs. Two consequences:

- **Not referentially transparent.** The response is baked into the `IO` value, so re-running or retrying that `IO` replays the old result instead of re-fetching.
- **Blocking call on the wrong pool.** The synchronous okhttp round trip lands on the caller's thread outside `IO.blocking` — the exact hazard the `paginate` doc comment describes, and `resolve` was the one `backendService` call site not honouring it.

Fix: build the `EitherT` from an `IO.blocking` instead. No change to the returned values or the error mapping.

Currently latent — `resolve` has no retry wrapper today (`DeployScriptsAndG2Setup:336`, `SubmitDeposit:199`, and the `NodeConfig` load path each call it once). It goes live the moment a backend call gets wrapped in a retry.

`just build-werror` green; `sbt test` 510 passed / 0 failed.

Found while reviewing #660, which touches this same line — whichever lands second needs a trivial rebase.