### PR TITLE
Build the evacuation commitment with an NTT and an MSM

### DIFF
--- a/benchmark/src/main/scala/hydrozoa/benchmarks/KzgCommitment.scala
+++ b/benchmark/src/main/scala/hydrozoa/benchmarks/KzgCommitment.scala
@@ -9,19 +9,27 @@ import org.scalacheck.{Arbitrary, Gen}
 import scalus.cardano.address.*
 import scalus.cardano.ledger.*
 import scalus.cardano.ledger.ArbitraryInstances.{genMapOfSizeFromArbitrary, given}
-import scalus.cardano.onchain.plutus.prelude.List as SList
 import scalus.cardano.onchain.plutus.v3.TxInInfo
-import scalus.uplc.builtin.Builtins.{blake2b_224, serialiseData}
+import scalus.crypto.accumulator.Poly
+import scalus.uplc.builtin.Builtins.{blake2b_224, bls12_381_G1_multiScalarMul, serialiseData}
 import scalus.uplc.builtin.Data.toData
+import scalus.uplc.builtin.bls12_381.G1Element
 import scalus.uplc.builtin.{ByteString, Data}
 import scalus.|>
-import supranational.blst.{P1, Scalar}
 
 def genUtxos(size: Int) =
     genMapOfSizeFromArbitrary[TransactionInput, TransactionOutput](size, size)(using
       transactionInput,
       transactionOutput
     ).sample.get
+
+/** The scalars a utxo set commits to, as the field elements the accumulator takes. */
+def genElements(size: Int): Vector[BigInt] =
+    KzgCommitment
+        .hashToScalar(genUtxos(size))
+        .toScalaList
+        .map(s => BigInt(1, s.to_bendian()))
+        .toVector
 
 /** N.B. don't use it BEFORE testing hashing, it will be memoized by JVM! Use it in the @TearDown
   * method after the benchmarks to control the test data set.
@@ -185,54 +193,54 @@ class HashUtxoBenchmark {
     def stat(): Unit = printUtxoStat(utxos)
 }
 
-// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ mkFinalPoly ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ The commitment polynomial ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+/** Multiplying the set's binomials out into the coefficients of their product — the first half of a
+  * commitment, and the half that grows fastest with the set size.
+  */
 @BenchmarkMode(Array(Mode.SingleShotTime))
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Thread)
-class MkFinalPolyBenchmark {
+class ProductPolyBenchmark {
 
     @Param(Array("10", "50", "100", "1000", "10000", "20000", "25000", "32767"))
-    // @Param(Array("10", "50", "100"))
     var size: Int = _
 
-    var utxosHashed: SList[Scalar] = _
+    var elements: Vector[BigInt] = _
 
     @Setup(Level.Iteration)
-    def setup(): Unit = {
-        val utxos = genUtxos(size)
-        utxosHashed = KzgCommitment.hashToScalar(utxos)
-    }
+    def setup(): Unit = elements = genElements(size)
 
     @Benchmark
-    def run(): Unit = KzgCommitment.mkFinalPoly(utxosHashed): Unit
+    def run(): Unit = Poly.product(elements): Unit
 
 }
-// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ evalFinalPoly ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Committing to that polynomial ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+/** Evaluating the polynomial at the setup's secret in the exponent: one multi-scalar multiplication
+  * of its coefficients against the SRS ladder — the second half of a commitment.
+  */
 @BenchmarkMode(Array(Mode.SingleShotTime))
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Thread)
-class EvalFinalPolyBenchmark {
+class CommitPolyBenchmark {
 
     @Param(Array("10", "50", "100", "1000", "10000", "20000", "25000", "32767"))
-    // @Param(Array("10", "50", "100"))
     var size: Int = _
 
-    var finalPoly: SList[Scalar] = _
-    var srs: SList[P1] = _
+    var coefficients: Vector[BigInt] = _
+    var srs: Vector[G1Element] = _
 
     @Setup(Level.Iteration)
     def setup(): Unit = {
         println(s"size: $size")
-        val utxos = genUtxos(size)
-        val utxosHashed = KzgCommitment.hashToScalar(utxos)
-        finalPoly = KzgCommitment.mkFinalPoly(utxosHashed)
-        srs = TrustedSetup.takeSrsG1(size)
+        coefficients = Poly.product(genElements(size)).coefficients
+        srs = TrustedSetup.srsG1Elements.take(coefficients.length)
     }
 
     @Benchmark
-    def run(): Unit = KzgCommitment.evalFinalPoly(srs, finalPoly): Unit
+    def run(): Unit = bls12_381_G1_multiScalarMul(coefficients, srs): Unit
 
 }
 

--- a/src/main/scala/hydrozoa/multisig/ledger/commitment/KzgCommitment.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/commitment/KzgCommitment.scala
@@ -1,17 +1,16 @@
 package hydrozoa.multisig.ledger.commitment
 
 import hydrozoa.lib.cardano.scalus.Scalar as ScalusScalar
-import java.math.BigInteger
 import scalus.cardano.ledger.*
 import scalus.cardano.onchain.plutus.prelude.List as SList
-import scalus.cardano.onchain.plutus.prelude.bls12_381.G1
 import scalus.cardano.onchain.plutus.v3.TxInInfo
+import scalus.crypto.accumulator.BilinearAccumulatorProver
 import scalus.uplc.builtin.Builtins.{blake2b_224, serialiseData}
 import scalus.uplc.builtin.ByteString
 import scalus.uplc.builtin.Data.toData
 import scalus.uplc.builtin.bls12_381.G1Element
 import scalus.|>
-import supranational.blst.{P1, Scalar}
+import supranational.blst.Scalar
 
 export KzgCommitment.asG1Element
 export KzgCommitment.kzgCommitment
@@ -62,81 +61,37 @@ object KzgCommitment {
 
     /** Calculates the commitment for the pairing-based accumulator.
       *
+      * The commitment is the polynomial `P(x) = product (x + s_i)` over the set's scalars,
+      * evaluated at the setup's secret `tau` in the exponent — that is, the multi-scalar
+      * multiplication of `P`'s coefficients against the SRS's G1 ladder.
+      *
+      * Both halves come from `scalus.crypto.accumulator`: the coefficients from a binary subproduct
+      * tree with NTT multiplication (`O(n log^2 n)`), and the evaluation from a Pippenger
+      * multi-scalar multiplication.
+      *
       * @param scalars
       *   utxo set (active, though might be any)
       * @return
       *   G1 point that corresponds to the commitment
       */
     def calculateKzgCommitment(scalars: SList[Scalar]): KzgCommitment = {
+        val setup = TrustedSetup.accumulatorSetupG1
 
-        // println(s"elems: ${scalars.length}")
-        // println(s"elems: ${scalars.map(e => BigInt.apply(e.to_bendian()))}")
-
-        // Get as much from the setup as we need: n + 1 elements
+        // The product polynomial has one coefficient more than it has roots, so an n-element set
+        // needs n + 1 points off the ladder.
         val size = scalars.length.toInt + 1
-        val srs = TrustedSetup.takeSrsG1(size)
-
-        // Check the size of the setup is big enough
         assert(
-          size == srs.length,
+          size <= setup.g1Powers.length,
           s"There are more UTxOs than supported by the setup: $size"
         )
 
-        val finalPoly = mkFinalPoly(scalars)
-
-        // println(s"finalPoly: ${finalPoly.map(e => BigInt.apply(e.to_bendian()))}")
-
-        val commitment = evalFinalPoly(srs, finalPoly).compress()
-//        println(s"UTxO set commitment is: ${HexUtil.encodeHexString(commitment)}")
-        ByteString.fromArray(commitment)
+        BilinearAccumulatorProver
+            .accumulateG1(setup, scalars.toScalaList.map(asFieldElement).toVector)
+            .toCompressedByteString
     }
 
-    /** Multiply normalized N binomials represented by their only coeeficients to get a final
-      * polynomial with N+1 coefficients. Uses the schoolbook convolution, which is `O(N^2)`. This
-      * is alleviated by the rather quick Montgomery multiplication the underlying `blst` library
-      * uses.
-      *
-      * Example: for (x+2)(x+3)(x+5)(x+7)(x+11) = 2310 + 2927 x + 1358 x^2 + 288 x^3 + 28 x^4 + x^5
-      *
-      * @param binomials
-      *   coefficients for binomials, order doesn't matter
-      * @return
-      *   the coefficients for the final polynomial, with the lowest-degree coefficient coming first
+    /** A `blst` scalar as the plain non-negative integer the accumulator prover takes. `blst`
+      * reduces on the way in, so the round trip through big-endian bytes is exact.
       */
-    def mkFinalPoly(binomials: SList[Scalar]): SList[Scalar] =
-        val zero = Scalar(BigInteger("0"))
-        val one = Scalar(BigInteger("1"))
-
-        binomials
-            .foldLeft(SList.single(one.dup())): (acc, term) =>
-                // We need to clone the whole `acc` since `mul` mutates it
-                // and the final adding gets mutated `shiftedPoly`
-                val shiftedPoly: SList[Scalar] = SList.Cons(zero.dup(), acc.map(_.dup))
-                val multipliedPoly = acc.map(s => s.mul(term)).appended(zero.dup())
-                SList.map2(shiftedPoly, multipliedPoly)((l, r) => l.add(r))
-
-    /** Evaluates the commitment to the final polynomial using the given SRS.
-      *
-      * TODO: use multi-scalar multiplication, once we have it in the java-blst
-      *
-      * @param srsG1
-      *   setup, should be big enough, controlled by the caller
-      * @param finalPoly
-      *   coefficients of the final polynimial
-      * @return
-      *   commitment, a point in G1
-      */
-    def evalFinalPoly(
-        srsG1: SList[P1],
-        finalPoly: SList[Scalar]
-    ): P1 =
-        // Multiply
-        val subsetPoints: SList[P1] =
-            SList.map2(finalPoly, srsG1): (sb, st) =>
-                // This dup is needed, since otherwise we modify the loaded SRS itself
-                st.dup().mult(sb)
-        // Add
-        val zero = P1(G1.zero.toCompressedByteString.bytes)
-        subsetPoints.foldLeft(zero.dup()): (a, b) =>
-            a.add(b)
+    private def asFieldElement(scalar: Scalar): BigInt = BigInt(1, scalar.to_bendian())
 }

--- a/src/main/scala/hydrozoa/multisig/ledger/commitment/TrustedSetup.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/commitment/TrustedSetup.scala
@@ -4,6 +4,9 @@ import com.bloxbean.cardano.client.util.HexUtil
 import com.github.plokhotnyuk.jsoniter_scala.core.{JsonReader, JsonValueCodec, JsonWriter, readFromStream}
 import com.github.plokhotnyuk.jsoniter_scala.macros.{CodecMakerConfig, JsonCodecMaker}
 import scalus.cardano.onchain.plutus.prelude.List as SList
+import scalus.crypto.accumulator.BilinearAccumulatorProver
+import scalus.uplc.builtin.ByteString
+import scalus.uplc.builtin.bls12_381.G1Element
 import supranational.blst.{P1, P2}
 
 /** Cached trusted setup.
@@ -26,6 +29,24 @@ object TrustedSetup:
     lazy val setup: TrustedSetup[P1, P2] = readFromResource[P1, P2]
 
     def takeSrsG1(n: Int): SList[P1] = SList.from(setup.g1Monomial.take(n))
+
+    /** The whole G1 ladder as scalus `G1Element`s, converted once.
+      *
+      * [[BilinearAccumulatorProver]] commits by multi-scalar multiplication over these, and
+      * converting a `blst` `P1` means compressing it — cheap per point, but 32,768 of them add up.
+      * Converting the ladder once at first use costs a fraction of reading the setup itself, and
+      * the result is immutable, so every commitment on every thread shares it.
+      */
+    lazy val srsG1Elements: Vector[G1Element] =
+        setup.g1Monomial.iterator.map(p1 => G1Element(ByteString.fromArray(p1.compress()))).toVector
+
+    /** The accumulator setup commitments are built against.
+      *
+      * `g2Powers` is empty because `accumulateG1` reads `g1Powers` alone; the G2 ladder is needed
+      * only to *verify* a proof, which goes through [[takeSrsG2]].
+      */
+    lazy val accumulatorSetupG1: BilinearAccumulatorProver.Setup =
+        BilinearAccumulatorProver.Setup.fromPoints(srsG1Elements, Vector.empty)
 
     def takeSrsG2(n: Int): SList[P2] = SList.from(setup.g2Monomial.take(n))
 

--- a/src/test/scala/hydrozoa/multisig/ledger/commitment/KzgCommitmentOnChainConformanceTest.scala
+++ b/src/test/scala/hydrozoa/multisig/ledger/commitment/KzgCommitmentOnChainConformanceTest.scala
@@ -1,0 +1,134 @@
+package hydrozoa.multisig.ledger.commitment
+
+import hydrozoa.config.head.network.CardanoNetwork
+import hydrozoa.multisig.ledger.block.BlockNumber
+import hydrozoa.multisig.ledger.joint.EvacuationMap as JointEvacuationMap
+import hydrozoa.multisig.ledger.stack.{PartitionEffects, Stack, StackEffects, StackNumber}
+import hydrozoa.multisig.persistence.StoreKey
+import java.nio.ByteBuffer
+import java.nio.file.{Files, Path, Paths}
+import java.util.ArrayList as JArrayList
+import org.rocksdb.{ColumnFamilyDescriptor, ColumnFamilyHandle, DBOptions, Options, RocksDB}
+import org.scalatest.funsuite.AnyFunSuite
+import scala.jdk.CollectionConverters.*
+
+/** Does the current derivation reproduce the commitments a real head already signed?
+  *
+  * The sibling `KzgCommitmentStoreFidelityTest` checks the fast derivation against the schoolbook
+  * one over the same inputs. That is an equivalence property: it cannot detect a commitment that
+  * both implementations compute the same way and the deployed binary computed differently, which is
+  * the failure that would fork a live head or strand funds behind an unspendable treasury.
+  *
+  * This closes that gap from the other side. Every standalone evacuation commitment in the store
+  * carries the block it commits to and the commitment value the head signed at the time — a value
+  * produced by whatever binary was running then, not by this one. Re-deriving from the stored map
+  * at that block and comparing is a conformance check against recorded output rather than against a
+  * second implementation.
+  *
+  * Skipped when no synced store is present, so it is a no-op in CI.
+  */
+class KzgCommitmentOnChainConformanceTest extends AnyFunSuite {
+
+    private val storePath: Path = Paths.get(
+      sys.props.getOrElse(
+        "hydrozoa.store.path",
+        s"${sys.props("user.home")}/hz-mainnet/store/rocksdb"
+      )
+    )
+
+    private given CardanoNetwork.Section with {
+        def cardanoNetwork: CardanoNetwork = CardanoNetwork.Mainnet
+    }
+
+    test("every commitment a real head signed is reproduced by the current derivation") {
+        val _ = assume(Files.isDirectory(storePath), s"no store at $storePath")
+        RocksDB.loadLibrary()
+
+        val names = RocksDB.listColumnFamilies(new Options(), storePath.toString).asScala.toList
+        val descriptors = new JArrayList[ColumnFamilyDescriptor]()
+        names.foreach(n => descriptors.add(new ColumnFamilyDescriptor(n)))
+        val handles = new JArrayList[ColumnFamilyHandle]()
+        val db = RocksDB.openReadOnly(new DBOptions(), storePath.toString, descriptors, handles)
+
+        try {
+            def handleFor(cf: String): ColumnFamilyHandle =
+                names
+                    .zip(handles.asScala)
+                    .collectFirst {
+                        case (n, h) if new String(n, "UTF-8") == cf => h
+                    }
+                    .get
+
+            // Codecs are declared on the store keys, so go through them — this is then the same
+            // decode the recovery path performs, not a re-derivation that could drift from it.
+            val mapCodec = StoreKey.EvacuationMap(BlockNumber.zero).codec
+            val stackCodec = StoreKey.UnsignedStack(StackNumber.zero).codec
+
+            // Pass 1: the cumulative map at each block, by block number (4-byte big-endian key).
+            val mapsByBlock = scala.collection.mutable.HashMap.empty[Int, JointEvacuationMap]
+            val mapIt = db.newIterator(handleFor("EvacuationMap"))
+            try {
+                mapIt.seekToFirst()
+                while mapIt.isValid do {
+                    val blockNum = ByteBuffer.wrap(mapIt.key()).getInt
+                    val _ = mapsByBlock.put(blockNum, mapCodec.decode(mapIt.value()))
+                    mapIt.next()
+                }
+            } finally mapIt.close()
+
+            // Pass 2: every commitment the head actually signed, with the block it commits to.
+            var checked = 0
+            var disagreed = 0
+            var noStoredMap = 0
+            var stacks = 0
+            val firstDisagreement = scala.collection.mutable.ListBuffer.empty[String]
+
+            val stackIt = db.newIterator(handleFor("UnsignedStack"))
+            try {
+                stackIt.seekToFirst()
+                while stackIt.isValid do {
+                    val stack: Stack.Unsigned = stackCodec.decode(stackIt.value())
+                    stacks += 1
+                    val partitions = stack.effects match {
+                        case r: StackEffects.Unsigned.Regular => r.partitions.toList
+                        case _: StackEffects.Unsigned.Initial => Nil // stack 0 carries no SEC
+                    }
+                    partitions.foreach { p =>
+                        val secs = p match {
+                            case PartitionEffects.Major(_, _, _, _, sec) => sec.toList
+                            case PartitionEffects.Minor(sec, _)          => List(sec)
+                            case _: PartitionEffects.Final               => Nil
+                        }
+                        secs.foreach { sec =>
+                            mapsByBlock.get(sec.blockNum: Int) match {
+                                case None => noStoredMap += 1
+                                case Some(map) =>
+                                    checked += 1
+                                    if map.kzgCommitment != sec.kzgCommitment then {
+                                        disagreed += 1
+                                        if firstDisagreement.size < 3 then
+                                            firstDisagreement += s"block=${sec.blockNum: Int} " +
+                                                s"signed=${sec.kzgCommitment} " +
+                                                s"derived=${map.kzgCommitment}"
+                                    }
+                            }
+                        }
+                    }
+                    stackIt.next()
+                }
+            } finally stackIt.close()
+
+            println(
+              s"[kzg-conformance] store=$storePath stacks=$stacks maps=${mapsByBlock.size} " +
+                  s"commitmentsChecked=$checked disagreed=$disagreed noStoredMap=$noStoredMap"
+            )
+            // The control: with no commitments checked the equality assertion below is vacuous.
+            val _ = assert(checked > 0, "no signed commitments could be paired with a stored map")
+            assert(
+              disagreed == 0,
+              s"$disagreed of $checked signed commitments were not reproduced: " +
+                  firstDisagreement.mkString("; ")
+            )
+        } finally db.close()
+    }
+}

--- a/src/test/scala/hydrozoa/multisig/ledger/commitment/KzgCommitmentStoreFidelityTest.scala
+++ b/src/test/scala/hydrozoa/multisig/ledger/commitment/KzgCommitmentStoreFidelityTest.scala
@@ -1,0 +1,110 @@
+package hydrozoa.multisig.ledger.commitment
+
+import hydrozoa.config.head.network.CardanoNetwork
+import hydrozoa.multisig.ledger.block.BlockNumber
+import hydrozoa.multisig.ledger.joint.EvacuationMap as JointEvacuationMap
+import hydrozoa.multisig.persistence.StoreKey
+import java.nio.file.{Files, Path, Paths}
+import java.util.ArrayList as JArrayList
+import org.rocksdb.{ColumnFamilyDescriptor, ColumnFamilyHandle, DBOptions, Options, RocksDB}
+import org.scalatest.funsuite.AnyFunSuite
+import scala.jdk.CollectionConverters.*
+
+/** Does the accumulator library agree with the textbook formulation on the maps a real head has
+  * actually committed to?
+  *
+  * [[KzgCommitmentTest]] pins the two against each other over generated sets and at the sizes that
+  * straddle the library's algorithm switches. This runs the same equality over every evacuation map
+  * in a synced production store — the exact shapes mainnet committed to, in the order it committed
+  * to them.
+  *
+  * The commitment is a consensus value: it goes into the treasury datum every peer signs and into
+  * the on-chain evacuation proof. A disagreement on any one of these is a fork, not a slowdown.
+  *
+  * ⚠️ This covers **correctness on real shapes, not the large-N regime**. Mainnet's maps are small,
+  * and the run prints their size distribution so the claim is bounded by what was actually tested.
+  * The large-N evidence is the demo-stand sweep in the PR.
+  *
+  * External fixture, so it cancels rather than fails when absent. Point it elsewhere with
+  * `-Dhydrozoa.store.path=/some/rocksdb`.
+  */
+class KzgCommitmentStoreFidelityTest extends AnyFunSuite {
+
+    private val storePath: Path = Paths.get(
+      sys.props.getOrElse(
+        "hydrozoa.store.path",
+        s"${sys.props("user.home")}/hz-mainnet/store/rocksdb"
+      )
+    )
+
+    private given CardanoNetwork.Section with {
+        def cardanoNetwork: CardanoNetwork = CardanoNetwork.Mainnet
+    }
+
+    test("every evacuation map in a real store commits to the same point both ways") {
+        assume(Files.isDirectory(storePath), s"no store at $storePath")
+        RocksDB.loadLibrary()
+
+        val names = RocksDB.listColumnFamilies(new Options(), storePath.toString).asScala.toList
+        val target = names.find(n => new String(n, "UTF-8") == "EvacuationMap")
+        assume(target.isDefined, s"no EvacuationMap column family in $storePath")
+
+        val descriptors = new JArrayList[ColumnFamilyDescriptor]()
+        names.foreach(n => descriptors.add(new ColumnFamilyDescriptor(n)))
+        val handles = new JArrayList[ColumnFamilyHandle]()
+        val db = RocksDB.openReadOnly(new DBOptions(), storePath.toString, descriptors, handles)
+
+        try {
+            val handle = names
+                .zip(handles.asScala)
+                .collectFirst {
+                    case (n, h) if new String(n, "UTF-8") == "EvacuationMap" => h
+                }
+                .get
+            // The codec is declared on the key, so go through the key rather than re-deriving it —
+            // this is then the same decode the recovery path performs.
+            val codec = StoreKey.EvacuationMap(BlockNumber.zero).codec
+
+            var checked = 0
+            var disagreed = 0
+            val sizes = scala.collection.mutable.SortedMap.empty[Int, Int]
+            val firstDisagreement = scala.collection.mutable.ListBuffer.empty[String]
+
+            val it = db.newIterator(handle)
+            try {
+                it.seekToFirst()
+                while it.isValid do {
+                    val map: JointEvacuationMap = codec.decode(it.value())
+                    val scalars = map.scalars
+                    val n = scalars.length.toInt
+                    sizes.updateWith(n)(c => Some(c.getOrElse(0) + 1))
+                    if KzgCommitment.calculateKzgCommitment(scalars) != Schoolbook.commitment(
+                          scalars
+                        )
+                    then {
+                        disagreed += 1
+                        if firstDisagreement.size < 3 then
+                            firstDisagreement += s"blockKey=${it.key().mkString(",")} setSize=$n"
+                    }
+                    checked += 1
+                    it.next()
+                }
+            } finally it.close()
+
+            println(
+              s"[kzg-fidelity] store=$storePath maps=$checked disagreed=$disagreed " +
+                  s"setSizes=${sizes.map((n, c) => s"$n:$c").mkString(" ")}"
+            )
+            // The control: a run that decoded nothing would satisfy the equality assertion below.
+            assert(checked > 0, s"no evacuation maps found in $storePath")
+            assert(
+              disagreed == 0,
+              s"$disagreed of $checked maps committed to a different point: " +
+                  firstDisagreement.mkString("; ")
+            )
+        } finally {
+            handles.asScala.foreach(_.close())
+            db.close()
+        }
+    }
+}

--- a/src/test/scala/hydrozoa/multisig/ledger/commitment/KzgCommitmentStoreFidelityTest.scala
+++ b/src/test/scala/hydrozoa/multisig/ledger/commitment/KzgCommitmentStoreFidelityTest.scala
@@ -42,12 +42,12 @@ class KzgCommitmentStoreFidelityTest extends AnyFunSuite {
     }
 
     test("every evacuation map in a real store commits to the same point both ways") {
-        assume(Files.isDirectory(storePath), s"no store at $storePath")
+        val _ = assume(Files.isDirectory(storePath), s"no store at $storePath")
         RocksDB.loadLibrary()
 
         val names = RocksDB.listColumnFamilies(new Options(), storePath.toString).asScala.toList
         val target = names.find(n => new String(n, "UTF-8") == "EvacuationMap")
-        assume(target.isDefined, s"no EvacuationMap column family in $storePath")
+        val _ = assume(target.isDefined, s"no EvacuationMap column family in $storePath")
 
         val descriptors = new JArrayList[ColumnFamilyDescriptor]()
         names.foreach(n => descriptors.add(new ColumnFamilyDescriptor(n)))
@@ -77,7 +77,7 @@ class KzgCommitmentStoreFidelityTest extends AnyFunSuite {
                     val map: JointEvacuationMap = codec.decode(it.value())
                     val scalars = map.scalars
                     val n = scalars.length.toInt
-                    sizes.updateWith(n)(c => Some(c.getOrElse(0) + 1))
+                    val _ = sizes.updateWith(n)(c => Some(c.getOrElse(0) + 1))
                     if KzgCommitment.calculateKzgCommitment(scalars) != Schoolbook.commitment(
                           scalars
                         )
@@ -96,7 +96,7 @@ class KzgCommitmentStoreFidelityTest extends AnyFunSuite {
                   s"setSizes=${sizes.map((n, c) => s"$n:$c").mkString(" ")}"
             )
             // The control: a run that decoded nothing would satisfy the equality assertion below.
-            assert(checked > 0, s"no evacuation maps found in $storePath")
+            val _ = assert(checked > 0, s"no evacuation maps found in $storePath")
             assert(
               disagreed == 0,
               s"$disagreed of $checked maps committed to a different point: " +

--- a/src/test/scala/hydrozoa/multisig/ledger/commitment/KzgCommitmentTest.scala
+++ b/src/test/scala/hydrozoa/multisig/ledger/commitment/KzgCommitmentTest.scala
@@ -1,0 +1,90 @@
+package hydrozoa.multisig.ledger.commitment
+
+import java.math.BigInteger
+import org.scalacheck.Gen
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import scalus.cardano.onchain.plutus.prelude.List as SList
+import scalus.cardano.onchain.plutus.prelude.bls12_381.G1
+import scalus.uplc.builtin.ByteString
+import supranational.blst.{P1, Scalar}
+
+/** The commitment is a consensus value — it goes into the treasury datum every peer signs and into
+  * the on-chain evacuation proof — so the accumulator library it is computed with is not a free
+  * choice. This suite pins the current implementation against the textbook one it replaced:
+  * multiply the binomials out by schoolbook convolution, then evaluate the polynomial against the
+  * SRS one point at a time.
+  *
+  * The two agree byte for byte or the switch is not a speedup, it is a fork.
+  */
+class KzgCommitmentTest extends AnyFunSuite with ScalaCheckPropertyChecks {
+
+    /** Distinct scalars, derived from the index so a size is reproducible without a generator. */
+    private def scalarsOfSize(n: Int): SList[Scalar] =
+        SList.from((1 to n).toList.map(i => Scalar(BigInteger.valueOf(i.toLong * 7919))))
+
+    private def agrees(scalars: SList[Scalar]): Boolean =
+        KzgCommitment.calculateKzgCommitment(scalars) == Schoolbook.commitment(scalars)
+
+    test("the commitment matches the schoolbook one over a generated set") {
+        // Sizes are kept small on purpose: the oracle is quadratic in the set size, so a large
+        // generated case would dominate the suite's runtime. The sizes that exercise the
+        // library's algorithm switches are covered explicitly below.
+        forAll(Gen.listOf(Gen.choose(1L, Long.MaxValue)), minSuccessful(20)) { values =>
+            assert(agrees(SList.from(values.map(v => Scalar(BigInteger.valueOf(v))))))
+        }
+    }
+
+    test("the commitment matches the schoolbook one across the library's algorithm switches") {
+        // `Poly.product` goes iterative below 33 elements and subproduct-tree above it, and the
+        // tree's multiplication goes naive below 256 coefficients and NTT above. A commitment
+        // computed on the wrong side of either boundary would still look like a point, so the
+        // sizes that straddle both thresholds are named rather than left to the generator.
+        val sizes = List(0, 1, 2, 32, 33, 255, 256, 257, 400)
+        assert(sizes.filterNot(n => agrees(scalarsOfSize(n))) == Nil)
+    }
+
+    test("the empty set commits to the setup's first point") {
+        assert(KzgCommitment.empty == Schoolbook.commitment(SList.Nil))
+    }
+
+    test("a set larger than the setup is refused") {
+        val tooMany = TrustedSetup.srsG1Elements.length
+        assertThrows[AssertionError](KzgCommitment.calculateKzgCommitment(scalarsOfSize(tooMany)))
+    }
+}
+
+/** The commitment computed the textbook way, as an independent check on the accumulator library.
+  *
+  * Deliberately the slow formulation: `O(n^2)` to multiply the binomials out, and one scalar
+  * multiplication per coefficient to evaluate them. Being slow is what makes it a useful oracle —
+  * it shares no code with the implementation beyond the SRS itself.
+  */
+private object Schoolbook {
+
+    def commitment(scalars: SList[Scalar]): ByteString = {
+        val srs = TrustedSetup.takeSrsG1(scalars.length.toInt + 1)
+        ByteString.fromArray(evaluate(srs, expand(scalars)).compress())
+    }
+
+    /** Multiplies the normalized binomials `(x + s)` out into the coefficients of their product,
+      * lowest degree first, by schoolbook convolution.
+      */
+    private def expand(binomials: SList[Scalar]): SList[Scalar] = {
+        val zero = Scalar(BigInteger.ZERO)
+        val one = Scalar(BigInteger.ONE)
+        binomials.foldLeft(SList.single(one.dup())) { (acc, term) =>
+            // `mul` mutates its receiver, so both operands are cloned before they are combined.
+            val shifted: SList[Scalar] = SList.Cons(zero.dup(), acc.map(_.dup))
+            val multiplied = acc.map(s => s.mul(term)).appended(zero.dup())
+            SList.map2(shifted, multiplied)((l, r) => l.add(r))
+        }
+    }
+
+    /** Evaluates the polynomial in the exponent: one scalar multiplication per coefficient, summed.
+      */
+    private def evaluate(srsG1: SList[P1], coefficients: SList[Scalar]): P1 = {
+        val terms = SList.map2(coefficients, srsG1)((c, point) => point.dup().mult(c))
+        terms.foldLeft(P1(G1.zero.toCompressedByteString.bytes))((a, b) => a.add(b))
+    }
+}


### PR DESCRIPTION
The commitment path did both halves the slow way, and said so itself.

## What was wrong

`KzgCommitment.mkFinalPoly` multiplied the set's binomials out by schoolbook convolution — its own
scaladoc: *"Uses the schoolbook convolution, which is `O(N^2)`"*. `evalFinalPoly` then evaluated the
polynomial one scalar multiplication at a time, under a standing `TODO: use multi-scalar
multiplication, once we have it in the java-blst`.

We have it. Scalus 1.0.0 is already on the classpath and ships both halves — `Poly.product` builds
`∏(x + aᵢ)` with a binary subproduct tree over an NTT, and `bls12_381_G1_multiScalarMul` is a
Pippenger MSM. `BilinearAccumulatorProver.accumulateG1` is exactly those two composed, so the change
is to call it, fed the head's own SRS.

## Same value, faster

Both paths compute `P(τ)·G1` for the same `P`. `KzgCommitmentTest` pins that: it carries the
schoolbook formulation as an independent oracle and asserts the two agree byte for byte — over a
generated set, and at the sizes straddling both of the library's algorithm switches (32/33
iterative-vs-tree, 255/256/257 naive-vs-NTT). Perturbing the oracle makes every non-empty case fail,
so the equality is a real assertion and not a tautology.

It also runs over the real ones. `KzgCommitmentStoreFidelityTest` commits every evacuation map in a
synced production store both ways and compares byte for byte: **1,816 maps, 0 disagreements**. Every
one of them is 30 entries or fewer, so that is correctness on the shapes mainnet actually signs — not
evidence about large N, which is what the sweep below is for.

Both of those are equivalence properties, and equivalence cannot see a commitment that both
implementations compute one way and the deployed binary computed another. `KzgCommitmentOnChainConformanceTest`
closes that from the other side: every standalone evacuation commitment in the store carries the
block it commits to and the value the head signed at the time, so re-deriving from the stored map at
that block compares against recorded output rather than against a second implementation.
**1,785 signed commitments across 1,775 stacks, 0 not reproduced, 0 unpairable.** Pairing each
commitment with the next block's map instead makes the test fail, so it is sensitive to the map it
derives from.

Both store tests skip when no synced store is present, so they are no-ops in CI.

## Measured

Against the demo-stand head's real evacuation maps, both paths fed that head's own SRS:

| map entries | before | after | speedup |
|------------:|-------:|------:|--------:|
| 422 | 42.3 ms | 20.5 ms | 2.1× |
| 3,930 | 1,542 ms | 187.7 ms | **8.2×** |

The old path scales about `N^1.8`, the new one about `N^1.07`. The difference in exponent is the
result; the factor at any one size is just where you sampled it. Full sweep and the Amdahl
accounting: https://claude.ai/code/artifact/ba57c1d6-4960-46bf-8473-ca8e4b4b9ae9

## Cost and safety

The SRS is converted out of blst's `P1` into scalus's `G1Element` once, on first use, and shared
read-only from there. Converting the whole 32,768-point ladder is a fraction of what reading the
trusted setup already costs, and it is immutable, so concurrent commitments share it safely.

The setup-size bound is unchanged: a set larger than the ladder still fails with the same message,
and there is a test for it.

## Scope

`Membership.mkMembershipProofValidated` builds its proof by committing to the complement set, so it
inherits the speedup without changing.

The two JMH benchmarks that measured the old halves are re-pointed at the new ones
(`ProductPolyBenchmark`, `CommitPolyBenchmark`) so the decomposition stays measurable.

A commitment is built per partition, and partitions come from major blocks, so a head doing more
business builds more commitments over a larger map. At the map's design ceiling of 32,767 entries the
two curves extrapolate to roughly **68 s against 1.8 s** per commitment.

373 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
