### PR TITLE
chore(release): 0.1.10

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -27,7 +27,7 @@ the image with `sbt Docker/stage` and pushes it to ghcr. No manual `docker push`
    as `version := "X.Y.Z"` and in prose:
 
    ```bash
-   grep -rn "0\.1\.8" --include=* . | grep -vE "^\./(target|\.git|head)/"
+   grep -rn "0\.1\.9" --include=* . | grep -vE "^\./(target|\.git|head)/"
    ```
 
    Not bumped: `HydrozoaRoutes.apiVersion` + `docs/openapi*.yaml` (the API-contract version,

--- a/build.sbt
+++ b/build.sbt
@@ -472,7 +472,7 @@ inThisBuild(
   List(
     // Release version — drives the Docker image tag, `hydrozoa.BuildInfo.version`, and `GET
     // /version`. Bump here for a release (see RELEASE.md), then tag `v<version>`.
-    version := "0.1.9",
+    version := "0.1.10",
     scalaVersion := "3.3.7",
     semanticdbEnabled := true,
     semanticdbVersion := scalafixSemanticdb.revision

--- a/docs/user-guide/DEPLOYMENT.md
+++ b/docs/user-guide/DEPLOYMENT.md
@@ -124,13 +124,13 @@ under it. Then load the CLI alias and check you are on the version you expect:
 source ./hydrozoa.sh   # sets the `hydrozoa` alias + HYDROZOA_HOME (this folder, an absolute path)
 
 hydrozoa version       # verify the image you are running
-#   hydrozoa 0.1.9
-#   git:   v0.1.9
+#   hydrozoa 0.1.10
+#   git:   v0.1.10
 #   built: 2026-07-28 14:00:37.834-0600
 ```
 
-(The `git:` line is `git describe` provenance; a published image built from the `v0.1.9` tag reads a
-clean `v0.1.9`. A locally built image between releases shows the distance from the newest tag, e.g.
+(The `git:` line is `git describe` provenance; a published image built from the `v0.1.10` tag reads a
+clean `v0.1.10`. A locally built image between releases shows the distance from the newest tag, e.g.
 `v0.1.0-10-gaa9d7c69`.)
 
 Need a version that isn't in the registry? Build it from this repo — see §3.
@@ -425,8 +425,8 @@ finalization) appears in the same section as the head progresses.
 build (§3) is already tagged `…:latest`, so it is picked up without either:
 
 ```bash
-HYDROZOA_VERSION=0.1.9 just head-up                          # a specific published release
-HYDROZOA_IMAGE=cardano-hydrozoa/hydrozoa:0.1.9 just head-up  # a specific/other image name
+HYDROZOA_VERSION=0.1.10 just head-up                          # a specific published release
+HYDROZOA_IMAGE=cardano-hydrozoa/hydrozoa:0.1.10 just head-up  # a specific/other image name
 ```
 
 **Another head** — each head directory carries its own `docker-compose.yml`, so switch heads by

--- a/src/main/resources/scaffold/hydrozoa.sh
+++ b/src/main/resources/scaffold/hydrozoa.sh
@@ -13,7 +13,7 @@
 # scaffolded workspace — resolved to an absolute path, so the alias mounts correctly no matter which
 # directory you run it from. Override HYDROZOA_HOME (to an absolute path) or HYDROZOA_VERSION before
 # sourcing, or edit the defaults below.
-: "${HYDROZOA_VERSION:=0.1.9}"   # published image tag (ghcr.io/cardano-hydrozoa/hydrozoa)
+: "${HYDROZOA_VERSION:=0.1.10}"   # published image tag (ghcr.io/cardano-hydrozoa/hydrozoa)
 : "${HYDROZOA_HOME:=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)}"   # head directory (absolute)
 export HYDROZOA_VERSION HYDROZOA_HOME
 


### PR DESCRIPTION
Version bump only — step 1 of [RELEASE.md](RELEASE.md). Tagging `v0.1.10` after this merges is what publishes the image.

## Bumped

| file | what |
|---|---|
| `build.sbt` | `version := "0.1.10"` — drives the image tag, `BuildInfo.version`, `GET /version` |
| `src/main/resources/scaffold/hydrozoa.sh` | `HYDROZOA_VERSION` default |
| `docs/user-guide/DEPLOYMENT.md` | `hydrozoa version` sample, the `git describe` paragraph, the `HYDROZOA_VERSION=` / `HYDROZOA_IMAGE=` run examples |
| `RELEASE.md` | straggler grep now names `0.1.9` |

`scaffold/docker-compose.yml` needs no edit — its image default follows `hydrozoa.sh`. `HydrozoaRoutes.apiVersion` and `docs/openapi*.yaml` are deliberately not bumped (API-contract version, separate from the release version).

Verified: `grep -rn "0\.1\.9"` over the tree is clean, and a local `hydrozoa version` reports `hydrozoa 0.1.10`.

## What ships in 0.1.10

Three merged PRs since `v0.1.9`:

- **#666** `feat(bootstrap): require an explicit --l2-ledger for build-head-config` — **operator-visible breaking change**, see below
- **#663** `fix(backend): suspend the Blockfrost call in resolve` — the `getTxOutput` round trip ran when `resolve` was *called* rather than when its `IO` ran, so the result was baked into the value and the blocking call landed off the blocking pool
- **#660** `fix(backend): cache BloxBean services to stop per-call OkHttpClient churn` — `get*Service` built a fresh Retrofit + default `OkHttpClient` per call, and `paginate` calls it once per page

The two backend fixes matter for anyone who saw a head accumulate held TLS connections and `OkHttp` threads under polling load.

### Breaking: `build-head-config` now requires `--l2-ledger`

`hydrozoa build-head-config` and `just build-head-config` both now require the ledger kind explicitly — `cardano-eutxo` or `any-remote`. There is no default. Existing invocations must add it:

```bash
hydrozoa build-head-config --l2-ledger cardano-eutxo
just build-head-config cardano-eutxo
```

Previously the build hard-coded `cardano-eutxo`, so a head meant for a remote L2 ledger silently came out running the in-process EUTXO ledger.

## Runbook checks

- **Step 2 — baked reference UTxOs:** no change to `cardano-onchain`, the validator sources, `plutus.json`, or the Scalus version since `v0.1.9`, so the compiled scripts are unchanged and the baked `scaffold/ref-utxos/` stay valid. Nothing to redeploy.
- **Step 3 — shipped logger levels:** `logback-docker.xml` is untouched by this release; worth a glance before tagging if you want different levels shipped.

## Tests

`sbt "testOnly *"` (a genuine full run — plain `test` is aliased to `testQuick` here and reports only what recompiled): **510 passed, 0 failed, 71 suites**. `just build-werror` and the pre-commit lint/fmt hook green.