### PR TITLE
config: let a node bind somewhere other than it advertises

### DIFF
--- a/src/main/scala/hydrozoa/app/Serve.scala
+++ b/src/main/scala/hydrozoa/app/Serve.scala
@@ -226,6 +226,53 @@ object Serve {
       * `None` and mounts no L2-query endpoints. The EUTXO ledger owns its own RocksDB persistence,
       * separate from the consensus store.
       */
+    /** Where this node's peer websocket server listens.
+      *
+      * Normally that is the address the shared head config advertises for this peer, so there is
+      * one source of truth and no way for the two to drift. The override exists for the case where
+      * they genuinely differ: with a TLS-terminating proxy in front, peers dial a public name that
+      * resolves to the proxy, and no host can bind that name. The node then advertises the public
+      * address to the head and listens wherever the proxy can reach it.
+      *
+      * Each half overrides independently -- moving the local port while keeping the advertised one
+      * is a normal thing to want, and requiring both would make that awkward.
+      */
+    private[hydrozoa] def peerBindAddress(
+        peerBindHost: Option[String],
+        peerBindPort: Option[String],
+        advertised: Uri,
+        ownHeadNum: HeadPeerNumber
+    ): (Host, Port) = {
+        val host = peerBindHost match {
+            case Some(h) =>
+                Host.fromString(h)
+                    .getOrElse(throw IllegalArgumentException(s"peerBindHost is not a host: $h"))
+            case None =>
+                advertised.host
+                    .flatMap(h => Host.fromString(h.value))
+                    .getOrElse(
+                      throw IllegalArgumentException(
+                        s"own head peer $ownHeadNum webSocketAddress has no valid host: $advertised"
+                      )
+                    )
+        }
+        val port = peerBindPort match {
+            case Some(p) =>
+                p.toIntOption
+                    .flatMap(Port.fromInt)
+                    .getOrElse(throw IllegalArgumentException(s"peerBindPort is not a port: $p"))
+            case None =>
+                advertised.port
+                    .flatMap(Port.fromInt)
+                    .getOrElse(
+                      throw IllegalArgumentException(
+                        s"own head peer $ownHeadNum webSocketAddress has no valid port: $advertised"
+                      )
+                    )
+        }
+        (host, port)
+    }
+
     private def mkL2Ledger(
         nodeConfig: NodeConfig,
         dataDir: Path,
@@ -312,6 +359,11 @@ object Serve {
         // The inter-peer transport server binds where the shared head config advertises this peer,
         // so bind address == the address other peers dial (single source of truth). The user-facing
         // HTTP server uses the private httpHost/httpPort instead.
+        //
+        // The two come apart whenever something terminates the connection in front of this node --
+        // a TLS proxy demanding a client certificate, say. Then peers dial a public name this host
+        // cannot bind, and `peerBindHost`/`peerBindPort` in the node's private config say where to
+        // listen instead. Advertised address stays shared and agreed; bind address stays local.
         val ownWsAddress = nodeConfig.headConfig.headPeers.headPeerData
             .lookup(ownHeadNum)
             .map(_.webSocketAddress)
@@ -320,20 +372,12 @@ object Serve {
                 s"no webSocketAddress configured for own head peer $ownHeadNum"
               )
             )
-        val bindHost = ownWsAddress.host
-            .flatMap(h => Host.fromString(h.value))
-            .getOrElse(
-              throw new IllegalArgumentException(
-                s"own head peer $ownHeadNum webSocketAddress has no valid host: $ownWsAddress"
-              )
-            )
-        val bindPort = ownWsAddress.port
-            .flatMap(Port.fromInt)
-            .getOrElse(
-              throw new IllegalArgumentException(
-                s"own head peer $ownHeadNum webSocketAddress has no valid port: $ownWsAddress"
-              )
-            )
+        val (bindHost, bindPort) = peerBindAddress(
+          nodeConfig.peerBindHost,
+          nodeConfig.peerBindPort,
+          ownWsAddress,
+          ownHeadNum
+        )
         val remoteHeadUris: Map[HeadPeerId, Uri] = nodeConfig.headPeerIds
             .filterNot(_.peerNum == ownHeadNum)
             .toList

--- a/src/main/scala/hydrozoa/config/node/NodePrivateConfig.scala
+++ b/src/main/scala/hydrozoa/config/node/NodePrivateConfig.scala
@@ -19,6 +19,8 @@ final case class NodePrivateConfig(
     override val adminPassword: String,
     override val httpHost: String,
     override val httpPort: String,
+    override val peerBindHost: Option[String] = None,
+    override val peerBindPort: Option[String] = None,
 ) extends NodePrivateConfig.Section {
     override transparent inline def nodePrivateConfig: NodePrivateConfig = this
 }
@@ -58,6 +60,27 @@ object NodePrivateConfig {
         def httpHost: String = nodePrivateConfig.httpHost
 
         def httpPort: String = nodePrivateConfig.httpPort
+
+        /** Where this node's peer websocket server actually binds, when that is not where other
+          * peers reach it.
+          *
+          * A peer's `webSocketAddress` in the shared head config is the address the rest of the
+          * head dials, so every peer must agree on it. It is also, by default, the address this
+          * node binds. Those coincide on a flat network and stop coinciding the moment anything
+          * sits in front: behind a TLS-terminating proxy the head is dialed at
+          * `wss://head.example:4001` but must listen on a private interface the proxy can reach,
+          * and `head.example` is not an address this host can bind at all.
+          *
+          * Being per-node private config is the point: the bind address is this machine's business,
+          * and putting it in the shared config would force every peer to agree on a detail none of
+          * them can observe.
+          */
+        def peerBindHost: Option[String] = nodePrivateConfig.peerBindHost
+
+        /** Port counterpart to [[peerBindHost]]; see there. Settable independently, so a node can
+          * keep the advertised port and move only the local one.
+          */
+        def peerBindPort: Option[String] = nodePrivateConfig.peerBindPort
     }
 
     given nodePrivateConfigEncoder: Encoder[NodePrivateConfig] =

--- a/src/test/scala/hydrozoa/app/PeerBindAddressTest.scala
+++ b/src/test/scala/hydrozoa/app/PeerBindAddressTest.scala
@@ -1,0 +1,65 @@
+package hydrozoa.app
+
+import hydrozoa.multisig.consensus.peer.HeadPeerNumber
+import org.http4s.Uri
+import org.http4s.implicits.uri
+import org.scalatest.funsuite.AnyFunSuite
+
+/** [[Serve.peerBindAddress]]: where the peer websocket server listens, versus where the shared head
+  * config says to dial this peer.
+  *
+  * They coincide on a flat network, and stop coinciding the moment something terminates connections
+  * in front of the node -- a mutual-TLS proxy, say. Then peers dial a public name that resolves to
+  * the proxy, which no host can bind, and the node has to be told where to listen instead.
+  */
+class PeerBindAddressTest extends AnyFunSuite:
+
+    private val peer0 = HeadPeerNumber(0)
+
+    test("with no override, the node binds exactly what the head config advertises") {
+        val (host, port) = Serve.peerBindAddress(None, None, uri"ws://127.0.0.1:4001", peer0)
+        assert(host.toString == "127.0.0.1")
+        assert(port.value == 4001)
+    }
+
+    test("behind a proxy, the advertised name is unbindable and the override decides") {
+        // The head advertises the public name so coils know where to dial; the node
+        // listens on every interface so the proxy in front can reach it.
+        val (host, port) = Serve.peerBindAddress(
+          Some("0.0.0.0"),
+          Some("4001"),
+          uri"wss://head.sugar.rush.sundae.fi:4001",
+          peer0
+        )
+        assert(host.toString == "0.0.0.0")
+        assert(port.value == 4001)
+    }
+
+    test("host and port override independently") {
+        val advertised = uri"wss://head.sugar.rush.sundae.fi:4001"
+        val (h1, p1) = Serve.peerBindAddress(Some("0.0.0.0"), None, advertised, peer0)
+        assert(
+          h1.toString == "0.0.0.0" && p1.value == 4001,
+          "port falls back to the advertised one"
+        )
+
+        val (h2, p2) = Serve.peerBindAddress(None, Some("14001"), advertised, peer0)
+        assert(h2.toString == "head.sugar.rush.sundae.fi", "host falls back to the advertised one")
+        assert(p2.value == 14001)
+    }
+
+    test("a malformed override fails loudly rather than silently binding somewhere else") {
+        val advertised = uri"ws://127.0.0.1:4001"
+        assertThrows[IllegalArgumentException] {
+            Serve.peerBindAddress(None, Some("not-a-port"), advertised, peer0)
+        }
+        assertThrows[IllegalArgumentException] {
+            Serve.peerBindAddress(None, Some("70000"), advertised, peer0)
+        }
+    }
+
+    test("an advertised address with no port is still an error when nothing overrides it") {
+        assertThrows[IllegalArgumentException] {
+            Serve.peerBindAddress(None, None, uri"ws://127.0.0.1", peer0)
+        }
+    }

--- a/src/test/scala/hydrozoa/app/PeerBindAddressTest.scala
+++ b/src/test/scala/hydrozoa/app/PeerBindAddressTest.scala
@@ -1,7 +1,6 @@
 package hydrozoa.app
 
 import hydrozoa.multisig.consensus.peer.HeadPeerNumber
-import org.http4s.Uri
 import org.http4s.implicits.uri
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -15,46 +14,40 @@ import org.scalatest.funsuite.AnyFunSuite
 class PeerBindAddressTest extends AnyFunSuite:
 
     private val peer0 = HeadPeerNumber(0)
+    private val public = uri"wss://head.sugar.rush.sundae.fi:4001"
+    private val local = uri"ws://127.0.0.1:4001"
 
     test("with no override, the node binds exactly what the head config advertises") {
-        val (host, port) = Serve.peerBindAddress(None, None, uri"ws://127.0.0.1:4001", peer0)
-        assert(host.toString == "127.0.0.1")
-        assert(port.value == 4001)
+        val (host, port) = Serve.peerBindAddress(None, None, local, peer0)
+        assert(host.toString == "127.0.0.1" && port.value == 4001)
     }
 
     test("behind a proxy, the advertised name is unbindable and the override decides") {
         // The head advertises the public name so coils know where to dial; the node
         // listens on every interface so the proxy in front can reach it.
-        val (host, port) = Serve.peerBindAddress(
-          Some("0.0.0.0"),
-          Some("4001"),
-          uri"wss://head.sugar.rush.sundae.fi:4001",
-          peer0
-        )
-        assert(host.toString == "0.0.0.0")
-        assert(port.value == 4001)
+        val (host, port) = Serve.peerBindAddress(Some("0.0.0.0"), Some("4001"), public, peer0)
+        assert(host.toString == "0.0.0.0" && port.value == 4001)
     }
 
-    test("host and port override independently") {
-        val advertised = uri"wss://head.sugar.rush.sundae.fi:4001"
-        val (h1, p1) = Serve.peerBindAddress(Some("0.0.0.0"), None, advertised, peer0)
-        assert(
-          h1.toString == "0.0.0.0" && p1.value == 4001,
-          "port falls back to the advertised one"
-        )
-
-        val (h2, p2) = Serve.peerBindAddress(None, Some("14001"), advertised, peer0)
-        assert(h2.toString == "head.sugar.rush.sundae.fi", "host falls back to the advertised one")
-        assert(p2.value == 14001)
+    test("overriding only the host leaves the advertised port in place") {
+        val (host, port) = Serve.peerBindAddress(Some("0.0.0.0"), None, public, peer0)
+        assert(host.toString == "0.0.0.0" && port.value == 4001)
     }
 
-    test("a malformed override fails loudly rather than silently binding somewhere else") {
-        val advertised = uri"ws://127.0.0.1:4001"
+    test("overriding only the port leaves the advertised host in place") {
+        val (host, port) = Serve.peerBindAddress(None, Some("14001"), public, peer0)
+        assert(host.toString == "head.sugar.rush.sundae.fi" && port.value == 14001)
+    }
+
+    test("a non-numeric port override fails loudly rather than binding somewhere else") {
         assertThrows[IllegalArgumentException] {
-            Serve.peerBindAddress(None, Some("not-a-port"), advertised, peer0)
+            Serve.peerBindAddress(None, Some("not-a-port"), local, peer0)
         }
+    }
+
+    test("an out-of-range port override fails loudly too") {
         assertThrows[IllegalArgumentException] {
-            Serve.peerBindAddress(None, Some("70000"), advertised, peer0)
+            Serve.peerBindAddress(None, Some("70000"), local, peer0)
         }
     }
 


### PR DESCRIPTION
## Why

A peer's `webSocketAddress` in the shared head config does double duty today: it
is the address the rest of the head dials, **and** the address the node binds
(`Serve.scala`). That works on a flat network and breaks as soon as anything
terminates connections in front of the node.

Concretely: we're putting external coil peers behind an ALB that demands a
client certificate. Coils dial `wss://head.sugar.rush.sundae.fi:4001`, the ALB
verifies the certificate and forwards to the head. The head must therefore
*advertise* the public name and *listen* on an interface the ALB can reach —
and `head.sugar.rush.sundae.fi` is not an address any host can bind.

## What

`peerBindHost` / `peerBindPort` on `NodePrivateConfig`. Both optional and
independent; absent, a node binds whatever it advertises, so **every existing
config behaves exactly as before**.

Private config rather than shared is deliberate: where a node listens is that
machine's business, and putting it in the shared config would force every peer
to agree on a detail none of them can observe or verify.

Resolution is extracted to `Serve.peerBindAddress` — a pure function, so it can
be tested. The previous inline version was reachable only by starting a node.

## Testing

`PeerBindAddressTest` covers: default (bind == advertised), full override,
host-only and port-only override, malformed overrides failing loudly rather
than silently binding elsewhere, and a portless advertised address still erroring
when nothing overrides it.

Full suite on a clean build: 56 suites, 0 aborted, 391 passed. The 7 failures
are `CardanoBackendBlockfrostTest`, which needs a real Blockfrost project token
and fails identically on an unmodified `main`.