### PR TITLE
Log escalated supervision failures through the tracer, not a sync logger

### DIFF
--- a/src/main/scala/hydrozoa/lib/logging/Logging.scala
+++ b/src/main/scala/hydrozoa/lib/logging/Logging.scala
@@ -18,13 +18,4 @@ object Logging {
     /** log4cats SLF4J adapter used by [[Slf4jTracer.sink]]. */
     def loggerIO(name: String): Logger[IO] =
         Slf4jLogger.getLoggerFromName[IO](name)
-
-    /** A synchronous logger, for the few places that have no effect context to log in.
-      *
-      * A supervision decider is one: it is a pure `Throwable => Directive` the actor library calls
-      * on the failure path, so there is no `IO` to sequence a log into. Everything else should use
-      * [[loggerIO]] or a tracer.
-      */
-    def loggerSync(name: String): org.slf4j.Logger =
-        org.slf4j.LoggerFactory.getLogger(name)
 }

--- a/src/main/scala/hydrozoa/multisig/CoilMultisigRegimeManagerEventFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/CoilMultisigRegimeManagerEventFormat.scala
@@ -1,6 +1,6 @@
 package hydrozoa.multisig
 
-import hydrozoa.lib.logging.LogEvent
+import hydrozoa.lib.logging.{Level, LogEvent}
 import hydrozoa.multisig.consensus.liaison.PeerLiaisonEventFormat
 import hydrozoa.multisig.consensus.limiter.LimiterEventFormat
 import hydrozoa.multisig.consensus.peer.{CoilPeerNumber, HeadPeerNumber, PeerId}
@@ -30,6 +30,13 @@ object CoilMultisigRegimeManagerEventFormat:
             case LifecycleEvent.WatchingActors            => info("Watching multisig actors...")
             case LifecycleEvent.TerminatedActor(actor)    => warn(s"Terminated $actor actor")
             case LifecycleEvent.TerminatedDependency(dep) => warn(s"Terminated dependency $dep")
+            case LifecycleEvent.SupervisedFailureEscalated(cause) =>
+                LogEvent(
+                  Level.Error,
+                  "A supervised actor failed; escalating to the guardian, which will stop the system.",
+                  cause = Some(cause),
+                  routingKey = Some("Supervision")
+                )
             case CommonChildEvent.BlockWeaver(bw) =>
                 BlockWeaverEventFormat.humanFormat(syntheticLabel)(bw)
             case CommonChildEvent.JointLedger(jl) =>

--- a/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManagerEventFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManagerEventFormat.scala
@@ -1,6 +1,6 @@
 package hydrozoa.multisig
 
-import hydrozoa.lib.logging.LogEvent
+import hydrozoa.lib.logging.{Level, LogEvent}
 import hydrozoa.multisig.consensus.liaison.PeerLiaisonEventFormat
 import hydrozoa.multisig.consensus.limiter.LimiterEventFormat
 import hydrozoa.multisig.consensus.peer.{HeadPeerNumber, PeerId}
@@ -22,6 +22,13 @@ object HeadMultisigRegimeManagerEventFormat:
             case LifecycleEvent.WatchingActors            => info("Watching multisig actors...")
             case LifecycleEvent.TerminatedActor(actor)    => warn(s"Terminated $actor actor")
             case LifecycleEvent.TerminatedDependency(dep) => warn(s"Terminated dependency $dep")
+            case LifecycleEvent.SupervisedFailureEscalated(cause) =>
+                LogEvent(
+                  Level.Error,
+                  "A supervised actor failed; escalating to the guardian, which will stop the system.",
+                  cause = Some(cause),
+                  routingKey = Some("Supervision")
+                )
             case CommonChildEvent.BlockWeaver(bw) =>
                 BlockWeaverEventFormat.humanFormat(peerNum)(bw)
             case CommonChildEvent.JointLedger(jl) =>

--- a/src/main/scala/hydrozoa/multisig/MultisigRegimeManagerBase.scala
+++ b/src/main/scala/hydrozoa/multisig/MultisigRegimeManagerBase.scala
@@ -5,10 +5,10 @@ import cats.effect.{Deferred, IO, Ref}
 import cats.implicits.*
 import com.suprnation.actor.Actor.{Actor, Receive}
 import com.suprnation.actor.ActorRef.NoSendActorRef
-import com.suprnation.actor.SupervisorStrategy.Escalate
-import com.suprnation.actor.{OneForOneStrategy, SupervisionStrategy}
+import com.suprnation.actor.SupervisorStrategy.{Directive, Escalate}
+import com.suprnation.actor.{ActorContext, OneForOneStrategy, SupervisionStrategy}
 import hydrozoa.config.node.NodeConfig
-import hydrozoa.lib.logging.{ContraTracer, Logging}
+import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.HeadMultisigRegimeManager.*
 import hydrozoa.multisig.MultisigRegimeManagerBase.CoreActors
 import hydrozoa.multisig.backend.cardano.CardanoBackend
@@ -74,39 +74,31 @@ trait MultisigRegimeManagerBase[E >: LifecycleEvent <: RegimeManagerEvent]
       * conspicuous.
       */
     override def supervisorStrategy: SupervisionStrategy[IO] =
-        OneForOneStrategy[IO](maxNrOfRetries = 3, withinTimeRange = 1.minute)(
-          PartialFunction.fromFunction { failure =>
-              recordFailure(failure)
-              failure match {
-                  case _: IllegalArgumentException =>
-                      Escalate // Normally `Stop` but we can't handle stopped actors yet
-                  case _: RuntimeException =>
-                      Escalate // Normally `Restart` but our actors can't do that yet
-                  case _: Exception => Escalate
-                  // `Error`, and anything extending `Throwable` directly. Keeping this arm last
-                  // leaves the intent of the arms above legible for when they can take their real
-                  // directives.
-                  case _ => Escalate
-              }
+        new OneForOneStrategy[IO](maxNrOfRetries = 3, withinTimeRange = 1.minute)(
+          PartialFunction.fromFunction {
+              case _: IllegalArgumentException =>
+                  Escalate // Normally `Stop` but we can't handle stopped actors yet
+              case _: RuntimeException =>
+                  Escalate // Normally `Restart` but our actors can't do that yet
+              case _: Exception => Escalate
+              // `Error`, and anything extending `Throwable` directly. Keeping this arm last leaves
+              // the intent of the arms above legible for when they can take their real directives.
+              case _ => Escalate
           }
-        )
-
-    /** Write down a child's failure while it is still intact.
-      *
-      * This is the last place that holds it. Escalation is the only directive available, and the
-      * escalation path itself raises before the cause is re-reported, so what survives in the log
-      * names that secondary failure and not this one — a node stops with no record of why.
-      * Everything downstream (`/ready`, the exit code, an operator reading journald) can say that
-      * the node died but not what killed it, unless it is written here.
-      *
-      * Synchronous, because a decider is a pure function with no effect context. It runs once per
-      * failure, which is once per node lifetime given every directive escalates.
-      */
-    private def recordFailure(cause: Throwable): Unit =
-        MultisigRegimeManagerBase.supervisionLog.error(
-          "A supervised actor failed; escalating to the guardian, which will stop the system.",
-          cause
-        )
+        ) {
+            override def logFailure(
+                context: ActorContext[IO, ?, ?],
+                child: NoSendActorRef[IO],
+                cause: Option[Throwable],
+                decision: Directive
+            ): IO[Unit] =
+                decision match
+                    case Escalate =>
+                        cause.traverse_(c =>
+                            tracer.traceWith(LifecycleEvent.SupervisedFailureEscalated(c))
+                        )
+                    case _ => super.logFailure(context, child, cause, decision)
+        }
 
     override def preStart: IO[Unit] = context.self ! PreStart
 
@@ -215,11 +207,6 @@ trait MultisigRegimeManagerBase[E >: LifecycleEvent <: RegimeManagerEvent]
 }
 
 object MultisigRegimeManagerBase {
-
-    /** Where a supervised failure's cause is written. Its own route so the line survives a log
-      * config that quiets `hydrozoa` generally — it is the only record of why a node stopped.
-      */
-    private val supervisionLog = Logging.loggerSync("Supervision")
 
     /** The actors spawned by [[MultisigRegimeManagerBase.spawnCoreActors]] — present on every
       * multisig peer regardless of role.

--- a/src/main/scala/hydrozoa/multisig/RegimeManagerEvent.scala
+++ b/src/main/scala/hydrozoa/multisig/RegimeManagerEvent.scala
@@ -35,6 +35,12 @@ object LifecycleEvent:
     final case class TerminatedActor(actor: Actors) extends LifecycleEvent
     final case class TerminatedDependency(dep: Dependencies) extends LifecycleEvent
 
+    /** A supervised child failed and the decider escalated to the guardian, which stops the system.
+      * Carries the original `cause`: escalation re-raises a secondary failure before the cause is
+      * reported, so this is the only record of why the node stopped.
+      */
+    final case class SupervisedFailureEscalated(cause: Throwable) extends LifecycleEvent
+
 /** Child actors every regime+role spawns — the "core" set in
   * [[MultisigRegimeManagerBase.spawnCoreActors]] plus the peer liaison (which both head-mesh and
   * coil-uplink reuse, tagged by `remotePeerId`).


### PR DESCRIPTION
Stacked on #679 (bases on `fix/startup-and-readiness`).

#679 records a supervised child's escalated failure so a node no longer stops with nothing in the log saying why. It does so from the supervisor **decider** — a pure `Throwable => Directive` — which has no effect context, so it reaches for a synchronous slf4j logger (`Logging.loggerSync`). That reintroduces the sync-logging escape hatch removed in the `ContraTracer` + `IO~>Id` logging refactor (`e886b518`, `4caead57`).

The decider is the wrong seam. cats-actors' `SupervisionStrategy` already exposes an **effectful** one: `logFailure(...): F[Unit]`, called on the failure path with a full `IO` context — and its default implementation **no-ops on `Escalate`**, which is exactly the gap #679 fills.

This overrides `logFailure` instead:

- On `Escalate`, emits a new `LifecycleEvent.SupervisedFailureEscalated(cause)` through the regime `tracer` (via `cause.traverse_`), so the log is a sequenced `IO` effect on the library's intended seam, routed through `ContraTracer`/`Slf4jTracer.sink` like every other event. Other directives delegate to `super`.
- The decider is pure again — no side effect smuggled into `PartialFunction.fromFunction`.
- `loggerSync` and the object-level `supervisionLog` are removed.

Operator-facing behaviour is unchanged: the two `*EventFormat`s render the event at **error** level, carrying the cause, on `routingKey = "Supervision"` — so #679's `<logger name="Supervision">` logback lines remain the routing target and are unchanged.

`just precommit` and `just build-werror` (incl. `integration/Test/compile`) pass.