### PR TITLE
Cap each liaison outbox and serve older entries from the journal

### DIFF
--- a/docs/spec/coil-network.md
+++ b/docs/spec/coil-network.md
@@ -309,7 +309,8 @@ peer's `GetMsgBatch` from them (per-liaison outboxes, not a
 shared `CoilRelay` buffer sliced per coil peer — this keeps each liaison the single
 owner of its link's send-state, uniform with `PeerLiaisonHeadToHead` and
 recovery-aligned per link, at the accepted cost of buffering each lane item once
-per coil peer on the hub, §4.1). It aggregates **nothing** — the six lane families
+per coil peer on the hub, §4.1 — bounded, because each outbox caps what it holds
+and serves anything older from the journal). It aggregates **nothing** — the six lane families
 stay separate end-to-end.
 
 **What feeds it:**

--- a/docs/spec/persistence-and-crash-recovery.md
+++ b/docs/spec/persistence-and-crash-recovery.md
@@ -690,7 +690,7 @@ is safe because every journal is **append-only** — entries are appended in ind
 and never mutated ([§3.2](#32-satellites), [§7.1](#71-key-layout--journal-ids)): a reader — even one running concurrently
 with the writer, e.g. a liaison re-seeding its lanes after the start barrier — sees a
 consistent prefix. It can at worst miss the newest append, never a torn entry, and a
-stale high-water self-corrects through the normal `append` / `backfill` path (and the
+stale high-water self-corrects through the normal `append` / journal-serve path (and the
 re-pull cursor protocol). The one read carrying a **cross-CF invariant** — the
 markers' `confirmed ≤ acked` — is derived **before** the start barrier, while no
 writer is producing yet ([§8](#8-boot-sequence)), and is fail-safed by `validateInvariants`.
@@ -871,8 +871,9 @@ differing only in which lanes each serves.
   source of truth and the outbox is only a cache. Recovery therefore restores almost
   nothing:
   - **Queue stays empty.** No payloads are eagerly seeded; it fills only as live
-    production appends new items, and `reply` hot-loads anything else from the journal
-    on demand.
+    production appends new items, and `reply` serves anything else from the journal.
+    That is not a recovery-only mode — it is what the cap makes routine for any remote
+    lagging more than `peerLiaisonOutboxCap` behind.
   - **One scalar is restored** — the high-water number (`lastAppended = max(journal
     key)`, payload-free — `LaneOutgoingBacking.highWater`). It is not state to serve; it
     exists so (a) the first post-crash `append` is legal — live production resumes at
@@ -880,9 +881,10 @@ differing only in which lanes each serves.
     cold `None` would make it throw — and (b) it is `reply`'s out-of-bounds bound
     (`next(lastAppended)`) for a remote that re-pulls before we append anything.
   - **Serving is a DB-backed view.** On `GetMsgBatch` from R, `LaneOutbound.reply`
-    returns the in-memory tail if it holds R's cursor, else hot-loads the prefix from
-    the journal (`LaneOutgoingBacking.backfill`). Because every served entry is persisted, the
-    journal always backs it — the cache need never be authoritative.
+    returns the in-memory window if it holds R's cursor, else reads from the journal
+    (`LaneOutgoingBacking.serveFromJournal`). Because every served entry is persisted,
+    the journal always backs it — the cache need never be authoritative, which is what
+    lets the window be capped.
   - **`append` is idempotent below the high-water.** A consensus actor re-emitting an
     already-durable entry during replay (e.g. `SlowConsensusActor` re-broadcasting the
     in-flight stack's round-1 ack, number `n1`, after the lane restored its high-water
@@ -906,9 +908,14 @@ differing only in which lanes each serves.
   `GetMsgBatch` cursors**, not local confirmation, *"so that messages can be
   retransmitted if needed during recovery scenarios"* (peer-network
   `#outbox-queues-and-confirmation`); persistence extends that retransmissibility
-  across a process restart, not just a transient disconnect. Reading from the
-  store on demand (rather than eagerly seeding the whole own production) also
-  bounds the in-memory outbox to the live tail.
+  across a process restart, not just a transient disconnect. Cursor-pruning alone
+  bounds an outbox only as well as its remote pulls, though: a configured peer that
+  never connects never advances a cursor, so its lanes retain everything the process
+  has relayed. `LaneOutbound` therefore also caps each outbox at
+  `peerLiaisonOutboxCap` items (floored at that lane's `maxPerReply`) and evicts the
+  oldest past it. Eviction costs only a store read: everything on a lane is durable
+  before it is appended (CR4), so an evicted item is still servable — the same path
+  every lane uses from a cold start.
 - **Inputs:** remote lane entries — **cursor-gated (CR8)**.
 - **Persists:** each inbound remote lane entry into its journal (CR8); each persisted
   value carries a **12-byte `ArrivalStamp` prefix** ([§5.4](#54-total-order-of-the-replayed-streams), [§7.1](#71-key-layout--journal-ids)) — `(generation,
@@ -928,10 +935,10 @@ differing only in which lanes each serves.
 
 > **Code reality.** All three shapes recover the same way: each outbound
 > lane is built with a `LaneOutgoingBacking` over its journal, `preStart` restores the
-> lane high-waters (`seedHighWater`), and `LaneOutbound.reply` hot-loads below the
-> in-memory floor (`LaneOutgoingBacking.backfill`); inbound receive cursors restore off a
-> `LaneIncomingCursors` read. No lane eagerly seeds its whole own
-> production.
+> lane high-waters (`seedHighWater`), and `LaneOutbound.reply` reads below the
+> in-memory floor (`LaneOutgoingBacking.serveFromJournal`); inbound receive cursors
+> restore off a `LaneIncomingCursors` read. No lane eagerly seeds its whole own
+> production, and none accumulates it either — the outbox is capped.
 
 #### 6.1.3 `CardanoLiaison`
 

--- a/src/main/resources/scaffold/peer-private.template.json
+++ b/src/main/resources/scaffold/peer-private.template.json
@@ -11,6 +11,7 @@
   "nodeOperationMultisigConfig": {
     "cardanoLiaisonPollingPeriod": 20000,
     "peerLiaisonMaxRequestsPerBatch": 500,
+    "peerLiaisonOutboxCap": 1024,
     "peerLiaisonResendInterval": 5000,
     "rateLimits": {
       "softBlockMinPeriod": 100,

--- a/src/main/scala/hydrozoa/config/node/operation/multisig/NodeOperationMultisigConfig.scala
+++ b/src/main/scala/hydrozoa/config/node/operation/multisig/NodeOperationMultisigConfig.scala
@@ -9,6 +9,7 @@ import scala.concurrent.duration.{DurationInt, FiniteDuration}
 final case class NodeOperationMultisigConfig(
     override val cardanoLiaisonPollingPeriod: FiniteDuration,
     override val peerLiaisonMaxRequestsPerBatch: PositiveInt,
+    override val peerLiaisonOutboxCap: PositiveInt,
     override val peerLiaisonResendInterval: FiniteDuration,
     override val rateLimits: RateLimits
 ) extends NodeOperationMultisigConfig.Section {
@@ -24,6 +25,18 @@ object NodeOperationMultisigConfig {
         def peerLiaisonMaxRequestsPerBatch: PositiveInt =
             nodeOperationMultisigConfig.peerLiaisonMaxRequestsPerBatch
 
+        /** How many items each [[hydrozoa.multisig.consensus.liaison.LaneOutbound]] keeps in
+          * memory, floored at that lane's `maxPerReply`. Above the cap the oldest is evicted; a
+          * pull below the remaining floor is served from the journal instead, which is sound
+          * because nothing reaches a lane before it is durable (CR4) and is already how every lane
+          * serves after a restart.
+          *
+          * Node-local on purpose: it changes only how much this peer caches, never what it sends,
+          * so peers may run different values without diverging.
+          */
+        def peerLiaisonOutboxCap: PositiveInt =
+            nodeOperationMultisigConfig.peerLiaisonOutboxCap
+
         /** How often each [[hydrozoa.multisig.consensus.PeerLiaisonHeadToHead]] re-sends its
           * currently outstanding `GetMsgBatch` to the remote peer, to recover from a stalled
           * request-response chain (e.g. caused by a dropped WS frame). The re-send is idempotent on
@@ -35,14 +48,39 @@ object NodeOperationMultisigConfig {
         override def rateLimits: RateLimits = nodeOperationMultisigConfig.rateLimits
     }
 
+    /** Two `peerLiaisonMaxRequestsPerBatch` batches of requests, which is also generous headroom on
+      * the lanes that reply one item at a time. At the market-maker payload mix a request lane then
+      * holds tens of MB rather than everything the process has ever relayed.
+      */
+    val defaultPeerLiaisonOutboxCap: PositiveInt = PositiveInt.unsafeApply(1024)
+
     lazy val default: NodeOperationMultisigConfig = NodeOperationMultisigConfig(
       cardanoLiaisonPollingPeriod = 10.seconds,
       peerLiaisonMaxRequestsPerBatch = PositiveInt.unsafeApply(500),
+      peerLiaisonOutboxCap = defaultPeerLiaisonOutboxCap,
       peerLiaisonResendInterval = 5.seconds,
       rateLimits = RateLimits.default
     )
 
     given Encoder[NodeOperationMultisigConfig] = deriveEncoder[NodeOperationMultisigConfig]
 
-    given Decoder[NodeOperationMultisigConfig] = deriveDecoder[NodeOperationMultisigConfig]
+    /** Hand-written rather than derived so `peerLiaisonOutboxCap` may be **absent**: every config
+      * file written before this field existed must still decode, and a node whose config fails to
+      * decode does not start at all.
+      */
+    given Decoder[NodeOperationMultisigConfig] = Decoder.instance(c =>
+        for {
+            pollingPeriod <- c.downField("cardanoLiaisonPollingPeriod").as[FiniteDuration]
+            maxRequestsPerBatch <- c.downField("peerLiaisonMaxRequestsPerBatch").as[PositiveInt]
+            outboxCap <- c.downField("peerLiaisonOutboxCap").as[Option[PositiveInt]]
+            resendInterval <- c.downField("peerLiaisonResendInterval").as[FiniteDuration]
+            limits <- c.downField("rateLimits").as[RateLimits]
+        } yield NodeOperationMultisigConfig(
+          cardanoLiaisonPollingPeriod = pollingPeriod,
+          peerLiaisonMaxRequestsPerBatch = maxRequestsPerBatch,
+          peerLiaisonOutboxCap = outboxCap.getOrElse(defaultPeerLiaisonOutboxCap),
+          peerLiaisonResendInterval = resendInterval,
+          rateLimits = limits
+        )
+    )
 }

--- a/src/main/scala/hydrozoa/multisig/consensus/liaison/LaneBidirectional.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/liaison/LaneBidirectional.scala
@@ -40,34 +40,50 @@ final class LaneBidirectional[T, N] private (
 object LaneBidirectional {
 
     /** A contiguous bidirectional lane: both directions start at `first`, successor `+1`.
-      * `backfill` reads the outbound prefix below the in-memory outbox floor from the store on a
-      * reply.
+      * `serveFromJournal` reads the outbound entries below the in-memory outbox floor from the
+      * store on a reply; `outboxCap` bounds how many that floor leaves in memory.
       */
     def contiguous[T, N: Ordering](
         numberOf: T => N,
         first: N,
         increment: N => N,
         maxPerReply: Int = 1,
-        backfill: (N, Int) => IO[List[T]]
+        outboxCap: Int,
+        serveFromJournal: (N, Int) => IO[List[T]]
     ): LaneBidirectional[T, N] =
         new LaneBidirectional[T, N](
-          LaneOutbound.contiguous(numberOf, first, increment, maxPerReply, backfill),
+          LaneOutbound.contiguous(
+            numberOf,
+            first,
+            increment,
+            maxPerReply,
+            outboxCap = outboxCap,
+            serveFromJournal = serveFromJournal
+          ),
           LaneInbound.contiguous(numberOf, first, increment)
         )
 
     /** A sparse bidirectional lane: outbound follows this side's leader schedule (`outboundNext`),
-      * inbound the remote's (`inboundNext`). `zero` is "before the first" for both. `backfill`
-      * reads the outbound prefix below the in-memory outbox floor from the store on a reply.
+      * inbound the remote's (`inboundNext`). `zero` is "before the first" for both.
+      * `serveFromJournal` reads the outbound entries below the in-memory outbox floor from the
+      * store on a reply; `outboxCap` bounds how many that floor leaves in memory.
       */
     def sparse[T, N: Ordering](
         numberOf: T => N,
         zero: N,
         outboundNext: N => Option[N],
         inboundNext: N => Option[N],
-        backfill: (N, Int) => IO[List[T]]
+        outboxCap: Int,
+        serveFromJournal: (N, Int) => IO[List[T]]
     ): LaneBidirectional[T, N] =
         new LaneBidirectional[T, N](
-          LaneOutbound.sparse(numberOf, zero, outboundNext, backfill),
+          LaneOutbound.sparse(
+            numberOf,
+            zero,
+            outboundNext,
+            outboxCap = outboxCap,
+            serveFromJournal = serveFromJournal
+          ),
           LaneInbound.sparse(numberOf, zero, inboundNext)
         )
 }

--- a/src/main/scala/hydrozoa/multisig/consensus/liaison/LaneOutbound.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/liaison/LaneOutbound.scala
@@ -1,14 +1,26 @@
 package hydrozoa.multisig.consensus.liaison
 
 import cats.effect.{IO, Ref}
-import scala.collection.immutable.Queue
+import cats.syntax.foldable.*
+import scala.collection.immutable.TreeMap
 
 /** An **outbound** next-expected lane (§4.2 of `docs/spec/coil-network.md`) [doc-ref]: a lane we
-  * only produce on. It owns an [[outbox]] queue of items we append plus the high-water number ever
+  * only produce on. It owns a bounded [[outbox]] of items we append plus the high-water number ever
   * appended; the remote pulls with its [[LaneInbound]] counterpart's cursor, we prune what it has
   * already seen, and we hand back the head ([[reply]]). On a link that produces *and* receives on
   * this number space it is paired with that [[LaneInbound]] (see [[LaneBidirectional]]); on a
   * produce-only link it stands alone.
+  *
+  * ==The outbox is a cache, not a buffer==
+  *
+  * Everything that reaches this lane is already durable — it is persisted before it is appended
+  * (CR4 write-before-send, §4 of `docs/spec/persistence-and-crash-recovery.md`) — so the journal,
+  * not the outbox, is what makes a pull servable. The outbox only saves a store read for a remote
+  * that is roughly current, and it is capped at [[capacity]]: appending past the cap evicts the
+  * oldest entry, and a pull below the remaining floor is served from the journal instead
+  * ([[serveFromJournal]]). Recovery already runs in exactly that state — [[seedHighWater]] restores
+  * the high-water and leaves the outbox empty, so every pull after a restart is a journal serve
+  * until live production refills the window.
   *
   * A lane is **author-agnostic**: a per-author lane family is a `Map[author, LaneOutbound[T, N]]`,
   * so "this item is from peer P" is encoded by *which* lane it lives in, not by an in-lane check.
@@ -31,27 +43,53 @@ import scala.collection.immutable.Queue
   * @param maxPerReply
   *   how many items a single [[reply]] may carry (1 for single-item lanes; the request lane
   *   batches).
+  * @param outboxCap
+  *   how many items to keep in memory; see [[capacity]] for the floor applied to it.
+  * @param serveFromJournal
+  *   read up to `limit` durable items from a number, for a pull below the outbox floor.
   */
 final class LaneOutbound[T, N] private (
     numberOf: T => N,
     next: Option[N] => Option[N],
     maxPerReply: Int,
-    backfill: (N, Int) => IO[List[T]]
+    outboxCap: Int,
+    serveFromJournal: (N, Int) => IO[List[T]]
 )(using ord: Ordering[N]) {
     import LaneOutbound.*
     import ord.mkOrderingOps
 
+    /** The outbox's item cap: `outboxCap`, floored at [[maxPerReply]].
+      *
+      * The floor is what keeps the outbox worth having. A reply may carry `maxPerReply` items, so a
+      * cap below that could not serve even a perfectly current remote from memory — every pull on
+      * the request lane (`maxPerReply` = `peerLiaisonMaxRequestsPerBatch`) would go to the store.
+      */
+    private val capacity: Int = math.max(outboxCap, maxPerReply)
+
     private val lastAppended = Ref.unsafe[IO, Option[N]](None)
-    private val outbox = Ref.unsafe[IO, Queue[T]](Queue.empty)
+    private val outbox = Ref.unsafe[IO, TreeMap[N, T]](TreeMap.empty)
+
+    /** The highest number [[append]] has evicted, or `None` if nothing has been evicted yet.
+      *
+      * Held only so eviction can fail loudly. An evicted item was appended, and everything appended
+      * is durable (CR4), so the journal owes us every number at or below this mark; a pull there
+      * that the journal cannot answer is a broken backing, not an empty lane. Without the mark that
+      * mistake reads as "nothing new to send" and the remote's lane stalls in silence.
+      */
+    private val evictedThrough = Ref.unsafe[IO, Option[N]](None)
 
     /** Append an item we produce to the outbox, enforcing gap-free monotonic numbering for *new*
       * items. An item whose number is **at or below the high-water is a no-op**: it is something we
       * already produced and persisted (everything that reaches a lane is durable, CR4), so the lane
-      * serves it from the journal on demand ([[reply]]'s hot-load) and need not re-hold it. This
-      * absorbs a replay re-broadcast — e.g. `SlowConsensusActor` re-emitting the in-flight stack's
-      * round-1 ack (number `n1`) after the lane has restored its high-water to round-2 (`n1 + 1`) —
-      * which would otherwise be a spurious out-of-order error. A *new* item (above the high-water)
-      * must still be exactly the expected next ([[next]] of the last appended); a gap raises.
+      * serves it from the journal on demand ([[reply]]) and need not re-hold it. This absorbs a
+      * replay re-broadcast — e.g. `SlowConsensusActor` re-emitting the in-flight stack's round-1
+      * ack (number `n1`) after the lane has restored its high-water to round-2 (`n1 + 1`) — which
+      * would otherwise be a spurious out-of-order error. A *new* item (above the high-water) must
+      * still be exactly the expected next ([[next]] of the last appended); a gap raises.
+      *
+      * Appending past [[capacity]] evicts the oldest held item. Eviction costs nothing but a store
+      * read later: the evicted item is durable by CR4, so it stays servable via
+      * [[serveFromJournal]].
       */
     def append(item: T): IO[Unit] =
         lastAppended.get.flatMap { last =>
@@ -62,28 +100,41 @@ final class LaneOutbound[T, N] private (
                     val expected = next(last)
                     IO.raiseUnless(expected.contains(n))(
                       AppendOutOfOrder(last.toString, n.toString, expected.toString)
-                    ) >> lastAppended.set(Some(n)) >> outbox.update(_ :+ item)
+                    ) >> lastAppended.set(Some(n)) >> outbox
+                        .modify { held =>
+                            val grown = held.updated(n, item)
+                            val excess = grown.size - capacity
+                            if excess <= 0 then (grown, None)
+                            else (grown.drop(excess), grown.take(excess).lastOption.map(_._1))
+                        }
+                        .flatMap(
+                          _.traverse_(highest =>
+                              evictedThrough.update(
+                                _.fold(Some(highest))(prev => Some(ord.max(prev, highest)))
+                              )
+                          )
+                        )
         }
 
     /** Restore only the lane's high-water on recovery, leaving the outbox empty: the lane serves
-      * the older prefix from the store via [[backfill]] and lets replay / live production re-append
-      * the tail on top. This is the gap-free baseline an [[append]] continues from (the first
-      * post-boot append must be `next(high-water)`), and the [[reply]] out-of-bounds guard. `None`
-      * is the cold state.
+      * the older prefix from the store via [[serveFromJournal]] and lets replay / live production
+      * re-append the tail on top. This is the gap-free baseline an [[append]] continues from (the
+      * first post-boot append must be `next(high-water)`), and the [[reply]] out-of-bounds guard.
+      * `None` is the cold state.
       */
     def seedHighWater(highWater: Option[N]): IO[Unit] =
-        lastAppended.set(highWater) >> outbox.set(Queue.empty)
+        lastAppended.set(highWater) >> outbox.set(TreeMap.empty) >> evictedThrough.set(None)
 
-    /** Serve the remote's pull. Prune everything strictly below its cursor (retransmit-safe — the
-      * head is kept until the remote moves past it). If the in-memory outbox head *is* the
-      * requested number, serve up to [[maxPerReply]] items from it (the live / replayed tail,
-      * including not-yet-persisted entries); otherwise the requested entry is below the outbox
-      * floor (older, already durable, or the remote regressed across a restart), so hot-load it
-      * from the store via [[backfill]] — **capped at the released high-water `lastAppended`**: the
-      * store may hold entries persisted but not yet released onto this lane (a postponed own
-      * soft-ack), and serving those would push the remote's cursor past our bound. Returns
-      * [[OutOfBounds]] if the remote's cursor is ahead of what we could have produced (protocol
-      * desync — the caller raises), else the (possibly empty) slice.
+    /** Serve the remote's pull. Prune everything strictly below its cursor — retransmit-safe: the
+      * requested entry stays *servable* until the remote moves past it, from memory if it is still
+      * within the outbox window and from the journal otherwise. If the outbox holds the requested
+      * number, serve up to [[maxPerReply]] items from there; otherwise it is below the outbox floor
+      * (evicted, restored-but-not-re-appended, or the remote regressed across a restart) and the
+      * journal serves it — **capped at the released high-water `lastAppended`**: the store may hold
+      * entries persisted but not yet released onto this lane (a postponed own soft-ack), and
+      * serving those would push the remote's cursor past our bound. Returns [[OutOfBounds]] if the
+      * remote's cursor is ahead of what we could have produced (protocol desync — the caller
+      * raises), else the (possibly empty) slice.
       */
     def reply(remoteCursor: N, ceiling: Option[N] = None): IO[Reply[T]] =
         // `ceiling`, when set, is an absolute upper bound on the item numbers we may serve this reply
@@ -104,33 +155,54 @@ final class LaneOutbound[T, N] private (
                   )
                 )
             else
-                outbox
-                    .modify { q =>
-                        val pruned = q.dropWhile(item => numberOf(item) < remoteCursor)
-                        (pruned, pruned)
-                    }
-                    .flatMap { pruned =>
-                        pruned.headOption match
-                            case Some(head) if numberOf(head) == remoteCursor =>
-                                IO.pure(Items(withinCeiling(pruned.take(maxPerReply).toList)))
-                            case _ =>
-                                // The store can hold entries already persisted but **not yet
-                                // released** onto this lane (e.g. a postponed own soft-ack that the
-                                // producer persisted at block time but `announceAck`s only when the
-                                // previous block's cell completes). Serve only up to the announced
-                                // high-water — never past `lastAppended` — or the remote's cursor
-                                // would run ahead of our bound and the next pull would be a false
-                                // out-of-bounds.
-                                backfill(remoteCursor, maxPerReply).map(fromStore =>
-                                    Items(
-                                      withinCeiling(
-                                        last.fold(List.empty[T])(hw =>
-                                            fromStore.filter(item => numberOf(item) <= hw)
+                last match
+                    // Nothing released on this lane yet, so nothing is servable whatever the store
+                    // holds — and this is the steady state of a lane the peer never produces on
+                    // (a non-hub's `HubHardAck` lane). Answer without touching the store: the
+                    // journal read below would be discarded by the high-water filter anyway.
+                    case None => IO.pure(Items(Nil))
+                    case Some(highWater) =>
+                        outbox
+                            .modify { held =>
+                                val kept = held.rangeFrom(remoteCursor)
+                                (kept, kept)
+                            }
+                            .flatMap { kept =>
+                                if kept.contains(remoteCursor) then
+                                    IO.pure(
+                                      Items(withinCeiling(kept.values.take(maxPerReply).toList))
+                                    )
+                                else
+                                    // The store can hold entries already persisted but **not yet
+                                    // released** onto this lane (e.g. a postponed own soft-ack that
+                                    // the producer persisted at block time but `announceAck`s only
+                                    // when the previous block's cell completes). Serve only up to
+                                    // the announced high-water — never past `lastAppended` — or the
+                                    // remote's cursor would run ahead of our bound and the next pull
+                                    // would be a false out-of-bounds.
+                                    for {
+                                        fromStore <- serveFromJournal(remoteCursor, maxPerReply)
+                                        evicted <- evictedThrough.get
+                                        // We held this number and dropped it; CR4 says the journal
+                                        // has it. Nothing coming back means the backing is wrong
+                                        // (missing CF, over-strict `keep`), which would otherwise
+                                        // present as a permanently idle remote.
+                                        _ <- IO.raiseWhen(
+                                          fromStore.isEmpty &&
+                                              evicted.exists(mark => remoteCursor <= mark)
+                                        )(
+                                          EvictedButUnservable(
+                                            asked = remoteCursor.toString,
+                                            evictedThrough = evicted.fold("none")(_.toString),
+                                            lastAppended = highWater.toString
+                                          )
                                         )
+                                    } yield Items(
+                                      withinCeiling(
+                                        fromStore.filter(item => numberOf(item) <= highWater)
                                       )
                                     )
-                                )
-                    }
+                            }
         }
 
     /** Whether the outbox currently holds nothing (for the link's empty-batch bookkeeping). */
@@ -164,39 +236,57 @@ object LaneOutbound {
           s"append out of order: last=$last attempted=$attempted expected=$expected"
         )
 
+    /** The outbox evicted an entry the journal then could not serve. Everything appended to a lane
+      * is persisted first (CR4), so this means the lane's backing is wrong — not that there is
+      * nothing to send. Raised rather than answered with an empty batch, which would leave the
+      * remote's lane stalled with nothing in the log to say why.
+      */
+    final case class EvictedButUnservable(
+        asked: String,
+        evictedThrough: String,
+        lastAppended: String
+    ) extends RuntimeException(
+          s"outbox evicted through $evictedThrough but the journal served nothing from $asked " +
+              s"(lastAppended=$lastAppended)"
+        )
+
     /** A contiguous outbound lane whose first number is `first` and whose successor is `+1` (acks,
-      * requests, re-sequenced relay lanes). `increment` supplies the `+1`; `backfill` reads the
-      * prefix below the in-memory outbox floor from the store on [[reply]].
+      * requests, re-sequenced relay lanes). `increment` supplies the `+1`; `serveFromJournal` reads
+      * the entries below the in-memory outbox floor from the store on [[reply]].
       */
     def contiguous[T, N: Ordering](
         numberOf: T => N,
         first: N,
         increment: N => N,
         maxPerReply: Int = 1,
-        backfill: (N, Int) => IO[List[T]]
+        outboxCap: Int,
+        serveFromJournal: (N, Int) => IO[List[T]]
     ): LaneOutbound[T, N] =
         new LaneOutbound[T, N](
           numberOf = numberOf,
           next = _.fold(Some(first))(last => Some(increment(last))),
           maxPerReply = maxPerReply,
-          backfill = backfill
+          outboxCap = outboxCap,
+          serveFromJournal = serveFromJournal
         )
 
     /** A sparse outbound lane: only the round-robin leader emits, so the successor is this side's
       * leader schedule. `next(after)` is this side's next-led number after `after`; `zero` is
-      * "before the first". `backfill` reads the prefix below the in-memory outbox floor from the
-      * store on [[reply]].
+      * "before the first". `serveFromJournal` reads the entries below the in-memory outbox floor
+      * from the store on [[reply]].
       */
     def sparse[T, N: Ordering](
         numberOf: T => N,
         zero: N,
         next: N => Option[N],
-        backfill: (N, Int) => IO[List[T]]
+        outboxCap: Int,
+        serveFromJournal: (N, Int) => IO[List[T]]
     ): LaneOutbound[T, N] =
         new LaneOutbound[T, N](
           numberOf = numberOf,
           next = last => next(last.getOrElse(zero)),
           maxPerReply = 1,
-          backfill = backfill
+          outboxCap = outboxCap,
+          serveFromJournal = serveFromJournal
         )
 }

--- a/src/main/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonCoilToHub.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonCoilToHub.scala
@@ -125,8 +125,8 @@ abstract class PeerLiaisonCoilToHub(
         }.toMap
 
     // Outbound: this coil peer's own hard-ack, served to the hub. Backed by the own coil `HardAck`
-    // journal so a reply hot-loads acks below the in-memory outbox floor (the hub re-pulls old acks
-    // it missed during our crash); preStart restores only the high-water, replay re-appends the
+    // journal so a reply reads acks below the in-memory outbox floor (the hub re-pulls old acks it
+    // missed during our crash); preStart restores only the high-water, replay re-appends the
     // in-flight tail.
     private val ownHardAckBacking =
         LaneOutgoingBacking.hardAck(persistence.backend, PeerId.Coil(ownCoilPeerNumber))
@@ -135,7 +135,8 @@ abstract class PeerLiaisonCoilToHub(
           _.hardAckNum,
           HardAckNumber.zero,
           _.increment,
-          backfill = ownHardAckBacking.backfill
+          outboxCap = config.peerLiaisonOutboxCap,
+          serveFromJournal = ownHardAckBacking.serveFromJournal
         )
 
     // ---- Connections ----------------------------------------------------------------------------

--- a/src/main/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonHeadToHead.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonHeadToHead.scala
@@ -82,7 +82,7 @@ abstract class PeerLiaisonHeadToHead(
 
     // ---- Lanes (bidirectional: outbox = our production, cursor = the remote head peer's next) ----
     // Each outbound side is backed by the journal this peer's own production lives in, so a reply
-    // hot-loads entries below the in-memory outbox floor and preStart restores only the high-water.
+    // reads entries below the in-memory outbox floor and preStart restores only the high-water.
     // The spines carry every leader's brief, so their backings keep only the ones THIS peer leads;
     // the satellites are this peer's own author (CF per author).
     private val backend = persistence.backend
@@ -97,48 +97,68 @@ abstract class PeerLiaisonHeadToHead(
     private val hubHardAckBacking: Option[LaneOutgoingBacking[HardAckWithId, HubHardAckNumber]] =
         Option.when(ownIsHub)(LaneOutgoingBacking.hubHardAck(backend, ownHeadPeerNum))
 
+    // Every outbound lane holds at most this many items; older ones are served from the journal.
+    private val outboxCap: Int = config.peerLiaisonOutboxCap
+
     private val blockLane = LaneBidirectional.sparse[BlockBrief.Next, BlockNumber](
       numberOf = _.blockNum,
       zero = BlockNumber.zero,
       outboundNext = config.nextOwnLeaderBlock,
       inboundNext = after => Some(remoteHead.nextLeaderBlock(after)),
-      backfill = blockBacking.backfill
+      outboxCap = outboxCap,
+      serveFromJournal = blockBacking.serveFromJournal
     )
     private val stackLane = LaneBidirectional.sparse[StackBrief, StackNumber](
       numberOf = _.stackNum,
       zero = StackNumber.zero,
       outboundNext = config.nextOwnSlowLeaderStack,
       inboundNext = after => Some(remoteHead.nextSlowLeaderStack(after)),
-      backfill = stackBacking.backfill
+      outboxCap = outboxCap,
+      serveFromJournal = stackBacking.serveFromJournal
     )
     private val requestLane = LaneBidirectional.contiguous[UserRequestWithId, RequestNumber](
       _.requestId.requestNum,
       RequestNumber.zero,
       _.increment,
       config.peerLiaisonMaxRequestsPerBatch,
-      backfill = requestBacking.backfill
+      outboxCap = outboxCap,
+      serveFromJournal = requestBacking.serveFromJournal
     )
     private val softAckLane =
         LaneBidirectional.contiguous[SoftAck, SoftAckNumber](
           _.ackNum,
           SoftAckNumber.zero.increment,
           _.increment,
-          backfill = softAckBacking.backfill
+          outboxCap = outboxCap,
+          serveFromJournal = softAckBacking.serveFromJournal
         )
     private val hardAckLane =
         LaneBidirectional.contiguous[HardAck, HardAckNumber](
           _.hardAckNum,
           HardAckNumber.zero,
           _.increment,
-          backfill = hardAckBacking.backfill
+          outboxCap = outboxCap,
+          serveFromJournal = hardAckBacking.serveFromJournal
         )
     private val hubHardAckLane =
         LaneBidirectional.contiguous[HardAckWithId, HubHardAckNumber](
           _.seqNum,
           HubHardAckNumber.zero,
           _.increment,
-          backfill = (from, limit) =>
-              hubHardAckBacking.fold(IO.pure(List.empty[HardAckWithId]))(_.backfill(from, limit))
+          outboxCap = outboxCap,
+          // A non-hub has no `HubHardAck` CF, and also never appends here — so `reply` answers from
+          // the un-seeded high-water without asking, and this is unreachable. Raising rather than
+          // returning nothing keeps it that way: were a non-hub ever to append, the item would be
+          // evictable with no journal behind it, and returning `Nil` would wedge the remote's lane
+          // silently instead of failing where the mistake is.
+          serveFromJournal = (from, limit) =>
+              hubHardAckBacking.fold(
+                IO.raiseError[List[HardAckWithId]](
+                  IllegalStateException(
+                    s"hub-hard-ack lane asked to serve from $from on a non-hub head peer"
+                  )
+                )
+              )(_.serveFromJournal(from, limit))
         )
 
     // The remote head peer's confirmed request high-water, learned from the local FastConsensusActor
@@ -370,7 +390,7 @@ abstract class PeerLiaisonHeadToHead(
     }
 
     /** Restore each outbound lane's high-water from its backing journal, leaving the queues empty
-      * (R3): the Server half hot-loads older own-produced entries from the store on the remote's
+      * (R3): the Server half reads older own-produced entries from the store on the remote's
       * `Mesh.Get`, and replay / live production re-appends the tail. The hub-hard-ack lane restores
       * on a **hub** head peer (its own `HubHardAck` is persisted by `CoilAckSequencer`); it is cold
       * on a non-hub.
@@ -450,7 +470,7 @@ abstract class PeerLiaisonHeadToHead(
             c <- resolveConnections
             _ <- connections.set(Some(c))
             _ <- tracer.traceWith(PeerLiaisonEvent.Started)
-            // Restore each lane's own-produced high-water; the Server half hot-loads older entries
+            // Restore each lane's own-produced high-water; the Server half reads older entries
             // from the store on the remote's Mesh.Get, and replay / live production re-appends the
             // tail. An empty store leaves every lane cold.
             _ <- restoreOutboundHighWaters

--- a/src/main/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonHubToCoil.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonHubToCoil.scala
@@ -76,7 +76,7 @@ abstract class PeerLiaisonHubToCoil(
 
     // ---- Outbox lanes (the population we serve to the coil peer) ---------------------------------
     // Each lane is backed by the journal the hub already persists as a head-mesh member (own-produced
-    // or inbound-replicated), so a reply hot-loads entries below the in-memory outbox floor and
+    // or inbound-replicated), so a reply reads entries below the in-memory outbox floor and
     // preStart restores only the high-water; the hub serves every author (no own-led filter).
     private val backend = persistence.backend
     private val blockBacking = LaneOutgoingBacking.block(backend, _ => true)
@@ -90,19 +90,26 @@ abstract class PeerLiaisonHubToCoil(
     private val coilHardAckBackings =
         hubNums.map(h => h -> LaneOutgoingBacking.hubHardAck(backend, h)).toMap
 
+    // Every outbound lane holds at most this many items; older ones are served from the journal.
+    // One liaison exists per *configured* coil peer, so a coil that is configured but not connected
+    // advances no cursor here — the cap is the only thing that bounds its lanes.
+    private val outboxCap: Int = config.peerLiaisonOutboxCap
+
     private val blockLane =
         LaneOutbound.contiguous[BlockBrief.Next, BlockNumber](
           _.blockNum,
           BlockNumber(1),
           _.increment,
-          backfill = blockBacking.backfill
+          outboxCap = outboxCap,
+          serveFromJournal = blockBacking.serveFromJournal
         )
     private val stackLane =
         LaneOutbound.contiguous[StackBrief, StackNumber](
           _.stackNum,
           StackNumber(1),
           _.increment,
-          backfill = stackBacking.backfill
+          outboxCap = outboxCap,
+          serveFromJournal = stackBacking.serveFromJournal
         )
     private val requestLanes: Map[HeadPeerNumber, LaneOutbound[UserRequestWithId, RequestNumber]] =
         headPeerNums.map { h =>
@@ -111,7 +118,8 @@ abstract class PeerLiaisonHubToCoil(
               RequestNumber.zero,
               _.increment,
               config.peerLiaisonMaxRequestsPerBatch,
-              backfill = requestBackings(h).backfill
+              outboxCap = outboxCap,
+              serveFromJournal = requestBackings(h).serveFromJournal
             )
         }.toMap
     private val softAckLanes: Map[HeadPeerNumber, LaneOutbound[SoftAck, SoftAckNumber]] =
@@ -120,7 +128,8 @@ abstract class PeerLiaisonHubToCoil(
               _.ackNum,
               SoftAckNumber.zero.increment,
               _.increment,
-              backfill = softAckBackings(h).backfill
+              outboxCap = outboxCap,
+              serveFromJournal = softAckBackings(h).serveFromJournal
             )
         }.toMap
     private val headHardAckLanes: Map[HeadPeerNumber, LaneOutbound[HardAck, HardAckNumber]] =
@@ -129,7 +138,8 @@ abstract class PeerLiaisonHubToCoil(
               _.hardAckNum,
               HardAckNumber.zero,
               _.increment,
-              backfill = headHardAckBackings(h).backfill
+              outboxCap = outboxCap,
+              serveFromJournal = headHardAckBackings(h).serveFromJournal
             )
         }.toMap
     private val coilHardAckLanes
@@ -139,7 +149,8 @@ abstract class PeerLiaisonHubToCoil(
               _.seqNum,
               HubHardAckNumber.zero,
               _.increment,
-              backfill = coilHardAckBackings(h).backfill
+              outboxCap = outboxCap,
+              serveFromJournal = coilHardAckBackings(h).serveFromJournal
             )
         }.toMap
 
@@ -329,9 +340,9 @@ abstract class PeerLiaisonHubToCoil(
     }
 
     /** Restore each population outbox lane's high-water from its backing journal, leaving the
-      * queues empty. The Server half answers the coil peer's `Population.Get` by hot-loading older
-      * entries from the store (`LaneOutgoingBacking.backfill`); live `CoilRelay` production
-      * re-appends the tail. An empty store leaves every lane cold.
+      * outboxes empty. The Server half answers the coil peer's `Population.Get` from the store
+      * (`LaneOutgoingBacking.serveFromJournal`); live `CoilRelay` production re-appends the tail.
+      * An empty store leaves every lane cold.
       */
     private def restoreHighWaters: IO[Unit] =
         for {
@@ -369,7 +380,7 @@ abstract class PeerLiaisonHubToCoil(
             c <- resolveConnections
             _ <- connections.set(Some(c))
             _ <- tracer.traceWith(PeerLiaisonEvent.Started)
-            // Restore each lane's high-water; the Server half hot-loads older population entries
+            // Restore each lane's high-water; the Server half reads older population entries
             // from the store on the coil peer's Population.Get, and live CoilRelay production
             // re-appends the tail. An empty store leaves every lane cold.
             _ <- restoreHighWaters

--- a/src/main/scala/hydrozoa/multisig/persistence/recovery/LaneOutgoingBacking.scala
+++ b/src/main/scala/hydrozoa/multisig/persistence/recovery/LaneOutgoingBacking.scala
@@ -19,15 +19,16 @@ import java.nio.ByteBuffer
   *   - [[highWater]] — the lane's last own-produced number (`lastKey` of the journal), so
   *     `preStart` seeds only the high-water (no payloads): the gap-free [[LaneOutbound.append]]
   *     check and the out-of-bounds guard work, and replay can re-append the live tail on top.
-  *   - [[backfill]] — up to `limit` payloads from a `from` number, so [[LaneOutbound.reply]] reads
-  *     the prefix below its in-memory outbox floor when a remote pulls an old entry, instead of
-  *     holding the whole own production in memory.
+  *   - [[serveFromJournal]] — up to `limit` payloads from a `from` number, so
+  *     [[LaneOutbound.reply]] reads the entries below its in-memory outbox floor when a remote
+  *     pulls an old one, instead of holding the whole own production in memory.
   *
   * `keep` filters a spine journal to this peer's own-led entries (a head-mesh liaison serves only
   * its own-led briefs); the satellites are already a single author per CF, and a hub→coil link
-  * serves every author, so both pass the default accept-all. Only [[backfill]] consults `keep`;
-  * [[highWater]] is the whole-CF `lastKey`. Restoring an **inbound** receive cursor needs neither
-  * `keep` nor a payload decode (nor a `CardanoNetwork.Section`) — see [[LaneIncomingCursors]].
+  * serves every author, so both pass the default accept-all. Only [[serveFromJournal]] consults
+  * `keep`; [[highWater]] is the whole-CF `lastKey`. Restoring an **inbound** receive cursor needs
+  * neither `keep` nor a payload decode (nor a `CardanoNetwork.Section`) — see
+  * [[LaneIncomingCursors]].
   */
 final class LaneOutgoingBacking[T, N] private (
     backend: BackendStore[IO],
@@ -41,7 +42,7 @@ final class LaneOutgoingBacking[T, N] private (
     def highWater: IO[Option[N]] = backend.lastKey(cf).map(_.map(decodeNum))
 
     /** Up to `limit` own-produced payloads with number `>= from`, ascending. */
-    def backfill(from: N, limit: Int): IO[List[T]] =
+    def serveFromJournal(from: N, limit: Int): IO[List[T]] =
         JournalScan.loadFrom(backend, seekKey(from), decodePayload, keep, limit)
 
 object LaneOutgoingBacking:

--- a/src/test/scala/hydrozoa/config/node/operation/multisig/NodeOperationMultisigConfigGen.scala
+++ b/src/test/scala/hydrozoa/config/node/operation/multisig/NodeOperationMultisigConfigGen.scala
@@ -5,7 +5,9 @@ import org.scalacheck.Gen
 import scala.concurrent.duration.{DurationInt, DurationLong, FiniteDuration}
 
 /** Generates a [[NodeOperationMultisigConfig]] with a `cardanoLiaisonPollingPeriod` uniformly
-  * sampled from `[1ms, maxPollingPeriod]` and a `peerLiaisonMaxRequestsPerBatch` between 1 and 100.
+  * sampled from `[1ms, maxPollingPeriod]`, a `peerLiaisonMaxRequestsPerBatch` between 1 and 100,
+  * and a `peerLiaisonOutboxCap` between 1 and 4096 — deliberately spanning values *below*
+  * `maxPerReply`, so anything property-tested through this generator meets the floor case.
   *
   * The polling period must respect the head's
   * [[hydrozoa.config.head.multisig.timing.TxTiming.Section.maxCardanoLiaisonPollingPeriod]]
@@ -17,10 +19,12 @@ def generateNodeOperationMultisigConfig(
 ): Gen[NodeOperationMultisigConfig] =
     for {
         maxRequestsPerBatch <- Gen.choose(1, 100)
+        outboxCap <- Gen.choose(1, 4096)
         millis <- Gen.choose(1L, maxPollingPeriod.toMillis)
     } yield NodeOperationMultisigConfig(
       cardanoLiaisonPollingPeriod = millis.millis,
       peerLiaisonMaxRequestsPerBatch = PositiveInt(maxRequestsPerBatch).get,
+      peerLiaisonOutboxCap = PositiveInt(outboxCap).get,
       peerLiaisonResendInterval = 5.seconds,
       rateLimits = rateLimits
     )

--- a/src/test/scala/hydrozoa/config/node/operation/multisig/NodeOperationMultisigConfigTest.scala
+++ b/src/test/scala/hydrozoa/config/node/operation/multisig/NodeOperationMultisigConfigTest.scala
@@ -1,0 +1,44 @@
+package hydrozoa.config.node.operation.multisig
+
+import hydrozoa.lib.number.PositiveInt
+import io.circe.parser.decode
+import io.circe.syntax.*
+import org.scalatest.funsuite.AnyFunSuite
+
+/** Decoding [[NodeOperationMultisigConfig]], with the compatibility case that matters
+  * operationally: `peerLiaisonOutboxCap` was added after nodes were already deployed, so a config
+  * file written without it must still decode. A node whose private config fails to decode does not
+  * start at all.
+  */
+class NodeOperationMultisigConfigTest extends AnyFunSuite {
+
+    private val withoutOutboxCap =
+        """{
+          |  "cardanoLiaisonPollingPeriod": 20000,
+          |  "peerLiaisonMaxRequestsPerBatch": 500,
+          |  "peerLiaisonResendInterval": 5000,
+          |  "rateLimits": { "softBlockMinPeriod": 100, "hardStackMinPeriod": 30000 }
+          |}""".stripMargin
+
+    test("a config predating peerLiaisonOutboxCap decodes, taking the default") {
+        val decoded = decode[NodeOperationMultisigConfig](withoutOutboxCap)
+        assert(
+          decoded.map(_.peerLiaisonOutboxCap) ==
+              Right(NodeOperationMultisigConfig.defaultPeerLiaisonOutboxCap)
+        )
+    }
+
+    test("an explicit peerLiaisonOutboxCap is taken over the default") {
+        val json = withoutOutboxCap.replace(
+          """"peerLiaisonMaxRequestsPerBatch": 500,""",
+          """"peerLiaisonMaxRequestsPerBatch": 500, "peerLiaisonOutboxCap": 64,"""
+        )
+        val decoded = decode[NodeOperationMultisigConfig](json)
+        assert(decoded.map(_.peerLiaisonOutboxCap) == Right(PositiveInt.unsafeApply(64)))
+    }
+
+    test("the encoder round-trips through the decoder") {
+        val config = NodeOperationMultisigConfig.default
+        assert(decode[NodeOperationMultisigConfig](config.asJson.noSpaces) == Right(config))
+    }
+}

--- a/src/test/scala/hydrozoa/multisig/consensus/CoilRelayOrderingTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/CoilRelayOrderingTest.scala
@@ -64,15 +64,17 @@ object CoilRelayOrderingTest extends Properties("CoilRelay block-lane ordering")
         )
     }
 
-    /** The real hub→coil block lane, built exactly as `PeerLiaisonHubToCoil` builds it (`:93`).
-      * `backfill` is unused here — nothing in this scenario reads below the outbox floor.
+    /** The real hub→coil block lane, built exactly as `PeerLiaisonHubToCoil` builds it (`:93`). The
+      * journal read is unused here — the cap is far above what this scenario appends, so nothing is
+      * ever evicted and no reply falls below the outbox floor.
       */
     private def blockLane: LaneOutbound[BlockBrief.Next, BlockNumber] =
         LaneOutbound.contiguous[BlockBrief.Next, BlockNumber](
           _.blockNum,
           BlockNumber(1),
           _.increment,
-          backfill = (_, _) => IO.pure(Nil)
+          outboxCap = 1024,
+          serveFromJournal = (_, _) => IO.pure(Nil)
         )
 
     /** Stands in for `PeerLiaisonHubToCoil`, doing what its `appendArtifact` does for a block brief

--- a/src/test/scala/hydrozoa/multisig/consensus/liaison/LaneOutboundTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/liaison/LaneOutboundTest.scala
@@ -4,6 +4,7 @@ import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import hydrozoa.multisig.consensus.liaison.LaneOutbound.*
 import org.scalatest.funsuite.AnyFunSuite
+import scala.collection.mutable
 
 /** Unit tests for the outbound half ([[LaneOutbound]]) — append + reply. Items are plain `Int`s
   * that are their own item number (`numberOf = identity`), so the sequencing logic is exercised in
@@ -11,16 +12,42 @@ import org.scalatest.funsuite.AnyFunSuite
   */
 class LaneOutboundTest extends AnyFunSuite {
 
-    // A lane with an empty durable backing: a reply below the in-memory floor finds nothing.
-    private val emptyBackfill: (Int, Int) => IO[List[Int]] = (_, _) => IO.pure(Nil)
+    // Wide enough that nothing is evicted: the tests that are not about the cap should not have to
+    // think about it.
+    private val noEviction = 1024
 
-    private def contiguousFrom(first: Int, maxPerReply: Int = 1): LaneOutbound[Int, Int] =
+    // A lane with an empty durable backing: a reply below the in-memory floor finds nothing.
+    private val emptyJournal: (Int, Int) => IO[List[Int]] = (_, _) => IO.pure(Nil)
+
+    /** A journal holding exactly `items`, read the way `LaneOutgoingBacking` reads one, counting
+      * its reads.
+      *
+      * The count is the control for the cap tests: each asserts that a capped lane answers what an
+      * uncapped one would, which is trivially true if nothing was ever evicted and no read ever
+      * happened. `reads` is what makes that failure visible.
+      */
+    private final class StubJournal(items: Iterable[Int]) {
+        var reads: Int = 0
+        val read: (Int, Int) => IO[List[Int]] = (from, limit) =>
+            IO { reads += 1 } >> IO.pure(items.filter(_ >= from).take(limit).toList)
+    }
+
+    private def journalOf(items: Iterable[Int]): (Int, Int) => IO[List[Int]] =
+        StubJournal(items).read
+
+    private def contiguousFrom(
+        first: Int,
+        maxPerReply: Int = 1,
+        outboxCap: Int = noEviction,
+        serveFromJournal: (Int, Int) => IO[List[Int]] = emptyJournal
+    ): LaneOutbound[Int, Int] =
         LaneOutbound.contiguous[Int, Int](
           numberOf = identity,
           first = first,
           increment = _ + 1,
           maxPerReply,
-          backfill = emptyBackfill
+          outboxCap = outboxCap,
+          serveFromJournal = serveFromJournal
         )
 
     // Sparse own-led schedule: the lane's zero (0) is the bootstrap sentinel, never led. This side
@@ -30,7 +57,8 @@ class LaneOutboundTest extends AnyFunSuite {
           numberOf = identity,
           zero = 0,
           next = after => Some(if after % 2 == 0 then after + 2 else after + 1),
-          backfill = emptyBackfill
+          outboxCap = noEviction,
+          serveFromJournal = emptyJournal
         )
 
     test("contiguous append enforces gap-free order from the first number") {
@@ -76,17 +104,10 @@ class LaneOutboundTest extends AnyFunSuite {
         assert(lane.reply(1).unsafeRunSync() == Items(List(1, 2)))
     }
 
-    test("reply hot-loads from the store when the cursor is below the in-memory outbox floor") {
+    test("reply reads from the store when the cursor is below the in-memory outbox floor") {
         // A stub store holding 0..4; on recovery the lane restores only its high-water (empty
-        // outbox), so a pull below the in-memory floor is served from the store via `backfill`.
-        val store = (0 to 4).toList
-        val lane = LaneOutbound.contiguous[Int, Int](
-          numberOf = identity,
-          first = 0,
-          increment = _ + 1,
-          maxPerReply = 2,
-          backfill = (from, limit) => IO.pure(store.filter(_ >= from).take(limit))
-        )
+        // outbox), so a pull below the in-memory floor is served from the store.
+        val lane = contiguousFrom(0, maxPerReply = 2, serveFromJournal = journalOf(0 to 4))
         lane.seedHighWater(Some(4)).unsafeRunSync()
         // Outbox empty → served from the store.
         val _ = assert(lane.reply(1).unsafeRunSync() == Items(List(1, 2)))
@@ -97,20 +118,13 @@ class LaneOutboundTest extends AnyFunSuite {
     }
 
     test("append at or below the high-water is a no-op (absorbs a replay re-broadcast)") {
-        // The store holds 0..3; on recovery the lane restores high-water = 3 (e.g. round-2), queue
+        // The store holds 0..3; on recovery the lane restores high-water = 3 (e.g. round-2), outbox
         // empty. SlowConsensusActor then re-broadcasts the in-flight stack's round-1 (= 2, below the
         // high-water) — this must be a no-op, not an out-of-order error.
-        val store = (0 to 3).toList
-        val lane = LaneOutbound.contiguous[Int, Int](
-          numberOf = identity,
-          first = 0,
-          increment = _ + 1,
-          maxPerReply = 1,
-          backfill = (from, limit) => IO.pure(store.filter(_ >= from).take(limit))
-        )
+        val lane = contiguousFrom(0, serveFromJournal = journalOf(0 to 3))
         lane.seedHighWater(Some(3)).unsafeRunSync()
         lane.append(2).unsafeRunSync() // re-broadcast of an already-durable ack: no throw
-        // It is still servable — hot-loaded from the store, since the queue stayed empty.
+        // It is still servable — read from the store, since the outbox stayed empty.
         val _ = assert(lane.reply(2).unsafeRunSync() == Items(List(2)))
         // A genuinely new item (high-water + 1) still appends; a gap above it still raises.
         lane.append(4).unsafeRunSync()
@@ -125,8 +139,8 @@ class LaneOutboundTest extends AnyFunSuite {
         // above the high-water still raises (the baseline is 3, not None).
         val _ = assertThrows[AppendOutOfOrder](lane.append(5).unsafeRunSync())
         lane.append(4).unsafeRunSync()
-        // Empty backing → the restored prefix is not in memory and the store has nothing to
-        // backfill; a pull below the tail is empty.
+        // Empty backing → the restored prefix is not in memory and the store has nothing to serve;
+        // a pull below the tail is empty.
         assert(lane.reply(2).unsafeRunSync() == Items(Nil))
     }
 
@@ -139,27 +153,124 @@ class LaneOutboundTest extends AnyFunSuite {
         assertThrows[AppendOutOfOrder](lane.append(5).unsafeRunSync()) // 5 is remote-led
     }
 
-    test("reply backfill never serves a store entry above the released high-water") {
+    test("a journal read never serves a store entry above the released high-water") {
         // The store durably holds 0..3, but only 0..1 are released (appended) — e.g. #2 is a
         // postponed own soft-ack the producer persisted at block time but has not yet announced
         // onto the lane. seedHighWater(1) models that: high-water 1, empty outbox, so every serve
-        // is a backfill from the store.
-        val store = (0 to 3).toList
-        val lane = LaneOutbound.contiguous[Int, Int](
-          numberOf = identity,
-          first = 0,
-          increment = _ + 1,
-          maxPerReply = 2,
-          backfill = (from, limit) => IO.pure(store.filter(_ >= from).take(limit))
-        )
+        // reads from the store.
+        val lane = contiguousFrom(0, maxPerReply = 2, serveFromJournal = journalOf(0 to 3))
         lane.seedHighWater(Some(1)).unsafeRunSync()
         // The released prefix is served from the store, capped at the high-water (no #2/#3 leak)...
         val _ = assert(lane.reply(0).unsafeRunSync() == Items(List(0, 1)))
-        // ...and a pull for the not-yet-released #2 comes back empty, not hot-loaded — otherwise the
+        // ...and a pull for the not-yet-released #2 comes back empty, not served — otherwise the
         // remote's cursor would run past our bound and the next pull would be a false OutOfBounds.
         val _ = assert(lane.reply(2).unsafeRunSync() == Items(Nil))
         // Once #2 is released (announced), it serves; #3 (still unreleased) stays withheld.
         lane.append(2).unsafeRunSync()
         assert(lane.reply(2).unsafeRunSync() == Items(List(2)))
+    }
+
+    // ---- The cap ----------------------------------------------------------------------------
+
+    test("a cap below maxPerReply is floored, so a full batch is still servable from memory") {
+        // maxPerReply 4 against a cap of 1: without the floor the outbox would hold one item and
+        // every pull — even from a perfectly current remote — would go to the store. The empty
+        // journal makes that visible: anything not in memory comes back empty.
+        val lane = contiguousFrom(0, maxPerReply = 4, outboxCap = 1)
+        (0 to 3).foreach(n => lane.append(n).unsafeRunSync())
+        assert(lane.reply(0).unsafeRunSync() == Items(List(0, 1, 2, 3)))
+    }
+
+    test("appending past the cap evicts the oldest, and the journal serves it") {
+        val items = mutable.ArrayBuffer.empty[Int]
+        val journal = StubJournal(items)
+        // CR4: everything reaches the lane already durable, so the stub is written before append.
+        val lane = contiguousFrom(0, outboxCap = 3, serveFromJournal = journal.read)
+        (0 to 5).foreach { n =>
+            items += n; lane.append(n).unsafeRunSync()
+        }
+        // The window is the last 3 (3..5): #4 comes from memory, so the journal is untouched...
+        val _ = assert(lane.reply(4).unsafeRunSync() == Items(List(4)))
+        val _ = assert(journal.reads == 0)
+        // ...and #1, long evicted, comes from the journal — same answer, different source.
+        val _ = assert(lane.reply(1).unsafeRunSync() == Items(List(1)))
+        assert(journal.reads == 1)
+    }
+
+    test("a capped lane answers exactly as an uncapped one, over the same append/pull sequence") {
+        // The property the cap has to have: it changes where an item is read from, never what the
+        // remote receives. A cap of 1 is the harshest case — everything but the newest is evicted.
+        val items = mutable.ArrayBuffer.empty[Int]
+        val cappedJournal = StubJournal(items)
+        val uncappedJournal = StubJournal(items)
+        val capped =
+            contiguousFrom(0, maxPerReply = 2, outboxCap = 1, serveFromJournal = cappedJournal.read)
+        val uncapped = contiguousFrom(
+          0,
+          maxPerReply = 2,
+          outboxCap = noEviction,
+          serveFromJournal = uncappedJournal.read
+        )
+
+        // Three regimes, and only the first tells the two lanes apart. A remote lagging steadily
+        // by 6 sits inside the uncapped window and outside the capped one, so the cap alone decides
+        // where its pull is served from. Then it regresses to the start (below both floors — `reply`
+        // prunes destructively, so a regressing cursor leaves an uncapped window too), and finally
+        // catches up to the head (inside both).
+        def cursorAt(n: Int): Int =
+            if n < 10 then math.max(0, n - 6) else if n == 10 then 0 else n
+
+        val (cappedReplies, uncappedReplies) = (0 to 15).map { n =>
+            items += n
+            capped.append(n).unsafeRunSync()
+            uncapped.append(n).unsafeRunSync()
+            val cursor = cursorAt(n)
+            (capped.reply(cursor).unsafeRunSync(), uncapped.reply(cursor).unsafeRunSync())
+        }.unzip
+
+        val _ = assert(cappedReplies == uncappedReplies)
+        // The control: the cap must have forced journal serves the uncapped lane did not need,
+        // or the two agree only because eviction never happened.
+        assert(cappedJournal.reads > uncappedJournal.reads)
+    }
+
+    test("a ceiling still bounds a reply served from the journal after eviction") {
+        val items = mutable.ArrayBuffer.empty[Int]
+        val journal = StubJournal(items)
+        val lane =
+            contiguousFrom(0, maxPerReply = 4, outboxCap = 1, serveFromJournal = journal.read)
+        (0 to 9).foreach { n =>
+            items += n; lane.append(n).unsafeRunSync()
+        }
+        // #2 is evicted, so this is a journal serve — the ceiling must apply to it too.
+        val _ = assert(lane.reply(2, ceiling = Some(4)).unsafeRunSync() == Items(List(2, 3, 4)))
+        assert(journal.reads == 1)
+    }
+
+    test("an evicted entry the journal cannot serve raises instead of replying empty") {
+        // The failure the cap could introduce: evict an item whose backing cannot produce it, and a
+        // silently empty reply leaves the remote's lane stalled forever with nothing logged. The
+        // journal here is empty, so #0 is gone the moment #1 pushes it out.
+        val lane = contiguousFrom(0, outboxCap = 1)
+        lane.append(0).unsafeRunSync()
+        lane.append(1).unsafeRunSync()
+        val thrown = intercept[EvictedButUnservable](lane.reply(0).unsafeRunSync())
+        val _ = assert(thrown.asked == "0")
+        assert(thrown.evictedThrough == "0")
+    }
+
+    test("nothing appended yet: the lane answers without consulting the journal at all") {
+        // A lane its peer never produces on — a non-hub's HubHardAck lane — is pulled on every
+        // batch for the life of the process. Nothing is released, so nothing is servable whatever
+        // the store holds, and asking the store would be a read per pull that is then discarded.
+        // The backing here raises to prove it is not called; on a non-hub it genuinely does.
+        var consulted = false
+        val lane = contiguousFrom(
+          0,
+          serveFromJournal = (_, _) =>
+              IO { consulted = true } >> IO.raiseError(IllegalStateException("no backing"))
+        )
+        val _ = assert(lane.reply(0).unsafeRunSync() == Items(Nil))
+        assert(!consulted)
     }
 }

--- a/src/test/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonCoilRecoveryTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonCoilRecoveryTest.scala
@@ -51,8 +51,8 @@ class PeerLiaisonCoilRecoveryTest extends AnyFunSuite:
                   JournalValue(stamp, coilHardAck(coil, 1, stack = 2))
                 )
                 hw <- backing.highWater
-                fromZero <- backing.backfill(HardAckNumber(0), 16)
-                fromOne <- backing.backfill(HardAckNumber(1), 16)
+                fromZero <- backing.serveFromJournal(HardAckNumber(0), 16)
+                fromOne <- backing.serveFromJournal(HardAckNumber(1), 16)
             } yield (hw, fromZero, fromOne)
         }
         val _ = assert(hw == Some(HardAckNumber(1)), s"high-water = max; got $hw")
@@ -68,7 +68,7 @@ class PeerLiaisonCoilRecoveryTest extends AnyFunSuite:
             val backing = LaneOutgoingBacking.hardAck(p.backend, PeerId.Coil(CoilPeerNumber(0)))
             for {
                 hw <- backing.highWater
-                loaded <- backing.backfill(HardAckNumber.zero, 16)
+                loaded <- backing.serveFromJournal(HardAckNumber.zero, 16)
             } yield (hw, loaded)
         }
         assert(hw.isEmpty && loaded.isEmpty)
@@ -107,10 +107,10 @@ class PeerLiaisonCoilRecoveryTest extends AnyFunSuite:
                   )
                 )
                 blockHw <- blockBacking.highWater
-                blocks <- blockBacking.backfill(BlockNumber(1), 16)
-                stacks <- stackBacking.backfill(StackNumber(1), 16)
-                headAcks <- headHardAckBacking.backfill(HardAckNumber.zero, 16)
-                relay <- relayBacking.backfill(HubHardAckNumber.zero, 16)
+                blocks <- blockBacking.serveFromJournal(BlockNumber(1), 16)
+                stacks <- stackBacking.serveFromJournal(StackNumber(1), 16)
+                headAcks <- headHardAckBacking.serveFromJournal(HardAckNumber.zero, 16)
+                relay <- relayBacking.serveFromJournal(HubHardAckNumber.zero, 16)
             } yield Out(
               blockHw,
               blocks.map(_.blockNum),

--- a/src/test/scala/hydrozoa/multisig/persistence/recovery/RecoverSeamsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/persistence/recovery/RecoverSeamsTest.scala
@@ -679,7 +679,7 @@ class RecoverSeamsTest extends AnyFunSuite:
             for
                 hwHardAck <- hardAckBacking.highWater
                 hwBlock <- blockBacking.highWater
-                loaded <- hardAckBacking.backfill(HardAckNumber.zero, 16)
+                loaded <- hardAckBacking.serveFromJournal(HardAckNumber.zero, 16)
             yield assert(hwHardAck.isEmpty && hwBlock.isEmpty && loaded.isEmpty)
         }
     }
@@ -719,9 +719,9 @@ class RecoverSeamsTest extends AnyFunSuite:
                 hwHardAck <- hardAckBacking.highWater
                 hwBlock <- blockBacking.highWater
                 hwStack <- stackBacking.highWater
-                ownHardAcks <- hardAckBacking.backfill(HardAckNumber.zero, 16)
-                ownBlocks <- blockBacking.backfill(BlockNumber.zero, 16)
-                ownStacks <- stackBacking.backfill(StackNumber.zero, 16)
+                ownHardAcks <- hardAckBacking.serveFromJournal(HardAckNumber.zero, 16)
+                ownBlocks <- blockBacking.serveFromJournal(BlockNumber.zero, 16)
+                ownStacks <- stackBacking.serveFromJournal(StackNumber.zero, 16)
             yield assert(
               // satellite high-water = own max (other peer's CF is separate);
               hwHardAck == Some(HardAckNumber(2)) &&


### PR DESCRIPTION
A `LaneOutbound` outbox is pruned only when the remote's pull cursor moves past an entry — not by
confirmation, not by time, not by memory pressure. So a lane whose remote never pulls holds every
item it has ever carried, for the life of the process.

The mainnet head has one. `head-config.json` names coil peers 0 and 1, one `PeerLiaisonHubToCoil` is
created per **configured** coil, `CoilRelay` fans every population artifact out to all of them, and
**coil 1 has never connected in any of the head's six incarnations** (`HardAck:2` holds 0 keys; there
is no `HubHardAck:1` CF at all). `coilQuorum: 1` means coil 0 alone keeps the head healthy, so
nothing surfaces it.

Measured in a controlled A/B on this branch: the head retains **1.11 bytes of heap per byte relayed**
without the cap, linearly, over 20,000 market-maker-shaped requests — while the connected coil sits
on the head's block at every sample. Evidence, arms and caveats:
https://claude.ai/code/artifact/3e7b54d4-61bf-4b2c-a41b-c1dcee1be044

## How to review

Start with `LaneOutbound.scala`; everything else follows from it. Three things, in order of danger:

1. **`reply`'s branch structure** — the `lastAppended = None` short-circuit and the
   `EvictedButUnservable` condition. This is where a mistake wedges a lane.
2. **`Queue` → `TreeMap[N, T]`** in `append` / `reply`. The pruning predicate is unchanged
   (`dropWhile(_ < cursor)` becomes `rangeFrom(cursor)`); the memory-vs-journal test becomes
   `kept.contains(remoteCursor)`, exact where the queue version compared the head.
3. **Two spec edits** in `persistence-and-crash-recovery.md`, which correct a claim the code did not
   honour.

The rest is two named arguments threaded through three liaisons.

## Rationale

The spec already claims this property (§6):

> Reading from the store on demand (rather than eagerly seeding the whole own production) also
> bounds the in-memory outbox to the live tail.

True of what recovery *seeds*, false of what live production *accumulates*. Corrected here.

Eviction is safe for the reason the same section gives: *"Everything that ever reaches a liaison
outbox is persisted before it is appended (CR4) … the outbox is only a cache."* Verified on both feed
paths — `RequestSequencer` writes the journal before `coilRelay ! …`, and a replicated artifact goes
through `persistInbound` before `dispatch`.

So this is not new behaviour. It is what every lane already does immediately after a restart, made
the steady state — and the journal-serve path is already load-bearing in production: when hydrozoa
restarted at 23:21 UTC on 2026-08-24, `seedHighWater` emptied every outbound lane, coil 0 reconnected
pulling from below the floor, and **130 stacks hard-confirmed in the next 65 minutes**.

**Items, not batches.** The cap could have been counted in `maxPerReply` batches. It cannot:
`maxPerReply` is `peerLiaisonMaxRequestsPerBatch` on the request lane and 1 on every other, so any
batch count either starves the single-item lanes or multiplies the one lane whose payloads dominate
memory. Fixing that needs a floor, and the floor then does all the work. One number in items, floored
at the lane's own `maxPerReply`.

## Risk

**The failure mode is a silently wedged lane** — evict an entry the backing cannot produce, and
`reply` returns an empty batch, the remote never advances, and nothing is logged. Two changes make it
loud:

- The lane records the highest number it has evicted; a pull at or below that mark which the journal
  answers with nothing raises `EvictedButUnservable`. Sound rather than heuristic: an evicted entry
  was appended, everything appended is durable, and `JournalScan.loadFrom` limits its *results*, not
  its scan — so silence means the backing is wrong.
- `PeerLiaisonHeadToHead`'s hub-hard-ack lane returned `List.empty` on a non-hub. Now a raise; a
  non-hub never appends there, so it is unreachable, and making it loud keeps it that way.

Worth knowing what "loud" costs today: a raise out of a liaison goes through the cats-actors
supervisor defect, where the original cause is buried and `/ready` keeps reporting `Active`. Still
the right call — the alternative is a lane that stalls with nothing logged — but it is a reason to
ship the `/ready` fix in the same release.

**`reply` no longer reads the store when nothing has been released.** With `lastAppended = None` the
read was issued and its result discarded by the high-water filter, so every non-hub was doing a store
read per pull on its hub-hard-ack lane for the life of the process. That short-circuit is also what
makes the raise above safe; without it, it would fire on every healthy non-hub.

**Config decode.** `peerLiaisonOutboxCap` is optional. Every deployed `private.json` predates it, and
a config that fails to decode is a node that does not start — the same class as the 2026-08-24
crash-loop. The derived decoder is replaced with a hand-written one that defaults the field.

## Testing

The property the change has to have: **a capped lane answers exactly as an uncapped one** over the
same append/pull sequence, driven through a shared journal stub written before each append (CR4).

Its stub counts reads, and the test asserts the capped lane read *more* than the uncapped one. That
control earned its place twice: the first cursor sequence put both lanes on the journal path equally
— it regressed, which defeats an uncapped floor too — so the equivalence held while proving nothing
about eviction.

Also: a cap below `maxPerReply` is floored; eviction plus a journal serve returns the same entry; a
`ceiling` still bounds a post-eviction serve; an unservable evicted entry raises; a lane with nothing
appended never consults the journal (its stub raises if called).

385 unit tests pass; `integration` and `examples` compile. Beyond the unit tests, on this branch:
`CoilLateJoinTest` passes — a coil with no store joining a running, evicting head ends identical to
the head in all six markers, including a deposit absorbed before it existed.

## Scope

A memory bound on one cache. No change to the wire protocol, consensus, or what any peer receives.

It does not address the ~3× per-request amplification (a `lazy val` hex cache in scalus forced by a
`toString` on the ingress path — separate PR), nor the `maxPerReply = 1` throttle on the block and
stack lanes.

`backfill` is renamed to `serveFromJournal` throughout, and the "hot-load" framing goes with it: with
the cap, reading from the journal is the ordinary path for a lagging remote, not an exceptional
catch-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)