### PR TITLE
fix(rulebased): make RuleBasedActor tick-timer start idempotent

### DIFF
--- a/src/main/scala/hydrozoa/rulebased/RuleBasedActor.scala
+++ b/src/main/scala/hydrozoa/rulebased/RuleBasedActor.scala
@@ -1128,15 +1128,14 @@ final case class RuleBasedActor(
     // evacuation regime then spawns but never polls, so funds never come back (custody-critical). A
     // fixed-cadence self-tick fires every `evacuationBotPollingPeriod` regardless of mailbox
     // activity, which is correct here because `handleTick` is a poll-then-retry safe to re-run.
-    // Idempotent: cancel whatever is already in `tickFiber` before storing the new fiber, so a second
-    // call can never orphan a poll loop. Not load-bearing under cats-actors' own restart path — the
-    // default `preRestart` runs `postStop` (which cancels) before a restart, and each restart rebuilds
-    // the actor from `props` with a fresh `tickFiber` Ref — but the cancel-on-swap keeps the single-
-    // fiber invariant local to this method instead of resting on that framework ordering.
     private def startTickTimer: IO[Unit] =
-        (IO.sleep(config.evacuationBotPollingPeriod) >> (context.self ! Tick)).foreverM.start
-            .flatMap(fib => tickFiber.getAndSet(Some(fib)))
-            .flatMap(_.fold(IO.unit)(_.cancel))
+        val pollLoop =
+            (IO.sleep(config.evacuationBotPollingPeriod) >> (context.self ! Tick)).foreverM
+        for
+            fib <- pollLoop.start
+            previous <- tickFiber.getAndSet(Some(fib))
+            _ <- previous.fold(IO.unit)(_.cancel)
+        yield ()
 
     /** Cancel the self-tick fiber so it stops pinging `self` once the actor has stopped, instead of
       * leaking a fiber that keeps delivering `Tick` to a dead actor (dead letters).

--- a/src/main/scala/hydrozoa/rulebased/RuleBasedActor.scala
+++ b/src/main/scala/hydrozoa/rulebased/RuleBasedActor.scala
@@ -1128,13 +1128,15 @@ final case class RuleBasedActor(
     // evacuation regime then spawns but never polls, so funds never come back (custody-critical). A
     // fixed-cadence self-tick fires every `evacuationBotPollingPeriod` regardless of mailbox
     // activity, which is correct here because `handleTick` is a poll-then-retry safe to re-run.
-    // TODO(#622-review): this overwrites `tickFiber` without cancelling any fiber already there. If
-    // cats-actors ever re-runs `preStart` on a restart without `postStop` in between, the old tick
-    // fiber orphans (two poll loops, one uncancellable). Cancel the existing fiber before replacing
-    // it — or confirm cats-actors' restart path always runs `postStop` first, and note that here.
+    // Idempotent: cancel whatever is already in `tickFiber` before storing the new fiber, so a second
+    // call can never orphan a poll loop. Not load-bearing under cats-actors' own restart path — the
+    // default `preRestart` runs `postStop` (which cancels) before a restart, and each restart rebuilds
+    // the actor from `props` with a fresh `tickFiber` Ref — but the cancel-on-swap keeps the single-
+    // fiber invariant local to this method instead of resting on that framework ordering.
     private def startTickTimer: IO[Unit] =
         (IO.sleep(config.evacuationBotPollingPeriod) >> (context.self ! Tick)).foreverM.start
-            .flatMap(fib => tickFiber.set(Some(fib)))
+            .flatMap(fib => tickFiber.getAndSet(Some(fib)))
+            .flatMap(_.fold(IO.unit)(_.cancel))
 
     /** Cancel the self-tick fiber so it stops pinging `self` once the actor has stopped, instead of
       * leaking a fiber that keeps delivering `Tick` to a dead actor (dead letters).


### PR DESCRIPTION
## What

`RuleBasedActor.startTickTimer` overwrote `tickFiber` with `set`, discarding any fiber already stored without cancelling it. This swaps to `getAndSet` + cancel so a second call can never orphan a poll loop — the single-fiber invariant is now local to the method rather than dependent on external call ordering.

Closes out the `TODO(#622-review)` on that method.

## Is the orphan actually reachable?

No — verified against **cats-actors 2.1.0**:

- The default `preRestart` (`Actor.scala`) stops children then calls `postStop`, which cancels the fiber, **before** a restart.
- `finishRecreate` (`dungeon/FaultHandling.scala`) calls `newActor`, which rebuilds the actor from `props` (`dungeon/Creation.scala`) — so each restart gets a **fresh `tickFiber` Ref**, and `postRestart` → `preStart` runs on that fresh instance.

So under the standard supervision path the feared "two poll loops, one uncancellable" cannot happen. The cancel-on-swap is defensive belt-and-suspenders that keeps the invariant holding even if `startTickTimer` were ever invoked twice on one instance (e.g. a future `preRestart` override that drops the `postStop`).

## Why not a `Supervisor`?

A cats-effect `Supervisor` would need a `Resource` scope spanning the actor's lifetime to auto-cancel the fiber. cats-actors doesn't hand the actor body a `Resource` scope — `postStop` already provides exactly that teardown hook. A `Supervisor` would therefore add machinery without removing the manual cancel, so it's not an improvement here.

## Testing

- `scalafmtCheckAll` + `scalafixAll --check` — clean
- `just build-werror` (main + test + integration, -Werror) — clean
- `sbt "clean; test"` — 293 succeeded, 0 failed, 0 errors, 0 aborted (Total 375)