### PR TITLE
chore(release): 0.1.11

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -27,7 +27,7 @@ the image with `sbt Docker/stage` and pushes it to ghcr. No manual `docker push`
    as `version := "X.Y.Z"` and in prose:
 
    ```bash
-   grep -rn "0\.1\.9" --include=* . | grep -vE "^\./(target|\.git|head)/"
+   grep -rn "0\.1\.10" --include=* . | grep -vE "^\./(target|\.git|head)/"
    ```
 
    Not bumped: `HydrozoaRoutes.apiVersion` + `docs/openapi*.yaml` (the API-contract version,

--- a/build.sbt
+++ b/build.sbt
@@ -472,7 +472,7 @@ inThisBuild(
   List(
     // Release version — drives the Docker image tag, `hydrozoa.BuildInfo.version`, and `GET
     // /version`. Bump here for a release (see RELEASE.md), then tag `v<version>`.
-    version := "0.1.10",
+    version := "0.1.11",
     scalaVersion := "3.3.7",
     semanticdbEnabled := true,
     semanticdbVersion := scalafixSemanticdb.revision

--- a/docs/user-guide/DEPLOYMENT.md
+++ b/docs/user-guide/DEPLOYMENT.md
@@ -124,13 +124,13 @@ under it. Then load the CLI alias and check you are on the version you expect:
 source ./hydrozoa.sh   # sets the `hydrozoa` alias + HYDROZOA_HOME (this folder, an absolute path)
 
 hydrozoa version       # verify the image you are running
-#   hydrozoa 0.1.10
-#   git:   v0.1.10
+#   hydrozoa 0.1.11
+#   git:   v0.1.11
 #   built: 2026-07-28 14:00:37.834-0600
 ```
 
-(The `git:` line is `git describe` provenance; a published image built from the `v0.1.10` tag reads a
-clean `v0.1.10`. A locally built image between releases shows the distance from the newest tag, e.g.
+(The `git:` line is `git describe` provenance; a published image built from the `v0.1.11` tag reads a
+clean `v0.1.11`. A locally built image between releases shows the distance from the newest tag, e.g.
 `v0.1.0-10-gaa9d7c69`.)
 
 Need a version that isn't in the registry? Build it from this repo — see §3.
@@ -425,8 +425,8 @@ finalization) appears in the same section as the head progresses.
 build (§3) is already tagged `…:latest`, so it is picked up without either:
 
 ```bash
-HYDROZOA_VERSION=0.1.10 just head-up                          # a specific published release
-HYDROZOA_IMAGE=cardano-hydrozoa/hydrozoa:0.1.10 just head-up  # a specific/other image name
+HYDROZOA_VERSION=0.1.11 just head-up                          # a specific published release
+HYDROZOA_IMAGE=cardano-hydrozoa/hydrozoa:0.1.11 just head-up  # a specific/other image name
 ```
 
 **Another head** — each head directory carries its own `docker-compose.yml`, so switch heads by

--- a/src/main/resources/scaffold/hydrozoa.sh
+++ b/src/main/resources/scaffold/hydrozoa.sh
@@ -13,7 +13,7 @@
 # scaffolded workspace — resolved to an absolute path, so the alias mounts correctly no matter which
 # directory you run it from. Override HYDROZOA_HOME (to an absolute path) or HYDROZOA_VERSION before
 # sourcing, or edit the defaults below.
-: "${HYDROZOA_VERSION:=0.1.10}"   # published image tag (ghcr.io/cardano-hydrozoa/hydrozoa)
+: "${HYDROZOA_VERSION:=0.1.11}"   # published image tag (ghcr.io/cardano-hydrozoa/hydrozoa)
 : "${HYDROZOA_HOME:=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)}"   # head directory (absolute)
 export HYDROZOA_VERSION HYDROZOA_HOME
 


### PR DESCRIPTION
Version bump only — step 1 of [RELEASE.md](RELEASE.md). Tagging `v0.1.11` after merge is what publishes the image.

## Bumped

`build.sbt`, `src/main/resources/scaffold/hydrozoa.sh` (`HYDROZOA_VERSION` default), `docs/user-guide/DEPLOYMENT.md` (version sample, `git describe` paragraph, run examples), and `RELEASE.md`'s straggler grep (now names `0.1.10`).

`grep -rn "0\.1\.10"` over the tree comes back clean.

## What ships in 0.1.11

- **#668** `config: let a node bind somewhere other than it advertises` (@Quantumplation)

The only change since `v0.1.10`.

## Runbook check

No change to `cardano-onchain`, the validator sources, `plutus.json`, or the Scalus version since `v0.1.10`, so the compiled scripts are unchanged and the baked `scaffold/ref-utxos/` stay valid — nothing to redeploy (step 2).