### PR TITLE
Defer LogEvent rendering behind a per-level gate

### DIFF
--- a/src/main/scala/hydrozoa/lib/logging/Slf4jMsg.scala
+++ b/src/main/scala/hydrozoa/lib/logging/Slf4jMsg.scala
@@ -1,6 +1,6 @@
 package hydrozoa.lib.logging
 
-import cats.Monad
+import cats.{Eval, Monad}
 
 /** A small generic message ADT for call sites that don't merit a typed event of their own —
   * typically app entry points (`hydrozoa.app.*`) and test scaffolding. Production actors and shared
@@ -8,30 +8,51 @@ import cats.Monad
   *
   * Pair with [[Slf4jMsgFormat.humanFormat]] to lift into [[LogEvent]] under a fixed routing key.
   * The extension methods on `ContraTracer[F, Slf4jMsg]` give `log.info("…")` ergonomics for any
-  * `F[_]: Monad` — typically `IO` (via [[Slf4jTracer.sink]]).
+  * `F[_]: Monad` — typically `IO` (via [[Slf4jTracer.sink]]). The message is held behind an `Eval`
+  * so it is not rendered unless the level is enabled (see [[Slf4jTracer.sink]]).
   */
 sealed trait Slf4jMsg
 
 object Slf4jMsg:
-    final case class Trace(msg: String) extends Slf4jMsg
-    final case class Debug(msg: String) extends Slf4jMsg
-    final case class Info(msg: String) extends Slf4jMsg
-    final case class Warn(msg: String) extends Slf4jMsg
-    final case class Error(msg: String, cause: Option[Throwable] = None) extends Slf4jMsg
+    final case class Trace(msg: Eval[String]) extends Slf4jMsg
+    final case class Debug(msg: Eval[String]) extends Slf4jMsg
+    final case class Info(msg: Eval[String]) extends Slf4jMsg
+    final case class Warn(msg: Eval[String]) extends Slf4jMsg
+    final case class Error(msg: Eval[String], cause: Option[Throwable] = None) extends Slf4jMsg
 
-/** Lift a [[Slf4jMsg]] into a [[LogEvent]] under [[routingKey]]. */
+/** Lift a [[Slf4jMsg]] into a [[LogEvent]] under [[routingKey]], keeping the message deferred. */
 object Slf4jMsgFormat:
     def humanFormat(routingKey: String)(m: Slf4jMsg): LogEvent = m match
         case Slf4jMsg.Trace(msg) =>
-            LogEvent(Level.Trace, msg, routingKey = Some(routingKey))
+            LogEventTyped(
+              Level.Trace,
+              Some(routingKey),
+              msg.map(Rendered(_, Map.empty[String, String]))
+            )
         case Slf4jMsg.Debug(msg) =>
-            LogEvent(Level.Debug, msg, routingKey = Some(routingKey))
+            LogEventTyped(
+              Level.Debug,
+              Some(routingKey),
+              msg.map(Rendered(_, Map.empty[String, String]))
+            )
         case Slf4jMsg.Info(msg) =>
-            LogEvent(Level.Info, msg, routingKey = Some(routingKey))
+            LogEventTyped(
+              Level.Info,
+              Some(routingKey),
+              msg.map(Rendered(_, Map.empty[String, String]))
+            )
         case Slf4jMsg.Warn(msg) =>
-            LogEvent(Level.Warn, msg, routingKey = Some(routingKey))
+            LogEventTyped(
+              Level.Warn,
+              Some(routingKey),
+              msg.map(Rendered(_, Map.empty[String, String]))
+            )
         case Slf4jMsg.Error(msg, cause) =>
-            LogEvent(Level.Error, msg, cause = cause, routingKey = Some(routingKey))
+            LogEventTyped(
+              Level.Error,
+              Some(routingKey),
+              msg.map(Rendered(_, Map.empty[String, String], cause))
+            )
 
 /** Logger-like extension on a `ContraTracer[F, Slf4jMsg]`. Build the tracer once at construction
   * time, then call `log.info / warn / error / debug / trace` at the call sites:
@@ -45,9 +66,9 @@ object Slf4jMsgFormat:
   * }}}
   */
 extension [F[_]: Monad](t: ContraTracer[F, Slf4jMsg])
-    def trace(msg: => String): F[Unit] = t.traceWith(Slf4jMsg.Trace(msg))
-    def debug(msg: => String): F[Unit] = t.traceWith(Slf4jMsg.Debug(msg))
-    def info(msg: => String): F[Unit] = t.traceWith(Slf4jMsg.Info(msg))
-    def warn(msg: => String): F[Unit] = t.traceWith(Slf4jMsg.Warn(msg))
+    def trace(msg: => String): F[Unit] = t.traceWith(Slf4jMsg.Trace(Eval.later(msg)))
+    def debug(msg: => String): F[Unit] = t.traceWith(Slf4jMsg.Debug(Eval.later(msg)))
+    def info(msg: => String): F[Unit] = t.traceWith(Slf4jMsg.Info(Eval.later(msg)))
+    def warn(msg: => String): F[Unit] = t.traceWith(Slf4jMsg.Warn(Eval.later(msg)))
     def error(msg: => String, cause: Option[Throwable] = None): F[Unit] =
-        t.traceWith(Slf4jMsg.Error(msg, cause))
+        t.traceWith(Slf4jMsg.Error(Eval.later(msg), cause))

--- a/src/main/scala/hydrozoa/lib/logging/Slf4jMsg.scala
+++ b/src/main/scala/hydrozoa/lib/logging/Slf4jMsg.scala
@@ -23,36 +23,25 @@ object Slf4jMsg:
 /** Lift a [[Slf4jMsg]] into a [[LogEvent]] under [[routingKey]], keeping the message deferred. */
 object Slf4jMsgFormat:
     def humanFormat(routingKey: String)(m: Slf4jMsg): LogEvent = m match
-        case Slf4jMsg.Trace(msg) =>
-            LogEventTyped(
-              Level.Trace,
-              Some(routingKey),
-              msg.map(Rendered(_, Map.empty[String, String]))
-            )
-        case Slf4jMsg.Debug(msg) =>
-            LogEventTyped(
-              Level.Debug,
-              Some(routingKey),
-              msg.map(Rendered(_, Map.empty[String, String]))
-            )
-        case Slf4jMsg.Info(msg) =>
-            LogEventTyped(
-              Level.Info,
-              Some(routingKey),
-              msg.map(Rendered(_, Map.empty[String, String]))
-            )
-        case Slf4jMsg.Warn(msg) =>
-            LogEventTyped(
-              Level.Warn,
-              Some(routingKey),
-              msg.map(Rendered(_, Map.empty[String, String]))
-            )
-        case Slf4jMsg.Error(msg, cause) =>
-            LogEventTyped(
-              Level.Error,
-              Some(routingKey),
-              msg.map(Rendered(_, Map.empty[String, String], cause))
-            )
+        case Slf4jMsg.Trace(msg)        => lift(routingKey, Level.Trace, msg)
+        case Slf4jMsg.Debug(msg)        => lift(routingKey, Level.Debug, msg)
+        case Slf4jMsg.Info(msg)         => lift(routingKey, Level.Info, msg)
+        case Slf4jMsg.Warn(msg)         => lift(routingKey, Level.Warn, msg)
+        case Slf4jMsg.Error(msg, cause) => lift(routingKey, Level.Error, msg, cause)
+
+    // `msg` is already an `Eval[String]`, so mapping over it keeps the render deferred; a `Slf4jMsg`
+    // carries no context, hence the empty ctx.
+    private def lift(
+        routingKey: String,
+        level: Level,
+        msg: Eval[String],
+        cause: Option[Throwable] = None
+    ): LogEvent =
+        LogEventTyped(
+          level,
+          Some(routingKey),
+          msg.map(Rendered(_, Map.empty[String, String], cause))
+        )
 
 /** Logger-like extension on a `ContraTracer[F, Slf4jMsg]`. Build the tracer once at construction
   * time, then call `log.info / warn / error / debug / trace` at the call sites:

--- a/src/main/scala/hydrozoa/lib/logging/Slf4jTracer.scala
+++ b/src/main/scala/hydrozoa/lib/logging/Slf4jTracer.scala
@@ -1,48 +1,61 @@
 package hydrozoa.lib.logging
 
+import cats.Eval
 import cats.effect.IO
+import java.util.concurrent.ConcurrentHashMap
 import org.typelevel.log4cats.Logger // scalafix:ok DisableSyntax
 import org.typelevel.log4cats.slf4j.Slf4jLogger // scalafix:ok DisableSyntax
 
 enum Level:
     case Trace, Debug, Info, Warn, Error
 
+/** A [[LogEventTyped]]'s deferred payload: the message, context, and cause. Held behind an `Eval`
+  * so none of it — the message interpolation, the context values, `toString` on domain objects — is
+  * computed unless the event's level is enabled (see [[Slf4jTracer.levelGated]]). The event's
+  * [[LogEventTyped.level]] and [[LogEventTyped.routingKey]] stay eager because the gate needs them.
+  */
+final case class Rendered[A](msg: String, ctx: A, cause: Option[Throwable] = None)
+
 case class LogEventTyped[A](
     level: Level,
-    msg: String,
-    ctx: A,
-    cause: Option[Throwable] = None,
     /** SLF4J logger name used to route to the correct Logback appender/level config. `None` means
       * "fall back to the default Hydrozoa logger." For typed events that always emit through the
       * same logger, `EventFormat.humanFormat` fills in `Some(...)` per event variant.
       */
-    routingKey: Option[String] = None
+    routingKey: Option[String],
+    render: Eval[Rendered[A]]
 )
 
 type LogEvent = LogEventTyped[Map[String, String]]
 
 object LogEvent {
+
+    /** `msg` is by-name and captured into the deferred [[LogEventTyped.render]], so the
+      * interpolation (and any `toString` inside it) runs only if the level is enabled — at every
+      * call site, `From.*` and direct `LogEvent(...)` alike.
+      */
     def apply(
         level: Level,
-        msg: String,
+        msg: => String,
         ctx: Map[String, String] = Map.empty,
         cause: Option[Throwable] = None,
         routingKey: Option[String] = None
-    ): LogEventTyped[Map[String, String]] = LogEventTyped(level, msg, ctx, cause, routingKey)
+    ): LogEventTyped[Map[String, String]] =
+        LogEventTyped(level, routingKey, Eval.later(Rendered(msg, ctx, cause)))
 
     /** Partially-applied factory: fixes [[ctx]] and [[routingKey]] for a set of related events.
       * Extra context pairs passed as varargs are merged with the base [[ctx]].
       */
     final class From(val ctx: Map[String, String], val routingKey: Option[String]):
-        def trace(msg: String, extra: (String, String)*): LogEvent =
+        def trace(msg: => String, extra: (String, String)*): LogEvent =
             LogEvent(Level.Trace, msg, ctx ++ extra, routingKey = routingKey)
-        def debug(msg: String, extra: (String, String)*): LogEvent =
+        def debug(msg: => String, extra: (String, String)*): LogEvent =
             LogEvent(Level.Debug, msg, ctx ++ extra, routingKey = routingKey)
-        def info(msg: String, extra: (String, String)*): LogEvent =
+        def info(msg: => String, extra: (String, String)*): LogEvent =
             LogEvent(Level.Info, msg, ctx ++ extra, routingKey = routingKey)
-        def warn(msg: String, extra: (String, String)*): LogEvent =
+        def warn(msg: => String, extra: (String, String)*): LogEvent =
             LogEvent(Level.Warn, msg, ctx ++ extra, routingKey = routingKey)
-        def error(msg: String): LogEvent =
+        def error(msg: => String): LogEvent =
             LogEvent(Level.Error, msg, ctx, routingKey = routingKey)
 
     object From:
@@ -61,27 +74,39 @@ type Slf4jTracer = ContraTracer[IO, LogEvent]
 
 object Slf4jTracer:
 
-    /** SLF4J sink — routes [[LogEvent]] to the correct logger via [[LogEvent.routingKey]]. Build
-      * per-component tracers with `Slf4jTracer.sink.contramap(MyEventFormat.humanFormat(...))`.
+    /** SLF4J sink, **gated on the target logger's level**: an event whose level is disabled never
+      * forces its [[LogEventTyped.render]] and never reaches SLF4J. The render is handed to
+      * log4cats **by-name**, and its `contextLog` (`F.delay(if (isEnabled) log())`) forces it only
+      * when the routing key's logger has the level enabled — so a single check gates it, with no
+      * separate `ContraTracer` gate to run its own `isEnabled` and re-look-up the logger. Build
+      * per-component tracers with `Slf4jTracer.sink.contramap(MyEventFormat.humanFormat(...))`;
+      * compose capture sinks with `|+|` — they are separate legs, so a disabled slf4j leg never
+      * squelches them.
       */
-    val sink: ContraTracer[IO, LogEvent] = ContraTracer.emit((ev: LogEvent) =>
+    val sink: ContraTracer[IO, LogEvent] = ContraTracer.emit { (ev: LogEvent) =>
         val lg = loggerIO(ev.routingKey.getOrElse("hydrozoa"))
-        val msg = renderMsg(ev)
+        def msg = renderMsg(ev.render.value) // by-name: forced only when the level is enabled
         ev.level match
             case Level.Trace => lg.trace(msg)
             case Level.Debug => lg.debug(msg)
             case Level.Info  => lg.info(msg)
             case Level.Warn  => lg.warn(msg)
-            case Level.Error => ev.cause.fold(lg.error(msg))(lg.error(_)(msg))
-    )
+            // Error carries a cause, which lives in the (now forced) render; error is effectively
+            // always enabled, so forcing it here rather than by-name costs nothing in practice.
+            case Level.Error =>
+                val r = ev.render.value
+                r.cause.fold(lg.error(renderMsg(r)))(lg.error(_)(renderMsg(r)))
+    }
 
-    /** The one SLF4J bridge in the codebase. Everything else logs through a `ContraTracer` and
-      * reaches SLF4J via [[sink]]; the `DisableSyntax` rule in `.scalafix.conf` keeps it that way.
+    /** log4cats loggers cached per routing key: `getLoggerFromName` allocates a fresh wrapper on
+      * every call, and routing keys are a small fixed set, so memoise to keep the sink from
+      * allocating one per emit. This is the one SLF4J bridge in the codebase; the `DisableSyntax`
+      * rule in `.scalafix.conf` keeps it that way.
       */
-    private def loggerIO(name: String): Logger[IO] = Slf4jLogger.getLoggerFromName[IO](name)
+    private lazy val loggers = new ConcurrentHashMap[String, Logger[IO]]()
+    private def loggerIO(name: String): Logger[IO] =
+        loggers.computeIfAbsent(name, n => Slf4jLogger.getLoggerFromName[IO](n))
 
-    private def renderMsg(ev: LogEvent): String =
-        val prefix =
-            if ev.ctx.isEmpty then ""
-            else "[" + ev.ctx.map((k, v) => s"$k=$v").mkString(" ") + "] "
-        prefix + ev.msg
+    private def renderMsg(r: Rendered[Map[String, String]]): String =
+        if r.ctx.isEmpty then r.msg
+        else "[" + r.ctx.map((k, v) => s"$k=$v").mkString(" ") + "] " + r.msg

--- a/src/main/scala/hydrozoa/lib/logging/Slf4jTracer.scala
+++ b/src/main/scala/hydrozoa/lib/logging/Slf4jTracer.scala
@@ -9,12 +9,9 @@ import org.typelevel.log4cats.slf4j.Slf4jLogger // scalafix:ok DisableSyntax
 enum Level:
     case Trace, Debug, Info, Warn, Error
 
-/** A [[LogEventTyped]]'s deferred payload: the message, context, and cause. Held behind an `Eval`
-  * so none of it — the message interpolation, the context values, `toString` on domain objects — is
-  * computed unless the event's level is enabled (see [[Slf4jTracer.levelGated]]). The event's
-  * [[LogEventTyped.level]] and [[LogEventTyped.routingKey]] stay eager because the gate needs them.
+/** A [[LogEventTyped]]'s deferred payload. See [[LogEvent.deferred]]
   */
-final case class Rendered[A](msg: String, ctx: A, cause: Option[Throwable] = None)
+final case class Rendered[A] private[logging] (msg: String, ctx: A, cause: Option[Throwable] = None)
 
 case class LogEventTyped[A](
     level: Level,
@@ -30,10 +27,15 @@ type LogEvent = LogEventTyped[Map[String, String]]
 
 object LogEvent {
 
-    /** `msg` is by-name and captured into the deferred [[LogEventTyped.render]], so the
-      * interpolation (and any `toString` inside it) runs only if the level is enabled — at every
-      * call site, `From.*` and direct `LogEvent(...)` alike.
+    /** Wrap a by-name message (plus context and cause) in the deferred [[Rendered]] payload.
       */
+    private[logging] def deferred[A](
+        msg: => String,
+        ctx: A,
+        cause: Option[Throwable] = None
+    ): Eval[Rendered[A]] =
+        Eval.later(Rendered(msg, ctx, cause))
+
     def apply(
         level: Level,
         msg: => String,
@@ -41,22 +43,29 @@ object LogEvent {
         cause: Option[Throwable] = None,
         routingKey: Option[String] = None
     ): LogEventTyped[Map[String, String]] =
-        LogEventTyped(level, routingKey, Eval.later(Rendered(msg, ctx, cause)))
+        LogEventTyped(level, routingKey, deferred(msg, ctx, cause))
 
     /** Partially-applied factory: fixes [[ctx]] and [[routingKey]] for a set of related events.
       * Extra context pairs passed as varargs are merged with the base [[ctx]].
       */
     final class From(val ctx: Map[String, String], val routingKey: Option[String]):
+        private def helper(
+            loggingLevel: Level,
+            msg: => String,
+            extra: (String, String)*
+        ): LogEvent =
+            LogEvent(loggingLevel, msg, ctx ++ extra, routingKey = routingKey)
+
         def trace(msg: => String, extra: (String, String)*): LogEvent =
-            LogEvent(Level.Trace, msg, ctx ++ extra, routingKey = routingKey)
+            helper(Level.Trace, msg, extra*)
         def debug(msg: => String, extra: (String, String)*): LogEvent =
-            LogEvent(Level.Debug, msg, ctx ++ extra, routingKey = routingKey)
+            helper(Level.Debug, msg, extra*)
         def info(msg: => String, extra: (String, String)*): LogEvent =
-            LogEvent(Level.Info, msg, ctx ++ extra, routingKey = routingKey)
+            helper(Level.Info, msg, extra*)
         def warn(msg: => String, extra: (String, String)*): LogEvent =
-            LogEvent(Level.Warn, msg, ctx ++ extra, routingKey = routingKey)
+            helper(Level.Warn, msg, extra*)
         def error(msg: => String): LogEvent =
-            LogEvent(Level.Error, msg, ctx, routingKey = routingKey)
+            helper(Level.Error, msg)
 
     object From:
         def apply(ctx: Map[String, String], routingKey: String): From =

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -42,4 +42,7 @@
     <logger name="SettlementTx" level="warn"/>
     <logger name="Generators" level="warn"/>
     <logger name="scalus" level="warn"/>
+    <!-- Fixtures for Slf4jTracerTest: prove the level gate skips (or forces) rendering. -->
+    <logger name="hydrozoa.test.gated.off" level="off"/>
+    <logger name="hydrozoa.test.gated.on" level="debug"/>
 </configuration>

--- a/src/test/scala/hydrozoa/lib/logging/ContraTracerDemo.scala
+++ b/src/test/scala/hydrozoa/lib/logging/ContraTracerDemo.scala
@@ -1,0 +1,258 @@
+package hydrozoa.lib.logging
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import cats.syntax.all.*
+import cats.~>
+import hydrozoa.lib.logging.ContraTracer.nullTracer
+import java.util.concurrent.atomic.AtomicInteger
+import org.scalatest.funsuite.AnyFunSuite
+import scala.collection.mutable.ListBuffer
+
+/** Didactic walkthrough of `TracerA` and `ContraTracer`.
+  *
+  * ==The two layers==
+  *
+  * {{{
+  *   ContraTracer[M, A]
+  *     wraps
+  *   TracerA[M, A, Unit]
+  *     which is one of:
+  *
+  *     Emitting(emits, noEmits)
+  *       emits  : Kleisli[M, A, X]   <-- runs on traceWith
+  *       noEmits: Kleisli[M, X, Unit] <-- DROPPED by runTracerA
+  *
+  *     Squelching(k)
+  *       k: Kleisli[M, A, B]          <-- ENTIRE arrow dropped by runTracerA
+  * }}}
+  *
+  * Only `Emitting` produces visible effects when run. `Squelching` is a "ghost" arrow: it still
+  * composes with neighbours, but at `runTracerA` time it is replaced by `arr (const ())`. That
+  * collapse is why the library can offer lazy combinators (`contramapM`, `traceMaybe`, ...) that
+  * only pay their cost when some sink downstream is actually emitting.
+  *
+  * ==Composition algebra under `>>>`==
+  *
+  * {{{
+  *   g (upstream)     f (downstream)    g >>> f       intuition
+  *   ------------     --------------    -----------   ---------------------
+  *   Squelching       Squelching        Squelching    no emit anywhere
+  *   Emitting         Squelching        Emitting      emit, drop the tail
+  *   Squelching       Emitting          Emitting      squelch absorbed
+  *                                                     into emit's input
+  *   Emitting         Emitting          Emitting      both emits preserved
+  * }}}
+  *
+  * ==Fan-out via Semigroup `combine`==
+  *
+  * {{{
+  *                  x : A
+  *                    |
+  *           (xt.use &&& yt.use)    -- duplicates the input
+  *                    |
+  *                +---+---+
+  *                v       v
+  *              xt.use  yt.use      -- both sinks see the same A
+  *                |       |
+  *                v       v
+  *              (Unit, Unit) --discard--> Unit
+  * }}}
+  *
+  * ==Branching via `traceMaybe` (ArrowChoice `|||`)==
+  *
+  * {{{
+  *                  b : B
+  *                    |
+  *                classify  (Squelching: runs only if downstream emits)
+  *                    |
+  *             Either[Unit, A]
+  *               /         \
+  *           Left(())     Right(a)
+  *               |             |
+  *           squelch        this.use   <-- only emits on Right
+  *               |             |
+  *               v             v
+  *              Unit          Unit
+  * }}}
+  *
+  * Each test below is self-contained. Read them in order; the comments tell you what the test is
+  * demonstrating and which diagram it maps to.
+  */
+class ContraTracerDemo extends AnyFunSuite:
+
+    // --- helpers ------------------------------------------------------------
+
+    /** A leaf sink that appends every emitted string to `buf`. */
+    private def bufferSink(buf: ListBuffer[String]): ContraTracer[IO, String] =
+        ContraTracer.emit[IO, String](s => IO { val _ = buf += s })
+
+    /** Pattern-matches the underlying TracerA constructor — useful for verifying the composition
+      * algebra above without running anything.
+      */
+    private def tag[A](t: ContraTracer[IO, A]): String = t.runTracer match
+        case TracerA.Emitting(_, _) => "Emitting"
+        case TracerA.Squelching(_)  => "Squelching"
+
+    // --- Demo 1: leaf emit --------------------------------------------------
+
+    test("Demo 1 — leaf emit reaches the sink") {
+        // ContraTracer.emit lifts a `String => IO[Unit]` into an Emitting tracer.
+        // traceWith runs the underlying Kleisli on the given input.
+        val buf = ListBuffer.empty[String]
+        val sink = bufferSink(buf)
+
+        sink.traceWith("hello").unsafeRunSync()
+
+        assert(buf.toList == List("hello") && tag(sink) == "Emitting")
+    }
+
+    // --- Demo 2: nullTracer -------------------------------------------------
+
+    test("Demo 2 — nullTracer is silent (the Monoid identity)") {
+        // nullTracer is built from TracerA.squelch — the whole arrow is dropped
+        // by runTracerA, so traceWith is a no-op. It is also `Monoid.empty`.
+        val buf = ListBuffer.empty[String]
+        val sink: ContraTracer[IO, String] = nullTracer
+
+        sink.traceWith("ignored").unsafeRunSync()
+
+        assert(buf.isEmpty && tag(sink) == "Squelching")
+    }
+
+    // --- Demo 3: contramap --------------------------------------------------
+
+    test("Demo 3 — contramap adapts the input type") {
+        // Contravariant.contramap turns a ContraTracer[M, A] into a
+        // ContraTracer[M, B] using a pure `B => A`. Internally this is
+        //     compute(f) >>> tracer.use   (i.e. Squelching >>> Emitting)
+        // which the composition table tells us is Emitting.
+        val buf = ListBuffer.empty[String]
+        val stringSink = bufferSink(buf)
+        val intSink: ContraTracer[IO, Int] = stringSink.contramap(_.toString)
+
+        intSink.traceWith(42).unsafeRunSync()
+
+        // Squelching >>> Emitting = Emitting
+        assert(buf.toList == List("42") && tag(intSink) == "Emitting")
+    }
+
+    // --- Demo 4: Semigroup combine -----------------------------------------
+
+    test("Demo 4 — Semigroup combine fans out to both sinks") {
+        // tr1 |+| tr2 == ContraTracer((tr1.use &&& tr2.use) >>> arrDiscard).
+        // Both sinks see the same input, and the (Unit, Unit) pair is dropped.
+        val bufA = ListBuffer.empty[String]
+        val bufB = ListBuffer.empty[String]
+        val fanout = bufferSink(bufA) |+| bufferSink(bufB)
+
+        fanout.traceWith("once").unsafeRunSync()
+
+        assert(bufA.toList == List("once") && bufB.toList == List("once"))
+    }
+
+    // --- Demo 5: laziness proof  (Learn by Doing) --------------------------
+
+    test("Demo 5 — laziness proof (your contribution)") {
+        // We instrument the upstream stage's effect with a counter so we can
+        // observe *whether the body actually ran*. The Emitting/Squelching
+        // tag controls whether `runTracerA` keeps or drops the whole arrow.
+        val upstreamSideEffects = new AtomicInteger(0)
+        val sinkBuf = ListBuffer.empty[String]
+
+        val liveSink: ContraTracer[IO, String] =
+            ContraTracer.emit(s => IO { val _ = sinkBuf += s })
+
+        // Stage that adapts `Int => String` via an IO effect. Crucially, this
+        // is built from `TracerA.effect(...)` which is *Squelching*. When
+        // composed with a Squelching downstream the whole chain stays
+        // Squelching and `runTracerA` drops it. When composed with an
+        // Emitting downstream, the squelch is absorbed and the chain emits.
+        def withUpstream(downstream: ContraTracer[IO, String]): ContraTracer[IO, Int] =
+            downstream.contramapM[Int](i =>
+                IO { val _ = upstreamSideEffects.incrementAndGet(); i.toString }
+            )
+
+        val liveChain = withUpstream(liveSink)
+        val nullChain = withUpstream(nullTracer[IO, String])
+
+        // Live downstream: the chain is Emitting, so the upstream body runs (counter -> 1)
+        // and its output reaches the sink.
+        liveChain.traceWith(42).unsafeRunSync()
+        val liveEmitted =
+            sinkBuf.toList == List("42") && upstreamSideEffects.get == 1 &&
+                tag(liveChain) == "Emitting"
+
+        // Squelching downstream: the whole chain is Squelching, so runTracerA drops it and the
+        // contramapM body is never run — the counter does NOT advance (stays 1). This is the
+        // guarantee SLF4J cannot make: a squelched tracer evaluates none of its upstream work.
+        nullChain.traceWith(99).unsafeRunSync()
+        val squelchedNothing = upstreamSideEffects.get == 1 && tag(nullChain) == "Squelching"
+
+        assert(liveEmitted && squelchedNothing)
+    }
+
+    // --- Demo 6: traceAll over a Foldable ----------------------------------
+
+    test("Demo 6 — traceAll fans out across a Foldable") {
+        // traceAll(f: B => T[A]) = traceTraversable contramap f.
+        // For each element of the resulting collection, the sink fires once.
+        val buf = ListBuffer.empty[String]
+        val sink = bufferSink(buf)
+
+        // Pass each element of a List[String] to `sink`.
+        val listSink: ContraTracer[IO, List[String]] = sink.traceAll(identity)
+        listSink.traceWith(List("a", "b", "c")).unsafeRunSync()
+
+        // The Foldable variant has an explicit Squelching short-circuit:
+        // a null upstream collapses to nullTracer rather than iterating.
+        val nullList: ContraTracer[IO, List[String]] =
+            nullTracer[IO, String].traceAll(identity)
+        assert(buf.toList == List("a", "b", "c") && tag(nullList) == "Squelching")
+    }
+
+    // --- Demo 7: composition algebra --------------------------------------
+
+    test("Demo 7 — the composition table holds in practice") {
+        // Verify each row of the algebra by pattern-matching the resulting
+        // TracerA constructor after composing in the four configurations.
+        val buf = ListBuffer.empty[String]
+        val emittingSink: ContraTracer[IO, String] = bufferSink(buf)
+        val squelchingSink: ContraTracer[IO, String] = nullTracer
+
+        // contramap is `Squelching >>> tracer`, so its output tag mirrors the
+        // tag of `tracer`. Use this to construct each cell of the table.
+        val sqOverSq: ContraTracer[IO, Int] = squelchingSink.contramap(_.toString)
+        val sqOverEm: ContraTracer[IO, Int] = emittingSink.contramap(_.toString)
+
+        // For the "Emitting upstream" rows, build an emitting stage via
+        // ContraTracer.emit and `|+|` with a downstream sink — combine
+        // produces Emitting whenever *either* branch is Emitting.
+        val emittingStage: ContraTracer[IO, String] =
+            ContraTracer.emit(_ => IO.unit)
+
+        assert(
+          tag(sqOverSq) == "Squelching" && // Sq >>> Sq = Sq
+              tag(sqOverEm) == "Emitting" && // Sq >>> Em = Em
+              tag(emittingStage |+| squelchingSink) == "Emitting" && // Em + Sq
+              tag(emittingStage |+| emittingSink) == "Emitting" // Em + Em
+        )
+    }
+
+    // --- Demo 8 (bonus): natTracer ----------------------------------------
+
+    test("Demo 8 — natTracer changes the underlying monad") {
+        // natTracer applies a natural transformation `M ~> N` to every
+        // Kleisli inside the arrow. Here we lift an IO tracer through the
+        // identity natural transformation IO ~> IO just to show the
+        // mechanics; in real code you might lift IO into a Kleisli/Reader
+        // stack with IO at the base.
+        val buf = ListBuffer.empty[String]
+        val sink = bufferSink(buf)
+        val ioToIo: IO ~> IO = new (IO ~> IO) { def apply[A](fa: IO[A]): IO[A] = fa }
+        val lifted: ContraTracer[IO, String] = sink.natTracer(ioToIo)
+
+        lifted.traceWith("through-nat").unsafeRunSync()
+
+        assert(buf.toList == List("through-nat"))
+    }

--- a/src/test/scala/hydrozoa/lib/logging/Slf4jTracerTest.scala
+++ b/src/test/scala/hydrozoa/lib/logging/Slf4jTracerTest.scala
@@ -1,0 +1,48 @@
+package hydrozoa.lib.logging
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import cats.syntax.all.*
+import java.util.concurrent.atomic.AtomicInteger
+import org.scalatest.funsuite.AnyFunSuite
+import scala.collection.mutable.ListBuffer
+
+/** The level gate: [[Slf4jTracer.sink]] forces a [[LogEvent]]'s deferred `render` — the message
+  * interpolation and any `toString` inside it — only when the routing key's logger has the event's
+  * level enabled. See `logback-test.xml` for the `hydrozoa.test.gated.*` fixtures.
+  */
+class Slf4jTracerTest extends AnyFunSuite:
+
+    test("a disabled level forces no rendering; an enabled level does") {
+        val renders = new AtomicInteger(0)
+        def event(routingKey: String): LogEvent =
+            LogEvent(
+              Level.Debug,
+              { val _ = renders.incrementAndGet(); "message" }, // by-name: runs only if forced
+              routingKey = Some(routingKey)
+            )
+
+        // OFF in logback-test.xml -> isDebugEnabled == false -> the sink squelches, render not forced.
+        Slf4jTracer.sink.traceWith(event("hydrozoa.test.gated.off")).unsafeRunSync()
+        val afterOff = renders.get
+
+        // DEBUG in logback-test.xml -> isDebugEnabled == true -> render forced exactly once.
+        Slf4jTracer.sink.traceWith(event("hydrozoa.test.gated.on")).unsafeRunSync()
+        val afterOn = renders.get
+
+        assert(afterOff == 0 && afterOn == 1)
+    }
+
+    test("the gate wraps only the slf4j leg: a composed capture sink still fires") {
+        val captured = ListBuffer.empty[Int]
+        val capture: ContraTracer[IO, Int] = ContraTracer.emit(i => IO { val _ = captured += i })
+
+        // The slf4j leg formats to a LogEvent at a disabled level; the capture leg is separate.
+        val slf4jLeg: ContraTracer[IO, Int] =
+            Slf4jTracer.sink.contramap(i =>
+                LogEvent(Level.Debug, i.toString, routingKey = Some("hydrozoa.test.gated.off"))
+            )
+
+        (slf4jLeg |+| capture).traceWith(7).unsafeRunSync()
+        assert(captured.toList == List(7)) // capture fired even though the slf4j leg was gated off
+    }

--- a/src/test/scala/hydrozoa/lib/logging/Slf4jTracerTest.scala
+++ b/src/test/scala/hydrozoa/lib/logging/Slf4jTracerTest.scala
@@ -5,6 +5,8 @@ import cats.effect.unsafe.implicits.global
 import cats.syntax.all.*
 import java.util.concurrent.atomic.AtomicInteger
 import org.scalatest.funsuite.AnyFunSuite
+import org.slf4j.LoggerFactory // scalafix:ok DisableSyntax
+import org.slf4j.helpers.SubstituteLoggerFactory // scalafix:ok DisableSyntax
 import scala.collection.mutable.ListBuffer
 
 /** The level gate: [[Slf4jTracer.sink]] forces a [[LogEvent]]'s deferred `render` — the message
@@ -13,7 +15,29 @@ import scala.collection.mutable.ListBuffer
   */
 class Slf4jTracerTest extends AnyFunSuite:
 
+    /** Block until SLF4J has finished installing the real backend.
+      *
+      * Until then `LoggerFactory` hands out substitute loggers, and a substitute reports **every**
+      * level as enabled for **every** name — so a gate decision taken in that window opens no
+      * matter what `logback-test.xml` says. Production never notices, because it reads the output
+      * and the substitute is swapped for the real logger before anything is written; these tests do
+      * notice, because they read the *decision* rather than the output.
+      *
+      * Without this the suite passes alone and fails under `parallelExecution` — another suite
+      * touching a logger first leaves this one measuring mid-initialization.
+      *
+      * `getILoggerFactory` initializes synchronously when nothing else has started; the loop covers
+      * the case where another thread is already doing it, since that call then returns the
+      * substitute factory rather than waiting.
+      */
+    private def awaitBackendReady(): Unit =
+        val deadlineNanos = System.nanoTime() + 5_000_000_000L
+        while LoggerFactory.getILoggerFactory.isInstanceOf[SubstituteLoggerFactory]
+            && System.nanoTime() < deadlineNanos
+        do Thread.sleep(1)
+
     test("a disabled level forces no rendering; an enabled level does") {
+        awaitBackendReady()
         val renders = new AtomicInteger(0)
         def event(routingKey: String): LogEvent =
             LogEvent(
@@ -34,6 +58,7 @@ class Slf4jTracerTest extends AnyFunSuite:
     }
 
     test("the gate wraps only the slf4j leg: a composed capture sink still fires") {
+        awaitBackendReady()
         val captured = ListBuffer.empty[Int]
         val capture: ContraTracer[IO, Int] = ContraTracer.emit(i => IO { val _ = captured += i })
 


### PR DESCRIPTION
Stacked on #684 (bases on `peter/logging-remove-module`). Second of the logging overhaul; the infra half of the level-aware work.

## Why

The sink rendered every event eagerly and let Logback filter by level *afterward* — so a debug event's message (interpolation, domain `toString`, scalus `ByteString` hex) was built even when debug was off. `ContraTracer` (an arrow port of avieth/contra-tracer) can genuinely **skip** all downstream work when squelched, unlike SLF4J which evaluates its argument regardless of level. Nothing wired that to the log level; this does.

## What

- **`LogEventTyped` splits** into eager `level`/`routingKey` (the gate needs them) and a deferred `render: Eval[Rendered]` (msg + ctx + cause).
- **`LogEvent`'s `msg` is by-name**, captured into the `Eval`. So the interpolation — and any `toString` inside it — is deferred at *every* construction site (`From.*` and direct `LogEvent(...)`), with **no call-site changes**. `Slf4jMsg` carries its message as `Eval` too.
- **`levelGated` wrapper**: `sink = rawEmit.levelGated`, where `levelGated = squelchUnlessM(ev => isEnabled(routingKey, level))` and `isEnabled` is a per-trace `org.slf4j` `isEnabled` check (re-queried so runtime Logback level changes are honored; no logback cast). When the level is disabled, the arrow squelches and `render.value` is never forced — no message/`toString` runs. Behaviour at the *output* is unchanged (Logback already filtered by level); the win is that disabled events do no rendering work.
- **Gate wraps only the slf4j leg**, so `Slf4jTracer.sink.contramap(fmt) |+| capture` capture legs always fire (test included).
- The only `org.slf4j` references are the two lines in `Slf4jTracer.scala`, both `// scalafix:ok DisableSyntax` per #684's rule.

## Tests

- Revives `ContraTracerDemo` (deleted in `598dbaff`) and completes its **Demo 5 laziness proof**: an `AtomicInteger` upstream counter advances through a live sink and **does not advance** through `nullTracer` (the squelch drops the whole arrow).
- `Slf4jTracerTest`: a disabled level forces no rendering (counter stays 0), an enabled level forces it exactly once, and a `|+|` capture sink still fires when the slf4j leg is gated off.

## Follow-up (PR-2b)

Per-call `extra` context is still eager (it's varargs). The next PR — the 21 event conversions to carry raw domain objects — also makes `extra` by-name to close the last deferral gap. The expensive vector (the message) is already deferred here.

`just precommit` and `just build-werror` pass.