### PR TITLE
feat(bootstrap): require an explicit --l2-ledger for build-head-config

### DIFF
--- a/docs/user-guide/DEPLOYMENT.md
+++ b/docs/user-guide/DEPLOYMENT.md
@@ -341,9 +341,14 @@ the ladder never changes.
 ### Step 5 — Build the shared head config
 
 ```bash
-hydrozoa build-head-config   # Docker; reads $HYDROZOA_HOME/bootstrap/, writes $HYDROZOA_HOME/head-config/head-config.json
-just build-head-config       # local
+hydrozoa build-head-config --l2-ledger cardano-eutxo   # Docker; reads $HYDROZOA_HOME/bootstrap/, writes $HYDROZOA_HOME/head-config/head-config.json
+just build-head-config cardano-eutxo                   # local
 ```
+
+`--l2-ledger` is required and has no default. `cardano-eutxo` is the ledger this guide deploys:
+every node runs the built-in EUTXO ledger in-process, and the head's opening evacuation map is
+projected from `bootstrap/l2-cardano-eutxo.json`. The other value, `any-remote`, points the head
+at a separate L2 ledger and is out of scope here.
 
 The build assembles the bootstrap directory's four files (roster, defaults, opening L2 state,
 script refs) and talks to L1: it fetches head peer 0's UTxOs (to select funding inputs and verify
@@ -452,7 +457,7 @@ So the restart cycle is:
 just head-down
 # re-fund head peer 0 if the previous head consumed the funding — `just head-zero-address`
 # prints the address; check it in the network's explorer
-just build-head-config
+just build-head-config cardano-eutxo
 just head-up           # right after the build — the config is freshest now
 ```
 

--- a/justfile
+++ b/justfile
@@ -243,7 +243,11 @@ deploy-scripts-and-g2-setup LADDER_REFS="": _require-launcher
 # ref-utxos), writing $HYDROZOA_HOME/head-config/head-config.json. Reads the Blockfrost key from the .local
 # template (else $BLOCKFROST_API_KEY); head peer 0's address must be funded on the target network
 # first (the tool logs the exact lovelace required and fails with the shortfall if not).
-build-head-config: _require-launcher
+#
+# L2_LEDGER is required and explicit — `cardano-eutxo` runs the built-in ledger in-process, while
+# `any-remote` points the head at a remote L2 ledger and additionally reads the map that ledger
+# exported into bootstrap/initial-evacuation-map.json, using it verbatim.
+build-head-config L2_LEDGER: _require-launcher
   #!/usr/bin/env bash
   set -euo pipefail
   trap 'just notify "build-head-config"' EXIT
@@ -251,7 +255,7 @@ build-head-config: _require-launcher
   key="${BLOCKFROST_API_KEY:-}"
   if [ -f "$template" ]; then key=$(sed -n 's/.*"blockfrostApiKey"[^"]*"\([^"]*\)".*/\1/p' "$template"); fi
   if [ -z "$key" ]; then echo "error: no Blockfrost key — create $template (deployment guide step 1) or export BLOCKFROST_API_KEY" >&2; exit 1; fi
-  {{hydrozoa}} build-head-config --home {{HYDROZOA_HOME}} --blockfrost-key "$key"
+  {{hydrozoa}} build-head-config --home {{HYDROZOA_HOME}} --blockfrost-key "$key" --l2-ledger {{L2_LEDGER}}
 
 # Run a head node in the foreground from a generated head-config + a peer's private config.
 serve HEAD_CONFIG PRIVATE_CONFIG: _require-launcher

--- a/src/main/scala/hydrozoa/bootstrap/Bootstrap.scala
+++ b/src/main/scala/hydrozoa/bootstrap/Bootstrap.scala
@@ -32,6 +32,7 @@ import hydrozoa.multisig.consensus.peer.HeadPeerNumber.given
 import hydrozoa.multisig.ledger.block.{Block, BlockBrief, BlockEffects, BlockHeader}
 import hydrozoa.multisig.ledger.eutxol2.toEvacuationMap
 import hydrozoa.multisig.ledger.eutxol2.tx.L2Genesis
+import hydrozoa.multisig.ledger.joint.EvacuationMap
 import hydrozoa.multisig.ledger.l1.tx.RawTx
 import hydrozoa.multisig.ledger.l1.txseq.InitializationTxSeq
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
@@ -249,6 +250,12 @@ object Bootstrap:
         val roster = "roster.json"
         val defaults = "defaults.json"
         val l2CardanoEutxo = "l2-cardano-eutxo.json"
+
+        /** The opening evacuation map a remote L2 ledger exports, consumed verbatim under
+          * `--l2-ledger any-remote`. Absent for the built-in EUTXO ledger, which projects its map
+          * from `l2-cardano-eutxo.json` instead.
+          */
+        val initialEvacuationMap = "initial-evacuation-map.json"
         val refUtxos = "ref-utxos.json"
     }
 
@@ -324,7 +331,9 @@ object Bootstrap:
       */
     def mkSharedHeadConfig(cardanoNetwork: CardanoNetwork, backend: CardanoBackend[IO])(
         bootstrapConfig: BootstrapConfig,
-        scriptReferenceUtxos: ScriptReferenceUtxos
+        scriptReferenceUtxos: ScriptReferenceUtxos,
+        l2Ledger: L2LedgerKind,
+        mbInitialEvacuationMap: Option[EvacuationMap]
     ): IO[HeadConfig] = for {
         blockCreationStartTime <- bootstrapConfig.blockZeroStartTime.fold(
           realTimeQuantizedInstant(cardanoNetwork.slotConfig).map(BlockCreationStartTime(_))
@@ -341,16 +350,18 @@ object Bootstrap:
           // Placeholder: the L2 params hash is not consumed yet. Hash32 requires 32 bytes, so use
           // a zero hash rather than empty bytes (which fail the length check).
           l2ParamsHash = Hash32.fromByteString(ByteString.fromArray(new Array[Byte](32))),
-          // The demo build targets the built-in EUTXO ledger. TODO: surface via a --l2-ledger flag.
-          l2Ledger = L2LedgerKind.CardanoEutxo,
+          l2Ledger = l2Ledger,
           // Enforce the headId pin (format isomorphism only). TODO: surface via a flag.
           identityIsomorphism = false,
         )
 
-        // The opening L2 state's total value is what the treasury must back on L1 (the initial L2
-        // value). The evacuation map itself is built later, once the seed utxo — the source of the
-        // synthetic key ids — is resolved.
-        initialL2Value = Value.combine(bootstrapConfig.initialL2State.map(_.value))
+        // The opening L2 state.s total value is what the treasury must back on L1 (the initial L2
+        // value). A remote ledger supplies its own opening map, so its total is authoritative there;
+        // for the built-in EUTXO ledger the map is projected from `initialL2State` further down,
+        // once the seed utxo — the source of the synthetic key ids — is resolved.
+        initialL2Value = mbInitialEvacuationMap.fold(
+          Value.combine(bootstrapConfig.initialL2State.map(_.value))
+        )(_.totalValue)
 
         // Equity comes from the config (per head peer). Its total is what the treasury backs beyond
         // the L2 value; the per-peer split is recorded but the init tx consumes only the sum.
@@ -478,9 +489,11 @@ object Bootstrap:
         initialUtxos: Utxos = bootstrapConfig.initialL2State.zipWithIndex.map { case (out, i) =>
             TransactionInput(genesisTxId, i) -> out.toTransactionOutput
         }.toMap
-        evacMap <- IO.fromEither(
-          initialUtxos.toEvacuationMap(cardanoNetwork).left.map(e => RuntimeException(e.toString))
-        )
+        evacMap <- mbInitialEvacuationMap.fold(
+          IO.fromEither(
+            initialUtxos.toEvacuationMap(cardanoNetwork).left.map(e => RuntimeException(e.toString))
+          )
+        )(IO.pure)
 
         initializationParameters = InitializationParameters(
           initialEvacuationMap = evacMap,
@@ -1064,6 +1077,20 @@ object BuildHeadConfig:
           Opts.env[String]("BLOCKFROST_API_KEY", "Blockfrost API key for the Cardano backend")
         ).orNone
 
+    /** Which L2 ledger the head runs. Required and explicit: the two differ in trust model, and a
+      * head built for the wrong one starts its in-process EUTXO ledger and never speaks to the
+      * remote ledger at all — a silent misconfiguration that only shows up at runtime.
+      */
+    private val l2LedgerOpt: Opts[L2LedgerKind] =
+        Opts.option[String](
+          "l2-ledger",
+          "Which L2 ledger the head runs: cardano-eutxo | any-remote (required)"
+        ).mapValidated { s =>
+            Decoder[L2LedgerKind]
+                .decodeJson(Json.fromString(s))
+                .fold(e => Validated.invalidNel(e.getMessage), Validated.validNel)
+        }
+
     /** The `build-head-config` subcommand. */
     lazy val command: Command[IO[ExitCode]] =
         Command(
@@ -1072,20 +1099,48 @@ object BuildHeadConfig:
         )(runOpts)
 
     private def runOpts: Opts[IO[ExitCode]] =
-        (Bootstrap.homeOpt, blockfrostKeyOpt).mapN((home, mbKey) =>
+        (Bootstrap.homeOpt, blockfrostKeyOpt, l2LedgerOpt).mapN((home, mbKey, l2Ledger) =>
             buildHeadConfig(
               Bootstrap.HomeLayout.bootstrapDir(home),
               mbKey,
               Bootstrap.defaultPrivateTemplate(home),
-              Bootstrap.HomeLayout.headConfig(home)
+              Bootstrap.HomeLayout.headConfig(home),
+              l2Ledger
             )
         )
+
+    /** Read the opening evacuation map a remote L2 ledger exported into the bootstrap directory.
+      * Used **verbatim**: the remote ledger owns its opening state, so this build projects nothing
+      * and validates nothing beyond the map's own decoder — the peers' agreement on it is checked
+      * by the ledger's own boot-time digest.
+      */
+    private def readInitialEvacuationMap(
+        bootstrapDir: Path,
+        network: CardanoNetwork
+    ): IO[EvacuationMap] = {
+        val path = bootstrapDir.resolve(Bootstrap.BootstrapDir.initialEvacuationMap)
+        for {
+            exists <- IO.blocking(Files.exists(path))
+            _ <- IO.raiseUnless(exists)(
+              RuntimeException(
+                s"--l2-ledger any-remote requires $path — export the opening evacuation map " +
+                    "from the remote L2 ledger and place it there"
+              )
+            )
+            str <- IO.blocking(Files.readString(path))
+            map <- {
+                given CardanoNetwork.Section = network
+                IO.fromEither(parser.decode[EvacuationMap](str))
+            }
+        } yield map
+    }
 
     private def buildHeadConfig(
         bootstrapDir: Path,
         mbBlockfrostKey: Option[String],
         template: Path,
-        outPath: Path
+        outPath: Path,
+        l2Ledger: L2LedgerKind
     ): IO[ExitCode] =
         for {
             // No --blockfrost-key / $BLOCKFROST_API_KEY → fall back to the key set in the template.
@@ -1138,9 +1193,18 @@ object BuildHeadConfig:
                         )
                     )
             }
+            // A remote ledger's opening map comes from the ledger itself; the built-in EUTXO ledger
+            // projects its own from `l2-cardano-eutxo.json` inside mkSharedHeadConfig.
+            mbInitialEvacuationMap <- l2Ledger match {
+                case L2LedgerKind.CardanoEutxo => IO.pure(None)
+                case L2LedgerKind.AnyRemote =>
+                    readInitialEvacuationMap(bootstrapDir, cardanoNetwork).map(Some(_))
+            }
             headConfig <- Bootstrap.mkSharedHeadConfig(cardanoNetwork, backend)(
               bootstrapConfig,
-              scriptReferenceUtxos
+              scriptReferenceUtxos,
+              l2Ledger,
+              mbInitialEvacuationMap
             )
             _ <- IO.blocking {
                 Option(outPath.getParent).foreach(Files.createDirectories(_))


### PR DESCRIPTION
## Why

`mkSharedHeadConfig` hard-coded `l2Ledger = L2LedgerKind.CardanoEutxo` (with a `TODO: surface via a --l2-ledger flag`). A head intended for a remote L2 ledger therefore came out of the build running the **built-in EUTXO ledger in-process** and never spoke to the remote ledger at all. Nothing fails at build time — it only shows up at runtime, and the workaround has been to hand-patch `head-config.json` after every build.

## What changes

**`--l2-ledger` is required, with no default.** It takes the same `cardano-eutxo | any-remote` strings as the config field and is validated by that field's own `Decoder[L2LedgerKind]`, so the accepted values and the rejection message have one source of truth.

**`cardano-eutxo`** — unchanged behaviour. The opening evacuation map is still projected from `bootstrap/l2-cardano-eutxo.json` onto synthetic genesis ids derived from the seed utxo.

**`any-remote`** — sets the kind, and reads `bootstrap/initial-evacuation-map.json`, the map the remote L2 ledger exported, using it **verbatim**: the remote ledger owns its opening state, so this build projects nothing and validates nothing beyond the map's decoder (peer agreement on it is already enforced by the ledger's own boot-time digest). Its `totalValue` becomes the L2 value the treasury must back, in place of the total over `l2-cardano-eutxo.json`. A missing file fails with a message naming the file and what to put there.

**justfile** — `just build-head-config L2_LEDGER` takes it as a required parameter, so the recipe cannot silently pick a side either.

**DEPLOYMENT.md** — updated for the `cardano-eutxo` path only, which is the ledger that guide deploys; `any-remote` is named as out of scope rather than documented there.

## Note

`readBootstrapDir` still requires `l2-cardano-eutxo.json` to be present on the `any-remote` path, where its contents are then ignored — an empty `[]` satisfies it. Making it conditional means reshaping `readBootstrapDir`, which felt out of scope here.

## Tests

`sbt clean` then `sbt test` — 331 passed, 0 failed, 44 suites. `just build-werror` and `just lint` green. CLI behaviour smoke-checked for the help text, the required-ness, and the rejection of an unknown value.