### PR TITLE
Render retained hash hex via ByteVector, not the cached ByteString.toHex

### DIFF
--- a/src/main/scala/hydrozoa/lib/logging/Logging.scala
+++ b/src/main/scala/hydrozoa/lib/logging/Logging.scala
@@ -18,13 +18,4 @@ object Logging {
     /** log4cats SLF4J adapter used by [[Slf4jTracer.sink]]. */
     def loggerIO(name: String): Logger[IO] =
         Slf4jLogger.getLoggerFromName[IO](name)
-
-    /** A synchronous logger, for the few places that have no effect context to log in.
-      *
-      * A supervision decider is one: it is a pure `Throwable => Directive` the actor library calls
-      * on the failure path, so there is no `IO` to sequence a log into. Everything else should use
-      * [[loggerIO]] or a tracer.
-      */
-    def loggerSync(name: String): org.slf4j.Logger =
-        org.slf4j.LoggerFactory.getLogger(name)
 }

--- a/src/main/scala/hydrozoa/multisig/CoilMultisigRegimeManagerEventFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/CoilMultisigRegimeManagerEventFormat.scala
@@ -1,6 +1,6 @@
 package hydrozoa.multisig
 
-import hydrozoa.lib.logging.LogEvent
+import hydrozoa.lib.logging.{Level, LogEvent}
 import hydrozoa.multisig.consensus.liaison.PeerLiaisonEventFormat
 import hydrozoa.multisig.consensus.limiter.LimiterEventFormat
 import hydrozoa.multisig.consensus.peer.{CoilPeerNumber, HeadPeerNumber, PeerId}
@@ -30,6 +30,13 @@ object CoilMultisigRegimeManagerEventFormat:
             case LifecycleEvent.WatchingActors            => info("Watching multisig actors...")
             case LifecycleEvent.TerminatedActor(actor)    => warn(s"Terminated $actor actor")
             case LifecycleEvent.TerminatedDependency(dep) => warn(s"Terminated dependency $dep")
+            case LifecycleEvent.SupervisedFailureEscalated(cause) =>
+                LogEvent(
+                  Level.Error,
+                  "A supervised actor failed; escalating to the guardian, which will stop the system.",
+                  cause = Some(cause),
+                  routingKey = Some("Supervision")
+                )
             case CommonChildEvent.BlockWeaver(bw) =>
                 BlockWeaverEventFormat.humanFormat(syntheticLabel)(bw)
             case CommonChildEvent.JointLedger(jl) =>

--- a/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManagerEventFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManagerEventFormat.scala
@@ -1,6 +1,6 @@
 package hydrozoa.multisig
 
-import hydrozoa.lib.logging.LogEvent
+import hydrozoa.lib.logging.{Level, LogEvent}
 import hydrozoa.multisig.consensus.liaison.PeerLiaisonEventFormat
 import hydrozoa.multisig.consensus.limiter.LimiterEventFormat
 import hydrozoa.multisig.consensus.peer.{HeadPeerNumber, PeerId}
@@ -22,6 +22,13 @@ object HeadMultisigRegimeManagerEventFormat:
             case LifecycleEvent.WatchingActors            => info("Watching multisig actors...")
             case LifecycleEvent.TerminatedActor(actor)    => warn(s"Terminated $actor actor")
             case LifecycleEvent.TerminatedDependency(dep) => warn(s"Terminated dependency $dep")
+            case LifecycleEvent.SupervisedFailureEscalated(cause) =>
+                LogEvent(
+                  Level.Error,
+                  "A supervised actor failed; escalating to the guardian, which will stop the system.",
+                  cause = Some(cause),
+                  routingKey = Some("Supervision")
+                )
             case CommonChildEvent.BlockWeaver(bw) =>
                 BlockWeaverEventFormat.humanFormat(peerNum)(bw)
             case CommonChildEvent.JointLedger(jl) =>

--- a/src/main/scala/hydrozoa/multisig/MultisigRegimeManagerBase.scala
+++ b/src/main/scala/hydrozoa/multisig/MultisigRegimeManagerBase.scala
@@ -5,10 +5,10 @@ import cats.effect.{Deferred, IO, Ref}
 import cats.implicits.*
 import com.suprnation.actor.Actor.{Actor, Receive}
 import com.suprnation.actor.ActorRef.NoSendActorRef
-import com.suprnation.actor.SupervisorStrategy.Escalate
-import com.suprnation.actor.{OneForOneStrategy, SupervisionStrategy}
+import com.suprnation.actor.SupervisorStrategy.{Directive, Escalate}
+import com.suprnation.actor.{ActorContext, OneForOneStrategy, SupervisionStrategy}
 import hydrozoa.config.node.NodeConfig
-import hydrozoa.lib.logging.{ContraTracer, Logging}
+import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.HeadMultisigRegimeManager.*
 import hydrozoa.multisig.MultisigRegimeManagerBase.CoreActors
 import hydrozoa.multisig.backend.cardano.CardanoBackend
@@ -74,39 +74,31 @@ trait MultisigRegimeManagerBase[E >: LifecycleEvent <: RegimeManagerEvent]
       * conspicuous.
       */
     override def supervisorStrategy: SupervisionStrategy[IO] =
-        OneForOneStrategy[IO](maxNrOfRetries = 3, withinTimeRange = 1.minute)(
-          PartialFunction.fromFunction { failure =>
-              recordFailure(failure)
-              failure match {
-                  case _: IllegalArgumentException =>
-                      Escalate // Normally `Stop` but we can't handle stopped actors yet
-                  case _: RuntimeException =>
-                      Escalate // Normally `Restart` but our actors can't do that yet
-                  case _: Exception => Escalate
-                  // `Error`, and anything extending `Throwable` directly. Keeping this arm last
-                  // leaves the intent of the arms above legible for when they can take their real
-                  // directives.
-                  case _ => Escalate
-              }
+        new OneForOneStrategy[IO](maxNrOfRetries = 3, withinTimeRange = 1.minute)(
+          PartialFunction.fromFunction {
+              case _: IllegalArgumentException =>
+                  Escalate // Normally `Stop` but we can't handle stopped actors yet
+              case _: RuntimeException =>
+                  Escalate // Normally `Restart` but our actors can't do that yet
+              case _: Exception => Escalate
+              // `Error`, and anything extending `Throwable` directly. Keeping this arm last leaves
+              // the intent of the arms above legible for when they can take their real directives.
+              case _ => Escalate
           }
-        )
-
-    /** Write down a child's failure while it is still intact.
-      *
-      * This is the last place that holds it. Escalation is the only directive available, and the
-      * escalation path itself raises before the cause is re-reported, so what survives in the log
-      * names that secondary failure and not this one — a node stops with no record of why.
-      * Everything downstream (`/ready`, the exit code, an operator reading journald) can say that
-      * the node died but not what killed it, unless it is written here.
-      *
-      * Synchronous, because a decider is a pure function with no effect context. It runs once per
-      * failure, which is once per node lifetime given every directive escalates.
-      */
-    private def recordFailure(cause: Throwable): Unit =
-        MultisigRegimeManagerBase.supervisionLog.error(
-          "A supervised actor failed; escalating to the guardian, which will stop the system.",
-          cause
-        )
+        ) {
+            override def logFailure(
+                context: ActorContext[IO, ?, ?],
+                child: NoSendActorRef[IO],
+                cause: Option[Throwable],
+                decision: Directive
+            ): IO[Unit] =
+                decision match
+                    case Escalate =>
+                        cause.traverse_(c =>
+                            tracer.traceWith(LifecycleEvent.SupervisedFailureEscalated(c))
+                        )
+                    case _ => super.logFailure(context, child, cause, decision)
+        }
 
     override def preStart: IO[Unit] = context.self ! PreStart
 
@@ -215,11 +207,6 @@ trait MultisigRegimeManagerBase[E >: LifecycleEvent <: RegimeManagerEvent]
 }
 
 object MultisigRegimeManagerBase {
-
-    /** Where a supervised failure's cause is written. Its own route so the line survives a log
-      * config that quiets `hydrozoa` generally — it is the only record of why a node stopped.
-      */
-    private val supervisionLog = Logging.loggerSync("Supervision")
 
     /** The actors spawned by [[MultisigRegimeManagerBase.spawnCoreActors]] — present on every
       * multisig peer regardless of role.

--- a/src/main/scala/hydrozoa/multisig/RegimeManagerEvent.scala
+++ b/src/main/scala/hydrozoa/multisig/RegimeManagerEvent.scala
@@ -35,6 +35,12 @@ object LifecycleEvent:
     final case class TerminatedActor(actor: Actors) extends LifecycleEvent
     final case class TerminatedDependency(dep: Dependencies) extends LifecycleEvent
 
+    /** A supervised child failed and the decider escalated to the guardian, which stops the system.
+      * Carries the original `cause`: escalation re-raises a secondary failure before the cause is
+      * reported, so this is the only record of why the node stopped.
+      */
+    final case class SupervisedFailureEscalated(cause: Throwable) extends LifecycleEvent
+
 /** Child actors every regime+role spawns — the "core" set in
   * [[MultisigRegimeManagerBase.spawnCoreActors]] plus the peer liaison (which both head-mesh and
   * coil-uplink reuse, tagged by `remotePeerId`).

--- a/src/main/scala/hydrozoa/multisig/ledger/joint/EvacuationMap.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/joint/EvacuationMap.scala
@@ -24,6 +24,7 @@ import scalus.uplc.builtin.Builtins.{blake2b_224, serialiseData}
 import scalus.uplc.builtin.Data.toData
 import scalus.uplc.builtin.{ByteString, Data, ToData, platform}
 import scalus.|>
+import scodec.bits.ByteVector
 import supranational.blst.Scalar
 
 given toDataTransactionInput: ToData[TransactionInput] with {
@@ -56,7 +57,8 @@ object EvacuationMapInstances:
     }
 
     given evacuationKeyKeyEncoder: KeyEncoder[EvacuationKey] = {
-        KeyEncoder.encodeKeyString.contramap(_.byteString.toHex)
+        // Hex via ByteVector, not `byteString.toHex`: the latter caches its hex on the retained key.
+        KeyEncoder.encodeKeyString.contramap(ek => ByteVector(ek.byteString.bytes).toHex)
     }
 
     // FIXME: This is partial, but KeyDecoder lacks the "emap" method that Decoder has?
@@ -82,7 +84,9 @@ object EvacuationMapInstances:
   * golden, so a change to [[EvacuationMap.digest]] is a wire break.
   */
 final case class EvacuationMapHash(byteString: ByteString) {
-    def toHex: String = byteString.toHex
+    // ByteVector, not `byteString.toHex`: the latter caches its hex on this retained digest, and
+    // `toString`/the circe encoder both route through here. `bytes` is already in hand.
+    def toHex: String = ByteVector(byteString.bytes).toHex
 
     override def toString: String = toHex
 }

--- a/src/main/scala/hydrozoa/multisig/ledger/remote/RemoteL2LedgerCodecs.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/remote/RemoteL2LedgerCodecs.scala
@@ -11,6 +11,7 @@ import io.circe.generic.semiauto.*
 import io.circe.syntax.*
 import io.circe.{Codec, Decoder, Encoder}
 import scalus.cardano.ledger.{AssetName, Coin, KeepRaw, MultiAsset, PolicyId, ScriptHash, TransactionOutput, Value}
+import scodec.bits.ByteVector
 
 /** JSON codecs for RemoteL2Ledger WebSocket protocol */
 object RemoteL2LedgerCodecs {
@@ -42,8 +43,10 @@ object RemoteL2LedgerCodecs {
                 io.circe.Json.obj(
                   "asset" -> io.circe.Json.obj(
                     "tag" -> io.circe.Json.fromString("NativeToken"),
-                    "policyId" -> io.circe.Json.fromString(policyId.toHex),
-                    "assetName" -> io.circe.Json.fromString(assetName.bytes.toHex)
+                    // Hex via ByteVector, not `.toHex`: PolicyId/AssetName are ByteStrings that cache
+                    // hex on the instance, and these live in retained L2 ledger Values.
+                    "policyId" -> io.circe.Json.fromString(ByteVector(policyId.bytes).toHex),
+                    "assetName" -> io.circe.Json.fromString(ByteVector(assetName.bytes.bytes).toHex)
                   ),
                   "value" -> io.circe.Json.fromLong(quantity)
                 )


### PR DESCRIPTION
Stacked on #681 (bases on `peter/supervision-effectful-logfailure`).

## Why

scalus `ByteString` memoizes its hex representation on the instance:

```scala
override def toString: String = "\"" + toHex + "\""
@threadUnsafe lazy val toHex: String = bytes.toHex
```

So the first `toHex`/`toString`/`s"$bs"` on a `ByteString` **welds a hex string (~2× the payload bytes) onto that instance for its lifetime**. For a value that is long-retained, that is a permanent 3× (binary + 2× hex). All scalus hash types are affected — `opaque type Hash[…] <: ByteString = ByteString`, so `ScriptHash`/`PolicyId`/`TransactionHash`/etc. hit the same cached `lazy val`.

Three retained sites were forcing this on serialization:
- `EvacuationMap` evacuation-key `KeyEncoder` (`_.byteString.toHex`) — keys live in the retained map.
- `EvacuationMapHash.toHex` — the digest is retained; both its `toString` override and its circe `Encoder` route through it.
- `RemoteL2LedgerCodecs` `Value` encoder (`policyId.toHex`, `assetName.bytes.toHex`) — policy/asset ids live in retained L2 ledger `Value`s.

## Fix

Compute the hex transiently via `ByteVector(bytes).toHex` — the exact pattern already used in `cip116/JsonCodecs.scala` — which reads the underlying `Array[Byte]` and never touches the instance's cached `lazy val`. **Byte-identical output**, no wire/JSON change; it just stops poisoning the retained instances.

This is codec/digest hygiene, separate from the logging overhaul that stacks on top of it (that handles the *logging* paths that force the same cache).

`just precommit` and `just build-werror` pass.