### PR TITLE
Stop rendering requests to log them, retry a config load, and record the failure that stops a node

### DIFF
--- a/integration/src/test/resources/logback-ci.xml
+++ b/integration/src/test/resources/logback-ci.xml
@@ -23,6 +23,8 @@
         </layout>
     </appender>
     <logger name="Mermaid.PeerLiaison" level="info" additivity="false">
+    <!-- The only record of why a supervised actor failed; never quiet it. -->
+    <logger name="Supervision" level="error"/>
         <appender-ref ref="MERMAID"/>
     </logger>
 

--- a/integration/src/test/resources/logback-test.xml
+++ b/integration/src/test/resources/logback-test.xml
@@ -105,6 +105,8 @@
     <logger name="CoilPeerWsTransport" level="debug"/>
     <logger name="HubWsTransport" level="debug"/>
     <logger name="CoilAckSequencer" level="info"/>
+    <!-- The only record of why a supervised actor failed; never quiet it. -->
+    <logger name="Supervision" level="error"/>
     <logger name="HydrozoaHttp" level="info"/>
     <logger name="RemoteL2Ledger" level="info"/>
     <logger name="Persistence" level="info"/>

--- a/src/main/resources/logback-docker.xml
+++ b/src/main/resources/logback-docker.xml
@@ -48,4 +48,6 @@
     <logger name="com.bloxbean" level="warn"/>
     <logger name="scalus" level="warn"/>
     <logger name="CardanoBackend" level="warn"/>
+    <!-- The only record of why a supervised actor failed; never quiet it. -->
+    <logger name="Supervision" level="error"/>
 </configuration>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -63,6 +63,8 @@
     <logger name="CoilPeerWsTransport" level="trace"/>
     <logger name="HubWsTransport" level="trace"/>
     <logger name="CoilAckSequencer" level="trace"/>
+    <!-- The only record of why a supervised actor failed; never quiet it. -->
+    <logger name="Supervision" level="error"/>
     <logger name="Persistence" level="info"/>
     <logger name="BlockHeader" level="info"/>
     <logger name="TxTiming" level="info"/>

--- a/src/main/scala/hydrozoa/config/node/NodeConfig.scala
+++ b/src/main/scala/hydrozoa/config/node/NodeConfig.scala
@@ -15,12 +15,13 @@ import hydrozoa.config.node.NodePrivateConfig.given
 import hydrozoa.config.node.operation.evacuation.NodeOperationEvacuationConfig
 import hydrozoa.config.node.operation.multisig.NodeOperationMultisigConfig
 import hydrozoa.config.node.owninfo.{OwnCoilPeerPrivate, OwnHeadPeerPrivate}
-import hydrozoa.lib.logging.Slf4jTracer
+import hydrozoa.lib.logging.{Logging, Slf4jTracer}
 import hydrozoa.multisig.backend.cardano.{CardanoBackend, CardanoBackendBlockfrost, CardanoBackendEventFormat}
 import hydrozoa.multisig.consensus.peer.PeerId.isCoil
 import hydrozoa.multisig.consensus.peer.PeerWallet
 import io.circe.{parser, *}
 import java.nio.file.{Files, Path}
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
 
 final case class NodeConfig private (
     override val headConfig: HeadConfig,
@@ -48,6 +49,8 @@ final case class NodeConfig private (
 }
 
 object NodeConfig {
+
+    private val log = Logging.loggerIO("hydrozoa")
 
     def fromJson(
         headConfigStr: String,
@@ -186,13 +189,78 @@ object NodeConfig {
         for {
             headStr <- IO.blocking(Files.readString(headConfigPath))
             privateStr <- IO.blocking(Files.readString(privateConfigPath))
-            loaded <- NodeConfig
-                .fromJson(headStr, privateStr, backendOverride)
-                .foldF(
-                  err => IO.raiseError(new RuntimeException(s"Failed to load NodeConfig: $err")),
-                  IO.pure
-                )
+            loaded <- retryingBackendReads(
+              backendReadRetryWaits,
+              NodeConfig.fromJson(headStr, privateStr, backendOverride).value
+            ).flatMap {
+                case Left(err) =>
+                    IO.raiseError(new RuntimeException(s"Failed to load NodeConfig: $err"))
+                case Right(ok) => IO.pure(ok)
+            }
         } yield loaded
+
+    /** Waits before each retry of the config load's backend reads.
+      *
+      * Decoding a config resolves the script reference UTxOs against Cardano, so loading it is a
+      * network operation, and a node that cannot reach the backend for a few seconds exits — which
+      * a process supervisor answers by starting it again, immediately, into the same failure. That
+      * turns a brief loss of egress into a crash loop that outlives it.
+      *
+      * The total wait is a little under two minutes. Long enough to ride out a DNS or upstream
+      * blip; short enough that a genuinely wrong config still fails while someone is watching the
+      * deploy.
+      */
+    private val backendReadRetryWaits: List[FiniteDuration] =
+        List(2.seconds, 5.seconds, 15.seconds, 30.seconds, 60.seconds)
+
+    /** Whether a failed load is worth another attempt. Anything that reached the Cardano backend is
+      * — including an error the backend classified, since a DNS failure surfaces as a resolve error
+      * rather than a raised exception. A malformed config is not: re-reading the same bytes gives
+      * the same answer.
+      */
+    private def isWorthRetrying(
+        err: ScriptReferenceUtxos.Error | io.circe.Error
+    ): Boolean = err match
+        case _: ScriptReferenceUtxos.Error.CardanoBackendError => true
+        case _                                                 => false
+
+    /** Re-run `attempt` while it fails for a reason another attempt could fix, waiting `waits` in
+      * turn and giving up with the last failure once they run out. `waits` is a parameter so a test
+      * can drive the same loop without waiting minutes.
+      */
+    private[node] def retryingBackendReads[A](
+        waits: List[FiniteDuration],
+        attempt: IO[Either[ScriptReferenceUtxos.Error | io.circe.Error, A]]
+    ): IO[Either[ScriptReferenceUtxos.Error | io.circe.Error, A]] =
+        def go(
+            remaining: List[FiniteDuration]
+        ): IO[Either[ScriptReferenceUtxos.Error | io.circe.Error, A]] =
+            // A raised throwable gets the same treatment as a backend error: building the backend
+            // is itself a network operation, and it reports failure by raising rather than by a
+            // Left.
+            attempt.attempt.flatMap {
+                case Right(Right(ok)) => IO.pure(Right(ok))
+                case other =>
+                    val reason = other match
+                        case Left(t)         => t.toString
+                        case Right(Left(e))  => e.toString
+                        case Right(Right(_)) => ""
+                    val retryable = other match
+                        case Left(_)        => true
+                        case Right(Left(e)) => isWorthRetrying(e)
+                        case _              => false
+                    (remaining, retryable) match
+                        case (wait :: rest, true) =>
+                            log.warn(
+                              s"Config load failed against the Cardano backend ($reason); " +
+                                  s"retrying in $wait (${rest.length} attempts left after this)."
+                            ) >> IO.sleep(wait) >> go(rest)
+                        case _ =>
+                            other match
+                                case Left(t)     => IO.raiseError(t)
+                                case Right(left) => IO.pure(left)
+            }
+        go(waits)
 
     trait Section extends NodePrivateConfig.Section, HeadConfig.Section {
         def nodeConfig: NodeConfig

--- a/src/main/scala/hydrozoa/lib/logging/Logging.scala
+++ b/src/main/scala/hydrozoa/lib/logging/Logging.scala
@@ -18,4 +18,13 @@ object Logging {
     /** log4cats SLF4J adapter used by [[Slf4jTracer.sink]]. */
     def loggerIO(name: String): Logger[IO] =
         Slf4jLogger.getLoggerFromName[IO](name)
+
+    /** A synchronous logger, for the few places that have no effect context to log in.
+      *
+      * A supervision decider is one: it is a pure `Throwable => Directive` the actor library calls
+      * on the failure path, so there is no `IO` to sequence a log into. Everything else should use
+      * [[loggerIO]] or a tracer.
+      */
+    def loggerSync(name: String): org.slf4j.Logger =
+        org.slf4j.LoggerFactory.getLogger(name)
 }

--- a/src/main/scala/hydrozoa/multisig/MultisigRegimeManagerBase.scala
+++ b/src/main/scala/hydrozoa/multisig/MultisigRegimeManagerBase.scala
@@ -8,7 +8,7 @@ import com.suprnation.actor.ActorRef.NoSendActorRef
 import com.suprnation.actor.SupervisorStrategy.Escalate
 import com.suprnation.actor.{OneForOneStrategy, SupervisionStrategy}
 import hydrozoa.config.node.NodeConfig
-import hydrozoa.lib.logging.ContraTracer
+import hydrozoa.lib.logging.{ContraTracer, Logging}
 import hydrozoa.multisig.HeadMultisigRegimeManager.*
 import hydrozoa.multisig.MultisigRegimeManagerBase.CoreActors
 import hydrozoa.multisig.backend.cardano.CardanoBackend
@@ -75,16 +75,37 @@ trait MultisigRegimeManagerBase[E >: LifecycleEvent <: RegimeManagerEvent]
       */
     override def supervisorStrategy: SupervisionStrategy[IO] =
         OneForOneStrategy[IO](maxNrOfRetries = 3, withinTimeRange = 1.minute)(
-          PartialFunction.fromFunction {
-              case _: IllegalArgumentException =>
-                  Escalate // Normally `Stop` but we can't handle stopped actors yet
-              case _: RuntimeException =>
-                  Escalate // Normally `Restart` but our actors can't do that yet
-              case _: Exception => Escalate
-              // `Error`, and anything extending `Throwable` directly. Keeping this arm last leaves
-              // the intent of the arms above legible for when they can take their real directives.
-              case _ => Escalate
+          PartialFunction.fromFunction { failure =>
+              recordFailure(failure)
+              failure match {
+                  case _: IllegalArgumentException =>
+                      Escalate // Normally `Stop` but we can't handle stopped actors yet
+                  case _: RuntimeException =>
+                      Escalate // Normally `Restart` but our actors can't do that yet
+                  case _: Exception => Escalate
+                  // `Error`, and anything extending `Throwable` directly. Keeping this arm last
+                  // leaves the intent of the arms above legible for when they can take their real
+                  // directives.
+                  case _ => Escalate
+              }
           }
+        )
+
+    /** Write down a child's failure while it is still intact.
+      *
+      * This is the last place that holds it. Escalation is the only directive available, and the
+      * escalation path itself raises before the cause is re-reported, so what survives in the log
+      * names that secondary failure and not this one — a node stops with no record of why.
+      * Everything downstream (`/ready`, the exit code, an operator reading journald) can say that
+      * the node died but not what killed it, unless it is written here.
+      *
+      * Synchronous, because a decider is a pure function with no effect context. It runs once per
+      * failure, which is once per node lifetime given every directive escalates.
+      */
+    private def recordFailure(cause: Throwable): Unit =
+        MultisigRegimeManagerBase.supervisionLog.error(
+          "A supervised actor failed; escalating to the guardian, which will stop the system.",
+          cause
         )
 
     override def preStart: IO[Unit] = context.self ! PreStart
@@ -194,6 +215,11 @@ trait MultisigRegimeManagerBase[E >: LifecycleEvent <: RegimeManagerEvent]
 }
 
 object MultisigRegimeManagerBase {
+
+    /** Where a supervised failure's cause is written. Its own route so the line survives a log
+      * config that quiets `hydrozoa` generally — it is the only record of why a node stopped.
+      */
+    private val supervisionLog = Logging.loggerSync("Supervision")
 
     /** The actors spawned by [[MultisigRegimeManagerBase.spawnCoreActors]] — present on every
       * multisig peer regardless of role.

--- a/src/main/scala/hydrozoa/multisig/backend/cardano/CardanoBackendBlockfrost.scala
+++ b/src/main/scala/hydrozoa/multisig/backend/cardano/CardanoBackendBlockfrost.scala
@@ -87,10 +87,18 @@ class CardanoBackendBlockfrost private (
                         utxos <- EitherT(convertUtxosWithScripts(List(res.getValue)))
                         utxo = ledger.Utxo(utxos.head)
                     } yield Some(utxo)
-                // Resolution unsuccessful for some other reason
+                // Resolution unsuccessful for some other reason. The status code goes in the
+                // message: it is what separates "retry, the backend is having a moment" (429, 5xx)
+                // from "this will never work" (401 on a bad key, 400), and the response body alone
+                // does not carry it — a proxy's 502 body is often empty.
                 case _ =>
                     EitherT.left(
-                      IO.pure(ErrorResolving(input, s"resolution response: ${res.getResponse}"))
+                      IO.pure(
+                        ErrorResolving(
+                          input,
+                          s"resolution failed with HTTP ${res.code()}: ${res.getResponse}"
+                        )
+                      )
                     )
             }
         } yield mbUtxo).value

--- a/src/main/scala/hydrozoa/multisig/server/HydrozoaHttpEvent.scala
+++ b/src/main/scala/hydrozoa/multisig/server/HydrozoaHttpEvent.scala
@@ -31,8 +31,16 @@ object HydrozoaHttpEvent:
     /** Decode-failure history (the circe cursor breadcrumb path), separated for diagnostics. */
     final case class JsonDecodeErrorHistory(path: String, history: String) extends HydrozoaHttpEvent
 
-    /** The request body decoded to a domain object (debug). */
-    final case class RequestDecoded(path: String, decoded: String) extends HydrozoaHttpEvent
+    /** The request body decoded to a domain object (debug).
+      *
+      * Carries the request's shape rather than the request. Rendering a decoded request means
+      * `toString` on its payloads, and a `ByteString`'s `toString` is its hex — which scalus caches
+      * on the instance, so a payload that is later retained is retained at three times its size.
+      * The event is built on every request whatever the log level, so that cost is paid whether or
+      * not anyone is reading debug logs.
+      */
+    final case class RequestDecoded(path: String, kind: String, payloadBytes: Int)
+        extends HydrozoaHttpEvent
 
     /** A request was rejected by screening or backpressure — an expected 400, not a fault, so it
       * carries only the client-facing reason (no exception or stack trace).

--- a/src/main/scala/hydrozoa/multisig/server/HydrozoaHttpEventFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/server/HydrozoaHttpEventFormat.scala
@@ -33,8 +33,8 @@ object HydrozoaHttpEventFormat:
                 )
             case JsonDecodeErrorHistory(path, history) =>
                 error(s"$path - Decode error history: $history")
-            case RequestDecoded(path, decoded) =>
-                debug(s"$path - Decoded: $decoded")
+            case RequestDecoded(path, kind, payloadBytes) =>
+                debug(s"$path - Decoded: $kind, $payloadBytes payload bytes")
             case RequestRejected(path, reason) =>
                 warn(s"$path - Rejected: $reason")
             case RequestFailed(path, cause) =>

--- a/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
+++ b/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
@@ -7,7 +7,7 @@ import hydrozoa.config.head.HeadConfig
 import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.NodeStatus
 import hydrozoa.multisig.consensus.peer.HeadPeerNumber
-import hydrozoa.multisig.consensus.{BlockWeaver, RequestSequencer, UserRequestWithId}
+import hydrozoa.multisig.consensus.{BlockWeaver, RequestSequencer, UserRequest, UserRequestWithId}
 import hydrozoa.multisig.ledger.block.{BlockBrief, BlockNumber}
 import hydrozoa.multisig.ledger.event.RequestId
 import hydrozoa.multisig.ledger.l2.EutxoL2LedgerReader
@@ -663,7 +663,7 @@ class HydrozoaRoutes(
                         tracer.traceWith(JsonDecodeError(path, error)) *> IO.raiseError(error)
                     case Right(request) => IO.pure(request)
                 }
-                _ <- tracer.traceWith(RequestDecoded(path, userRequest.toString))
+                _ <- tracer.traceWith(HydrozoaRoutes.decodedEvent(path, userRequest))
                 result <- (requestSequencer ?: userRequest).flatMap {
                     case Right(id) =>
                         IO.pure(Right(ApiDto.mkRequestAcceptedResponse(id)))
@@ -947,6 +947,18 @@ class HydrozoaRoutes(
 }
 
 object HydrozoaRoutes {
+
+    /** Describe a decoded request without rendering it: its kind and its payload size, both read
+      * off fields that are already there. Never call `toString` on a request here — see
+      * [[HydrozoaHttpEvent.RequestDecoded]] for what that costs.
+      */
+    private[server] def decodedEvent(path: String, request: UserRequest): RequestDecoded =
+        request match
+            case UserRequest.DepositRequest(body) =>
+                RequestDecoded(path, "Deposit", body.l1Payload.size + body.l2Payload.size)
+            case UserRequest.TransactionRequest(body) =>
+                RequestDecoded(path, "Transaction", body.l2Payload.size)
+
     val apiTitle: String = "Hydrozoa node API"
     val l2ApiTitle: String = "Hydrozoa EUTXO L2 ledger API"
     val apiVersion: String = "0.1.0"

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -29,6 +29,8 @@
     <logger name="CoilPeerWsTransport" level="warn"/>
     <logger name="HubWsTransport" level="warn"/>
     <logger name="CoilAckSequencer" level="warn"/>
+    <!-- The only record of why a supervised actor failed; never quiet it. -->
+    <logger name="Supervision" level="error"/>
     <logger name="HydrozoaHttp" level="warn"/>
     <logger name="RemoteL2Ledger" level="warn"/>
     <logger name="RemoteL2Screener" level="warn"/>

--- a/src/test/scala/hydrozoa/config/node/NodeConfigRetryTest.scala
+++ b/src/test/scala/hydrozoa/config/node/NodeConfigRetryTest.scala
@@ -1,0 +1,87 @@
+package hydrozoa.config.node
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import hydrozoa.config.ScriptReferenceUtxos
+import hydrozoa.multisig.backend.cardano.CardanoBackend
+import org.scalatest.funsuite.AnyFunSuite
+import scala.concurrent.duration.DurationInt
+
+/** The config load's retry loop.
+  *
+  * Loading a config resolves script reference UTxOs against Cardano, so a node that cannot reach
+  * the backend exits — and a process supervisor answers by restarting it straight into the same
+  * failure. The waits are a parameter here so the loop can be driven without waiting minutes.
+  */
+class NodeConfigRetryTest extends AnyFunSuite {
+
+    private val backendDown: ScriptReferenceUtxos.Error =
+        ScriptReferenceUtxos.Error.CardanoBackendError(
+          CardanoBackend.Error.Unexpected("connection refused")
+        )
+
+    private val badConfig: io.circe.Error =
+        io.circe.DecodingFailure("not a config", Nil)
+
+    private val waits = List(1.milli, 1.milli, 1.milli)
+
+    /** An attempt that fails `failures` times with `error`, then succeeds. */
+    private def failing(
+        failures: Int,
+        error: ScriptReferenceUtxos.Error | io.circe.Error
+    ): (IO[Either[ScriptReferenceUtxos.Error | io.circe.Error, String]], () => Int) =
+        var attempts = 0
+        val io = IO {
+            attempts += 1
+            if attempts <= failures then Left(error) else Right("loaded")
+        }
+        (io, () => attempts)
+
+    test("a backend that comes back is retried until it does") {
+        val (attempt, attempts) = failing(2, backendDown)
+        val _ = assert(
+          NodeConfig.retryingBackendReads(waits, attempt).unsafeRunSync() == Right("loaded")
+        )
+        assert(attempts() == 3)
+    }
+
+    test("a backend that stays down gives up with its own error, not a different one") {
+        val (attempt, attempts) = failing(Int.MaxValue, backendDown)
+        val _ = assert(
+          NodeConfig.retryingBackendReads(waits, attempt).unsafeRunSync() == Left(backendDown)
+        )
+        // One attempt per wait, plus the first — not an unbounded loop.
+        assert(attempts() == waits.length + 1)
+    }
+
+    test("a malformed config is not retried: re-reading the same bytes gives the same answer") {
+        val (attempt, attempts) = failing(Int.MaxValue, badConfig)
+        val _ = assert(
+          NodeConfig.retryingBackendReads(waits, attempt).unsafeRunSync() == Left(badConfig)
+        )
+        assert(attempts() == 1)
+    }
+
+    test("a raised failure is retried too — building the backend reports failure by raising") {
+        var attempts = 0
+        val attempt: IO[Either[ScriptReferenceUtxos.Error | io.circe.Error, String]] = IO {
+            attempts += 1
+            if attempts <= 2 then
+                throw new java.net.UnknownHostException("cardano-mainnet.blockfrost.io")
+            else Right("loaded")
+        }
+        val _ = assert(
+          NodeConfig.retryingBackendReads(waits, attempt).unsafeRunSync() == Right("loaded")
+        )
+        assert(attempts == 3)
+    }
+
+    test("a raise that never clears is re-raised, so the caller still sees the real cause") {
+        val attempt: IO[Either[ScriptReferenceUtxos.Error | io.circe.Error, String]] =
+            IO.raiseError(new java.net.UnknownHostException("cardano-mainnet.blockfrost.io"))
+        val thrown = intercept[java.net.UnknownHostException](
+          NodeConfig.retryingBackendReads(waits, attempt).unsafeRunSync()
+        )
+        assert(thrown.getMessage == "cardano-mainnet.blockfrost.io")
+    }
+}

--- a/src/test/scala/hydrozoa/multisig/server/RequestDecodedEventTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/RequestDecodedEventTest.scala
@@ -1,0 +1,37 @@
+package hydrozoa.multisig.server
+
+import hydrozoa.multisig.consensus.{UserRequest, UserRequestBody}
+import hydrozoa.multisig.server.HydrozoaHttpEvent.RequestDecoded
+import org.scalatest.funsuite.AnyFunSuite
+import scalus.uplc.builtin.ByteString
+
+/** What the ingress debug event carries.
+  *
+  * The event is built on every accepted request, whatever the log level. Carrying the rendered
+  * request meant `toString` on its payloads, and a `ByteString`'s `toString` is its hex — cached on
+  * the instance by scalus, so a payload that goes on to be retained is retained at three times its
+  * size. Its type now admits only the request's shape, which is what keeps that from coming back:
+  * there is no field a rendered request would fit in.
+  */
+class RequestDecodedEventTest extends AnyFunSuite {
+
+    private def bytes(n: Int): ByteString = ByteString.fromArray(Array.fill[Byte](n)(7))
+
+    test("a transaction request reports its kind and payload size") {
+        val request =
+            UserRequest.TransactionRequest(UserRequestBody.TransactionRequestBody(bytes(1234)))
+        assert(
+          HydrozoaRoutes.decodedEvent("/api/L2/submit", request) ==
+              RequestDecoded("/api/L2/submit", "Transaction", 1234)
+        )
+    }
+
+    test("a deposit request counts both payloads") {
+        val request =
+            UserRequest.DepositRequest(UserRequestBody.DepositRequestBody(bytes(600), bytes(96)))
+        assert(
+          HydrozoaRoutes.decodedEvent("/api/L1/deposit", request) ==
+              RequestDecoded("/api/L1/deposit", "Deposit", 696)
+        )
+    }
+}


### PR DESCRIPTION
Four operational fixes. None changes consensus, the wire, or persistence. Reviewable in this order —
the first is the only one with measurement behind it, the rest are a few lines each.

## 1. The ingress debug event rendered the request it was describing

```scala
tracer.traceWith(RequestDecoded(path, userRequest.toString))
```

The argument is strict, so it runs on every accepted request whatever the log level — and
`RequestDecoded` is a **debug** event, so in production the string is built and thrown away.

The cost is not the string. Rendering a request calls `toString` on its payloads, and a scalus
`ByteString`'s `toString` is its hex, held in an instance `lazy val`:

```scala
override def toString: String = "\"" + toHex + "\""
@threadUnsafe lazy val toHex: String = bytes.toHex
```

Forcing it welds a string of twice the payload's bytes onto that `ByteString` for as long as it
lives — and this one lives a long time: the same instance goes on to the sequencer, the `Request`
journal, and every outbound lane.

That is the multiplier in the mainnet retention arithmetic: the OOM heap held hex and binary arrays
in 1:1 pairs at exactly twice the size, giving **three bytes retained per payload byte** — 73.3 KB
per request against a 24.5 KB mean payload. Counts and the rest of the memory picture:
https://claude.ai/code/artifact/3e7b54d4-61bf-4b2c-a41b-c1dcee1be044

The event now carries the request's kind and payload size, read off fields that already exist. Its
type no longer has a field a rendered request would fit in, which is what stops this coming back.

⚠️ This fixes the multiplier, not the retention. The lane cap is the other half.

## 2. A config load that could not reach Cardano exited the process

Decoding a config resolves the script reference UTxOs against the backend, so loading it is a network
operation — with no retry. One failed resolve raised, the process exited, and the supervisor
restarted it into the same failure. On 2026-08-24 a loss of egress became **61 restarts in a row**.

Backend reads now retry at 2s, 5s, 15s, 30s, 60s — a little under two minutes, long enough to ride
out a DNS blip and short enough that a wrong config still fails while someone is watching the deploy.

Two things it deliberately does not do: it does not retry a malformed config (re-reading the same
bytes gives the same answer, and the distinction is on the error type, not a guess), and it does not
swallow the failure — after the last wait the original error is returned or the original exception
re-raised.

## 3. A supervised actor's failure was never written down

Every directive escalates, and the escalation path raises before the cause is re-reported — so the
log names that secondary failure, not the original, and the node stops with nothing saying why.
`SupervisionDeciderTest` already established the other half: a supervised failure surfaces nothing on
the event stream either way.

The decider is the last place holding the real throwable, so it logs it there — on its own
`Supervision` route at error level in every `logback.xml`, because it is the only record of why a node
stopped. Synchronous, because a decider is a pure `Throwable => Directive` with no effect context.

## 4. A failed UTxO resolution did not say what the backend answered

The status code is what separates "retry, the backend is having a moment" from "this will never
work", and the response body does not carry it — a proxy's 502 body is often empty. It is in the
message now.

## Not fixed here: `/ready`

`/ready` still reports `Active` on a node whose actor system has fail-stopped, which has been
observed: consensus stopped, the dialer failed once a second, readiness stayed green.

The obvious fix does not work. Watching for termination misses the observed case exactly — that
node's system emergency-stopped *without ever completing termination*, which is why it was still
serving HTTP. Detecting it needs a positive liveness signal: a heartbeat routed through the actor
system, a staleness bound on it, and a decision about whether readiness should gate user traffic on
consensus progress. That last part has a real downside — a `/ready` that flips on a slow period takes
a working node out of rotation — so it wants its own change and its own review.

## Testing

`NodeConfigRetryTest` drives the retry loop with the waits injected: a backend that comes back; one
that stays down (asserting the attempt count is bounded and the final error is the backend's own); a
malformed config, not retried at all; a raised failure that clears; one that does not.

`RequestDecodedEventTest` covers the event's contents for both request kinds.

383 unit tests pass; `integration` and `examples` compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)