### PR TITLE
DO NOT MERGE (storage change) tx: emit Alonzo-format auxiliary data instead of Shelley-era Metadata

### DIFF
--- a/src/main/scala/hydrozoa/multisig/ledger/eutxol2/tx/L2Metadata.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/eutxol2/tx/L2Metadata.scala
@@ -4,7 +4,6 @@ import cats.syntax.all.*
 import hydrozoa.config.head.initialization.InitializationParameters.HeadId
 import hydrozoa.config.head.initialization.InitializationParameters.HeadId.toHex
 import scala.util.Try
-import scalus.cardano.ledger.AuxiliaryData.Metadata as MD
 import scalus.cardano.ledger.{AssetName, AuxiliaryData, Metadatum, MultiAsset, Transaction, Word64}
 
 /** The head-label metadata every EUTXO L2 transaction carries. It reuses the L1 transaction
@@ -65,7 +64,8 @@ object L2Metadata {
             )
         val headMap = Metadatum.Map(Map(Metadatum.Text(headId.toHex) -> Metadatum.Map(fields)))
         val roleMap = Metadatum.Map(Map(Metadatum.Text(role) -> headMap))
-        MD(Map(Word64(metadataLabel) -> roleMap))
+        // Alonzo-format (not Shelley-era Metadata) so Amaru accepts the submitted transaction.
+        AuxiliaryData.AlonzoFormat(Some(Map(Word64(metadataLabel) -> roleMap)))
     }
 
     /** Parse the head-label metadata out of `tx`, returning the pinned headId and the L2 metadata.
@@ -75,15 +75,11 @@ object L2Metadata {
     def parse(tx: Transaction): Either[String, (HeadId, L2Metadata)] =
         for {
             md <- tx.auxiliaryData match {
-                case Some(keepRaw) =>
-                    keepRaw.value match {
-                        case m: MD => Right(m)
-                        case _     => Left("L2 metadata: auxiliary data is not metadata")
-                    }
-                case None => Left("L2 metadata: transaction carries no auxiliary data")
+                case Some(keepRaw) => Right(keepRaw.value.getMetadata)
+                case None          => Left("L2 metadata: transaction carries no auxiliary data")
             }
             roleMap <- requireMap(
-              md.metadata.get(Word64(metadataLabel)),
+              md.get(Word64(metadataLabel)),
               s"head-tag label $metadataLabel"
             )
             headMap <- requireMap(roleMap.entries.get(Metadatum.Text(role)), s"role '$role'")

--- a/src/main/scala/hydrozoa/multisig/ledger/l1/tx/Metadata.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/l1/tx/Metadata.scala
@@ -4,7 +4,6 @@ import hydrozoa.config.head.initialization.InitializationParameters.HeadId
 import hydrozoa.multisig.ledger.l1.token.CIP67
 import hydrozoa.multisig.ledger.l1.tx.EnrichedTx.Type
 import scala.util.Try
-import scalus.cardano.ledger.AuxiliaryData.Metadata as MD
 import scalus.cardano.ledger.{AssetName, AuxiliaryData, Coin, Metadatum, ProtocolVersion, Transaction, Word64}
 import scalus.uplc.builtin.ByteString
 
@@ -46,7 +45,8 @@ sealed trait Metadata(val txType: EnrichedTx.Type) {
 
         val txTypeMdMap = Metadatum.Map(Map(Metadatum.Text(txTypeName) -> headMdMap))
 
-        MD(Map(Word64(CIP67.Tags.head) -> txTypeMdMap))
+        // Alonzo-format (not Shelley-era Metadata) so Amaru accepts the submitted transaction.
+        AuxiliaryData.AlonzoFormat(Some(Map(Word64(CIP67.Tags.head) -> txTypeMdMap)))
     }
 }
 
@@ -59,17 +59,17 @@ object Metadata {
             protocolVersion: ProtocolVersion,
             txSerialized: Array[Byte]
         ): Either[ParseError, (HeadId, T)] = for {
-            md <- parseMdFromTxSerialized(protocolVersion, txSerialized)
-            res <- parse(md)
+            auxData <- parseAuxDataFromTxSerialized(protocolVersion, txSerialized)
+            res <- parse(auxData)
         } yield res
 
         final def parse(tx: Transaction): Either[ParseError, (HeadId, T)] = for {
-            md <- parseMdFromTx(tx)
-            res <- parse(md)
+            auxData <- parseAuxDataFromTx(tx)
+            res <- parse(auxData)
         } yield res
 
-        final def parse(md: MD): Either[ParseError, (HeadId, T)] = for {
-            hydrMap <- parseHydrMapFromMd(md)
+        final def parse(auxData: AuxiliaryData): Either[ParseError, (HeadId, T)] = for {
+            hydrMap <- parseHydrMapFromAuxData(auxData)
             roleMap <- parseRoleMapFromHydrMap(txType, hydrMap)
             innerMapRes <- parseInnerMapFromRoleMap(roleMap)
             (headId, innerMap) = innerMapRes
@@ -265,33 +265,29 @@ object Metadata {
             Right(Settlement())
     }
 
-    private def parseMdFromTxSerialized(
+    private def parseAuxDataFromTxSerialized(
         protocolVersion: ProtocolVersion,
         txSerialized: Array[Byte]
-    ): Either[ParseError, MD] =
+    ): Either[ParseError, AuxiliaryData] =
         for {
             tx <- Try(Transaction.fromCbor(txSerialized)(using protocolVersion)).toEither.left
                 .map(CborDecodingError(_))
-            md <- parseMdFromTx(tx)
-        } yield md
+            auxData <- parseAuxDataFromTx(tx)
+        } yield auxData
 
-    private def parseMdFromTx(tx: Transaction): Either[ParseError, MD] = for {
-        ad <- tx.auxiliaryData.toRight(MissingAuxData)
-        md: MD <- ad.value match {
-            case md: MD => Right(md)
-            case _      => Left(AuxDataIsNotMetadata)
-        }
-    } yield md
+    private def parseAuxDataFromTx(tx: Transaction): Either[ParseError, AuxiliaryData] =
+        tx.auxiliaryData.toRight(MissingAuxData).map(_.value)
 
-    private def parseHydrMapFromMd(md: MD): Either[ParseError, Metadatum.Map] = for {
-        hydrEntry <- md.metadata
-            .get(Word64(CIP67.Tags.head))
-            .toRight(MissingCIP67Tag)
-        hydrMap <- hydrEntry match {
-            case m: Metadatum.Map => Right(m)
-            case _                => Left(MetadataValueIsNotMap)
-        }
-    } yield hydrMap
+    private def parseHydrMapFromAuxData(auxData: AuxiliaryData): Either[ParseError, Metadatum.Map] =
+        for {
+            hydrEntry <- auxData.getMetadata
+                .get(Word64(CIP67.Tags.head))
+                .toRight(MissingCIP67Tag)
+            hydrMap <- hydrEntry match {
+                case m: Metadatum.Map => Right(m)
+                case _                => Left(MetadataValueIsNotMap)
+            }
+        } yield hydrMap
 
     private def parseRoleMapFromHydrMap(
         txType: EnrichedTx.Type,
@@ -339,9 +335,6 @@ object Metadata {
     }
     case object MissingAuxData extends ParseError {
         override def toString: String = "Auxiliary Data is missing from the transaction"
-    }
-    case object AuxDataIsNotMetadata extends ParseError {
-        override def toString: String = "Auxiliary data is not metadata"
     }
     case object MissingCIP67Tag extends ParseError {
         override def toString: String =

--- a/src/test/scala/hydrozoa/multisig/ledger/l1/tx/DepositTxTest.scala
+++ b/src/test/scala/hydrozoa/multisig/ledger/l1/tx/DepositTxTest.scala
@@ -128,12 +128,8 @@ object DepositTxTest extends Properties("Deposit Tx Test") {
             } yield (index, fee, l2PayloadHash)
 
             Prop.forAll(gen)((idx, fee, l2PayloadHash) =>
-                val aux: AuxiliaryData.Metadata =
-                    AuxiliaryData.Metadata(
-                      MD.Deposit(idx, fee, l2PayloadHash)
-                          .asAuxData(config.headId)
-                          .getMetadata
-                    )
+                val aux: AuxiliaryData =
+                    MD.Deposit(idx, fee, l2PayloadHash).asAuxData(config.headId)
                 val expectedX = MD.Deposit(idx, fee, l2PayloadHash)
 
                 MD.Deposit.parse(aux) match {

--- a/src/test/scala/hydrozoa/multisig/ledger/l1/txseq/InitializationTxSeqTest.scala
+++ b/src/test/scala/hydrozoa/multisig/ledger/l1/txseq/InitializationTxSeqTest.scala
@@ -230,11 +230,7 @@ object InitializationTxSeqTest extends Properties("InitializationTxSeq"):
                         totalEquity = config.initialEquityContributed
                       )
                     )
-                val parsedMetadata = MD.Initialization.parse(
-                  AuxiliaryData.Metadata(
-                    iTx.tx.auxiliaryData.get.value.getMetadata
-                  ): AuxiliaryData.Metadata
-                )
+                val parsedMetadata = MD.Initialization.parse(iTx.tx.auxiliaryData.get.value)
 
                 s"Metadata parsing failed: $parsedMetadata" |:
                     (parsedMetadata == expectedMetadata)


### PR DESCRIPTION
## Why

Amaru has a bug that makes it reject transactions whose auxiliary data uses the Shelley-era `Metadata` encoding. Emitting the Alonzo-era format unblocks submitting via Amaru.

## What

- `L2Metadata.asAuxData` and L1 `Metadata.asAuxData` now build `AuxiliaryData.AlonzoFormat(Some(...))` instead of `AuxiliaryData.Metadata(...)`. The L1 change covers all tx types (Initialization, Deposit, Fallback, Refund, Rollout, Settlement, Finalization).
- Parsing reads metadata via `AuxiliaryData.getMetadata`, so all three auxiliary-data formats (Shelley, Shelley-MA, Alonzo) are accepted. The `Parser.parse(md: MD)` overload became `parse(auxData: AuxiliaryData)`; the now-impossible `AuxDataIsNotMetadata` error is removed.
- Tests that re-wrapped metadata into `AuxiliaryData.Metadata` to fit the old overload now pass the aux data directly. The malformed-metadata generator in `test/Generators.scala` keeps the Shelley constructor on purpose (negative case).

## Testing

`sbt "testOnly *DepositTxTest* *InitializationTxSeqTest* *L2MetadataTest*"` passes (6 properties, 100 cases each), including the asAuxData/parse round-trips.

## Related issue

https://github.com/pragma-org/amaru/issues/1277