### PR TITLE
feat(metrics): report head equity on /head/stats

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1296,6 +1296,7 @@ components:
       - mempoolSize
       - leaderMempoolDrain
       - sequencerHeadroom
+      - equityLovelace
       properties:
         uptimeSeconds:
           type: integer
@@ -1319,6 +1320,9 @@ components:
           type: integer
           format: int64
         sequencerHeadroom:
+          type: integer
+          format: int64
+        equityLovelace:
           type: integer
           format: int64
     RateStats:

--- a/docs/spec/peer-stats-endpoint.md
+++ b/docs/spec/peer-stats-endpoint.md
@@ -127,6 +127,7 @@ reference / `AtomicReference` publishes it to readers.
 | mempool size | gauge | requests held in the `BlockWeaver` mempool, not yet packed into a block |
 | leader mempool drain | gauge | requests the last lead pulled from the mempool into its block |
 | sequencer headroom | gauge | how many more requests the sequencer will admit before shedding load — the free space in its `backpressureCoefficient * maxRequestsPerBlock` window (the window itself is derivable from config, so only the live headroom is reported) |
+| head equity | gauge | the head's equity beyond its L2 liabilities, in lovelace — the treasury utxo's own `equity` field, one side of `treasury.value == evacuation map total + equity + beacon` |
 
 ## Instrumentation points
 
@@ -141,6 +142,7 @@ Three call sites, all on paths that already exist — no new plumbing:
 | block-lifecycle timings | **starts** in `BlockWeaver` (via `Connections.metrics`): `onLeadStart` on entering `Leader.ProcessingReadyRequests`, `onReplayStart` on entering `Follower.ProcessingReadyRequests`. **Close**: `JointLedger.handleBlock` calls `onBlockProduced(blockNum, requests)` where the brief is produced (own when leading, a reproduction when following) — this closes lead/replay *and* opens the soft-consensus clock; `FastConsensusActor.completeCell` then calls `onBlockConfirmed(blockNum, isMajor, events)` (merged with the block counters), which closes soft-consensus. `PeerMetrics` matches a produced block to whichever start (lead vs replay) the local peer opened, so the close site needs no lead/replay flag. |
 | mempool size / leader mempool drain | `BlockWeaver.Leader.ProcessingReadyRequests` — `onLeaderMempoolDrain(extracted)` and `onMempoolSize(surviving)` right after the leader extracts its block from the mempool; `onMempoolSize` also on `storeRequest`. |
 | sequencer headroom | `RequestSequencer` — `onSequencerHeadroom(headroom)` at PreStart, after each admit/reject, and on `SoftConfirmedHighWater` (which frees headroom). |
+| head equity | `StackComposer` — `onEquity(treasury.equity)` after `recoverOrBootstrap` (the recovered or initialization treasury, so the gauge is populated from boot) and after each `afterClose` on both the leader and follower paths, the points where the tracked treasury rotates. |
 
 Because `completeCell` / `completeStack` are the *only* places a soft-confirmed block / hard-confirmed
 stack is produced, those stats need exactly one line each and can never drift from reality.

--- a/src/main/scala/hydrozoa/multisig/MultisigRegimeManagerBase.scala
+++ b/src/main/scala/hydrozoa/multisig/MultisigRegimeManagerBase.scala
@@ -193,7 +193,13 @@ trait MultisigRegimeManagerBase[E >: LifecycleEvent <: RegimeManagerEvent]
               )
             )
             stackComposer <- context.actorOf(
-              StackComposer(config, pendingConnections, tracers.stackComposer, persistence)
+              StackComposer(
+                config,
+                pendingConnections,
+                tracers.stackComposer,
+                persistence,
+                metrics
+              )
             )
             slowConsensusActor <- context.actorOf(
               SlowConsensusActor(

--- a/src/main/scala/hydrozoa/multisig/consensus/StackComposer.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/StackComposer.scala
@@ -19,6 +19,7 @@ import hydrozoa.multisig.ledger.event.RequestId
 import hydrozoa.multisig.ledger.joint.{EvacuationMap, JointLedger}
 import hydrozoa.multisig.ledger.l1.utxo.MultisigTreasuryUtxo
 import hydrozoa.multisig.ledger.stack.*
+import hydrozoa.multisig.metrics.PeerMetrics
 import hydrozoa.multisig.persistence.recovery.{BlockResultScan, SoftConfirmationScan}
 import hydrozoa.multisig.persistence.{JournalKey, JournalValue, Markers, Persistence, StoreKey, WriteBatch}
 import scala.annotation.tailrec
@@ -49,7 +50,8 @@ final case class StackComposer(
     config: StackComposer.Config,
     pendingConnections: HeadMultisigRegimeManager.PendingConnections | StackComposer.Connections,
     tracer: ContraTracer[IO, StackComposerEvent],
-    persistence: Persistence[IO]
+    persistence: Persistence[IO],
+    metrics: PeerMetrics
 ) extends Actor[IO, StackComposer.Request] {
     import StackComposer.*
 
@@ -108,7 +110,18 @@ final case class StackComposer(
                 case Some(recoveredState) => state.set(recoveredState)
                 case None                 => bootstrapInitialStack
             }
+            // Seed the equity gauge from the boot treasury — the recovered one, or the
+            // initialization treasury `State.initial` starts from — so `/head/stats` reports the
+            // real figure from startup rather than zero until the first close.
+            s <- state.get
+            _ <- reportEquity(s.treasury)
         } yield ()
+
+    /** Publish the treasury's equity to [[PeerMetrics]] for `GET /head/stats`. Called at boot and
+      * on every stack close, the two points where the treasury this peer tracks changes.
+      */
+    private def reportEquity(treasury: MultisigTreasuryUtxo): IO[Unit] =
+        IO(metrics.onEquity(treasury.equity.coin.value))
 
     /** Compose and hand off stack 0 (the init + fallback) at startup.
       *
@@ -266,6 +279,7 @@ final case class StackComposer(
                     // withheld until local round-1 confirmation).
                     _ <- conn.slowConsensusActor ! handoff
                     _ <- state.update(_.afterClose(nextStackNum, prefix, newTreasury, newMap))
+                    _ <- reportEquity(newTreasury)
                 } yield ()
         }
 
@@ -466,6 +480,7 @@ final case class StackComposer(
                                 _ <- state.update(
                                   _.afterClose(nextStackNum, slice, newTreasury, newMap)
                                 )
+                                _ <- reportEquity(newTreasury)
                             } yield ()
                     }
         }

--- a/src/main/scala/hydrozoa/multisig/metrics/PeerMetrics.scala
+++ b/src/main/scala/hydrozoa/multisig/metrics/PeerMetrics.scala
@@ -69,6 +69,7 @@ final class PeerMetrics private (startedAtMillis: Long, remotePeerNums: Vector[I
     private val mempool = new AtomicLong(0)
     private val leaderMempoolDrain = new AtomicLong(0)
     private val seqHeadroom = new AtomicLong(0)
+    private val equityLovelace = new AtomicLong(0)
 
     // ---- derived rates (written only by the sampler fiber) ----
     private val rolling = new AtomicReference[Rolling](Rolling.empty(remotePeerNums))
@@ -145,6 +146,14 @@ final class PeerMetrics private (startedAtMillis: Long, remotePeerNums: Vector[I
     def onSequencerHeadroom(headroom: Long): Unit =
         seqHeadroom.set(math.max(0L, headroom))
 
+    /** The equity the head holds beyond its L2 liabilities, in lovelace — the treasury utxo's own
+      * `equity` field, one side of the double-entry identity `treasury.value == evacuation map
+      * total + equity + beacon`. Reported by [[hydrozoa.multisig.consensus.StackComposer]] from the
+      * initialization treasury at boot and from the rotated treasury on every stack close, so it is
+      * the equity as of the last stack this peer closed.
+      */
+    def onEquity(lovelace: Long): Unit = equityLovelace.set(lovelace)
+
     private def startClock(m: TrieMap[Long, Long], blockNum: Long): Unit =
         m.update(blockNum, now())
         // Defensive: a block that never closes (crash) would leak a start entry; cap the in-flight
@@ -198,7 +207,8 @@ final class PeerMetrics private (startedAtMillis: Long, remotePeerNums: Vector[I
           ),
           mempoolSize = mempool.get(),
           leaderMempoolDrain = leaderMempoolDrain.get(),
-          sequencerHeadroom = seqHeadroom.get()
+          sequencerHeadroom = seqHeadroom.get(),
+          equityLovelace = equityLovelace.get()
         )
 
     /** The 1 Hz sampler: feeds every rate's EWMAs from the cumulative counters, then publishes one
@@ -394,5 +404,6 @@ final case class PeerStats(
     blockTimings: BlockTimingSet,
     mempoolSize: Long,
     leaderMempoolDrain: Long,
-    sequencerHeadroom: Long
+    sequencerHeadroom: Long,
+    equityLovelace: Long
 )

--- a/src/main/scala/hydrozoa/multisig/metrics/PrometheusFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/metrics/PrometheusFormat.scala
@@ -139,6 +139,11 @@ object PrometheusFormat:
           "Requests the sequencer will admit now before backpressure trips.",
           s.sequencerHeadroom
         )
+        gauge(
+          "hydrozoa_equity_lovelace",
+          "Head equity beyond L2 liabilities, as of the last stack this peer closed.",
+          s.equityLovelace
+        )
 
         b.toString
 

--- a/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
+++ b/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
@@ -247,7 +247,11 @@ object ApiDto {
         blockTimings: BlockTimingSetView,
         mempoolSize: Long,
         leaderMempoolDrain: Long,
-        sequencerHeadroom: Long
+        sequencerHeadroom: Long,
+        /** The head's equity beyond its L2 liabilities, in lovelace, as of the last stack this peer
+          * closed. One side of `treasury.value == evacuation map total + equity + beacon`.
+          */
+        equityLovelace: Long
     )
     given Codec[PeerStatsView] = deriveCodec
 
@@ -295,7 +299,8 @@ object ApiDto {
           ),
           mempoolSize = s.mempoolSize,
           leaderMempoolDrain = s.leaderMempoolDrain,
-          sequencerHeadroom = s.sequencerHeadroom
+          sequencerHeadroom = s.sequencerHeadroom,
+          equityLovelace = s.equityLovelace
         )
 
     /** `{ "status": "success", "message": ... }` — the finalize-trigger body. */

--- a/src/test/scala/hydrozoa/multisig/consensus/StackComposerRecoveryTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/StackComposerRecoveryTest.scala
@@ -18,6 +18,7 @@ import hydrozoa.multisig.ledger.joint.{EvacuationMap, JointLedger}
 import hydrozoa.multisig.ledger.l1.tx.TxSignature
 import hydrozoa.multisig.ledger.l1.utxo.MultisigTreasuryUtxo
 import hydrozoa.multisig.ledger.stack.{PartitionEffects, Stack, StackBrief, StackEffects, StackNumber, StandaloneEvacuationCommitment}
+import hydrozoa.multisig.metrics.PeerMetrics
 import hydrozoa.multisig.persistence.codec.TreasuryFixture
 import hydrozoa.multisig.persistence.{ArrivalStamp, InMemoryBackendStore, JournalKey, JournalValue, Persistence, PersistenceEventFormat, StoreKey}
 import org.scalacheck.Gen
@@ -184,7 +185,8 @@ class StackComposerRecoveryTest extends AnyFunSuite:
                               headPeerLiaisons = List()
                             ),
                             ContraTracer.nullTracer[IO, StackComposerEvent],
-                            persistence
+                            persistence,
+                            PeerMetrics.create(0L, Vector.empty)
                           )
                         )
                         r <- check(gotHandoff)

--- a/src/test/scala/hydrozoa/multisig/metrics/PrometheusFormatTest.scala
+++ b/src/test/scala/hydrozoa/multisig/metrics/PrometheusFormatTest.scala
@@ -44,7 +44,8 @@ class PrometheusFormatTest extends AnyFunSuite:
       ),
       mempoolSize = 923,
       leaderMempoolDrain = 900,
-      sequencerHeadroom = 12
+      sequencerHeadroom = 12,
+      equityLovelace = 4_500_000L
     )
 
     test("counters carry the _total suffix and a TYPE line"):


### PR DESCRIPTION
## Why here

srtop reaches hydrozoa over **HTTP only**. It opens two RocksDBs as read-only secondaries — Sugar Rush's event log and the aggregator's views DB — and never hydrozoa's store (the one place hydrozoa's data dir appears in its config is as a directory to size-watch). So equity cannot be read locally by the dashboard; it has to travel on an endpoint.

`/head/stats` is the right one: srtop already polls it, and its contract is "cheap, served from a snapshot, no storage reads", which a pushed gauge satisfies.

## What it reports

`MultisigTreasuryUtxo` already carries `equity` as a field, so nothing needs deriving — this is the same quantity as the anchor `InitializationTx.Parse` checks:

```
treasury.value == evacuation map total + equity + beacon
```

`StackComposer` threads and rotates that treasury, so it reports:

- after `recoverOrBootstrap` — from the recovered treasury, or the initialization treasury `State.initial` starts from, so the gauge shows the real figure **from boot** rather than zero until the first stack closes
- after each `afterClose`, on both the leader and follower paths — the points where the tracked treasury rotates

`StackComposer` gains a `metrics: PeerMetrics` constructor field, mirroring `SlowConsensusActor`; `MultisigRegimeManagerBase` already had `metrics` in scope at the construction site.

## Surfaces

| where | name |
|---|---|
| `GET /head/stats` | `equityLovelace` |
| `GET /head/metrics` | `hydrozoa_equity_lovelace` |

`docs/api/openapi.yaml` regenerated by its golden test. `docs/spec/peer-stats-endpoint.md` gains rows in both the metrics catalog and the instrumentation-points table.

## Semantics worth a reviewer's eye

This is equity **as of the last stack this peer closed**, not the last hard-confirmed one. The composer rotates its treasury at close, one step ahead of hard-confirmation. That is the head's own working figure and what it will build the next stack from, but if you'd rather the gauge tracked the settled value it belongs on `SlowConsensusActor` beside `onStackConfirmed` instead, extracted from the confirmed stack's produced treasury. Happy to move it.

## Tests

`sbt "testOnly *"` — 517 passed, 0 failed, 72 suites. `just build-werror` and `just lint` green.