### PR TITLE
Two operational commands for clearing a head's multisig address

### DIFF
--- a/src/main/scala/hydrozoa/app/Main.scala
+++ b/src/main/scala/hydrozoa/app/Main.scala
@@ -5,6 +5,7 @@ import com.monovore.decline.effect.CommandIOApp
 import com.monovore.decline.{Command, Opts}
 import hydrozoa.BuildInfo
 import hydrozoa.app.cli.{Scaffold, SubmitDeposit, SubmitL2Transaction}
+import hydrozoa.rulebased.evacuator.RefundSweep
 import hydrozoa.bootstrap.{BuildHeadConfig, GenerateKeyPair, InitBootstrapFiles, KeygenFleet, Migrate, PrintHeadZeroAddress}
 
 /** The `hydrozoa` command-line entry point: a single dispatcher over every deployment and runtime
@@ -55,6 +56,7 @@ object Main
           SubmitL2Transaction.command,
           Migrate.command,
           Scaffold.command,
+          RefundSweep.command,
           versionCommand
         )
 

--- a/src/main/scala/hydrozoa/app/Main.scala
+++ b/src/main/scala/hydrozoa/app/Main.scala
@@ -5,7 +5,7 @@ import com.monovore.decline.effect.CommandIOApp
 import com.monovore.decline.{Command, Opts}
 import hydrozoa.BuildInfo
 import hydrozoa.app.cli.{Scaffold, SubmitDeposit, SubmitL2Transaction}
-import hydrozoa.rulebased.evacuator.RefundSweep
+import hydrozoa.rulebased.evacuator.{RefundSweep, ResidueSweep}
 import hydrozoa.bootstrap.{BuildHeadConfig, GenerateKeyPair, InitBootstrapFiles, KeygenFleet, Migrate, PrintHeadZeroAddress}
 
 /** The `hydrozoa` command-line entry point: a single dispatcher over every deployment and runtime
@@ -57,6 +57,7 @@ object Main
           Migrate.command,
           Scaffold.command,
           RefundSweep.command,
+          ResidueSweep.command,
           versionCommand
         )
 

--- a/src/main/scala/hydrozoa/rulebased/evacuator/RefundSweep.scala
+++ b/src/main/scala/hydrozoa/rulebased/evacuator/RefundSweep.scala
@@ -1,0 +1,351 @@
+package hydrozoa.rulebased.evacuator
+
+import cats.effect.{ExitCode, IO}
+import cats.syntax.apply.*
+import cats.syntax.traverse.*
+import cats.syntax.contravariant.*
+import com.monovore.decline.{Command, Opts}
+import hydrozoa.config.head.HeadConfig
+import hydrozoa.config.node.NodeConfig
+import hydrozoa.lib.logging.{ContraTracer, Slf4jMsg, Slf4jMsgFormat, Slf4jTracer, info}
+import hydrozoa.multisig.backend.cardano.CardanoBackend
+import hydrozoa.multisig.consensus.peer.PeerWallet
+import hydrozoa.multisig.consensus.peer.PeerWallet.peerWalletDecoder
+import hydrozoa.multisig.ledger.l1.tx.RawTx
+import io.circe.Decoder
+import io.circe.parser.decode
+import java.nio.file.{Files, Path}
+import scalus.cardano.address.ShelleyDelegationPart.Null
+import scalus.cardano.address.{ShelleyAddress, ShelleyPaymentPart}
+import scalus.cardano.ledger.*
+import scalus.cardano.txbuilder.{Change, TransactionBuilder}
+import scalus.cardano.txbuilder.TransactionBuilderStep.{Send, Spend}
+import scalus.uplc.builtin.ByteString
+
+/** Sweeps unabsorbed deposits out of a dead head's multisig address, consolidating them into one
+  * payout.
+  *
+  * When a head dies without absorbing its deposits, the depositors' funds stay locked at the head's
+  * multisig address. The head normally holds a pre-signed post-dated refund transaction for each
+  * one, but those live only in the peers' stores — so a generation whose stores were wiped leaves
+  * its deposits with no refund path at all.
+  *
+  * Nothing is lost, though: the refund *instructions* are in each deposit's inline datum, on chain,
+  * and the multisig address is a native script over the peers' keys. So given those keys the
+  * refunds can be rebuilt from chain state alone. That is what this does.
+  *
+  * It consolidates rather than paying each deposit separately: a thousand refund transactions of
+  * one input each would burn a thousand fees to produce a thousand dust utxos. Batches are chained
+  * — each transaction spends the previous one's output alongside its own slice of deposits, and
+  * only the last pays out — so however many transactions the size limit forces, the destination
+  * receives exactly one utxo.
+  */
+object RefundSweep {
+
+    private val log: ContraTracer[IO, Slf4jMsg] =
+        Slf4jTracer.sink.contramap(
+          Slf4jMsgFormat.humanFormat("hydrozoa.rulebased.evacuator.RefundSweep")
+        )
+
+    /** One deposit to sweep, as read from the chain. The inline datum is deliberately not carried:
+      * a native-script spend puts no datum in the witness set and there is no script-data hash to
+      * compute, so it cannot affect the transaction that gets built.
+      */
+    final case class Deposit(txHash: String, index: Int, lovelace: Long) derives Decoder
+
+    private val headConfigPathArg: Opts[Path] =
+        Opts.argument[String]("head-config.json").map(Path.of(_))
+
+    private val privateConfigPathArg: Opts[Path] =
+        Opts.argument[String]("peer-private.json").map(Path.of(_))
+
+    /** The peers' private configs, one per required signer. The multisig demands every head peer
+      * plus `coilQuorum` coils, so a short list produces a transaction the ledger rejects — which
+      * is why the count is checked against the script before anything is built.
+      */
+    private val keysOpt: Opts[List[Path]] =
+        Opts
+            .options[String]("signer", "A peer private.json whose wallet co-signs the sweep")
+            .map(_.toList.map(Path.of(_)))
+
+    private val depositsOpt: Opts[Path] =
+        Opts.option[String]("deposits", "JSON array of deposits to sweep").map(Path.of(_))
+
+    /** Destination as a payment key hash rather than bech32: the sweep is only ever pointed at an
+      * address read out of a deposit datum, which is where it arrives in this form anyway.
+      */
+    private val toOpt: Opts[String] =
+        Opts.option[String]("to-key-hash", "Payment key hash of the payout address (hex)")
+
+    private val batchOpt: Opts[Int] =
+        Opts
+            .option[Int]("batch", "Deposits per transaction")
+            .withDefault(200)
+
+    private val commitOpt: Opts[Boolean] =
+        Opts.flag("commit", "Actually submit; without it, build and report only").orFalse
+
+    lazy val command: Command[IO[ExitCode]] =
+        Command(
+          name = "sweep-refunds",
+          header = "Refund unabsorbed deposits from a head's multisig address into one payout utxo"
+        )(
+          (
+            headConfigPathArg,
+            privateConfigPathArg,
+            keysOpt,
+            depositsOpt,
+            toOpt,
+            batchOpt,
+            commitOpt
+          ).mapN(run)
+        )
+
+    def run(
+        headConfigPath: Path,
+        privateConfigPath: Path,
+        signerPaths: List[Path],
+        depositsPath: Path,
+        toKeyHash: String,
+        batchSize: Int,
+        commit: Boolean
+    ): IO[ExitCode] =
+        for {
+            loaded <- NodeConfig.load(headConfigPath, privateConfigPath, None)
+            (nodeConfig, backend) = loaded
+            exit <- {
+                given HeadConfig.Bootstrap.Section = nodeConfig.headConfig
+                drive(
+                  backend,
+                  signerPaths,
+                  depositsPath,
+                  toKeyHash,
+                  batchSize,
+                  commit
+                )
+            }
+        } yield exit
+
+    private def drive(
+        backend: CardanoBackend[IO],
+        signerPaths: List[Path],
+        depositsPath: Path,
+        toKeyHash: String,
+        batchSize: Int,
+        commit: Boolean
+    )(using config: HeadConfig.Bootstrap.Section): IO[ExitCode] = {
+
+        val script = config.headMultisigScript
+        val multisigAddress = config.headMultisigAddress
+        val payoutAddress = ShelleyAddress(
+          network = config.network,
+          payment = ShelleyPaymentPart.Key(AddrKeyHash(ByteString.fromHex(toKeyHash))),
+          delegation = Null
+        )
+
+        for {
+            signers <- signerPaths.traverse(loadSigner)
+            // The multisig is satisfied by all head peers plus `coilQuorum` coils, and
+            // `numSigners` is exactly that count. Checking it here turns an unsatisfiable
+            // witness set — which the ledger only rejects after the whole sweep is built and
+            // submitted — into an argument error before any work happens.
+            _ <- IO.raiseUnless(signers.size == script.numSigners)(
+              RuntimeException(
+                s"multisig needs ${script.numSigners} signatures, ${signers.size} supplied"
+              )
+            )
+            _ <- log.info(s"signers: ${signers.size}, as the script requires")
+
+            json <- IO.blocking(Files.readString(depositsPath))
+            deposits <- IO.fromEither(
+              decode[List[Deposit]](json).left.map(e => RuntimeException(s"deposits: $e"))
+            )
+            _ <- IO.raiseWhen(deposits.isEmpty)(RuntimeException("no deposits to sweep"))
+            total = deposits.map(_.lovelace).sum
+            batches = deposits.grouped(batchSize).toList
+            _ <- log.info(
+              s"${deposits.size} deposits, ${total / 1_000_000.0} ada, " +
+                  s"${batches.size} transaction(s) of up to $batchSize"
+            )
+            // The script is rebuilt from the roster, so log the address it yields: if it does not
+            // match the address the deposits sit at, every input is unspendable and the mistake is
+            // visible here rather than as a ledger rejection.
+            _ <- log.info(s"spending from $multisigAddress")
+            _ <- log.info(s"payout to    $payoutAddress")
+
+            params <- backend.fetchLatestParams.flatMap(
+              IO.fromEither(_).adaptError(e => RuntimeException(s"protocol params: $e"))
+            )
+
+            exit <- sweep(
+              batches,
+              signers,
+              multisigAddress,
+              payoutAddress,
+              params,
+              backend,
+              commit
+            )
+        } yield exit
+    }
+
+    private def loadSigner(path: Path): IO[PeerWallet] =
+        IO.blocking(Files.readString(path)).flatMap { s =>
+            IO.fromEither(
+              decode[PeerWallet](s)
+                  .orElse(
+                    io.circe.parser
+                        .parse(s)
+                        .flatMap(
+                          _.hcursor
+                              .downField("ownPeerPrivate")
+                              .downField("ownHeadWallet")
+                              .as[PeerWallet]
+                              .orElse(
+                                io.circe.parser
+                                    .parse(s)
+                                    .flatMap(
+                                      _.hcursor
+                                          .downField("ownPeerPrivate")
+                                          .downField("ownCoilWallet")
+                                          .as[PeerWallet]
+                                    )
+                              )
+                        )
+                  )
+                  .left
+                  .map(e => RuntimeException(s"$path: no peer wallet found ($e)"))
+            )
+        }
+
+    /** Build, sign and optionally submit the chain.
+      *
+      * Every batch but the last pays back to the multisig address, so the next transaction can
+      * spend it with the same script; only the last pays the destination. The carried output is
+      * always index 0, and it is known from the transaction just built — no query between steps.
+      */
+    private def sweep(
+        batches: List[List[Deposit]],
+        signers: List[PeerWallet],
+        multisigAddress: ShelleyAddress,
+        payoutAddress: ShelleyAddress,
+        params: ProtocolParams,
+        backend: CardanoBackend[IO],
+        commit: Boolean
+    )(using config: HeadConfig.Bootstrap.Section): IO[ExitCode] = {
+
+        val script = config.headMultisigScript
+        val last = batches.size - 1
+
+        def step(
+            remaining: List[(List[Deposit], Int)],
+            carry: Option[Utxo],
+            submitted: Int
+        ): IO[Int] = remaining match {
+            case Nil => IO.pure(submitted)
+            case (batch, i) :: rest =>
+                val destination = if i == last then payoutAddress else multisigAddress
+
+                val inputs: List[Utxo] =
+                    carry.toList ++ batch.map(d =>
+                        Utxo(
+                          TransactionInput(TransactionHash.fromHex(d.txHash), d.index),
+                          TransactionOutput.Babbage(
+                            address = multisigAddress,
+                            value = Value(Coin(d.lovelace)),
+                            datumOption = None,
+                            scriptRef = None
+                          )
+                        )
+                    )
+
+                // The script travels by value on the first spend that needs it and by reference
+                // after: the builder's steps are not commutative, so attaching first fails to
+                // resolve. Same ordering rule the treasury mint follows.
+                val spendSteps = inputs.zipWithIndex.map { case (u, n) =>
+                    Spend(u, if n == 0 then script.witnessValue else script.witnessAttached)
+                }
+
+                val steps = spendSteps ++ List(
+                  Send(
+                    TransactionOutput.Babbage(
+                      address = destination,
+                      value = Value(Coin(0L)),
+                      datumOption = None,
+                      scriptRef = None
+                    )
+                  )
+                )
+
+                val built = for {
+                    ctx <- TransactionBuilder
+                        .build(config.network, steps)
+                        .left
+                        .map(e => RuntimeException(s"build failed at batch $i: $e"))
+                    balanced <- ctx
+                        .balanceContext(
+                          diffHandler = Change.changeOutputDiffHandler(
+                            _,
+                            _,
+                            protocolParams = params,
+                            changeOutputIdx = 0
+                          ),
+                          protocolParams = params,
+                          evaluator = PlutusScriptEvaluator(
+                            config.cardanoInfo,
+                            EvaluatorMode.EvaluateAndComputeCost
+                          )
+                        )
+                        .left
+                        .map(e => RuntimeException(s"balancing failed at batch $i: $e"))
+                } yield balanced.transaction
+
+                IO.fromEither(built).flatMap { unsigned =>
+                    val signed = signers.foldLeft(unsigned)((tx, w) => w.signTx(tx))
+                    val out = signed.body.value.outputs.head.value
+                    val size = signed.toCbor.length
+                    for {
+                        _ <- log.info(
+                          s"batch $i: ${batch.size} deposits" +
+                              carry.fold("")(_ => " + carried") +
+                              s", out ${out.value.coin.value / 1_000_000.0} ada" +
+                              s", fee ${signed.body.value.fee.value / 1_000_000.0} ada" +
+                              s", ${size} bytes, ${signed.id}"
+                        )
+                        _ <- IO.raiseWhen(size > params.maxTxSize)(
+                          RuntimeException(
+                            s"batch $i is $size bytes, over the ${params.maxTxSize} limit" +
+                                " — lower --batch"
+                          )
+                        )
+                        n <-
+                            if !commit then step(rest, nextCarry(signed), submitted)
+                            else
+                                backend
+                                    .submitTx(RawTx(signed))
+                                    .flatMap(r =>
+                                        IO.fromEither(
+                                          r.left.map(e =>
+                                              RuntimeException(s"submit failed at batch $i: $e")
+                                          )
+                                        )
+                                    ) *> step(rest, nextCarry(signed), submitted + 1)
+                    } yield n
+                }
+        }
+
+        step(batches.zipWithIndex, None, 0).flatMap { n =>
+            if commit then log.info(s"submitted $n transactions").as(ExitCode.Success)
+            else log.info("not submitting; pass --commit to run it").as(ExitCode.Success)
+        }
+    }
+
+    /** The consolidated output the next batch spends: always index 0 of what we just built. */
+    private def nextCarry(signed: Transaction): Option[Utxo] =
+        Some(
+          Utxo(
+            TransactionInput(signed.id, 0),
+            signed.body.value.outputs.head.value
+          )
+        )
+}

--- a/src/main/scala/hydrozoa/rulebased/evacuator/RefundSweep.scala
+++ b/src/main/scala/hydrozoa/rulebased/evacuator/RefundSweep.scala
@@ -7,6 +7,7 @@ import cats.syntax.contravariant.*
 import com.monovore.decline.{Command, Opts}
 import hydrozoa.config.head.HeadConfig
 import hydrozoa.config.node.NodeConfig
+import hydrozoa.lib.cardano.scalus.contextualscalus.TransactionBuilder.addExpectedSigners
 import hydrozoa.lib.logging.{ContraTracer, Slf4jMsg, Slf4jMsgFormat, Slf4jTracer, info}
 import hydrozoa.multisig.backend.cardano.CardanoBackend
 import hydrozoa.multisig.consensus.peer.PeerWallet
@@ -278,10 +279,15 @@ object RefundSweep {
                 )
 
                 val built = for {
-                    ctx <- TransactionBuilder
+                    ctx0 <- TransactionBuilder
                         .build(config.network, steps)
                         .left
                         .map(e => RuntimeException(s"build failed at batch $i: $e"))
+                    // Balancing prices the transaction it can see, and the multisig's signatures
+                    // are not on it yet — so without declaring them the fee is short by exactly
+                    // their bytes and the ledger rejects it as FeeTooSmallUTxO. Only the count
+                    // matters here: these are placeholder hashes for sizing, not signers.
+                    ctx = ctx0.addExpectedSigners(script.numSigners)
                     balanced <- ctx
                         .balanceContext(
                           diffHandler = Change.changeOutputDiffHandler(

--- a/src/main/scala/hydrozoa/rulebased/evacuator/ResidueSweep.scala
+++ b/src/main/scala/hydrozoa/rulebased/evacuator/ResidueSweep.scala
@@ -1,0 +1,396 @@
+package hydrozoa.rulebased.evacuator
+
+import cats.effect.{ExitCode, IO}
+import cats.syntax.apply.*
+import cats.syntax.contravariant.*
+import cats.syntax.foldable.*
+import cats.syntax.traverse.*
+import com.monovore.decline.{Command, Opts}
+import hydrozoa.config.head.HeadConfig
+import hydrozoa.config.head.network.CardanoNetwork
+import hydrozoa.config.node.NodeConfig
+import hydrozoa.lib.cardano.scalus.contextualscalus.TransactionBuilder.addExpectedSigners
+import hydrozoa.lib.logging.{ContraTracer, Slf4jMsg, Slf4jMsgFormat, Slf4jTracer, info}
+import hydrozoa.lib.logging.Slf4jTracer as BackendTracer
+import hydrozoa.multisig.backend.cardano.{CardanoBackend, CardanoBackendBlockfrost, CardanoBackendEventFormat}
+import hydrozoa.multisig.consensus.peer.PeerWallet
+import hydrozoa.multisig.consensus.peer.PeerWallet.peerWalletDecoder
+import hydrozoa.multisig.ledger.l1.tx.RawTx
+import io.circe.Decoder
+import io.circe.parser.decode
+import java.nio.file.{Files, Path}
+import scalus.cardano.address.ShelleyDelegationPart.Null
+import scalus.cardano.address.{ShelleyAddress, ShelleyPaymentPart}
+import scalus.cardano.ledger.*
+import scalus.cardano.txbuilder.TransactionBuilderStep.{Mint, Send, Spend}
+import scalus.cardano.txbuilder.{Change, TransactionBuilder}
+import scalus.uplc.builtin.ByteString
+
+/** Clears the abandoned state that accumulates at a head's multisig address.
+  *
+  * Every head generation leaves its treasury and regime utxos behind when it dies, and because the
+  * peers' keys never change, every generation shares one address — so the residue accrues there
+  * indefinitely. It is not merely untidy: each peer's liaison polls that address on every tick, and
+  * a thousand utxos is a paginated query per tick per peer, forever.
+  *
+  * Two kinds of token sit in that residue, and they must be treated differently. Beacons minted
+  * under the head's own policy are dead once their generation is, and the same native script that
+  * guards the address is their minting policy — so they can be burned. Anything else is under a
+  * policy we do not control and is not ours to destroy, so it is moved out intact.
+  *
+  * ★ Selection is by AGE, not by shape: the live head's own treasury and regime utxos are
+  * indistinguishable from a dead generation's except that they are newer. Anything created at or
+  * after the running head's initialization is left alone — which also covers deposits arriving
+  * while the sweep is being prepared.
+  */
+object ResidueSweep {
+
+    private val log: ContraTracer[IO, Slf4jMsg] =
+        Slf4jTracer.sink.contramap(
+          Slf4jMsgFormat.humanFormat("hydrozoa.rulebased.evacuator.ResidueSweep")
+        )
+
+    /** One residue utxo as read off the chain. `tokens` is keyed by the full asset unit — policy id
+      * followed by asset name — exactly as Blockfrost reports it.
+      */
+    final case class Residue(
+        txHash: String,
+        index: Int,
+        lovelace: Long,
+        tokens: Map[String, Long],
+        hasScriptRef: Boolean
+    ) derives Decoder
+
+    private val headConfigPathArg: Opts[Path] =
+        Opts.argument[String]("head-config.json").map(Path.of(_))
+
+    private val privateConfigPathArg: Opts[Path] =
+        Opts.argument[String]("peer-private.json").map(Path.of(_))
+
+    private val keysOpt: Opts[List[Path]] =
+        Opts
+            .options[String]("signer", "A peer private.json whose wallet co-signs the sweep")
+            .map(_.toList.map(Path.of(_)))
+
+    private val utxosOpt: Opts[Path] =
+        Opts.option[String]("utxos", "JSON array of residue utxos to sweep").map(Path.of(_))
+
+    private val toOpt: Opts[String] =
+        Opts.option[String]("to-key-hash", "Payment key hash of the destination (hex)")
+
+    /** Ada to park alongside the foreign tokens, so they land in their own utxo rather than
+      * diluting the consolidated ada.
+      */
+    private val tokenAdaOpt: Opts[Long] =
+        Opts
+            .option[Long]("token-output-ada", "Ada to accompany the non-head tokens")
+            .withDefault(500L)
+            .map(_ * 1_000_000L)
+
+    /** Write the signed transaction out, so a rejected submission can be replayed by hand against
+      * whichever endpoint is being diagnosed.
+      */
+    private val dumpOpt: Opts[Option[Path]] =
+        Opts.option[String]("dump", "Write the signed tx CBOR (hex) here").map(Path.of(_)).orNone
+
+    private val commitOpt: Opts[Boolean] =
+        Opts.flag("commit", "Actually submit; without it, build and report only").orFalse
+
+    /** Point the chain queries at a local node instead of the hosted API. A sweep reads every
+      * residue utxo and its creating transaction, which over a hosted API is hundreds of round
+      * trips at ~80 ms; against a local Dolos it is LAN latency and no request quota.
+      */
+    private val backendUrlOpt: Opts[Option[String]] =
+        Opts
+            .option[String]("backend-url", "Blockfrost-compatible base URL (e.g. a local Dolos)")
+            .orNone
+
+    lazy val command: Command[IO[ExitCode]] =
+        Command(
+          name = "sweep-residue",
+          header = "Burn dead head beacons and move the remaining value out of a multisig address"
+        )(
+          (
+            headConfigPathArg,
+            privateConfigPathArg,
+            keysOpt,
+            utxosOpt,
+            toOpt,
+            tokenAdaOpt,
+            commitOpt,
+            backendUrlOpt,
+            dumpOpt
+          ).mapN(run)
+        )
+
+    def run(
+        headConfigPath: Path,
+        privateConfigPath: Path,
+        signerPaths: List[Path],
+        utxosPath: Path,
+        toKeyHash: String,
+        tokenAda: Long,
+        commit: Boolean,
+        backendUrl: Option[String],
+        dump: Option[Path]
+    ): IO[ExitCode] =
+        for {
+            override_ <- backendUrl.traverse(localBackend)
+            loaded <- NodeConfig.load(headConfigPath, privateConfigPath, override_)
+            (nodeConfig, backend) = loaded
+            exit <- {
+                given HeadConfig.Bootstrap.Section = nodeConfig.headConfig
+                drive(
+                  nodeConfig,
+                  backend,
+                  signerPaths,
+                  utxosPath,
+                  toKeyHash,
+                  tokenAda,
+                  commit,
+                  dump
+                )
+            }
+        } yield exit
+
+    private def drive(
+        nodeConfig: NodeConfig,
+        backend: CardanoBackend[IO],
+        signerPaths: List[Path],
+        utxosPath: Path,
+        toKeyHash: String,
+        tokenAda: Long,
+        commit: Boolean,
+        dump: Option[Path]
+    )(using config: HeadConfig.Bootstrap.Section): IO[ExitCode] = {
+
+        val script = config.headMultisigScript
+        val headPolicy = script.policyId
+        val multisigAddress = config.headMultisigAddress
+        val destination = ShelleyAddress(
+          network = config.network,
+          payment = ShelleyPaymentPart.Key(AddrKeyHash(ByteString.fromHex(toKeyHash))),
+          delegation = Null
+        )
+
+        for {
+            signers <- signerPaths.traverse(loadSigner)
+            _ <- IO.raiseUnless(signers.size == script.numSigners)(
+              RuntimeException(
+                s"multisig needs ${script.numSigners} signatures, ${signers.size} supplied"
+              )
+            )
+
+            json <- IO.blocking(Files.readString(utxosPath))
+            residue <- IO.fromEither(
+              decode[List[Residue]](json).left.map(e => RuntimeException(s"utxos: $e"))
+            )
+            _ <- IO.raiseWhen(residue.isEmpty)(RuntimeException("nothing to sweep"))
+
+            burn = residue
+                .flatMap(_.tokens.toList)
+                .filter((unit, _) => isHeadPolicy(unit, headPolicy))
+            foreign = residue
+                .flatMap(_.tokens.toList)
+                .filterNot((unit, _) => isHeadPolicy(unit, headPolicy))
+            totalAda = residue.map(_.lovelace).sum
+
+            _ <- log.info(s"${residue.size} residue utxos, ${totalAda / 1_000_000.0} ada")
+            _ <- log.info(s"burning ${burn.size} head-policy tokens (policy $headPolicy)")
+            _ <- log.info(
+              s"moving ${foreign.size} foreign token entries across " +
+                  s"${foreign.map(_._1.take(56)).distinct.size} policies"
+            )
+            _ <- log.info(s"destination $destination")
+            _ <- log.info(s"spending from $multisigAddress")
+
+            params <- backend.fetchLatestParams.flatMap(
+              IO.fromEither(_).adaptError(e => RuntimeException(s"protocol params: $e"))
+            )
+
+            tx <- IO.fromEither(
+              build(residue, burn, foreign, multisigAddress, destination, tokenAda, params, script)
+            )
+            signed = signers.foldLeft(tx)((t, w) => w.signTx(t))
+            size = signed.toCbor.length
+            _ <- IO.raiseWhen(size > params.maxTxSize)(
+              RuntimeException(s"$size bytes exceeds the ${params.maxTxSize} limit — sweep fewer")
+            )
+            outs = signed.body.value.outputs.toList.map(_.value)
+            _ <- outs.zipWithIndex.traverse_ { (o, i) =>
+                log.info(
+                  f"  output $i: ${o.value.coin.value / 1e6}%.6f ada" +
+                      (if o.value.assets.assets.nonEmpty then
+                           s", ${o.value.assets.assets.values.map(_.size).sum} token(s)"
+                       else "")
+                )
+            }
+            _ <- log.info(f"fee ${signed.body.value.fee.value / 1e6}%.6f ada")
+            _ <- log.info(s"size $size bytes of ${params.maxTxSize}, tx ${signed.id}")
+            _ <- dump.traverse_ { path =>
+                IO.blocking(Files.writeString(path, signed.toCbor.map("%02x".format(_)).mkString))
+                    .void *> log.info(s"signed tx written to $path")
+            }
+
+            exit <-
+                if !commit then
+                    log.info("not submitting; pass --commit to run it").as(ExitCode.Success)
+                else
+                    backend
+                        .submitTx(RawTx(signed))
+                        .flatMap(r =>
+                            IO.fromEither(r.left.map(e => RuntimeException(s"submit failed: $e")))
+                        ) *> log.info(s"submitted ${signed.id}").as(ExitCode.Success)
+        } yield exit
+    }
+
+    /** A backend pointed at a Blockfrost-compatible endpoint of our own.
+      *
+      * The network is declared `Custom` purely so the base URL is ours; its parameters are still
+      * preview's, because that is the chain the node is following.
+      */
+    private def localBackend(url: String): IO[CardanoBackend[IO]] =
+        CardanoBackendBlockfrost(
+          network = Right(
+            (
+              CardanoNetwork.Custom(
+                CardanoNetwork.Preview.cardanoInfo,
+                CardanoNetwork.Preview.protocolMagic
+              ),
+              url
+            )
+          ),
+          apiKey = "",
+          tracer = BackendTracer.sink.contramap(CardanoBackendEventFormat.humanFormat)
+        ).map(b => b: CardanoBackend[IO])
+
+    private def isHeadPolicy(unit: String, policy: PolicyId): Boolean =
+        unit.startsWith(policy.toHex)
+
+    private def build(
+        residue: List[Residue],
+        burn: List[(String, Long)],
+        foreign: List[(String, Long)],
+        multisigAddress: ShelleyAddress,
+        destination: ShelleyAddress,
+        tokenAda: Long,
+        params: ProtocolParams,
+        script: hydrozoa.multisig.ledger.l1.script.multisig.HeadMultisigScript
+    )(using config: HeadConfig.Bootstrap.Section): Either[Throwable, Transaction] = {
+
+        // ★ Every regime utxo carries the multisig script as a REFERENCE SCRIPT, and Conway
+        // collects reference scripts from spent inputs as well as reference inputs. So declaring
+        // them is not cosmetic: without it the balancer misses the reference-script fee the ledger
+        // charges (measured at exactly 15 lovelace per script byte), and attaching a second copy
+        // of the script by value is rejected outright as an extraneous witness.
+        val inputs = residue.map { r =>
+            Utxo(
+              TransactionInput(TransactionHash.fromHex(r.txHash), r.index),
+              TransactionOutput.Babbage(
+                address = multisigAddress,
+                value = Value(Coin(r.lovelace), multiAssetOf(r.tokens)),
+                datumOption = None,
+                scriptRef = Option.when(r.hasScriptRef)(ScriptRef(script.script))
+              )
+            )
+        }
+
+        // The script comes from the spent utxos' own reference scripts, so nothing needs to carry
+        // it by value. Only when the batch happens to hold none does a copy have to travel with
+        // the first spend.
+        val needsValue = !residue.exists(_.hasScriptRef)
+        val spends = inputs.zipWithIndex.map { (u, i) =>
+            Spend(u, if needsValue && i == 0 then script.witnessValue else script.witnessAttached)
+        }
+
+        // Burning is a negative mint under the head's own policy, which the same native script
+        // authorises — so no extra witness beyond the signatures already required to spend.
+        val burns = burn.map { (unit, qty) =>
+            Mint(
+              script.policyId,
+              assetName = AssetName(ByteString.fromHex(unit.drop(56))),
+              amount = -qty,
+              witness = script.witnessAttached
+            )
+        }
+
+        val foreignAssets = multiAssetOf(foreign.groupMapReduce(_._1)(_._2)(_ + _))
+
+        val sends =
+            List(
+              // Output 0 takes the balancer's change: the bulk of the ada, ada-only.
+              Send(
+                TransactionOutput.Babbage(
+                  address = destination,
+                  value = Value(Coin(0L)),
+                  datumOption = None,
+                  scriptRef = None
+                )
+              )
+            ) ++ Option
+                .when(foreignAssets.assets.nonEmpty)(
+                  Send(
+                    TransactionOutput.Babbage(
+                      address = destination,
+                      value = Value(Coin(tokenAda), foreignAssets),
+                      datumOption = None,
+                      scriptRef = None
+                    )
+                  )
+                )
+                .toList
+
+        for {
+            ctx <- TransactionBuilder
+                .build(config.network, spends ++ burns ++ sends)
+                .left
+                .map(e => RuntimeException(s"build failed: $e"))
+            balanced <- ctx
+                .addExpectedSigners(script.numSigners)
+                .balanceContext(
+                  diffHandler = Change.changeOutputDiffHandler(
+                    _,
+                    _,
+                    protocolParams = params,
+                    changeOutputIdx = 0
+                  ),
+                  protocolParams = params,
+                  evaluator = PlutusScriptEvaluator(
+                    config.cardanoInfo,
+                    EvaluatorMode.EvaluateAndComputeCost
+                  )
+                )
+                .left
+                .map(e => RuntimeException(s"balancing failed: $e"))
+        } yield balanced.transaction
+    }
+
+    private def multiAssetOf(tokens: Map[String, Long]): MultiAsset =
+        tokens.toList
+            .map { (unit, qty) =>
+                Value
+                    .asset(
+                      ScriptHash.fromByteString(ByteString.fromHex(unit.take(56))),
+                      AssetName(ByteString.fromHex(unit.drop(56))),
+                      qty
+                    )
+                    .assets
+            }
+            .foldLeft(MultiAsset.empty)(_ + _)
+
+    private def loadSigner(path: Path): IO[PeerWallet] =
+        IO.blocking(Files.readString(path)).flatMap { s =>
+            IO.fromEither(
+              io.circe.parser
+                  .parse(s)
+                  .flatMap { j =>
+                      val c = j.hcursor.downField("ownPeerPrivate")
+                      c.downField("ownHeadWallet")
+                          .as[PeerWallet]
+                          .orElse(c.downField("ownCoilWallet").as[PeerWallet])
+                  }
+                  .left
+                  .map(e => RuntimeException(s"$path: no peer wallet found ($e)"))
+            )
+        }
+}


### PR DESCRIPTION
Three commits, two new files, +756 lines. No changes to `cardano-onchain/`, the rule-based ledger, or anything a running head executes — only `app/Main.scala` gains three lines to register the commands.

Branched off `7c866e90` (release 0.1.9), not `main`, because both commands were built to act on a live preview head and had to reproduce that head's script and commitments byte-for-byte.

## The problem

A head's multisig address is derived from the peers' verification keys and the coil quorum. Those never change between generations, so **every head a fleet has ever run shares one address**, and each of them leaves state behind when it dies: its treasury utxo, its regime utxo, and any deposits it never absorbed.

Nothing cleans that up. On the preview fleet it had reached **1,090 utxos holding 20,603 ADA**, accumulated over a month across roughly a dozen generations. That is not merely untidy — `CardanoLiaison.runEffects` calls `utxosAt(headMultisigAddress)` on every tick, so the address size is a paginated query per tick per peer, forever.

The unabsorbed deposits are the part that matters, because they are other people's funds. A head holds a pre-signed post-dated refund transaction for each one, in the `HardConfirmation` column family — but those live only in the peers' stores, so a generation whose stores were wiped leaves its depositors with **no refund path at all**.

## What this adds

**`sweep-refunds`** rebuilds the refunds from chain state. The refund instructions survive in each deposit's inline datum, and the address is a native script over the peers' keys, so given those keys the transactions can be reconstructed without the stores. It consolidates rather than fanning out: batches are chained, each spending its slice plus the previous transaction's output, with only the last paying the destination — so however many transactions the size limit forces, the destination receives exactly one utxo. Paying each deposit separately would burn a thousand fees to create a thousand dust utxos.

**`sweep-residue`** clears the dead generations. Beacons minted under the head's own policy are burned, since the same native script that guards the address is their minting policy. Anything under a policy we do not control is moved out intact rather than destroyed.

Both default to a dry run and refuse to build unless the signer count matches `HeadMultisigScript.numSigners`, so an unsatisfiable witness set fails as an argument error rather than as a ledger rejection after everything is built.

### Selection is by age, never by shape

The live head's own treasury and regime utxos are structurally indistinguishable from a dead generation's — same address, same policy, same CIP-67 labels. The only thing that separates them is that they are newer, so `sweep-residue` takes the running head's initialization as a cutoff and leaves anything at or after it alone.

This is not theoretical. During the operation the fleet's bots restarted, and the head produced a settlement **while the sweep was being prepared** — creating a fresh treasury utxo that a shape-based filter would have swept and a live head would have lost.

## Two things the ledger taught us

Both cost a rejected submission, and both are worth knowing before writing any transaction that spends from a head address.

**Conway collects reference scripts from spent inputs, not only reference inputs.** Every regime utxo carries the multisig script as a `scriptRef` (`MultisigRegimeUtxo.scala:61`), and 40 of the 88 swept utxos were regime utxos. So the script was already supplied, and attaching a second copy by value was rejected as `ExtraneousScriptWitnessesUTXOW`. The same fact carries a fee: reference scripts are charged at 15 lovelace per byte, and 40 × 199 bytes came to exactly the 119,400 lovelace by which `FeeTooSmallUTxO` said the transaction was short. Setting `scriptRef` on the resolved utxos fixes both at once — the balancer then prices the reference scripts, every spend can use `witnessAttached`, and the transaction shrinks by the redundant copy.

**Balancing prices the transaction it can see, and multisig signatures are attached after it.** Without declaring them the fee is short by exactly their bytes — 17,996 lovelace for four signatures. `addExpectedSigners(numSigners)` before `balanceContext`, as `SettlementTx`, `RolloutTx`, `FallbackTx` and `DeinitTx` already do.

## What it did

Run against the preview fleet on 2026-08-22:

| | utxos | ADA |
|---|---|---|
| unabsorbed deposits consolidated to their depositor | 992 | 9,921.497503 in one utxo |
| dead generations burned and swept | 88 | 9,955.443015 + 500 with the foreign tokens |
| stragglers returned to three other owners | 8 | 79.432877 |

The address went from **1,090 utxos / 20,603 ADA to 2 utxos / 261.68 ADA** — only the live head's own regime and treasury — for 3.56 ADA in total fees. Every input was self-funding; no external wallet and no collateral, since these are native-script spends with no Plutus.

## What this does not do

- **No tests.** These are operational tools that act on a specific chain state, and the shapes they build are validated by the ledger accepting or rejecting them. The evidence for correctness is the runs above, not a suite. If they are to become anything more than one-shot tools, that changes.
- **It does not stop the accumulation.** The address is clear, but nothing prevents the next generation adding to it again. A durable fix belongs in whatever tears a head down, not here.
- **Deposits are consolidated per destination**, not refunded one output per deposit as the post-dated refund transactions would have. Same value to the same owner, far fewer fees — but the shape differs from what a depositor reconciling against their original refund instructions would expect.