### PR TITLE
feat(metrics): report what the StackComposer is waiting for

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -940,6 +940,26 @@ components:
           $ref: '#/components/schemas/TimingStats'
         softConsensus:
           $ref: '#/components/schemas/TimingStats'
+    ComposerStats:
+      title: ComposerStats
+      type: object
+      required:
+      - phase
+      - secondsInPhase
+      - partitionsDone
+      - partitionsTotal
+      properties:
+        phase:
+          type: string
+        secondsInPhase:
+          type: integer
+          format: int64
+        partitionsDone:
+          type: integer
+          format: int64
+        partitionsTotal:
+          type: integer
+          format: int64
     Deposit:
       title: Deposit
       type: object
@@ -1297,6 +1317,7 @@ components:
       - leaderMempoolDrain
       - sequencerHeadroom
       - equityLovelace
+      - composer
       properties:
         uptimeSeconds:
           type: integer
@@ -1325,6 +1346,8 @@ components:
         equityLovelace:
           type: integer
           format: int64
+        composer:
+          $ref: '#/components/schemas/ComposerStats'
     RateStats:
       title: RateStats
       type: object

--- a/src/main/scala/hydrozoa/multisig/consensus/StackComposer.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/StackComposer.scala
@@ -19,7 +19,7 @@ import hydrozoa.multisig.ledger.event.RequestId
 import hydrozoa.multisig.ledger.joint.{EvacuationMap, JointLedger}
 import hydrozoa.multisig.ledger.l1.utxo.MultisigTreasuryUtxo
 import hydrozoa.multisig.ledger.stack.*
-import hydrozoa.multisig.metrics.PeerMetrics
+import hydrozoa.multisig.metrics.{PeerMetrics, StackComposerPhase}
 import hydrozoa.multisig.persistence.recovery.{BlockResultScan, SoftConfirmationScan}
 import hydrozoa.multisig.persistence.{JournalKey, JournalValue, Markers, Persistence, StoreKey, WriteBatch}
 import scala.annotation.tailrec
@@ -225,17 +225,25 @@ final case class StackComposer(
       */
     private def tryProgress: IO[Unit] = state.get.flatMap { s =>
         val nextStackNum = s.lastClosedStackNum.increment
-        if !s.previousStackHardConfirmed then IO.unit
+        if !s.previousStackHardConfirmed then
+            reportPhase(StackComposerPhase.WaitingForPreviousHardConfirmation)
         else if config.canLeadSlow(nextStackNum) then tryCloseAsLeader(s, nextStackNum)
         else tryCloseAsFollower(s, nextStackNum)
     }
+
+    /** Publish the composer's phase for `GET /head/stats`. Re-reporting the same phase leaves its
+      * clock running, so `secondsInPhase` reads as time stuck rather than time since the last event
+      * — and `tryProgress` fires on every inbound message.
+      */
+    private def reportPhase(phase: StackComposerPhase): IO[Unit] =
+        IO.realTime.flatMap(t => IO(metrics.onComposerPhase(phase, t.toMillis)))
 
     /** Leader close-attempt: drain the longest contiguous prefix of `ready` starting at
       * `lastClosedBlockNum + 1` into a new stack.
       */
     private def tryCloseAsLeader(s: State, nextStackNum: StackNumber): IO[Unit] =
         s.longestReadyPrefix match {
-            case Nil => IO.unit
+            case Nil => reportPhase(StackComposerPhase.WaitingForBlockResultsOrSoftConfirmations)
             case prefix =>
                 for {
                     now <- realTimeQuantizedInstant(config.slotConfig)
@@ -415,7 +423,7 @@ final case class StackComposer(
       */
     private def tryCloseAsFollower(s: State, nextStackNum: StackNumber): IO[Unit] =
         s.inboundLeaderBrief.get(nextStackNum) match {
-            case None => IO.unit // no brief yet — wait
+            case None => reportPhase(StackComposerPhase.WaitingForStackBrief) // no brief yet — wait
             case Some(brief) =>
                 val expectedFirst = s.lastClosedBlockNum.increment
                 val structurallyConsistent =
@@ -441,7 +449,9 @@ final case class StackComposer(
                         case None =>
                             // (2) not caught up — benign; wait for more BlockResults /
                             // SoftConfirmeds. tryProgress re-fires on the next event.
-                            IO.unit
+                            reportPhase(
+                              StackComposerPhase.WaitingForBlockResultsOrSoftConfirmations
+                            )
                         case Some(slice) =>
                             // (3) covered — accept exactly the brief's range.
                             for {
@@ -502,7 +512,17 @@ final case class StackComposer(
     ): IO[ComposedStack] = {
         val results = NonEmptyList.fromListUnsafe(prefix.map(_.result))
         val partitions = StackPartition.partition(results)
-        StackEffectsBuilder.mkEffectsRegular(config, treasury, partitions, evacuationMap) match {
+        // Derivation runs to completion inside this one actor message — nothing else in the
+        // composer is processed meanwhile — so the phase is set before the fold, not during it.
+        metrics.onComposerPhase(StackComposerPhase.Deriving, System.currentTimeMillis())
+        StackEffectsBuilder.mkEffectsRegular(
+          config,
+          treasury,
+          partitions,
+          evacuationMap,
+          onPartitionDerived = metrics.onPartitionDerived,
+          onDerivationStarted = metrics.onDerivationStarted
+        ) match {
             case Right((effects, newTreasury, newMap, withdrawalTracking)) =>
                 IO.pure(
                   ComposedStack(

--- a/src/main/scala/hydrozoa/multisig/consensus/StackEffectsBuilder.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/StackEffectsBuilder.scala
@@ -69,6 +69,14 @@ object StackEffectsBuilder {
         initialTreasury: MultisigTreasuryUtxo,
         partitions: NonEmptyList[StackPartition],
         initialEvacuationMap: EvacuationMap,
+        // Called with the running count after each partition is derived, so a stack holding
+        // hundreds reports progress rather than going dark until it finishes. A `Unit` callback,
+        // not `IO`: this fold is pure and the only caller writes to an atomic gauge. Defaults to a
+        // no-op so tests and non-instrumented callers are unaffected.
+        onPartitionDerived: Int => Unit = _ => (),
+        // Called once with the partition count before the fold begins, so `partitionsDone` has a
+        // denominator from the start rather than after the first partition lands.
+        onDerivationStarted: Int => Unit = _ => ()
     ): Either[
       Error,
       (
@@ -162,126 +170,134 @@ object StackEffectsBuilder {
         // only at the blocks that need it: each Major (for its settlement's `nextKzg`) and each
         // last-of-partition minor (for its SEC). Other minors in a run only get their diffs
         // applied; no KZG paid. The fold short-circuits on the first treasury-build `Left`.
+        onDerivationStarted(partitions.length)
         val seed = Acc(initialTreasury, initialEvacuationMap)
 
         val folded: Either[Error, Acc] = partitions.toList.foldM(seed) { (acc, p) =>
+            // `effectsReversed` gains exactly one entry per partition, so its size after a step is
+            // the number derived so far.
+            def reportProgress(next: Acc): Acc =
+                onPartitionDerived(next.effectsReversed.size)
+                next
             import acc.*
             // Conservation gate first — cheap and pure, before any tx building: each block's
             // reported diffs must move the map by exactly what crossed the L1 boundary.
-            checkPartitionConservation(evacuationMap, p).flatMap { _ =>
-                p.kind match {
-                    case StackPartition.Kind.Major =>
-                        val major = p.blocks.head
-                        val trailingMinors = p.blocks.tail
-                        val mapAfterMajor = applyDiffs(evacuationMap, major.flatEvacuationDiffs)
-                        // Apply trailing minors' diffs cumulatively; the LAST minor's
-                        // post-map provides the SEC's KZG (if any trailing minor exists).
-                        val mapAfterPartition =
-                            trailingMinors.foldLeft(mapAfterMajor)((m, b) =>
+            checkPartitionConservation(evacuationMap, p)
+                .flatMap { _ =>
+                    p.kind match {
+                        case StackPartition.Kind.Major =>
+                            val major = p.blocks.head
+                            val trailingMinors = p.blocks.tail
+                            val mapAfterMajor = applyDiffs(evacuationMap, major.flatEvacuationDiffs)
+                            // Apply trailing minors' diffs cumulatively; the LAST minor's
+                            // post-map provides the SEC's KZG (if any trailing minor exists).
+                            val mapAfterPartition =
+                                trailingMinors.foldLeft(mapAfterMajor)((m, b) =>
+                                    applyDiffs(m, b.flatEvacuationDiffs)
+                                )
+                            major.brief match {
+                                case mb: BlockBrief.Major =>
+                                    mkSettlementTxSeq(
+                                      config = config,
+                                      treasury = treasury,
+                                      nextKzg = mapAfterMajor.kzgCommitment,
+                                      absorbedDeposits = major.absorbedDeposits,
+                                      payoutObligations = major.payoutObligations.toVector,
+                                      blockCreationEndTime = mb.header.endTime,
+                                      competingFallbackValidityStart = major.competingFallbackTxTime
+                                    ).map { case (newTreasury, seq) =>
+                                        val sec = trailingMinors.lastOption
+                                            .map(b => secOf(b, mapAfterPartition.kzgCommitment))
+                                        val pe = PartitionEffects.Major(
+                                          settlement = seq.settlementTx,
+                                          fallback = seq.fallbackTx,
+                                          rollouts = seq.rolloutTxs,
+                                          refunds = partitionRefunds(p.blocks.toList),
+                                          sec = sec
+                                        ): PartitionEffects[StandaloneEvacuationCommitment]
+                                        // The settlement drains the major block's withdrawals — every
+                                        // obligation is a real request (the settlement input is
+                                        // `major.payoutObligations`), so the whole vector is the prefix.
+                                        val newWithdrawals =
+                                            trackWithdrawals(
+                                              major.payoutRequestIds.toVector,
+                                              settlementSlices(seq)
+                                            )
+                                        acc.copy(
+                                          treasury = newTreasury,
+                                          evacuationMap = mapAfterPartition,
+                                          effectsReversed = pe :: effectsReversed,
+                                          withdrawalTracking = newWithdrawals ++ withdrawalTracking
+                                        )
+                                    }
+                                case _ =>
+                                    throw new IllegalStateException(
+                                      "Major partition's opener is not a Major block"
+                                    )
+                            }
+                        case StackPartition.Kind.Final =>
+                            // The finalization tx pays out two things: the final block's OWN withdrawals
+                            // (`fin.payoutObligations` — real L2 requests), and the residual L2 balances.
+                            // Like a
+                            // Major, the final block carries its own `evacuationMapDiff` (the final
+                            // window's L2 mutations); we fold it into the running map so `mapAfterFinal`
+                            // is the true post-final residual.
+                            // Withdrawals come first so they stay a
+                            // recognizable prefix (they carry request provenance; the residual balances
+                            // do not).
+                            val fin = p.blocks.head
+                            val mapAfterFinal = applyDiffs(evacuationMap, fin.flatEvacuationDiffs)
+                            val payoutObligationsRemaining =
+                                fin.payoutObligations.toVector ++ mapAfterFinal.outputs.toVector
+                            finalizeLedger(
+                              config = config,
+                              treasury = treasury,
+                              payoutObligationsRemaining = payoutObligationsRemaining,
+                              competingFallbackValidityStart = fin.competingFallbackTxTime
+                            ).map { seq =>
+                                val pe = PartitionEffects.Final(
+                                  finalization = seq.finalizationTx,
+                                  rollouts = seq.rolloutTxs
+                                ): PartitionEffects[StandaloneEvacuationCommitment]
+                                // The final block's withdrawals are the prefix of the combined
+                                // finalization input (`fin.payoutObligations ++ residual`), so its
+                                // request ids `[0, N)` are exactly the withdrawal positions; the residual
+                                // balances after them are not withdrawals.
+                                val newWithdrawals =
+                                    trackWithdrawals(
+                                      fin.payoutRequestIds.toVector,
+                                      finalizationSlices(seq)
+                                    )
+                                acc.copy(
+                                  evacuationMap = EvacuationMap.empty,
+                                  effectsReversed = pe :: effectsReversed,
+                                  withdrawalTracking = newWithdrawals ++ withdrawalTracking
+                                )
+                            }
+                        case StackPartition.Kind.Minor =>
+                            val mapAfterRun = p.blocks.toList.foldLeft(evacuationMap)((m, b) =>
                                 applyDiffs(m, b.flatEvacuationDiffs)
                             )
-                        major.brief match {
-                            case mb: BlockBrief.Major =>
-                                mkSettlementTxSeq(
-                                  config = config,
-                                  treasury = treasury,
-                                  nextKzg = mapAfterMajor.kzgCommitment,
-                                  absorbedDeposits = major.absorbedDeposits,
-                                  payoutObligations = major.payoutObligations.toVector,
-                                  blockCreationEndTime = mb.header.endTime,
-                                  competingFallbackValidityStart = major.competingFallbackTxTime
-                                ).map { case (newTreasury, seq) =>
-                                    val sec = trailingMinors.lastOption
-                                        .map(b => secOf(b, mapAfterPartition.kzgCommitment))
-                                    val pe = PartitionEffects.Major(
-                                      settlement = seq.settlementTx,
-                                      fallback = seq.fallbackTx,
-                                      rollouts = seq.rolloutTxs,
-                                      refunds = partitionRefunds(p.blocks.toList),
-                                      sec = sec
-                                    ): PartitionEffects[StandaloneEvacuationCommitment]
-                                    // The settlement drains the major block's withdrawals — every
-                                    // obligation is a real request (the settlement input is
-                                    // `major.payoutObligations`), so the whole vector is the prefix.
-                                    val newWithdrawals =
-                                        trackWithdrawals(
-                                          major.payoutRequestIds.toVector,
-                                          settlementSlices(seq)
-                                        )
-                                    acc.copy(
-                                      treasury = newTreasury,
-                                      evacuationMap = mapAfterPartition,
-                                      effectsReversed = pe :: effectsReversed,
-                                      withdrawalTracking = newWithdrawals ++ withdrawalTracking
-                                    )
-                                }
-                            case _ =>
-                                throw new IllegalStateException(
-                                  "Major partition's opener is not a Major block"
-                                )
-                        }
-                    case StackPartition.Kind.Final =>
-                        // The finalization tx pays out two things: the final block's OWN withdrawals
-                        // (`fin.payoutObligations` — real L2 requests), and the residual L2 balances.
-                        // Like a
-                        // Major, the final block carries its own `evacuationMapDiff` (the final
-                        // window's L2 mutations); we fold it into the running map so `mapAfterFinal`
-                        // is the true post-final residual.
-                        // Withdrawals come first so they stay a
-                        // recognizable prefix (they carry request provenance; the residual balances
-                        // do not).
-                        val fin = p.blocks.head
-                        val mapAfterFinal = applyDiffs(evacuationMap, fin.flatEvacuationDiffs)
-                        val payoutObligationsRemaining =
-                            fin.payoutObligations.toVector ++ mapAfterFinal.outputs.toVector
-                        finalizeLedger(
-                          config = config,
-                          treasury = treasury,
-                          payoutObligationsRemaining = payoutObligationsRemaining,
-                          competingFallbackValidityStart = fin.competingFallbackTxTime
-                        ).map { seq =>
-                            val pe = PartitionEffects.Final(
-                              finalization = seq.finalizationTx,
-                              rollouts = seq.rolloutTxs
+                            val pe = PartitionEffects.Minor(
+                              sec = secOf(p.blocks.last, mapAfterRun.kzgCommitment),
+                              refunds = partitionRefunds(p.blocks.toList)
                             ): PartitionEffects[StandaloneEvacuationCommitment]
-                            // The final block's withdrawals are the prefix of the combined
-                            // finalization input (`fin.payoutObligations ++ residual`), so its
-                            // request ids `[0, N)` are exactly the withdrawal positions; the residual
-                            // balances after them are not withdrawals.
-                            val newWithdrawals =
-                                trackWithdrawals(
-                                  fin.payoutRequestIds.toVector,
-                                  finalizationSlices(seq)
-                                )
-                            acc.copy(
-                              evacuationMap = EvacuationMap.empty,
-                              effectsReversed = pe :: effectsReversed,
-                              withdrawalTracking = newWithdrawals ++ withdrawalTracking
+                            // Minor blocks carry no withdrawals (a withdrawal forces a Major
+                            // block); a minor partition leaves the treasury untouched.
+                            Right(
+                              acc.copy(
+                                evacuationMap = mapAfterRun,
+                                effectsReversed = pe :: effectsReversed
+                              )
                             )
-                        }
-                    case StackPartition.Kind.Minor =>
-                        val mapAfterRun = p.blocks.toList.foldLeft(evacuationMap)((m, b) =>
-                            applyDiffs(m, b.flatEvacuationDiffs)
-                        )
-                        val pe = PartitionEffects.Minor(
-                          sec = secOf(p.blocks.last, mapAfterRun.kzgCommitment),
-                          refunds = partitionRefunds(p.blocks.toList)
-                        ): PartitionEffects[StandaloneEvacuationCommitment]
-                        // Minor blocks carry no withdrawals (a withdrawal forces a Major
-                        // block); a minor partition leaves the treasury untouched.
-                        Right(
-                          acc.copy(
-                            evacuationMap = mapAfterRun,
-                            effectsReversed = pe :: effectsReversed
-                          )
-                        )
-                    case StackPartition.Kind.Initial =>
-                        throw new IllegalStateException(
-                          "mkEffectsRegular received an Initial partition " +
-                              "(stack 0 uses mkEffectsInitial)"
-                        )
+                        case StackPartition.Kind.Initial =>
+                            throw new IllegalStateException(
+                              "mkEffectsRegular received an Initial partition " +
+                                  "(stack 0 uses mkEffectsInitial)"
+                            )
+                    }
                 }
-            }
+                .map(reportProgress)
         }
 
         folded.map { case Acc(finalTreasury, finalMap, effectsReversed, withdrawalTracking) =>

--- a/src/main/scala/hydrozoa/multisig/metrics/PeerMetrics.scala
+++ b/src/main/scala/hydrozoa/multisig/metrics/PeerMetrics.scala
@@ -71,6 +71,12 @@ final class PeerMetrics private (startedAtMillis: Long, remotePeerNums: Vector[I
     private val seqHeadroom = new AtomicLong(0)
     private val equityLovelace = new AtomicLong(0)
 
+    // ---- stack-composer phase (see StackComposerPhase) ----
+    private val composerPhase = new AtomicReference[StackComposerPhase](StackComposerPhase.Deriving)
+    private val composerPhaseSince = new AtomicLong(startedAtMillis)
+    private val partitionsDone = new AtomicLong(0)
+    private val partitionsTotal = new AtomicLong(0)
+
     // ---- derived rates (written only by the sampler fiber) ----
     private val rolling = new AtomicReference[Rolling](Rolling.empty(remotePeerNums))
 
@@ -154,6 +160,23 @@ final class PeerMetrics private (startedAtMillis: Long, remotePeerNums: Vector[I
       */
     def onEquity(lovelace: Long): Unit = equityLovelace.set(lovelace)
 
+    /** The [[StackComposer]] entered a new phase. Re-entering the same phase does NOT restart the
+      * clock, so `secondsInPhase` measures how long the composer has been stuck in it — the whole
+      * point of the gauge, and `tryProgress` re-evaluates on every inbound event.
+      */
+    def onComposerPhase(phase: StackComposerPhase, nowMillis: Long): Unit =
+        if composerPhase.getAndSet(phase) != phase then composerPhaseSince.set(nowMillis)
+
+    /** Effect-derivation progress. `total` is set once when a stack starts deriving; `done`
+      * advances per partition — a plain write, negligible beside the KZG commitment and tx building
+      * each partition costs, so it is not sampled.
+      */
+    def onDerivationStarted(totalPartitions: Int): Unit =
+        partitionsTotal.set(totalPartitions.toLong)
+        partitionsDone.set(0L)
+
+    def onPartitionDerived(done: Int): Unit = partitionsDone.set(done.toLong)
+
     private def startClock(m: TrieMap[Long, Long], blockNum: Long): Unit =
         m.update(blockNum, now())
         // Defensive: a block that never closes (crash) would leak a start entry; cap the in-flight
@@ -208,7 +231,13 @@ final class PeerMetrics private (startedAtMillis: Long, remotePeerNums: Vector[I
           mempoolSize = mempool.get(),
           leaderMempoolDrain = leaderMempoolDrain.get(),
           sequencerHeadroom = seqHeadroom.get(),
-          equityLovelace = equityLovelace.get()
+          equityLovelace = equityLovelace.get(),
+          composer = ComposerStats(
+            phase = composerPhase.get(),
+            secondsInPhase = math.max(0L, (nowMillis - composerPhaseSince.get()) / 1000),
+            partitionsDone = partitionsDone.get(),
+            partitionsTotal = partitionsTotal.get()
+          )
         )
 
     /** The 1 Hz sampler: feeds every rate's EWMAs from the cumulative counters, then publishes one
@@ -405,5 +434,19 @@ final case class PeerStats(
     mempoolSize: Long,
     leaderMempoolDrain: Long,
     sequencerHeadroom: Long,
-    equityLovelace: Long
+    equityLovelace: Long,
+    composer: ComposerStats
+)
+
+/** What the [[hydrozoa.multisig.consensus.StackComposer]] is doing, and for how long.
+  *
+  * Every path through `tryProgress` that is not `Deriving` returns `IO.unit` silently, so without
+  * this a composer waiting on a peer and one with nothing to do are indistinguishable. While
+  * `Deriving`, the partition counts show progress through a stack that may hold hundreds.
+  */
+final case class ComposerStats(
+    phase: StackComposerPhase,
+    secondsInPhase: Long,
+    partitionsDone: Long,
+    partitionsTotal: Long
 )

--- a/src/main/scala/hydrozoa/multisig/metrics/PrometheusFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/metrics/PrometheusFormat.scala
@@ -144,6 +144,28 @@ object PrometheusFormat:
           "Head equity beyond L2 liabilities, as of the last stack this peer closed.",
           s.equityLovelace
         )
+        gauge(
+          "hydrozoa_composer_seconds_in_phase",
+          "How long the StackComposer has been in its current phase.",
+          s.composer.secondsInPhase
+        )
+        gauge(
+          "hydrozoa_composer_partitions_done",
+          "Partitions derived so far for the stack being built.",
+          s.composer.partitionsDone
+        )
+        gauge(
+          "hydrozoa_composer_partitions_total",
+          "Partitions in the stack being built.",
+          s.composer.partitionsTotal
+        )
+        // The phase itself as a labelled 0/1 set, so a dashboard can select on it.
+        StackComposerPhase.values.foreach { p =>
+            b ++= "# TYPE hydrozoa_composer_phase gauge\n"
+            b ++= s"hydrozoa_composer_phase{phase=\"$p\"} ${
+                    if s.composer.phase == p then 1 else 0
+                }\n"
+        }
 
         b.toString
 

--- a/src/main/scala/hydrozoa/multisig/metrics/StackComposerPhase.scala
+++ b/src/main/scala/hydrozoa/multisig/metrics/StackComposerPhase.scala
@@ -1,0 +1,28 @@
+package hydrozoa.multisig.metrics
+
+/** The [[hydrozoa.multisig.consensus.StackComposer]]'s current phase, reported to [[PeerMetrics]].
+  *
+  * `tryProgress` re-evaluates these on every inbound event and returns `IO.unit` for all of them
+  * but [[Deriving]] — silently. A composer blocked on a peer therefore looks exactly like one with
+  * nothing to do, which is what this gauge exists to separate.
+  */
+enum StackComposerPhase:
+    /** The single-flight gate: stack N+1 cannot close until N hard-confirms. Applies to **both**
+      * roles — the check precedes the leader/follower branch — and covers the interval after this
+      * peer closed a stack and is awaiting its confirmation.
+      */
+    case WaitingForPreviousHardConfirmation
+
+    /** A block is stack-eligible only once both halves arrive: the `BlockResult` from JointLedger
+      * and the `Block.SoftConfirmed` from FastConsensusActor. They are tracked per block, so at any
+      * moment different blocks may be missing different halves — hence one phase rather than two.
+      */
+    case WaitingForBlockResultsOrSoftConfirmations
+
+    /** Follower only: no `StackBrief` yet for the stack this peer would close next. */
+    case WaitingForStackBrief
+
+    /** Building effects. The partition counts in [[ComposerStats]] track progress; a large stack
+      * holds hundreds, and the derivation runs to completion inside one actor message.
+      */
+    case Deriving

--- a/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
+++ b/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
@@ -237,6 +237,18 @@ object ApiDto {
     given Codec[BlockTimingSetView] = deriveCodec
     given Schema[BlockTimingSetView] = Schema.derived
 
+    /** What the StackComposer is doing and for how long. Every non-deriving path through
+      * `tryProgress` returns silently, so without this a composer blocked on a peer and one with
+      * nothing to do look identical.
+      */
+    final case class ComposerStatsView(
+        phase: String,
+        secondsInPhase: Long,
+        partitionsDone: Long,
+        partitionsTotal: Long
+    )
+    given Codec[ComposerStatsView] = deriveCodec
+
     /** The full peer-stats body. */
     final case class PeerStatsView(
         uptimeSeconds: Long,
@@ -251,7 +263,8 @@ object ApiDto {
         /** The head's equity beyond its L2 liabilities, in lovelace, as of the last stack this peer
           * closed. One side of `treasury.value == evacuation map total + equity + beacon`.
           */
-        equityLovelace: Long
+        equityLovelace: Long,
+        composer: ComposerStatsView
     )
     given Codec[PeerStatsView] = deriveCodec
 
@@ -300,7 +313,13 @@ object ApiDto {
           mempoolSize = s.mempoolSize,
           leaderMempoolDrain = s.leaderMempoolDrain,
           sequencerHeadroom = s.sequencerHeadroom,
-          equityLovelace = s.equityLovelace
+          equityLovelace = s.equityLovelace,
+          composer = ComposerStatsView(
+            phase = s.composer.phase.toString,
+            secondsInPhase = s.composer.secondsInPhase,
+            partitionsDone = s.composer.partitionsDone,
+            partitionsTotal = s.composer.partitionsTotal
+          )
         )
 
     /** `{ "status": "success", "message": ... }` — the finalize-trigger body. */

--- a/src/test/scala/hydrozoa/multisig/metrics/PrometheusFormatTest.scala
+++ b/src/test/scala/hydrozoa/multisig/metrics/PrometheusFormatTest.scala
@@ -45,7 +45,13 @@ class PrometheusFormatTest extends AnyFunSuite:
       mempoolSize = 923,
       leaderMempoolDrain = 900,
       sequencerHeadroom = 12,
-      equityLovelace = 4_500_000L
+      equityLovelace = 4_500_000L,
+      composer = ComposerStats(
+        phase = StackComposerPhase.WaitingForPreviousHardConfirmation,
+        secondsInPhase = 42,
+        partitionsDone = 17,
+        partitionsTotal = 300
+      )
     )
 
     test("counters carry the _total suffix and a TYPE line"):


### PR DESCRIPTION
> **Stacked on #670** — `StackComposer` only gets its `metrics` handle there. Merge that first; this retargets to `main` afterwards.

## Why

Every path through `tryProgress` except deriving returns `IO.unit` **silently**:

```scala
if !s.previousStackHardConfirmed then IO.unit          // single-flight gate
else if canLeadSlow then tryCloseAsLeader              // longestReadyPrefix == Nil -> IO.unit
else tryCloseAsFollower                                // no brief -> IO.unit
                                                       // brief spans unpaired blocks -> IO.unit
```

The follower's not-yet-covered branch even says *"wait silently"* in a comment. So a composer blocked on a peer and one with nothing to do produce identical output — none. Same class of blind spot as the transport work in #672.

## What it reports

| phase | meaning |
|---|---|
| `WaitingForPreviousHardConfirmation` | the single-flight gate — **both roles**, the check precedes the leader/follower branch. Also covers the interval after this peer closed a stack and awaits its confirmation |
| `WaitingForBlockResultsOrSoftConfirmations` | a block is stack-eligible only once **both** halves land: JointLedger's `BlockResult` and fast consensus's `Block.SoftConfirmed` |
| `WaitingForStackBrief` | follower only |
| `Deriving` | building effects |

Plus **`secondsInPhase`**, measured from entry — re-reporting the same phase does *not* restart the clock, so it reads as time **stuck**, not time since the last event. `tryProgress` fires on every inbound message, so that distinction matters.

While `Deriving`: **`partitionsDone` / `partitionsTotal`**. A stack can hold hundreds of partitions.

## Design notes

**One phase for both missing halves.** `pending` is keyed by block number, so block 5 can be missing its `BlockResult` while block 7 is missing its `SoftConfirmed`. A single-valued gauge cannot hold both, hence one phase rather than two.

**Progress is not sampled.** Each partition costs a KZG commitment over a 32768-point SRS plus settlement/rollout tx building; the gauge update is one atomic write. Sampling would save nothing measurable and lose resolution.

**`Deriving` is set before the fold, not during it.** `mkEffectsRegular` runs synchronously inside a single actor message, so nothing else in the composer executes meanwhile — the phase has to be published before entering, and per-partition progress is a plain write from that same thread.

**The builder stays pure.** `mkEffectsRegular` keeps returning `Either` with no `IO`; it takes `onPartitionDerived` / `onDerivationStarted` as `Unit`-returning callbacks defaulting to no-ops, matching how `PeerMetrics` already works. Existing callers and tests are unaffected.

## Surfaces

- `GET /head/stats` → `composer: { phase, secondsInPhase, partitionsDone, partitionsTotal }`
- `GET /head/metrics` → `hydrozoa_composer_seconds_in_phase`, `_partitions_done`, `_partitions_total`, and `hydrozoa_composer_phase{phase="…"}` as a labelled 0/1 set so a dashboard can select on it

`docs/api/openapi.yaml` regenerated by its golden test.

## Tests

`sbt "testOnly *"` — 517 passed, 0 failed, 72 suites. `just build-werror` and `just lint` green.