### PR TITLE
Make the evacuation-map fold linear instead of quadratic

### DIFF
--- a/src/main/scala/hydrozoa/multisig/ledger/joint/EvacuationMap.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/joint/EvacuationMap.scala
@@ -128,13 +128,13 @@ final case class EvacuationMap(
     /** The evac map, where we threw away the "KeepRaw"
       */
     // Its a silly name, but we use the term "value" too much
-    val cooked: TreeMap[EvacuationKey, TransactionOutput] =
+    lazy val cooked: TreeMap[EvacuationKey, TransactionOutput] =
         evacuationMap.map((i, obligation) => (i, obligation.utxo.value))
     val outputs: Iterable[Payout.Obligation] = evacuationMap.values
 
     /** The outputs of the evac map, where we threw away the "KeepRaw"
       */
-    val outputsCooked: Iterable[TransactionOutput] = evacuationMap.values.map(_.utxo.value)
+    lazy val outputsCooked: Iterable[TransactionOutput] = evacuationMap.values.map(_.utxo.value)
 
     lazy val kzgCommitment: KzgCommitment = KzgCommitment.calculateKzgCommitment(scalars)
 


### PR DESCRIPTION
Two characters: `val` → `lazy val`, twice, in `EvacuationMap`.

## What was wrong

`applyDiffsWithDelta` constructs a fresh `EvacuationMap` for **every diff** inside its fold, and the
class body holds two **strict** `val`s that each rebuild a full collection over the whole map on
construction (`cooked`, a complete `TreeMap` rebuild, and `outputsCooked`). Applying D diffs to an
N-entry map costs Θ(D·N) where the underlying `TreeMap` offers Θ(D·log N).

It only ever hurt slow consensus: `applyDiffs` is on the slow side and the recovery path, never the
fast one. The map is folded three times per stack close, and recovery folds it once more over every
block since the last stored map.

## Measured

Replaying the demo-stand head-0 store — 63,320 blocks, 801,512 real diffs, map growing 1 → 3,930:

| map entries | per diff before | per diff after |
|------------:|----------------:|---------------:|
| 22 | 11 µs | 6 µs |
| 122 | 56 µs | 2.0 µs |
| 3,930 | 442 µs | 0.3 µs |

Per-diff cost went from scaling with map size to flat. Before, a diff got more expensive every time
the head gained an account; after, it does not. Full sweep, the raw-`TreeMap` control, and the
Amdahl accounting: https://claude.ai/code/artifact/ba57c1d6-4960-46bf-8473-ca8e4b4b9ae9

## Why deferring is safe

Laziness moves the rebuild to first read rather than deleting it, so the question is where it lands.
`cooked` has one consumer in the tree (`EutxoL2Ledger.toUtxos:64`); `outputsCooked` has none outside
a test. Nothing in the slow-consensus path reads either — the 801,512 intermediate maps were building
values nobody looked at.

## Scope

A defect fix in one fold, not a throughput result for slow consensus: priced across the whole
demo-stand run the fold was ~743 s against 17,857 s of wall clock, and that denominator is wall clock
rather than work. ~83–95% of the slow round is outside the `StackComposer`.

The reason to take it now is the exponent, not the factor. The evacuation map grows with accounts,
and accounts are what grows if the launch works. Mainnet is at 18 because it is day one of a test
launch in a bear market; the map's design ceiling is 32,767.

369 unit tests pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)