### PR TITLE
feat(consensus): cap the major blocks a stack may cover

### DIFF
--- a/src/main/scala/hydrozoa/bootstrap/Bootstrap.scala
+++ b/src/main/scala/hydrozoa/bootstrap/Bootstrap.scala
@@ -13,6 +13,7 @@ import hydrozoa.config.head.multisig.block.BlockConfig
 import hydrozoa.config.head.multisig.fallback.FallbackContingency
 import hydrozoa.config.head.multisig.fallback.FallbackContingency.mkFallbackContingencyWithDefaults
 import hydrozoa.config.head.multisig.settlement.SettlementConfig
+import hydrozoa.config.head.multisig.stack.StackConfig
 import hydrozoa.config.head.multisig.timing.TxTiming
 import hydrozoa.config.head.multisig.timing.TxTiming.BlockTimes.{BlockCreationEndTime, BlockCreationStartTime}
 import hydrozoa.config.head.network.{CardanoNetwork, StandardCardanoNetwork}
@@ -159,6 +160,7 @@ object Bootstrap:
         disputeResolutionConfig: DisputeResolutionConfig,
         settlementConfig: SettlementConfig,
         blockConfig: BlockConfig,
+        stackConfig: StackConfig,
         coilQuorum: Int
     )
 
@@ -337,6 +339,7 @@ object Bootstrap:
           disputeResolutionConfig = bhp.disputeResolutionConfig,
           settlementConfig = bhp.settlementConfig,
           blockConfig = bhp.blockConfig,
+          stackConfig = bhp.stackConfig,
           coilQuorum = bhp.coilQuorum,
           // Placeholder: the L2 params hash is not consumed yet. Hash32 requires 32 bytes, so use
           // a zero hash rather than empty bytes (which fail the length check).
@@ -1229,6 +1232,7 @@ object InitBootstrapFiles:
               disputeResolutionConfig = DisputeResolutionConfig.default(network.slotConfig),
               settlementConfig = SettlementConfig(PositiveInt.unsafeApply(100)),
               blockConfig = BlockConfig(PositiveInt.unsafeApply(1000)),
+              stackConfig = StackConfig.default,
               coilQuorum = coilQuorum
             )
             // Demo equity: head peer 0 funds the whole head, the rest contribute zero and co-sign.

--- a/src/main/scala/hydrozoa/bootstrap/Bootstrap.scala
+++ b/src/main/scala/hydrozoa/bootstrap/Bootstrap.scala
@@ -166,8 +166,17 @@ object Bootstrap:
 
     object BootstrapHeadParams {
         given Encoder[BootstrapHeadParams] = deriveEncoder[BootstrapHeadParams]
+
+        /** Injects [[StackConfig.default]] when `stackConfig` is absent, so a `defaults.json`
+          * written before that section existed still builds. An operator's bootstrap directory
+          * outlives the head it first built — it is edited and re-run across releases — so a new
+          * head-parameter section must not turn an existing one into a decode failure.
+          */
         given (using CardanoNetwork.Section): Decoder[BootstrapHeadParams] =
-            deriveDecoder[BootstrapHeadParams]
+            deriveDecoder[BootstrapHeadParams].prepare { c =>
+                if c.downField("stackConfig").succeeded then c
+                else c.withFocus(_.mapObject(_.add("stackConfig", StackConfig.default.asJson)))
+            }
     }
 
     /** Assembly-time defaults (`defaults.json`): everything the head needs that is neither peer

--- a/src/main/scala/hydrozoa/config/head/multisig/stack/StackConfig.scala
+++ b/src/main/scala/hydrozoa/config/head/multisig/stack/StackConfig.scala
@@ -1,0 +1,41 @@
+package hydrozoa.config.head.multisig.stack
+
+import hydrozoa.lib.number.PositiveInt
+import io.circe.*
+import io.circe.generic.semiauto.*
+
+/** The per-stack composition limits the peers agree upon. Head-agreed (hashed into the treasury
+  * datum), so every peer closes and validates stacks under the same ceiling.
+  */
+final case class StackConfig(
+    override val maxMajorBlocksPerStack: PositiveInt
+) extends StackConfig.Section {
+    override transparent inline def stackConfig: StackConfig = this
+}
+
+object StackConfig {
+
+    /** Applied when a head config produced before this section existed is decoded. Large on
+      * purpose: a stack's hard-confirmation carries a fixed cost independent of its size, so a
+      * small cap closes many tiny stacks and *lowers* throughput (see docs/spec/slow-consensus.md).
+      */
+    val default: StackConfig = StackConfig(PositiveInt.unsafeApply(1000))
+
+    trait Section {
+        def stackConfig: StackConfig
+
+        /** The maximum number of Major blocks a single stack may cover. The slow leader closes on
+          * at most this many, holding the rest for the next stack; a follower rejects a brief
+          * spanning more.
+          *
+          * Majors are what a stack costs: each one derives a settlement, a fallback, rollouts and
+          * refunds, and every peer signs and verifies all of them. A run of Minor blocks collapses
+          * into a single partition, so minors are close to free and are deliberately not counted.
+          */
+        def maxMajorBlocksPerStack: PositiveInt = stackConfig.maxMajorBlocksPerStack
+    }
+
+    given stackConfigEncoder: Encoder[StackConfig] = deriveEncoder[StackConfig]
+
+    given stackConfigDecoder: Decoder[StackConfig] = deriveDecoder[StackConfig]
+}

--- a/src/main/scala/hydrozoa/config/head/parameters/HeadParameters.scala
+++ b/src/main/scala/hydrozoa/config/head/parameters/HeadParameters.scala
@@ -3,11 +3,13 @@ package hydrozoa.config.head.parameters
 import hydrozoa.config.head.multisig.block.BlockConfig
 import hydrozoa.config.head.multisig.fallback.FallbackContingency
 import hydrozoa.config.head.multisig.settlement.SettlementConfig
+import hydrozoa.config.head.multisig.stack.StackConfig
 import hydrozoa.config.head.multisig.timing.TxTiming
 import hydrozoa.config.head.network.CardanoNetwork
 import hydrozoa.config.head.rulebased.dispute.DisputeResolutionConfig
 import hydrozoa.lib.cardano.cip116.JsonCodecs.CIP0116.Conway.given
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import io.circe.syntax.*
 import io.circe.{Decoder, Encoder}
 import scalus.cardano.ledger.Hash32
 
@@ -20,6 +22,7 @@ final case class HeadParameters(
     override val disputeResolutionConfig: DisputeResolutionConfig,
     override val settlementConfig: SettlementConfig,
     override val blockConfig: BlockConfig,
+    override val stackConfig: StackConfig,
     // QUESTION: (from Peter to Ilia): I don't think we need to pin the coil quorum here, do we?
     //   It will be in the multisig native script; the hash will change if the peers don't agree.
     override val coilQuorum: Int,
@@ -34,15 +37,22 @@ object HeadParameters {
 
     given headParametersEncoder: Encoder[HeadParameters] = deriveEncoder[HeadParameters]
 
+    /** Injects [[StackConfig.default]] when `stackConfig` is absent, so a head config produced
+      * before that section existed still decodes rather than failing on the missing field.
+      */
     given headParametersDecoder(using CardanoNetwork.Section): Decoder[HeadParameters] =
-        deriveDecoder[HeadParameters]
+        deriveDecoder[HeadParameters].prepare { c =>
+            if c.downField("stackConfig").succeeded then c
+            else c.withFocus(_.mapObject(_.add("stackConfig", StackConfig.default.asJson)))
+        }
 
     trait Section
         extends TxTiming.Section,
           FallbackContingency.Section,
           DisputeResolutionConfig.Section,
           SettlementConfig.Section,
-          BlockConfig.Section {
+          BlockConfig.Section,
+          StackConfig.Section {
         def headParameters: HeadParameters
 
         /** A black-box, L2-specific blake2b-256 hash of the L2 parameters that the peers agree upon
@@ -78,5 +88,8 @@ object HeadParameters {
 
         def blockConfig: BlockConfig =
             headParameters.blockConfig
+
+        def stackConfig: StackConfig =
+            headParameters.stackConfig
     }
 }

--- a/src/main/scala/hydrozoa/multisig/consensus/StackComposer.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/StackComposer.scala
@@ -14,7 +14,7 @@ import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.HeadMultisigRegimeManager
 import hydrozoa.multisig.consensus.ack.{HardAck, HardAckId, HardAckNumber}
 import hydrozoa.multisig.consensus.peer.PeerId
-import hydrozoa.multisig.ledger.block.{Block, BlockNumber, BlockResult, BlockVersion}
+import hydrozoa.multisig.ledger.block.{Block, BlockNumber, BlockResult, BlockType, BlockVersion}
 import hydrozoa.multisig.ledger.event.RequestId
 import hydrozoa.multisig.ledger.joint.{EvacuationMap, JointLedger}
 import hydrozoa.multisig.ledger.l1.utxo.MultisigTreasuryUtxo
@@ -221,7 +221,7 @@ final case class StackComposer(
       * `lastClosedBlockNum + 1` into a new stack.
       */
     private def tryCloseAsLeader(s: State, nextStackNum: StackNumber): IO[Unit] =
-        s.longestReadyPrefix match {
+        s.longestReadyPrefix(config.maxMajorBlocksPerStack.convert) match {
             case Nil => IO.unit
             case prefix =>
                 for {
@@ -428,6 +428,23 @@ final case class StackComposer(
                             // (2) not caught up — benign; wait for more BlockResults /
                             // SoftConfirmeds. tryProgress re-fires on the next event.
                             IO.unit
+                        case Some(slice)
+                            if countMajors(slice) > config.maxMajorBlocksPerStack.convert =>
+                            // (1b) divergence — the leader closed on more Majors than the
+                            // head-agreed cap allows. Same class of break as a structurally
+                            // inconsistent range: this peer would derive a stack the cap forbids.
+                            tracer.traceWith(
+                              StackComposerEvent.MajorCapExceeded(
+                                nextStackNum,
+                                countMajors(slice),
+                                config.maxMajorBlocksPerStack.convert
+                              )
+                            ) >> panic(
+                              s"Stack $nextStackNum covers ${countMajors(slice)} major blocks," +
+                                  s" over the agreed cap of ${config.maxMajorBlocksPerStack.convert};" +
+                                  " consensus is broken."
+                            ) >> context.self.stop
+
                         case Some(slice) =>
                             // (3) covered — accept exactly the brief's range.
                             for {
@@ -831,6 +848,41 @@ object StackComposer {
         softConfirmed: Block.SoftConfirmed
     )
 
+    /** How many Major blocks a run of ready blocks covers — the count a stack is capped on, and the
+      * one a follower checks an inbound brief's range against.
+      */
+    private[consensus] def countMajors(blocks: List[ReadyBlock]): Int =
+        blocks.count(isMajor)
+
+    /** The longest prefix of `blocks` covering at most `maxMajors` Majors, cutting *before* the
+      * Major that would exceed it so the last included Major keeps its trailing Minors.
+      */
+    private[consensus] def takeUpToMajors(
+        blocks: List[ReadyBlock],
+        maxMajors: Int
+    ): List[ReadyBlock] = {
+        @tailrec
+        def loop(
+            remaining: List[ReadyBlock],
+            majors: Int,
+            acc: List[ReadyBlock]
+        ): List[ReadyBlock] =
+            remaining match {
+                case Nil => acc.reverse
+                case rb :: rest =>
+                    if isMajor(rb) then
+                        if majors == maxMajors then acc.reverse
+                        else loop(rest, majors + 1, rb :: acc)
+                    else loop(rest, majors, rb :: acc)
+            }
+        loop(blocks, 0, Nil)
+    }
+
+    private def isMajor(rb: ReadyBlock): Boolean = rb.result.brief match {
+        case _: BlockType.Major => true
+        case _                  => false
+    }
+
     /** The product of composing a stack from a prefix of paired blocks: the [[Stack.Unsigned]] to
       * hand to consensus, the rotated treasury + evacuation map the close advanced to, and the
       * [[StackPartition]] layout. The partitions are carried so the prefix is partitioned **once**
@@ -903,15 +955,25 @@ object StackComposer {
                 case _ => this
             }
 
-        /** Longest contiguous run of ready blocks starting at `lastClosedBlockNum + 1`. */
-        def longestReadyPrefix: List[ReadyBlock] = {
+        /** Longest contiguous run of ready blocks starting at `lastClosedBlockNum + 1`, truncated
+          * before the `maxMajors + 1`-th Major so one stack never carries more than `maxMajors`
+          * Major partitions.
+          *
+          * The cut lands *on* the next Major, so the last included Major keeps the Minor blocks
+          * trailing it — the partition it heads stays whole, and the remainder opens the following
+          * stack with a leading Minor run, which [[StackPartition.partition]] accepts.
+          *
+          * `maxMajors` is positive, so the first Major always fits and a truncated prefix is never
+          * empty.
+          */
+        def longestReadyPrefix(maxMajors: Int): List[ReadyBlock] = {
             @tailrec
             def loop(n: BlockNumber, acc: List[ReadyBlock]): List[ReadyBlock] =
                 ready.get(n) match {
                     case Some(rb) => loop(n.increment, rb :: acc)
                     case None     => acc.reverse
                 }
-            loop(lastClosedBlockNum.increment, Nil)
+            takeUpToMajors(loop(lastClosedBlockNum.increment, Nil), maxMajors)
         }
 
         /** The exact paired blocks for the inclusive range `[first, last]`, or `None` if any block

--- a/src/main/scala/hydrozoa/multisig/consensus/StackComposerEvent.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/StackComposerEvent.scala
@@ -38,3 +38,10 @@ object StackComposerEvent:
         leaderLast: BlockNumber,
         expectedFirst: BlockNumber
     ) extends StackComposerEvent
+
+    /** A leader closed a stack covering more Major blocks than the head-agreed cap allows. */
+    final case class MajorCapExceeded(
+        stackNum: StackNumber,
+        majors: Int,
+        cap: Int
+    ) extends StackComposerEvent

--- a/src/main/scala/hydrozoa/multisig/consensus/StackComposerEventFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/StackComposerEventFormat.scala
@@ -26,5 +26,10 @@ object StackComposerEventFormat:
                   s"Follower stack $sn structural divergence: leader brief [$lFirst..$lLast] but expected to start at $expected",
                   "stackNum" -> s"${sn: Int}"
                 )
+            case MajorCapExceeded(sn, majors, cap) =>
+                warn(
+                  s"Follower stack $sn covers $majors major blocks, over the agreed cap of $cap",
+                  "stackNum" -> s"${sn: Int}"
+                )
         }
     }

--- a/src/test/scala/hydrozoa/bootstrap/BootstrapMembershipTest.scala
+++ b/src/test/scala/hydrozoa/bootstrap/BootstrapMembershipTest.scala
@@ -84,6 +84,33 @@ class BootstrapMembershipTest extends AnyFunSuite {
         )
     }
 
+    test("the written defaults carry stackConfig, so a fresh scaffold pins the major cap") {
+        val network = CardanoNetwork.Preview
+        given CardanoNetwork.Section = network
+        val written = mkPreviewDefaults(coilQuorum = 0).asJson
+        val cap = written.hcursor
+            .downField("headParams")
+            .downField("stackConfig")
+            .get[Int]("maxMajorBlocksPerStack")
+        assert(cap == Right(StackConfig.default.maxMajorBlocksPerStack.convert))
+    }
+
+    test("a defaults.json written before stackConfig existed still decodes, to the default") {
+        val network = CardanoNetwork.Preview
+        given CardanoNetwork.Section = network
+        // An operator's bootstrap directory outlives the head it first built, so a new head-parameter
+        // section must not turn an existing `defaults.json` into a decode failure.
+        val old = mkPreviewDefaults(coilQuorum = 0).asJson.hcursor
+            .downField("headParams")
+            .withFocus(_.mapObject(_.remove("stackConfig")))
+            .top
+            .getOrElse(fail("could not rebuild the defaults JSON"))
+        val decoded = old
+            .as[Bootstrap.BootstrapDefaults]
+            .fold(e => fail(s"an older defaults.json must still decode, but: $e"), identity)
+        assert(decoded.headParams.stackConfig == StackConfig.default)
+    }
+
     test(
       "readBootstrapDir assembles the four bootstrap files into a BootstrapConfig"
     ) {

--- a/src/test/scala/hydrozoa/bootstrap/BootstrapMembershipTest.scala
+++ b/src/test/scala/hydrozoa/bootstrap/BootstrapMembershipTest.scala
@@ -4,6 +4,7 @@ import cats.effect.unsafe.implicits.global
 import hydrozoa.config.head.multisig.block.BlockConfig
 import hydrozoa.config.head.multisig.fallback.FallbackContingency.mkFallbackContingencyWithDefaults
 import hydrozoa.config.head.multisig.settlement.SettlementConfig
+import hydrozoa.config.head.multisig.stack.StackConfig
 import hydrozoa.config.head.multisig.timing.TxTiming
 import hydrozoa.config.head.network.CardanoNetwork
 import hydrozoa.config.head.rulebased.dispute.DisputeResolutionConfig
@@ -149,6 +150,7 @@ class BootstrapMembershipTest extends AnyFunSuite {
           disputeResolutionConfig = DisputeResolutionConfig.default(network.slotConfig),
           settlementConfig = SettlementConfig(PositiveInt.unsafeApply(100)),
           blockConfig = BlockConfig(PositiveInt.unsafeApply(1000)),
+          stackConfig = StackConfig.default,
           coilQuorum = coilQuorum
         )
         Bootstrap.BootstrapDefaults(

--- a/src/test/scala/hydrozoa/config/head/parameters/HeadParametersGen.scala
+++ b/src/test/scala/hydrozoa/config/head/parameters/HeadParametersGen.scala
@@ -4,6 +4,7 @@ import cats.data.*
 import hydrozoa.config.head.multisig.block.{BlockConfig, generateBlockConfig}
 import hydrozoa.config.head.multisig.fallback.{FallbackContingency, generateFallbackContingency}
 import hydrozoa.config.head.multisig.settlement.{SettlementConfig, generateSettlementConfig}
+import hydrozoa.config.head.multisig.stack.StackConfig
 import hydrozoa.config.head.multisig.timing.{TxTiming, generateDefaultTxTiming}
 import hydrozoa.config.head.rulebased.dispute.{DisputeResolutionConfig, generateDisputeResolutionConfig}
 import org.scalacheck.{Arbitrary, Gen}
@@ -19,6 +20,10 @@ def generateHeadParameters(
         generateDisputeResolutionConfig,
     generateSettlementConfig: Gen[SettlementConfig] = generateSettlementConfig,
     generateBlockConfig: Gen[BlockConfig] = generateBlockConfig,
+    // A plain value, not a `Gen`: drawing here would shift the seeded random stream that every
+    // fixed-seed fixture in the suite depends on. The cap has direct coverage in StackMajorCapTest;
+    // a test wanting a specific cap passes one.
+    stackConfig: StackConfig = StackConfig.default,
     generateL2ParamsHash: Gen[Hash32] = Arbitrary.arbitrary[Hash32],
     generateL2Ledger: Gen[L2LedgerKind] = Gen.const(L2LedgerKind.CardanoEutxo),
     // Default identity-isomorphism ON (headId pin NOT enforced) so generated L2 txs, which carry no
@@ -40,6 +45,7 @@ def generateHeadParameters(
       disputeResolutionConfig = disputeResolutionConfig,
       settlementConfig = settlementConfig,
       blockConfig = blockConfig,
+      stackConfig = stackConfig,
       // TODO: Generate
       coilQuorum = 0,
       l2ParamsHash = l2ParamsHash,

--- a/src/test/scala/hydrozoa/multisig/consensus/StackMajorCapTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/StackMajorCapTest.scala
@@ -1,0 +1,126 @@
+package hydrozoa.multisig.consensus
+
+import cats.effect.unsafe.implicits.global
+import hydrozoa.config.head.multisig.timing.TxTiming
+import hydrozoa.config.head.multisig.timing.TxTiming.BlockTimes.{BlockCreationEndTime, BlockCreationStartTime, FallbackTxStartTime}
+import hydrozoa.lib.cardano.scalus.QuantizedTime.QuantizedInstant.realTimeQuantizedInstant
+import hydrozoa.multisig.consensus.StackComposer.{ReadyBlock, countMajors, takeUpToMajors}
+import hydrozoa.multisig.ledger.block.{Block, BlockBody, BlockBrief, BlockHeader, BlockNumber, BlockResult, BlockVersion}
+import org.scalacheck.Gen
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import scalus.cardano.ledger.SlotConfig
+
+/** The stack's Major-block cap: a stack covers at most `maxMajorBlocksPerStack` Major blocks, and
+  * the overflow is held for the next stack rather than dropped.
+  *
+  * Minor blocks are deliberately uncapped — a run of them collapses into one partition, so they
+  * cost a stack almost nothing (docs/spec/slow-consensus.md, "Partition model").
+  */
+class StackMajorCapTest extends AnyFunSuite with ScalaCheckPropertyChecks {
+
+    private val slotConfig = SlotConfig.preprod
+    private val txTiming = TxTiming.default(slotConfig)
+    private val now = realTimeQuantizedInstant(slotConfig).unsafeRunSync()
+
+    private val start = BlockCreationStartTime(now)
+    private val end = BlockCreationEndTime(now)
+    private val fallback = FallbackTxStartTime(now)
+    private val forced = txTiming.forcedMajorBlockWakeupTime(fallback)
+
+    private def mkMajor(n: Int): ReadyBlock = {
+        val brief = BlockBrief.Major(
+          BlockHeader.Major(
+            blockNum = BlockNumber(n),
+            blockVersion = BlockVersion.Full(n, 0),
+            startTime = start,
+            endTime = end,
+            fallbackTxStartTime = fallback,
+            forcedMajorBlockWakeupTime = forced,
+            mDepositDecisionWakeupTime = None
+          ),
+          BlockBody.Major(requests = Nil, depositsAbsorbed = Nil, depositsRejected = Nil)
+        )
+        ReadyBlock(
+          BlockResult(brief, Nil, Nil, Nil, Nil, Nil, fallback),
+          Block.SoftConfirmed.Major(brief, Nil, finalizationRequested = false)
+        )
+    }
+
+    private def mkMinor(n: Int): ReadyBlock = {
+        val brief = BlockBrief.Minor(
+          BlockHeader.Minor(
+            blockNum = BlockNumber(n),
+            blockVersion = BlockVersion.Full(0, n),
+            startTime = start,
+            endTime = end,
+            fallbackTxStartTime = fallback,
+            forcedMajorBlockWakeupTime = forced,
+            mDepositDecisionWakeupTime = None
+          ),
+          BlockBody.Minor(requests = Nil, depositsRejected = Nil)
+        )
+        ReadyBlock(
+          BlockResult(brief, Nil, Nil, Nil, Nil, Nil, fallback),
+          Block.SoftConfirmed.Minor(brief, Nil, finalizationRequested = false)
+        )
+    }
+
+    /** A run of blocks, each independently Major or Minor, numbered from 1. */
+    private val genRun: Gen[List[ReadyBlock]] =
+        for {
+            kinds <- Gen.listOfN(30, Gen.oneOf(true, false))
+        } yield kinds.zipWithIndex.map { case (isMajor, i) =>
+            if isMajor then mkMajor(i + 1) else mkMinor(i + 1)
+        }
+
+    private val genCap: Gen[Int] = Gen.choose(1, 10)
+
+    test("a capped prefix never covers more majors than the cap") {
+        forAll(genRun, genCap) { (run, cap) =>
+            assert(countMajors(takeUpToMajors(run, cap)) <= cap)
+        }
+    }
+
+    test("the capped prefix is a prefix of the run — nothing is reordered or dropped from within") {
+        forAll(genRun, genCap) { (run, cap) =>
+            val taken = takeUpToMajors(run, cap)
+            assert(run.take(taken.length) == taken)
+        }
+    }
+
+    test("truncation cuts on a major, so the held remainder opens the next stack") {
+        forAll(genRun, genCap) { (run, cap) =>
+            val taken = takeUpToMajors(run, cap)
+            val dropped = run.drop(taken.length)
+            // Cutting before the (cap+1)-th Major means the first held block is that Major — never
+            // a Minor, which would needlessly split a Major's trailing run.
+            whenever(dropped.nonEmpty) {
+                assert(countMajors(List(dropped.head)) == 1 && countMajors(taken) == cap)
+            }
+        }
+    }
+
+    test("a run within the cap is taken whole") {
+        forAll(genRun) { run =>
+            // A cap at least as large as the run's own major count must not truncate it. Stated
+            // directly rather than filtered for: with 30 blocks the discard rate would be total.
+            assert(takeUpToMajors(run, countMajors(run).max(1)) == run)
+        }
+    }
+
+    test("minors alone never trigger truncation") {
+        forAll(genCap) { cap =>
+            val minors = (1 to 50).map(mkMinor).toList
+            assert(takeUpToMajors(minors, cap) == minors)
+        }
+    }
+
+    test("a positive cap always admits the first major, so a stack is never empty") {
+        forAll(genRun, genCap) { (run, cap) =>
+            whenever(run.nonEmpty) {
+                assert(takeUpToMajors(run, cap).nonEmpty)
+            }
+        }
+    }
+}


### PR DESCRIPTION
First of the slices bounding major-block load on the fast side. This one caps blast radius; it does not on its own stop the spiral (see "What this does not do").

## Config changes

**New head-agreed parameter.** `StackConfig.maxMajorBlocksPerStack`, default **1000**, in a new `stackConfig` section of `HeadParameters` — so it is hashed into the treasury datum and every peer closes and validates stacks under the same ceiling.

**Where it appears:**

| file | change |
|---|---|
| `head-config/head-config.json` | new `headParams.stackConfig.maxMajorBlocksPerStack` |
| `bootstrap/defaults.json` | new `headParams.stackConfig.maxMajorBlocksPerStack`, written by `init-bootstrap-files` / `keygen-fleet` |

```json
"stackConfig" : {
  "maxMajorBlocksPerStack" : 1000
}
```

**Existing configs keep working — no operator action required.** Both decoders inject the default when the field is absent, so a bootstrap directory or head config written before this release still builds and boots:

- `HeadParameters` — for an existing `head-config.json`
- `BootstrapHeadParams` — for an existing `bootstrap/defaults.json`

Both paths are pinned by tests, and verified end to end against a scaffolded head directory: a fresh `keygen-fleet` writes the section, and the same `defaults.json` with the section removed still runs `build-head-config`.

**Why the default is 1000 and not something small.** Hard-confirmation carries a large fixed cost per *stack*, independent of size, so a small cap closes many tiny stacks and *lowers* throughput. Measured on the deposit-bot crash: `confirm ≈ 180s + 0.63s × majors`, giving a sustained drain of 0.41 majors/s at a cap of 100 versus 1.23 at 1000.

## Why

A stack's cost is its **Major** partitions. Each derives a settlement, a fallback, rollouts and refunds, and every peer signs all of them and verifies every remote ack against them. A run of **Minor** blocks collapses into a single partition, so minors are close to free.

`tryCloseAsLeader` drains the *entire* longest contiguous ready prefix, and closure is single-flight. Under a deposit flood every block is Major (`decisions.absorbed.nonEmpty` forces `nextHeaderMajor`), so:

```
many absorbing blocks → every one Major → stack N holds k majors
  → k× sign/verify per peer → hard-confirm slow → more blocks pair into `ready`
  → stack N+1 drains a bigger prefix → k grows → stall
```

Observed on the deposit-bot crash — stacks 38→46 went 45, 157, 322, 1,000, 1,755, 1,567, 1,520, 3,420, then 10,774 and never confirmed. Arrival exceeded drain at every step.

## What it does

**Leader** — `State.longestReadyPrefix(maxMajors)` truncates the prefix before the `cap+1`-th Major. The cut lands *on* a Major, so the last included Major keeps its trailing minors (its partition stays whole) and the remainder opens the next stack with a leading Minor run, which `StackPartition.partition` accepts. `maxMajors` is positive, so the first Major always fits and a truncated prefix is never empty.

**Follower** — a brief whose range covers more majors than the cap is a divergence, alongside the existing structural check: new `MajorCapExceeded` event, warn + panic, handover to the rule-based regime. Head-agreed precisely so a follower can enforce it.

## What this does not do

Slice 1 alone does not stop the spiral — it relocates the divergence from the stack into the `ready` queue. Better (the head keeps hard-confirming) but still unbounded. Bounding production is the next slice.

## Tests

`StackMajorCapTest`, six properties: cap respected; result is a genuine prefix; truncation always cuts on a Major; a within-cap run is taken whole; minors never trigger truncation; a positive cap always admits the first Major. Plus the two config-compatibility tests above.

`sbt "testOnly *"` — 518 passed, 0 failed, 72 suites. `just build-werror` and `just lint` green.

## Note for reviewers

`stackConfig` is a plain value parameter in `HeadParametersGen`, not a `Gen`. Drawing it shifts the seeded random stream that fixed-seed fixtures depend on (`pureApply(Gen.Parameters.default, Seed(0L))`), which silently broke five unrelated suites — `RocksDbL2StoreTest`, `RecoverSeamsTest`, `EutxoL2LedgerRecoveryTest`, `TransientTokensEvacuationPurityTest`, `L2QueryEndpointsTest`. Same trap as `247eef4e` during the request cap. A test wanting a specific cap passes one explicitly.