### PR TITLE
Events carry raw domain objects (rendered, deferred, in the format)

### DIFF
--- a/integration/src/test/scala/hydrozoa/integration/harness/RestartAfterBlocksTest.scala
+++ b/integration/src/test/scala/hydrozoa/integration/harness/RestartAfterBlocksTest.scala
@@ -36,19 +36,23 @@ import scala.concurrent.duration.*
   */
 class RestartAfterBlocksTest extends AnyFunSuite {
 
-    /** Every case here is `ignore`, not `test`, and must stay that way until finding #57 is fixed.
+    /** Every case here is `ignore`, not `test`, pending one timed run that confirms the suite
+      * finishes.
       *
-      * The scenario itself is sound and the fixes it guards are real — but it does not finish. A
-      * thread dump of a run that looked deadlocked showed 31 parked workers and one thread inside
-      * `TestControl.tickOne` -> `CardanoLiaison.runEffects` -> `State.prettyDump` -> `stripMargin`:
-      * progressing, microscopically. `runEffects` builds that whole debug dump **eagerly** as an
-      * argument to `traceWith`, formatting the entire effect index on every liaison tick whether or
-      * not the trace is emitted, so cost grows with accumulated effects. A restarted peer is the
-      * worst case, because `CardanoLiaison.State.recover` rebuilds the full index.
+      * The scenario is sound and the fixes it guards are real. What stalled it was cost, not a
+      * deadlock: a thread dump of a run that looked wedged showed 31 parked workers and one thread
+      * inside `TestControl.tickOne` -> `CardanoLiaison.runEffects` -> `State.prettyDump` ->
+      * `stripMargin`, progressing microscopically. The dump was built for every liaison tick
+      * whether or not the trace was emitted, so cost grew with accumulated effects, and a restarted
+      * peer is the worst case because `CardanoLiaison.State.recover` rebuilds the full index.
       *
-      * This module is run by `integration/testOnly *` in CI, and CI has wedged in this suite before
-      * — five times, for up to six hours each. Enabling these before the eager dump is fixed would
-      * reintroduce exactly that failure, so they stay disabled rather than merely slow.
+      * That cost is gone. The dump now rides on `CardanoLiaisonEvent.CurrentL1State`, which renders
+      * at TRACE inside the format, and this module pins `CardanoLiaison` at DEBUG
+      * (`integration/src/test/resources/logback-test.xml`), so it never runs.
+      *
+      * The reason to keep them disabled is now narrower: CI has wedged in this suite five times,
+      * for up to six hours each, and nothing has yet measured a full run with the dump gone. Time
+      * one locally, then flip these to `test` — do not flip them on the strength of the fix alone.
       */
 
     /** Virtual time the head runs before the restart, so the victim has real history to recover. */

--- a/src/main/scala/hydrozoa/lib/logging/Slf4jMsg.scala
+++ b/src/main/scala/hydrozoa/lib/logging/Slf4jMsg.scala
@@ -1,6 +1,6 @@
 package hydrozoa.lib.logging
 
-import cats.Monad
+import cats.{Eval, Monad}
 
 /** A small generic message ADT for call sites that don't merit a typed event of their own —
   * typically app entry points (`hydrozoa.app.*`) and test scaffolding. Production actors and shared
@@ -8,30 +8,51 @@ import cats.Monad
   *
   * Pair with [[Slf4jMsgFormat.humanFormat]] to lift into [[LogEvent]] under a fixed routing key.
   * The extension methods on `ContraTracer[F, Slf4jMsg]` give `log.info("…")` ergonomics for any
-  * `F[_]: Monad` — typically `IO` (via [[Slf4jTracer.sink]]).
+  * `F[_]: Monad` — typically `IO` (via [[Slf4jTracer.sink]]). The message is held behind an `Eval`
+  * so it is not rendered unless the level is enabled (see [[Slf4jTracer.sink]]).
   */
 sealed trait Slf4jMsg
 
 object Slf4jMsg:
-    final case class Trace(msg: String) extends Slf4jMsg
-    final case class Debug(msg: String) extends Slf4jMsg
-    final case class Info(msg: String) extends Slf4jMsg
-    final case class Warn(msg: String) extends Slf4jMsg
-    final case class Error(msg: String, cause: Option[Throwable] = None) extends Slf4jMsg
+    final case class Trace(msg: Eval[String]) extends Slf4jMsg
+    final case class Debug(msg: Eval[String]) extends Slf4jMsg
+    final case class Info(msg: Eval[String]) extends Slf4jMsg
+    final case class Warn(msg: Eval[String]) extends Slf4jMsg
+    final case class Error(msg: Eval[String], cause: Option[Throwable] = None) extends Slf4jMsg
 
-/** Lift a [[Slf4jMsg]] into a [[LogEvent]] under [[routingKey]]. */
+/** Lift a [[Slf4jMsg]] into a [[LogEvent]] under [[routingKey]], keeping the message deferred. */
 object Slf4jMsgFormat:
     def humanFormat(routingKey: String)(m: Slf4jMsg): LogEvent = m match
         case Slf4jMsg.Trace(msg) =>
-            LogEvent(Level.Trace, msg, routingKey = Some(routingKey))
+            LogEventTyped(
+              Level.Trace,
+              Some(routingKey),
+              msg.map(Rendered(_, Map.empty[String, String]))
+            )
         case Slf4jMsg.Debug(msg) =>
-            LogEvent(Level.Debug, msg, routingKey = Some(routingKey))
+            LogEventTyped(
+              Level.Debug,
+              Some(routingKey),
+              msg.map(Rendered(_, Map.empty[String, String]))
+            )
         case Slf4jMsg.Info(msg) =>
-            LogEvent(Level.Info, msg, routingKey = Some(routingKey))
+            LogEventTyped(
+              Level.Info,
+              Some(routingKey),
+              msg.map(Rendered(_, Map.empty[String, String]))
+            )
         case Slf4jMsg.Warn(msg) =>
-            LogEvent(Level.Warn, msg, routingKey = Some(routingKey))
+            LogEventTyped(
+              Level.Warn,
+              Some(routingKey),
+              msg.map(Rendered(_, Map.empty[String, String]))
+            )
         case Slf4jMsg.Error(msg, cause) =>
-            LogEvent(Level.Error, msg, cause = cause, routingKey = Some(routingKey))
+            LogEventTyped(
+              Level.Error,
+              Some(routingKey),
+              msg.map(Rendered(_, Map.empty[String, String], cause))
+            )
 
 /** Logger-like extension on a `ContraTracer[F, Slf4jMsg]`. Build the tracer once at construction
   * time, then call `log.info / warn / error / debug / trace` at the call sites:
@@ -45,9 +66,9 @@ object Slf4jMsgFormat:
   * }}}
   */
 extension [F[_]: Monad](t: ContraTracer[F, Slf4jMsg])
-    def trace(msg: => String): F[Unit] = t.traceWith(Slf4jMsg.Trace(msg))
-    def debug(msg: => String): F[Unit] = t.traceWith(Slf4jMsg.Debug(msg))
-    def info(msg: => String): F[Unit] = t.traceWith(Slf4jMsg.Info(msg))
-    def warn(msg: => String): F[Unit] = t.traceWith(Slf4jMsg.Warn(msg))
+    def trace(msg: => String): F[Unit] = t.traceWith(Slf4jMsg.Trace(Eval.later(msg)))
+    def debug(msg: => String): F[Unit] = t.traceWith(Slf4jMsg.Debug(Eval.later(msg)))
+    def info(msg: => String): F[Unit] = t.traceWith(Slf4jMsg.Info(Eval.later(msg)))
+    def warn(msg: => String): F[Unit] = t.traceWith(Slf4jMsg.Warn(Eval.later(msg)))
     def error(msg: => String, cause: Option[Throwable] = None): F[Unit] =
-        t.traceWith(Slf4jMsg.Error(msg, cause))
+        t.traceWith(Slf4jMsg.Error(Eval.later(msg), cause))

--- a/src/main/scala/hydrozoa/lib/logging/Slf4jMsg.scala
+++ b/src/main/scala/hydrozoa/lib/logging/Slf4jMsg.scala
@@ -23,36 +23,25 @@ object Slf4jMsg:
 /** Lift a [[Slf4jMsg]] into a [[LogEvent]] under [[routingKey]], keeping the message deferred. */
 object Slf4jMsgFormat:
     def humanFormat(routingKey: String)(m: Slf4jMsg): LogEvent = m match
-        case Slf4jMsg.Trace(msg) =>
-            LogEventTyped(
-              Level.Trace,
-              Some(routingKey),
-              msg.map(Rendered(_, Map.empty[String, String]))
-            )
-        case Slf4jMsg.Debug(msg) =>
-            LogEventTyped(
-              Level.Debug,
-              Some(routingKey),
-              msg.map(Rendered(_, Map.empty[String, String]))
-            )
-        case Slf4jMsg.Info(msg) =>
-            LogEventTyped(
-              Level.Info,
-              Some(routingKey),
-              msg.map(Rendered(_, Map.empty[String, String]))
-            )
-        case Slf4jMsg.Warn(msg) =>
-            LogEventTyped(
-              Level.Warn,
-              Some(routingKey),
-              msg.map(Rendered(_, Map.empty[String, String]))
-            )
-        case Slf4jMsg.Error(msg, cause) =>
-            LogEventTyped(
-              Level.Error,
-              Some(routingKey),
-              msg.map(Rendered(_, Map.empty[String, String], cause))
-            )
+        case Slf4jMsg.Trace(msg)        => lift(routingKey, Level.Trace, msg)
+        case Slf4jMsg.Debug(msg)        => lift(routingKey, Level.Debug, msg)
+        case Slf4jMsg.Info(msg)         => lift(routingKey, Level.Info, msg)
+        case Slf4jMsg.Warn(msg)         => lift(routingKey, Level.Warn, msg)
+        case Slf4jMsg.Error(msg, cause) => lift(routingKey, Level.Error, msg, cause)
+
+    // `msg` is already an `Eval[String]`, so mapping over it keeps the render deferred; a `Slf4jMsg`
+    // carries no context, hence the empty ctx.
+    private def lift(
+        routingKey: String,
+        level: Level,
+        msg: Eval[String],
+        cause: Option[Throwable] = None
+    ): LogEvent =
+        LogEventTyped(
+          level,
+          Some(routingKey),
+          msg.map(Rendered(_, Map.empty[String, String], cause))
+        )
 
 /** Logger-like extension on a `ContraTracer[F, Slf4jMsg]`. Build the tracer once at construction
   * time, then call `log.info / warn / error / debug / trace` at the call sites:

--- a/src/main/scala/hydrozoa/lib/logging/Slf4jTracer.scala
+++ b/src/main/scala/hydrozoa/lib/logging/Slf4jTracer.scala
@@ -49,12 +49,16 @@ object LogEvent {
       * Extra context pairs passed as varargs are merged with the base [[ctx]].
       */
     final class From(val ctx: Map[String, String], val routingKey: Option[String]):
+        // `msg` is by-name and lives in the deferred `Rendered`, so the message — the expensive
+        // vector, where any domain `toString` sits — is not built unless the level is enabled. The
+        // `extra` context is evaluated eagerly, but it only ever carries cheap primitives
+        // (block/stack numbers, request ids); deferring it too would buy nothing.
         private def helper(
             loggingLevel: Level,
             msg: => String,
             extra: (String, String)*
         ): LogEvent =
-            LogEvent(loggingLevel, msg, ctx ++ extra, routingKey = routingKey)
+            LogEventTyped(loggingLevel, routingKey, deferred(msg, ctx ++ extra))
 
         def trace(msg: => String, extra: (String, String)*): LogEvent =
             helper(Level.Trace, msg, extra*)

--- a/src/main/scala/hydrozoa/lib/logging/Slf4jTracer.scala
+++ b/src/main/scala/hydrozoa/lib/logging/Slf4jTracer.scala
@@ -1,48 +1,61 @@
 package hydrozoa.lib.logging
 
+import cats.Eval
 import cats.effect.IO
+import java.util.concurrent.ConcurrentHashMap
 import org.typelevel.log4cats.Logger // scalafix:ok DisableSyntax
 import org.typelevel.log4cats.slf4j.Slf4jLogger // scalafix:ok DisableSyntax
 
 enum Level:
     case Trace, Debug, Info, Warn, Error
 
+/** A [[LogEventTyped]]'s deferred payload: the message, context, and cause. Held behind an `Eval`
+  * so none of it — the message interpolation, the context values, `toString` on domain objects — is
+  * computed unless the event's level is enabled (see [[Slf4jTracer.levelGated]]). The event's
+  * [[LogEventTyped.level]] and [[LogEventTyped.routingKey]] stay eager because the gate needs them.
+  */
+final case class Rendered[A](msg: String, ctx: A, cause: Option[Throwable] = None)
+
 case class LogEventTyped[A](
     level: Level,
-    msg: String,
-    ctx: A,
-    cause: Option[Throwable] = None,
     /** SLF4J logger name used to route to the correct Logback appender/level config. `None` means
       * "fall back to the default Hydrozoa logger." For typed events that always emit through the
       * same logger, `EventFormat.humanFormat` fills in `Some(...)` per event variant.
       */
-    routingKey: Option[String] = None
+    routingKey: Option[String],
+    render: Eval[Rendered[A]]
 )
 
 type LogEvent = LogEventTyped[Map[String, String]]
 
 object LogEvent {
+
+    /** `msg` is by-name and captured into the deferred [[LogEventTyped.render]], so the
+      * interpolation (and any `toString` inside it) runs only if the level is enabled — at every
+      * call site, `From.*` and direct `LogEvent(...)` alike.
+      */
     def apply(
         level: Level,
-        msg: String,
+        msg: => String,
         ctx: Map[String, String] = Map.empty,
         cause: Option[Throwable] = None,
         routingKey: Option[String] = None
-    ): LogEventTyped[Map[String, String]] = LogEventTyped(level, msg, ctx, cause, routingKey)
+    ): LogEventTyped[Map[String, String]] =
+        LogEventTyped(level, routingKey, Eval.later(Rendered(msg, ctx, cause)))
 
     /** Partially-applied factory: fixes [[ctx]] and [[routingKey]] for a set of related events.
       * Extra context pairs passed as varargs are merged with the base [[ctx]].
       */
     final class From(val ctx: Map[String, String], val routingKey: Option[String]):
-        def trace(msg: String, extra: (String, String)*): LogEvent =
+        def trace(msg: => String, extra: (String, String)*): LogEvent =
             LogEvent(Level.Trace, msg, ctx ++ extra, routingKey = routingKey)
-        def debug(msg: String, extra: (String, String)*): LogEvent =
+        def debug(msg: => String, extra: (String, String)*): LogEvent =
             LogEvent(Level.Debug, msg, ctx ++ extra, routingKey = routingKey)
-        def info(msg: String, extra: (String, String)*): LogEvent =
+        def info(msg: => String, extra: (String, String)*): LogEvent =
             LogEvent(Level.Info, msg, ctx ++ extra, routingKey = routingKey)
-        def warn(msg: String, extra: (String, String)*): LogEvent =
+        def warn(msg: => String, extra: (String, String)*): LogEvent =
             LogEvent(Level.Warn, msg, ctx ++ extra, routingKey = routingKey)
-        def error(msg: String): LogEvent =
+        def error(msg: => String): LogEvent =
             LogEvent(Level.Error, msg, ctx, routingKey = routingKey)
 
     object From:
@@ -61,27 +74,39 @@ type Slf4jTracer = ContraTracer[IO, LogEvent]
 
 object Slf4jTracer:
 
-    /** SLF4J sink — routes [[LogEvent]] to the correct logger via [[LogEvent.routingKey]]. Build
-      * per-component tracers with `Slf4jTracer.sink.contramap(MyEventFormat.humanFormat(...))`.
+    /** SLF4J sink, **gated on the target logger's level**: an event whose level is disabled never
+      * forces its [[LogEventTyped.render]] and never reaches SLF4J. The render is handed to
+      * log4cats **by-name**, and its `contextLog` (`F.delay(if (isEnabled) log())`) forces it only
+      * when the routing key's logger has the level enabled — so a single check gates it, with no
+      * separate `ContraTracer` gate to run its own `isEnabled` and re-look-up the logger. Build
+      * per-component tracers with `Slf4jTracer.sink.contramap(MyEventFormat.humanFormat(...))`;
+      * compose capture sinks with `|+|` — they are separate legs, so a disabled slf4j leg never
+      * squelches them.
       */
-    val sink: ContraTracer[IO, LogEvent] = ContraTracer.emit((ev: LogEvent) =>
+    val sink: ContraTracer[IO, LogEvent] = ContraTracer.emit { (ev: LogEvent) =>
         val lg = loggerIO(ev.routingKey.getOrElse("hydrozoa"))
-        val msg = renderMsg(ev)
+        def msg = renderMsg(ev.render.value) // by-name: forced only when the level is enabled
         ev.level match
             case Level.Trace => lg.trace(msg)
             case Level.Debug => lg.debug(msg)
             case Level.Info  => lg.info(msg)
             case Level.Warn  => lg.warn(msg)
-            case Level.Error => ev.cause.fold(lg.error(msg))(lg.error(_)(msg))
-    )
+            // Error carries a cause, which lives in the (now forced) render; error is effectively
+            // always enabled, so forcing it here rather than by-name costs nothing in practice.
+            case Level.Error =>
+                val r = ev.render.value
+                r.cause.fold(lg.error(renderMsg(r)))(lg.error(_)(renderMsg(r)))
+    }
 
-    /** The one SLF4J bridge in the codebase. Everything else logs through a `ContraTracer` and
-      * reaches SLF4J via [[sink]]; the `DisableSyntax` rule in `.scalafix.conf` keeps it that way.
+    /** log4cats loggers cached per routing key: `getLoggerFromName` allocates a fresh wrapper on
+      * every call, and routing keys are a small fixed set, so memoise to keep the sink from
+      * allocating one per emit. This is the one SLF4J bridge in the codebase; the `DisableSyntax`
+      * rule in `.scalafix.conf` keeps it that way.
       */
-    private def loggerIO(name: String): Logger[IO] = Slf4jLogger.getLoggerFromName[IO](name)
+    private lazy val loggers = new ConcurrentHashMap[String, Logger[IO]]()
+    private def loggerIO(name: String): Logger[IO] =
+        loggers.computeIfAbsent(name, n => Slf4jLogger.getLoggerFromName[IO](n))
 
-    private def renderMsg(ev: LogEvent): String =
-        val prefix =
-            if ev.ctx.isEmpty then ""
-            else "[" + ev.ctx.map((k, v) => s"$k=$v").mkString(" ") + "] "
-        prefix + ev.msg
+    private def renderMsg(r: Rendered[Map[String, String]]): String =
+        if r.ctx.isEmpty then r.msg
+        else "[" + r.ctx.map((k, v) => s"$k=$v").mkString(" ") + "] " + r.msg

--- a/src/main/scala/hydrozoa/lib/logging/Slf4jTracer.scala
+++ b/src/main/scala/hydrozoa/lib/logging/Slf4jTracer.scala
@@ -9,12 +9,9 @@ import org.typelevel.log4cats.slf4j.Slf4jLogger // scalafix:ok DisableSyntax
 enum Level:
     case Trace, Debug, Info, Warn, Error
 
-/** A [[LogEventTyped]]'s deferred payload: the message, context, and cause. Held behind an `Eval`
-  * so none of it — the message interpolation, the context values, `toString` on domain objects — is
-  * computed unless the event's level is enabled (see [[Slf4jTracer.levelGated]]). The event's
-  * [[LogEventTyped.level]] and [[LogEventTyped.routingKey]] stay eager because the gate needs them.
+/** A [[LogEventTyped]]'s deferred payload. See [[LogEvent.deferred]]
   */
-final case class Rendered[A](msg: String, ctx: A, cause: Option[Throwable] = None)
+final case class Rendered[A] private[logging] (msg: String, ctx: A, cause: Option[Throwable] = None)
 
 case class LogEventTyped[A](
     level: Level,
@@ -30,10 +27,15 @@ type LogEvent = LogEventTyped[Map[String, String]]
 
 object LogEvent {
 
-    /** `msg` is by-name and captured into the deferred [[LogEventTyped.render]], so the
-      * interpolation (and any `toString` inside it) runs only if the level is enabled — at every
-      * call site, `From.*` and direct `LogEvent(...)` alike.
+    /** Wrap a by-name message (plus context and cause) in the deferred [[Rendered]] payload.
       */
+    private[logging] def deferred[A](
+        msg: => String,
+        ctx: A,
+        cause: Option[Throwable] = None
+    ): Eval[Rendered[A]] =
+        Eval.later(Rendered(msg, ctx, cause))
+
     def apply(
         level: Level,
         msg: => String,
@@ -41,22 +43,29 @@ object LogEvent {
         cause: Option[Throwable] = None,
         routingKey: Option[String] = None
     ): LogEventTyped[Map[String, String]] =
-        LogEventTyped(level, routingKey, Eval.later(Rendered(msg, ctx, cause)))
+        LogEventTyped(level, routingKey, deferred(msg, ctx, cause))
 
     /** Partially-applied factory: fixes [[ctx]] and [[routingKey]] for a set of related events.
       * Extra context pairs passed as varargs are merged with the base [[ctx]].
       */
     final class From(val ctx: Map[String, String], val routingKey: Option[String]):
+        private def helper(
+            loggingLevel: Level,
+            msg: => String,
+            extra: (String, String)*
+        ): LogEvent =
+            LogEvent(loggingLevel, msg, ctx ++ extra, routingKey = routingKey)
+
         def trace(msg: => String, extra: (String, String)*): LogEvent =
-            LogEvent(Level.Trace, msg, ctx ++ extra, routingKey = routingKey)
+            helper(Level.Trace, msg, extra*)
         def debug(msg: => String, extra: (String, String)*): LogEvent =
-            LogEvent(Level.Debug, msg, ctx ++ extra, routingKey = routingKey)
+            helper(Level.Debug, msg, extra*)
         def info(msg: => String, extra: (String, String)*): LogEvent =
-            LogEvent(Level.Info, msg, ctx ++ extra, routingKey = routingKey)
+            helper(Level.Info, msg, extra*)
         def warn(msg: => String, extra: (String, String)*): LogEvent =
-            LogEvent(Level.Warn, msg, ctx ++ extra, routingKey = routingKey)
+            helper(Level.Warn, msg, extra*)
         def error(msg: => String): LogEvent =
-            LogEvent(Level.Error, msg, ctx, routingKey = routingKey)
+            helper(Level.Error, msg)
 
     object From:
         def apply(ctx: Map[String, String], routingKey: String): From =

--- a/src/main/scala/hydrozoa/multisig/consensus/CardanoLiaison.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/CardanoLiaison.scala
@@ -439,6 +439,51 @@ object CardanoLiaison:
 
     case object PreStart
 
+    // ===================================
+    // Actions
+    // ===================================
+
+    /** The set of effects the actor may want to execute against L1. Lives here (not in the trait
+      * body) so [[CardanoLiaisonEvent.ActionsDispatched]] can carry it raw and the format renders
+      * it.
+      */
+    sealed trait Action
+    sealed trait DirectAction extends Action
+
+    // TODO: narrow these element types beyond `EnrichedTx[?]` — the construction sites already
+    // carry concrete subtypes:
+    //   - FallbackToRuleBased.tx        => FallbackTx
+    //   - PushForwardMultisig.txs       => Seq[SettlementTx | FinalizationTx | RolloutTx]
+    //   - Rollout.txs                   => Seq[RolloutTx]
+    //   - InitializeHead.txs            => Seq[HappyPathEffect]
+    // Tightening these makes the `.tx` strip at the construction sites a compile error rather
+    // than a code-review catch (the "throwing away useful information too early" pattern that
+    // motivated this refactor).
+    object Action {
+
+        /** Switching into the rule-based regime. */
+        final case class FallbackToRuleBased(tx: FallbackTx) extends DirectAction
+
+        /** Pushing the existing state in the multisig regime forward. */
+        final case class PushForwardMultisig(txs: Seq[EnrichedTx[?]]) extends DirectAction
+
+        /** Finalizing a rollout sequence. */
+        final case class Rollout(txs: Seq[EnrichedTx[?]]) extends DirectAction
+
+        /** Represents noop action that may occur when the current time falls into the silence
+          * period - the gap between a treasury's two disjoint validity windows, when the
+          * settlement/finalization tx already expired but the fallback is not valid yet.
+          */
+        final case class SilencePeriodNoop(
+            currentTime: QuantizedInstant,
+            happyPathTxTtl: QuantizedInstant,
+            fallbackValidityStart: FallbackTxStartTime
+        ) extends DirectAction {}
+
+        /** Like [[PushForwardMultisig]] but starting from the initialization tx. */
+        final case class InitializeHead(txs: Seq[EnrichedTx[?]]) extends Action
+    }
+
 end CardanoLiaison
 
 trait CardanoLiaison(
@@ -560,7 +605,7 @@ trait CardanoLiaison(
             _ <- tracer.traceWith(CardanoLiaisonEvent.InitialStackEffectsLearned)
             newState <- stateRef.updateAndGet(State.applyInitialEffects(_, eff))
             _ <- advanceNodeStatus(nodeStatusOf(newState.targetState))
-            _ <- tracer.traceWith(CardanoLiaisonEvent.InitialStackEffectsState(newState.prettyDump))
+            _ <- tracer.traceWith(CardanoLiaisonEvent.InitialStackEffectsState(newState))
         } yield ()
 
     /** Learn a hard-confirmed stack's L1 effects into the submission state machine.
@@ -640,15 +685,15 @@ trait CardanoLiaison(
                     case v: DisjointWindowViolation =>
                         tracer.traceWith(
                           CardanoLiaisonEvent.DisjointWindowViolation(
-                            v.treasuryUtxo.toString,
-                            v.happyPathTtl.toString,
-                            v.fallbackValidityStart.toString
+                            v.treasuryUtxo,
+                            v.happyPathTtl,
+                            v.fallbackValidityStart
                           )
                         )
                 }
                 _ <- stateRef.set(newState)
                 _ <- advanceNodeStatus(nodeStatusOf(newState.targetState))
-                _ <- tracer.traceWith(CardanoLiaisonEvent.StackEffectsState(newState.prettyDump))
+                _ <- tracer.traceWith(CardanoLiaisonEvent.StackEffectsState(newState))
             } yield ()
         }
     }
@@ -699,11 +744,7 @@ trait CardanoLiaison(
                     currentTime <- IO.realTime.map(_.toEpochQuantizedInstant(config.slotConfig))
 
                     _ <- tracer.traceWith(
-                      CardanoLiaisonEvent.CurrentL1State(
-                        currentTime.toString,
-                        utxoIds.mkString(","),
-                        state.prettyDump
-                      )
+                      CardanoLiaisonEvent.CurrentL1State(currentTime, utxoIds, state)
                     )
 
                     // (i.e. those that are directly caused by effect inputs in L1 response).
@@ -740,7 +781,7 @@ trait CardanoLiaison(
                             )
                         tracer.traceWith(
                           CardanoLiaisonEvent.ActionsDispatched(
-                            actionsToSubmit.map(_.msg).toList,
+                            actionsToSubmit.toList,
                             hasFallback
                           )
                         )
@@ -797,14 +838,14 @@ trait CardanoLiaison(
                     // action above.
                     tracer.traceWith(
                       CardanoLiaisonEvent
-                          .TargetUtxoStatus(targetTreasuryUtxoId.toString, found = true)
+                          .TargetUtxoStatus(targetTreasuryUtxoId, found = true)
                     ) >> IO.pure(Seq.empty)
                 else
                     // The treasury is gone: either we fell into the rule-based regime, or an L1
                     // rollback took it. Steps (3)/(4) tell those apart.
                     tracer.traceWith(
                       CardanoLiaisonEvent
-                          .TargetUtxoStatus(targetTreasuryUtxoId.toString, found = false)
+                          .TargetUtxoStatus(targetTreasuryUtxoId, found = false)
                     ) >> handoffOrResubmit(state, currentTime)
 
             case TargetState.Finalized(finalizationTxHash) =>
@@ -818,13 +859,13 @@ trait CardanoLiaison(
                     case Right(true) =>
                         tracer.traceWith(
                           CardanoLiaisonEvent
-                              .FinalizationTxStatus(finalizationTxHash.toString, "known")
+                              .FinalizationTxStatus(finalizationTxHash, isKnown = true)
                         ) >> IO.pure(Seq.empty)
                     // Not on L1 — possible rollback of the finalization; fall to steps (3)/(4).
                     case Right(false) =>
                         tracer.traceWith(
                           CardanoLiaisonEvent
-                              .FinalizationTxStatus(finalizationTxHash.toString, "not known")
+                              .FinalizationTxStatus(finalizationTxHash, isKnown = false)
                         ) >> handoffOrResubmit(state, currentTime)
                 }
         }
@@ -884,20 +925,20 @@ trait CardanoLiaison(
                     case Right(true) =>
                         // Head is established — leave recovery to the direct-action path.
                         tracer.traceWith(
-                          CardanoLiaisonEvent.InitTxStatus(initTx.tx.id.toString, "known")
+                          CardanoLiaisonEvent.InitTxStatus(initTx.tx.id, isKnown = true)
                         ) >> IO.pure(Seq.empty)
                     case Right(false) =>
                         val initEnd = initTx.initializationTxEndTime.convert
                         if currentTime < initEnd then
                             tracer.traceWith(
-                              CardanoLiaisonEvent.InitTxStatus(initTx.tx.id.toString, "not known")
+                              CardanoLiaisonEvent.InitTxStatus(initTx.tx.id, isKnown = false)
                             ) >> IO.pure(
                               Seq(Action.InitializeHead(state.happyPathEffects.values.toSeq))
                             )
                         else
                             tracer.traceWith(
                               CardanoLiaisonEvent
-                                  .InitWindowElapsed(currentTime.toString, initEnd.toString)
+                                  .InitWindowElapsed(currentTime, initEnd)
                             ) >> IO.pure(Seq.empty)
                 }
             case _ =>
@@ -918,48 +959,6 @@ trait CardanoLiaison(
             )
             .map(_.map(_.keySet.headOption))
 
-    // ===================================
-    // Actions
-    // ===================================
-
-    /** The set of effects the actor may want to execute against L1. */
-    sealed trait Action
-    sealed trait DirectAction extends Action
-
-    // TODO: narrow these element types beyond `EnrichedTx[?]` — the construction sites already
-    // carry concrete subtypes:
-    //   - FallbackToRuleBased.tx        => FallbackTx
-    //   - PushForwardMultisig.txs       => Seq[SettlementTx | FinalizationTx | RolloutTx]
-    //   - Rollout.txs                   => Seq[RolloutTx]
-    //   - InitializeHead.txs            => Seq[HappyPathEffect]
-    // Tightening these makes the `.tx` strip at the construction sites a compile error rather
-    // than a code-review catch (the "throwing away useful information too early" pattern that
-    // motivated this refactor). HappyPathEffect would need to be promoted out of the trait body.
-    object Action {
-
-        /** Switching into the rule-based regime. */
-        final case class FallbackToRuleBased(tx: FallbackTx) extends DirectAction
-
-        /** Pushing the existing state in the multisig regime forward. */
-        final case class PushForwardMultisig(txs: Seq[EnrichedTx[?]]) extends DirectAction
-
-        /** Finalizing a rollout sequence. */
-        final case class Rollout(txs: Seq[EnrichedTx[?]]) extends DirectAction
-
-        /** Represents noop action that may occur when the current time falls into the silence
-          * period - the gap between a treasury's two disjoint validity windows, when the
-          * settlement/finalization tx already expired but the fallback is not valid yet.
-          */
-        final case class SilencePeriodNoop(
-            currentTime: QuantizedInstant,
-            happyPathTxTtl: QuantizedInstant,
-            fallbackValidityStart: FallbackTxStartTime
-        ) extends DirectAction {}
-
-        /** Like [[PushForwardMultisig]] but starting from the initialization tx. */
-        final case class InitializeHead(txs: Seq[EnrichedTx[?]]) extends Action
-    }
-
     private def actionTxs(action: Action): Seq[EnrichedTx[?]] = action match {
         case Action.FallbackToRuleBased(tx)    => Seq(tx)
         case Action.PushForwardMultisig(txs)   => txs
@@ -967,18 +966,6 @@ trait CardanoLiaison(
         case Action.SilencePeriodNoop(_, _, _) => Seq.empty
         case Action.InitializeHead(txs)        => txs
     }
-
-    extension (action: Action)
-
-        private def msg: String =
-            import Action.*
-            action match {
-                case FallbackToRuleBased(tx)         => s"FallbackToRuleBased (${tx.tx.id})"
-                case PushForwardMultisig(txs)        => s"PushForwardMultisig (${txs.map(_.tx.id)}"
-                case Rollout(txs)                    => s"Rollout (${txs.map(_.tx.id)}"
-                case sp @ SilencePeriodNoop(_, _, _) => s"$sp"
-                case InitializeHead(txs)             => s"InitializeHead (${txs.map(_.tx.id)}"
-            }
 
     /** A polled utxo classified as a due direct-action trigger, so [[mkDirectAction]] is total over
       * well-formed inputs. [[triggerFor]] owns the malformed combinations: a utxo that is neither

--- a/src/main/scala/hydrozoa/multisig/consensus/CardanoLiaisonEvent.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/CardanoLiaisonEvent.scala
@@ -1,7 +1,8 @@
 package hydrozoa.multisig.consensus
 
+import hydrozoa.lib.cardano.scalus.QuantizedTime.QuantizedInstant
 import hydrozoa.multisig.ledger.stack.StackNumber
-import scalus.cardano.ledger.TransactionHash
+import scalus.cardano.ledger.{TransactionHash, TransactionInput}
 
 /** Typed events emitted by [[CardanoLiaison]]. Pure data; formatters in
   * [[CardanoLiaisonEventFormat]] decide how each variant is rendered to a particular sink.
@@ -19,7 +20,8 @@ object CardanoLiaisonEvent:
       */
     case object InitialStackEffectsLearned extends CardanoLiaisonEvent
 
-    final case class InitialStackEffectsState(stateDump: String) extends CardanoLiaisonEvent
+    final case class InitialStackEffectsState(state: CardanoLiaison.State)
+        extends CardanoLiaisonEvent
 
     case object MinorOnlyStackReceived extends CardanoLiaisonEvent
 
@@ -34,14 +36,17 @@ object CardanoLiaisonEvent:
         hasFinalization: Boolean
     ) extends CardanoLiaisonEvent
 
-    final case class StackEffectsState(stateDump: String) extends CardanoLiaisonEvent
+    final case class StackEffectsState(state: CardanoLiaison.State) extends CardanoLiaisonEvent
 
     case object RunEffectsStarted extends CardanoLiaisonEvent
 
     final case class L1StateQueryError(err: String) extends CardanoLiaisonEvent
 
-    final case class CurrentL1State(time: String, utxoIds: String, stateDump: String)
-        extends CardanoLiaisonEvent
+    final case class CurrentL1State(
+        time: QuantizedInstant,
+        utxoIds: Set[TransactionInput],
+        state: CardanoLiaison.State
+    ) extends CardanoLiaisonEvent
 
     final case class CriticalError(msg: String) extends CardanoLiaisonEvent
 
@@ -50,7 +55,8 @@ object CardanoLiaisonEvent:
       */
     case object NoDirectActions extends CardanoLiaisonEvent
 
-    final case class TargetUtxoStatus(targetId: String, found: Boolean) extends CardanoLiaisonEvent
+    final case class TargetUtxoStatus(targetId: TransactionInput, found: Boolean)
+        extends CardanoLiaisonEvent
 
     /** The hard-confirmed init tx could not be submitted because its (config-baked) validity window
       * has already elapsed (`currentTime >= initializationTxEndTime`): the head can no longer be
@@ -58,10 +64,11 @@ object CardanoLiaisonEvent:
       * generation (which anchors the window) and stack-0 hard-confirmation — e.g. a long
       * restart/debug cycle.
       */
-    final case class InitWindowElapsed(currentTime: String, endTime: String)
+    final case class InitWindowElapsed(currentTime: QuantizedInstant, endTime: QuantizedInstant)
         extends CardanoLiaisonEvent
 
-    final case class FinalizationTxStatus(hash: String, isKnown: String) extends CardanoLiaisonEvent
+    final case class FinalizationTxStatus(hash: TransactionHash, isKnown: Boolean)
+        extends CardanoLiaisonEvent
 
     final case class FinalizationTxQueryError(err: String) extends CardanoLiaisonEvent
 
@@ -70,15 +77,16 @@ object CardanoLiaisonEvent:
       * after emitting this.
       */
     final case class DisjointWindowViolation(
-        treasuryUtxo: String,
-        happyPathTtl: String,
-        fallbackValidityStart: String
+        treasuryUtxo: TransactionInput,
+        happyPathTtl: QuantizedInstant,
+        fallbackValidityStart: QuantizedInstant
     ) extends CardanoLiaisonEvent
 
     /** Whether the init tx is on L1, probed (step 4) when the target anchor is missing and no
       * rule-based treasury exists. `isKnown == "not known"` triggers a full skeleton re-submission.
       */
-    final case class InitTxStatus(hash: String, isKnown: String) extends CardanoLiaisonEvent
+    final case class InitTxStatus(hash: TransactionHash, isKnown: Boolean)
+        extends CardanoLiaisonEvent
 
     final case class InitTxQueryError(err: String) extends CardanoLiaisonEvent
 
@@ -90,7 +98,7 @@ object CardanoLiaisonEvent:
     /** Some actions will be submitted to L1. `hasFallback` true means at least one is a fallback or
       * silence-period noop (logged at warn level).
       */
-    final case class ActionsDispatched(msgs: List[String], hasFallback: Boolean)
+    final case class ActionsDispatched(actions: List[CardanoLiaison.Action], hasFallback: Boolean)
         extends CardanoLiaisonEvent
 
     /** The rule-based treasury has been observed on L1 and the handoff to the rule-based regime has

--- a/src/main/scala/hydrozoa/multisig/consensus/CardanoLiaisonEvent.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/CardanoLiaisonEvent.scala
@@ -83,7 +83,7 @@ object CardanoLiaisonEvent:
     ) extends CardanoLiaisonEvent
 
     /** Whether the init tx is on L1, probed (step 4) when the target anchor is missing and no
-      * rule-based treasury exists. `isKnown == "not known"` triggers a full skeleton re-submission.
+      * rule-based treasury exists. `isKnown == false` triggers a full skeleton re-submission.
       */
     final case class InitTxStatus(hash: TransactionHash, isKnown: Boolean)
         extends CardanoLiaisonEvent

--- a/src/main/scala/hydrozoa/multisig/consensus/CardanoLiaisonEventFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/CardanoLiaisonEventFormat.scala
@@ -69,7 +69,7 @@ object CardanoLiaisonEventFormat:
             case RuleBasedTreasuryQueryError(err) =>
                 error(s"error when probing the rule-based treasury: $err")
             case ActionsDispatched(actions, hasFallback) =>
-                val text =
+                def text =
                     "Liaison's actions:" + actions.map(a => s"\n\t- ${actionMsg(a)}").mkString
                 if hasFallback then warn(text) else info(text)
             case FallbackToRuleBasedDispatched(txId) =>
@@ -88,7 +88,7 @@ object CardanoLiaisonEventFormat:
         import Action.*
         action match
             case FallbackToRuleBased(tx)         => s"FallbackToRuleBased (${tx.tx.id})"
-            case PushForwardMultisig(txs)        => s"PushForwardMultisig (${txs.map(_.tx.id)}"
-            case Rollout(txs)                    => s"Rollout (${txs.map(_.tx.id)}"
+            case PushForwardMultisig(txs)        => s"PushForwardMultisig (${txs.map(_.tx.id)})"
+            case Rollout(txs)                    => s"Rollout (${txs.map(_.tx.id)})"
             case sp @ SilencePeriodNoop(_, _, _) => s"$sp"
-            case InitializeHead(txs)             => s"InitializeHead (${txs.map(_.tx.id)}"
+            case InitializeHead(txs)             => s"InitializeHead (${txs.map(_.tx.id)})"

--- a/src/main/scala/hydrozoa/multisig/consensus/CardanoLiaisonEventFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/CardanoLiaisonEventFormat.scala
@@ -1,6 +1,7 @@
 package hydrozoa.multisig.consensus
 
 import hydrozoa.lib.logging.LogEvent
+import hydrozoa.multisig.consensus.CardanoLiaison.{DisjointWindowViolation as _, *}
 import hydrozoa.multisig.consensus.CardanoLiaisonEvent.*
 import hydrozoa.multisig.consensus.peer.HeadPeerNumber
 
@@ -17,22 +18,24 @@ object CardanoLiaisonEventFormat:
                 info(s"received Stack.HardConfirmed for stack $stackNum")
             case InitialStackEffectsLearned =>
                 info("initial stack effects learned; overriding unsigned init tx + fallback")
-            case InitialStackEffectsState(dump) =>
-                trace(s"state after initial-stack effects: $dump")
+            case InitialStackEffectsState(state) =>
+                trace(s"state after initial-stack effects: ${state.prettyDump}")
             case MinorOnlyStackReceived =>
                 info("minor-only stack: no backbone L1 effects to submit; nothing to do")
             case StackEffectsLearned(settlements, fallbacks, rollouts, hasFinalization) =>
                 info(
                   s"stack effects learned: ${settlements}s ${fallbacks}fb ${rollouts}ro finalization=$hasFinalization"
                 )
-            case StackEffectsState(dump) =>
-                trace(s"state after stack effects: $dump")
+            case StackEffectsState(state) =>
+                trace(s"state after stack effects: ${state.prettyDump}")
             case RunEffectsStarted =>
                 trace("entering `runEffects`")
             case L1StateQueryError(err) =>
                 error(s"error when getting Cardano L1 state: $err")
-            case CurrentL1State(time, utxoIds, dump) =>
-                trace(s"current time=$time utxoIds=$utxoIds state=$dump")
+            case CurrentL1State(time, utxoIds, state) =>
+                trace(
+                  s"current time=$time utxoIds=${utxoIds.mkString(",")} state=${state.prettyDump}"
+                )
             case CriticalError(msg) =>
                 error(s"Critical error: $msg")
             case NoDirectActions =>
@@ -48,7 +51,9 @@ object CardanoLiaisonEventFormat:
                       " happy path — regenerate head-config or widen the init window"
                 )
             case FinalizationTxStatus(hash, isKnown) =>
-                trace(s"finalizationTx: hash=$hash known=$isKnown")
+                trace(
+                  s"finalizationTx: hash=$hash known=${if isKnown then "known" else "not known"}"
+                )
             case FinalizationTxQueryError(err) =>
                 error(s"error when getting finalization tx info: $err")
             case DisjointWindowViolation(treasuryUtxo, happyPathTtl, fallbackValidityStart) =>
@@ -58,13 +63,14 @@ object CardanoLiaisonEventFormat:
                       " timing; stopping the liaison"
                 )
             case InitTxStatus(hash, isKnown) =>
-                trace(s"initTx: hash=$hash known=$isKnown")
+                trace(s"initTx: hash=$hash known=${if isKnown then "known" else "not known"}")
             case InitTxQueryError(err) =>
                 error(s"error when getting init tx info: $err")
             case RuleBasedTreasuryQueryError(err) =>
                 error(s"error when probing the rule-based treasury: $err")
-            case ActionsDispatched(msgs, hasFallback) =>
-                val text = "Liaison's actions:" + msgs.map(m => s"\n\t- $m").mkString
+            case ActionsDispatched(actions, hasFallback) =>
+                val text =
+                    "Liaison's actions:" + actions.map(a => s"\n\t- ${actionMsg(a)}").mkString
                 if hasFallback then warn(text) else info(text)
             case FallbackToRuleBasedDispatched(txId) =>
                 warn(s"FallbackToRuleBased dispatched: $txId — head entering rule-based regime")
@@ -74,3 +80,15 @@ object CardanoLiaisonEventFormat:
                 trace(s"Submission errors (generally ignored): $count")
         }
     }
+
+    /** Render one [[CardanoLiaison.Action]] for logging — relocated from the actor so the event can
+      * carry raw actions and this runs only when the level is enabled.
+      */
+    private def actionMsg(action: Action): String =
+        import Action.*
+        action match
+            case FallbackToRuleBased(tx)         => s"FallbackToRuleBased (${tx.tx.id})"
+            case PushForwardMultisig(txs)        => s"PushForwardMultisig (${txs.map(_.tx.id)}"
+            case Rollout(txs)                    => s"Rollout (${txs.map(_.tx.id)}"
+            case sp @ SilencePeriodNoop(_, _, _) => s"$sp"
+            case InitializeHead(txs)             => s"InitializeHead (${txs.map(_.tx.id)}"

--- a/src/main/scala/hydrozoa/multisig/consensus/SlowConsensusActor.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/SlowConsensusActor.scala
@@ -206,7 +206,7 @@ final case class SlowConsensusActor(
             round2Stash = Map.empty
           )
         )
-        _ <- tracer.traceWith(SlowConsensusActorEvent.StackHandedOff(stackNum, "2-phase"))
+        _ <- tracer.traceWith(SlowConsensusActorEvent.StackHandedOff(stackNum, twoPhase = true))
         _ <- broadcast(ownR1._1)
         _ <- replayOrphans(stackNum)
         _ <- tryAdvance(stackNum)
@@ -226,7 +226,7 @@ final case class SlowConsensusActor(
           stackNum,
           Cell.WaitingSole(unsigned = unsigned, sole = Map(ownPeer -> ownSole._2))
         )
-        _ <- tracer.traceWith(SlowConsensusActorEvent.StackHandedOff(stackNum, "sole"))
+        _ <- tracer.traceWith(SlowConsensusActorEvent.StackHandedOff(stackNum, twoPhase = false))
         _ <- broadcast(ownSole._1)
         _ <- replayOrphans(stackNum)
         _ <- tryAdvance(stackNum)

--- a/src/main/scala/hydrozoa/multisig/consensus/SlowConsensusActorEvent.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/SlowConsensusActorEvent.scala
@@ -13,7 +13,7 @@ object SlowConsensusActorEvent:
     /** Stack handed off from StackComposer: own acks verified, cell created, own acks broadcast.
       * `phase` is `"2-phase"` or `"sole"`.
       */
-    final case class StackHandedOff(stackNum: StackNumber, phase: String)
+    final case class StackHandedOff(stackNum: StackNumber, twoPhase: Boolean)
         extends SlowConsensusActorEvent
 
     /** Round-1 saturated: all peers' round-1 acks collected; own round-2 ack released. */

--- a/src/main/scala/hydrozoa/multisig/consensus/SlowConsensusActorEvent.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/SlowConsensusActorEvent.scala
@@ -11,7 +11,7 @@ sealed trait SlowConsensusActorEvent
 object SlowConsensusActorEvent:
 
     /** Stack handed off from StackComposer: own acks verified, cell created, own acks broadcast.
-      * `phase` is `"2-phase"` or `"sole"`.
+      * `twoPhase` distinguishes the two-phase handoff from the sole-peer one.
       */
     final case class StackHandedOff(stackNum: StackNumber, twoPhase: Boolean)
         extends SlowConsensusActorEvent

--- a/src/main/scala/hydrozoa/multisig/consensus/SlowConsensusActorEventFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/SlowConsensusActorEventFormat.scala
@@ -11,9 +11,11 @@ object SlowConsensusActorEventFormat:
         val ev = LogEvent.From.forPeer("SlowConsensusActor", peerNum)
         import ev.*
         e match {
-            case StackHandedOff(sn, phase) =>
+            case StackHandedOff(sn, twoPhase) =>
                 info(
-                  s"stack $sn handed off ($phase); broadcasting own acks",
+                  s"stack $sn handed off (${
+                          if twoPhase then "2-phase" else "sole"
+                      }); broadcasting own acks",
                   "stackNum" -> s"${sn: Int}"
                 )
             case Round1Confirmed(sn) =>

--- a/src/main/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonEvent.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonEvent.scala
@@ -9,6 +9,11 @@ import cats.Eval
   * One event type covers all three liaison kinds — they speak the same batch protocol, and the
   * per-liaison / per-remote identity comes from the wiring layer's `contramap` wrapper (e.g.
   * `HeadMultisigRegimeManagerEvent.PL`), not from separate event ADTs.
+  *
+  * [[BatchRequested]] and [[BatchReceived]] are the exception to "pure data": their `detail` is an
+  * `Eval`, which compares by reference, so those two variants have no value equality. Two of them
+  * with the same `batchNum` and identical detail text are unequal — do not assert on them by
+  * construction, and do not `distinct` or dedupe a collection of them.
   */
 sealed trait PeerLiaisonEvent
 

--- a/src/main/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonEvent.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonEvent.scala
@@ -1,5 +1,7 @@
 package hydrozoa.multisig.consensus.liaison
 
+import cats.Eval
+
 /** Typed events emitted by the liaison actors ([[PeerLiaisonHeadToHead]], [[PeerLiaisonCoilToHub]],
   * [[PeerLiaisonHubToCoil]]) and their shared [[Puller]] engine. Pure data; formatters in
   * [[PeerLiaisonEventFormat]] decide how each variant is rendered to a particular sink.
@@ -19,13 +21,15 @@ object PeerLiaisonEvent:
       * `detail` summarizes the requested cursors — including the backpressure `requestCeiling` — so
       * the mesh's request-flow throttling is visible. High-frequency: DEBUG.
       */
-    final case class BatchRequested(batchNum: BatchNumber, detail: String) extends PeerLiaisonEvent
+    final case class BatchRequested(batchNum: BatchNumber, detail: Eval[String])
+        extends PeerLiaisonEvent
 
     /** A `NewMsgBatch` reply accepted from the remote. `detail` summarizes the per-lane payload
       * (requests / soft-ack / block / …) so co-arriving lanes are visible — e.g. requests and acks
       * delivered in the same batch. High-frequency: DEBUG.
       */
-    final case class BatchReceived(batchNum: BatchNumber, detail: String) extends PeerLiaisonEvent
+    final case class BatchReceived(batchNum: BatchNumber, detail: Eval[String])
+        extends PeerLiaisonEvent
 
     /** A reply whose batch number does not match the outstanding request — a stale duplicate the
       * [[Puller]] drops.

--- a/src/main/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonEventFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonEventFormat.scala
@@ -22,9 +22,9 @@ object PeerLiaisonEventFormat:
             case Started =>
                 info(s"starting, remote peer: $remoteLabel")
             case BatchRequested(batchNum, detail) =>
-                debug(s"-> GetMsgBatch=$batchNum $detail")
+                debug(s"-> GetMsgBatch=$batchNum ${detail.value}")
             case BatchReceived(batchNum, detail) =>
-                debug(s"<- NewMsgBatch=$batchNum $detail")
+                debug(s"<- NewMsgBatch=$batchNum ${detail.value}")
             case StaleBatchDropped(received, outstanding) =>
                 debug(s"dropping stale reply batch=$received (outstanding=$outstanding)")
             case BatchRejected(batchNum, reason) =>

--- a/src/main/scala/hydrozoa/multisig/consensus/liaison/Puller.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/liaison/Puller.scala
@@ -1,5 +1,6 @@
 package hydrozoa.multisig.consensus.liaison
 
+import cats.Eval
 import cats.effect.{IO, Ref}
 import hydrozoa.lib.logging.ContraTracer
 
@@ -53,7 +54,7 @@ final class Puller[G, N](
     /** Send a pull, tracing it as a `BatchRequested` (covers initial, retransmit, and next). */
     private def sendTraced(g: G): IO[Unit] =
         tracer.traceWith(
-          PeerLiaisonEvent.BatchRequested(numberOfBatchRequest(g), describeGet(g))
+          PeerLiaisonEvent.BatchRequested(numberOfBatchRequest(g), Eval.later(describeGet(g)))
         ) >> send(g)
 
     /** Send the initial request, rebuilt from the current inbound cursors. After a crash the lanes
@@ -96,7 +97,7 @@ final class Puller[G, N](
                             _ <- tracer.traceWith(
                               PeerLiaisonEvent.BatchReceived(
                                 numberOfBatch(received),
-                                describeBatch(received)
+                                Eval.later(describeBatch(received))
                               )
                             )
                             next <- buildGet(numberOfBatchRequest(outstanding).increment)

--- a/src/main/scala/hydrozoa/multisig/consensus/limiter/Limiter.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/limiter/Limiter.scala
@@ -158,9 +158,8 @@ final case class Limiter[Msg](
     ): IO[Limiter.State[Msg]] =
         if st.holdStartedMs.isDefined then IO.pure(st)
         else
-            val name = t.getClass.getSimpleName
             for {
-                _ <- tracer.traceWith(LimiterEvent.HoldingMsg(name, waitMs))
+                _ <- tracer.traceWith(LimiterEvent.HoldingMsg(t.getClass, waitMs))
                 _ <- if gate.isEmpty then IO.unit else IO(metrics.foreach(_.onBlockGateHold()))
                 now <- IO.monotonic.map(_.toMillis)
                 updated <- stateRef.updateAndGet(_.copy(holdStartedMs = Some(now)))

--- a/src/main/scala/hydrozoa/multisig/consensus/limiter/LimiterEvent.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/limiter/LimiterEvent.scala
@@ -8,8 +8,10 @@ sealed trait LimiterEvent
 object LimiterEvent:
     case object Started extends LimiterEvent
 
-    /** Emitted once when a hold begins, not once per slice. */
-    final case class HoldingMsg(msgType: String, holdMs: Long) extends LimiterEvent
+    /** Emitted once when a hold begins, not once per slice. The message's class travels raw; the
+      * formatter decides how to name it.
+      */
+    final case class HoldingMsg(msgClass: Class[?], holdMs: Long) extends LimiterEvent
 
     /** The backlog gate re-derived its multiplier from a completed downstream cycle. */
     final case class GateUpdated(backlog: Long, residual: Double, multiplier: Double)

--- a/src/main/scala/hydrozoa/multisig/consensus/limiter/LimiterEventFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/limiter/LimiterEventFormat.scala
@@ -11,8 +11,9 @@ object LimiterEventFormat:
         val ev = LogEvent.From(Map.empty, s"Limiter.$label")
         import ev.*
         e match {
-            case Started           => debug(s"Limiter[$label] started.")
-            case HoldingMsg(t, ms) => debug(s"Limiter[$label] holding $t for ${ms}ms")
+            case Started => debug(s"Limiter[$label] started.")
+            case HoldingMsg(t, ms) =>
+                debug(s"Limiter[$label] holding ${t.getSimpleName} for ${ms}ms")
             case GateUpdated(backlog, residual, m) =>
                 debug(
                   f"Limiter[$label] gate: backlog=$backlog residual=$residual%.1f multiplier=$m%.3f"

--- a/src/main/scala/hydrozoa/multisig/consensus/transport/CoilPeerWsTransport.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/transport/CoilPeerWsTransport.scala
@@ -49,7 +49,7 @@ final class CoilPeerWsTransport private (
     override def send(request: LiaisonProtocol.HubToCoilRequest): IO[Unit] =
         CoilFrame.fromWire(request) match {
             case Some(wire) => outbox.offer(CoilFrame.encode(CoilFrame.Msg(wire)))
-            case None       => tracer.traceWith(DroppingNonWireRequest(request.toString))
+            case None       => tracer.traceWith(DroppingNonWireRequest(request))
         }
 
     private def dispatchInbound(payload: CoilFrame.Wire): IO[Unit] =
@@ -60,7 +60,7 @@ final class CoilPeerWsTransport private (
                     case Some(liaison) => liaison ! p
                     case None          => tracer.traceWith(NoLiaisonForInbound)
                 }
-            case other => tracer.traceWith(UnexpectedInboundWire(other.toString))
+            case other => tracer.traceWith(UnexpectedInboundWire(other))
         }
 
     private def onLine(s: String): IO[Unit] =

--- a/src/main/scala/hydrozoa/multisig/consensus/transport/CoilPeerWsTransportEvent.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/transport/CoilPeerWsTransportEvent.scala
@@ -1,5 +1,6 @@
 package hydrozoa.multisig.consensus.transport
 
+import hydrozoa.multisig.consensus.liaison.LiaisonProtocol
 import org.http4s.Uri
 
 /** Typed events emitted by [[CoilPeerWsTransport]]. Pure data; formatters in
@@ -12,7 +13,8 @@ object CoilPeerWsTransportEvent:
     // ---- send ----
 
     /** `send` was called with a request variant that cannot be serialised over the wire. */
-    final case class DroppingNonWireRequest(request: String) extends CoilPeerWsTransportEvent
+    final case class DroppingNonWireRequest(request: LiaisonProtocol.HubToCoilRequest)
+        extends CoilPeerWsTransportEvent
 
     // ---- inbound dispatch ----
 
@@ -20,7 +22,7 @@ object CoilPeerWsTransportEvent:
     case object NoLiaisonForInbound extends CoilPeerWsTransportEvent
 
     /** Received an inbound wire payload from the hub that is not in the hub-emitted subset. */
-    final case class UnexpectedInboundWire(payload: String) extends CoilPeerWsTransportEvent
+    final case class UnexpectedInboundWire(payload: CoilFrame.Wire) extends CoilPeerWsTransportEvent
 
     /** A frame received on the active dialer connection could not be decoded. */
     final case class DecodeError(cause: Throwable) extends CoilPeerWsTransportEvent

--- a/src/main/scala/hydrozoa/multisig/consensus/transport/HubWsTransport.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/transport/HubWsTransport.scala
@@ -62,7 +62,7 @@ final class HubWsTransport private (
                     case None    => tracer.traceWith(NoOutboxForCoil(coil))
                 }
             case None =>
-                tracer.traceWith(DroppingNonWireRequest(coil, request.toString))
+                tracer.traceWith(DroppingNonWireRequest(coil, request))
         }
 
     private def dispatchInbound(coil: CoilPeerNumber, payload: CoilFrame.Wire): IO[Unit] =
@@ -76,7 +76,7 @@ final class HubWsTransport private (
                     }
                 }
             case other =>
-                tracer.traceWith(UnexpectedInboundWire(coil, other.toString))
+                tracer.traceWith(UnexpectedInboundWire(coil, other))
         }
 
     private def serverHandler(wsb: WebSocketBuilder2[IO]): IO[org.http4s.Response[IO]] =

--- a/src/main/scala/hydrozoa/multisig/consensus/transport/HubWsTransportEvent.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/transport/HubWsTransportEvent.scala
@@ -1,5 +1,6 @@
 package hydrozoa.multisig.consensus.transport
 
+import hydrozoa.multisig.consensus.liaison.LiaisonProtocol
 import hydrozoa.multisig.consensus.peer.CoilPeerNumber
 
 /** Typed events emitted by [[HubWsTransport]]. Pure data; formatters in
@@ -15,14 +16,16 @@ object HubWsTransportEvent:
     final case class NoOutboxForCoil(coil: CoilPeerNumber) extends HubWsTransportEvent
 
     /** `send` was called with a request variant that cannot be serialised over the wire. */
-    final case class DroppingNonWireRequest(coil: CoilPeerNumber, request: String)
-        extends HubWsTransportEvent
+    final case class DroppingNonWireRequest(
+        coil: CoilPeerNumber,
+        request: LiaisonProtocol.CoilToHubRequest
+    ) extends HubWsTransportEvent
 
     /** An inbound frame arrived from a coil peer that has no registered local liaison. */
     final case class NoLiaisonForInbound(coil: CoilPeerNumber) extends HubWsTransportEvent
 
     /** Received an inbound wire payload from a coil peer that is not in the coil-emitted subset. */
-    final case class UnexpectedInboundWire(coil: CoilPeerNumber, payload: String)
+    final case class UnexpectedInboundWire(coil: CoilPeerNumber, payload: CoilFrame.Wire)
         extends HubWsTransportEvent
 
     // ---- server (accept side) ----

--- a/src/main/scala/hydrozoa/multisig/ledger/joint/JointLedger.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/joint/JointLedger.scala
@@ -473,7 +473,7 @@ final case class JointLedger(
                     p.nextBlockNumber,
                     blockCreationEndTime,
                     p.competingFallbackTxTime,
-                    split.toString
+                    split
                   )
                 )
 

--- a/src/main/scala/hydrozoa/multisig/ledger/joint/JointLedgerEvent.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/joint/JointLedgerEvent.scala
@@ -5,7 +5,7 @@ import hydrozoa.config.head.multisig.timing.TxTimingEvent
 import hydrozoa.multisig.ledger.block.{BlockBrief, BlockHeader, BlockHeaderEvent, BlockNumber}
 import hydrozoa.multisig.ledger.event.RequestId
 import hydrozoa.multisig.ledger.event.RequestId.ValidityFlag
-import hydrozoa.multisig.ledger.l1.deposits.map.DepositsMapEvent
+import hydrozoa.multisig.ledger.l1.deposits.map.{DepositsMap, DepositsMapEvent}
 
 /** Typed events emitted by [[JointLedger]]. Pure data; formatters in [[JointLedgerEventFormat]]
   * decide how each variant is rendered to a particular sink (SLF4J text, JSONL protocol trace,
@@ -56,7 +56,7 @@ object JointLedgerEvent:
         blockNum: BlockNumber,
         endTime: BlockCreationEndTime,
         competingFallbackTxTime: FallbackTxStartTime,
-        splitDescription: String
+        split: DepositsMap.Split
     ) extends JointLedgerEvent
 
     /** Verbose debug dump of the inputs to brief construction. */

--- a/src/main/scala/hydrozoa/rulebased/RuleBasedActor.scala
+++ b/src/main/scala/hydrozoa/rulebased/RuleBasedActor.scala
@@ -224,7 +224,7 @@ final case class RuleBasedActor(
                 case Left(e) => raiseError(e)
             }
             _ <- traceRight(
-              RuleBasedActorEvent.Treasury.Found(treasuryUtxo.treasuryOutput.value.toString)
+              RuleBasedActorEvent.Treasury.Found(treasuryUtxo.treasuryOutput.value)
             )
             _ <- traceRight(RuleBasedActorEvent.Treasury.Parsing)
             _ <- treasuryUtxo.treasuryOutput.datum match {
@@ -346,7 +346,7 @@ final case class RuleBasedActor(
             _ <- tracer.traceWith(
               RuleBasedActorEvent.Evacuation.CandidateMaps(
                 s"$latest",
-                candidateEvacMaps.keySet.map(k => s"$k").toList
+                candidateEvacMaps.keySet
               )
             )
         } yield EvacuationInputs(candidateEvacMaps, fallbackTxHash)
@@ -408,7 +408,7 @@ final case class RuleBasedActor(
             ): IO[Either[StackNumber, TransactionHash]] =
                 tracer
                     .traceWith(
-                      RuleBasedActorEvent.Evacuation.EvacuationAnchor(label, s"$txId")
+                      RuleBasedActorEvent.Evacuation.EvacuationAnchor(label, txId)
                     )
                     .as(Right(txId))
             persistence.get(StoreKey.HardConfirmation(stack)).map(_.map(_.payload)).flatMap {
@@ -948,7 +948,7 @@ final case class RuleBasedActor(
                 // past withdrawals; the original resolution-time map is committed by the oldest
                 // treasury tx's output datum, which is what `candidateEvacMaps` is keyed by.
                 _ <- EitherT.right[Error.RecoverableErrors](
-                  tracer.traceWith(RuleBasedActorEvent.Evacuation.ResolvedKzg(s"$resolutionKzg"))
+                  tracer.traceWith(RuleBasedActorEvent.Evacuation.ResolvedKzg(resolutionKzg))
                 )
                 evacuationMapAtResolution <- lookupMap(resolutionKzg, inputs.candidateEvacMaps)
 

--- a/src/main/scala/hydrozoa/rulebased/RuleBasedActorEvent.scala
+++ b/src/main/scala/hydrozoa/rulebased/RuleBasedActorEvent.scala
@@ -1,8 +1,10 @@
 package hydrozoa.rulebased
 
 import hydrozoa.multisig.backend.cardano.CardanoBackend
+import hydrozoa.multisig.ledger.commitment.KzgCommitment.KzgCommitment
 import hydrozoa.multisig.ledger.l1.tx.EnrichedTx
 import scalus.cardano.address.ShelleyAddress
+import scalus.cardano.ledger.{TransactionHash, Value}
 
 sealed trait RuleBasedActorEvent
 
@@ -19,7 +21,7 @@ object RuleBasedActorEvent:
 
     object Treasury:
         case object Querying extends RuleBasedActorEvent
-        final case class Found(value: String) extends RuleBasedActorEvent
+        final case class Found(value: Value) extends RuleBasedActorEvent
         case object NotFound extends RuleBasedActorEvent
         case object Parsing extends RuleBasedActorEvent
         case object ParsedUnresolved extends RuleBasedActorEvent
@@ -98,13 +100,15 @@ object RuleBasedActorEvent:
           * latest hard-confirmed stack they were derived from — logged to compare against the
           * commitment the treasury actually resolved to (see [[ResolvedKzg]]).
           */
-        final case class CandidateMaps(latestHardConfirmed: String, candidateKzgs: List[String])
-            extends RuleBasedActorEvent
+        final case class CandidateMaps(
+            latestHardConfirmed: String,
+            candidateKzgs: Set[KzgCommitment]
+        ) extends RuleBasedActorEvent
 
         /** DIAGNOSTIC: the commitment the resolution wrote into the treasury, looked up against the
           * candidate set. A miss is the `UnknownResolvedKzg` crash.
           */
-        final case class ResolvedKzg(kzg: String) extends RuleBasedActorEvent
+        final case class ResolvedKzg(kzg: KzgCommitment) extends RuleBasedActorEvent
 
         /** DIAGNOSTIC: the provenance of the candidate evacuation-map set — the default-vote map's
           * source block + commitment, and every votable SEC commitment collected (as
@@ -123,5 +127,5 @@ object RuleBasedActorEvent:
           * minor-only stack is walked past; the stack shown is the one that actually supplied the
           * anchor.
           */
-        final case class EvacuationAnchor(anchorStack: String, fallbackTxId: String)
+        final case class EvacuationAnchor(anchorStack: String, fallbackTxId: TransactionHash)
             extends RuleBasedActorEvent

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -42,4 +42,7 @@
     <logger name="SettlementTx" level="warn"/>
     <logger name="Generators" level="warn"/>
     <logger name="scalus" level="warn"/>
+    <!-- Fixtures for Slf4jTracerTest: prove the level gate skips (or forces) rendering. -->
+    <logger name="hydrozoa.test.gated.off" level="off"/>
+    <logger name="hydrozoa.test.gated.on" level="debug"/>
 </configuration>

--- a/src/test/scala/hydrozoa/lib/logging/ContraTracerDemo.scala
+++ b/src/test/scala/hydrozoa/lib/logging/ContraTracerDemo.scala
@@ -1,0 +1,258 @@
+package hydrozoa.lib.logging
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import cats.syntax.all.*
+import cats.~>
+import hydrozoa.lib.logging.ContraTracer.nullTracer
+import java.util.concurrent.atomic.AtomicInteger
+import org.scalatest.funsuite.AnyFunSuite
+import scala.collection.mutable.ListBuffer
+
+/** Didactic walkthrough of `TracerA` and `ContraTracer`.
+  *
+  * ==The two layers==
+  *
+  * {{{
+  *   ContraTracer[M, A]
+  *     wraps
+  *   TracerA[M, A, Unit]
+  *     which is one of:
+  *
+  *     Emitting(emits, noEmits)
+  *       emits  : Kleisli[M, A, X]   <-- runs on traceWith
+  *       noEmits: Kleisli[M, X, Unit] <-- DROPPED by runTracerA
+  *
+  *     Squelching(k)
+  *       k: Kleisli[M, A, B]          <-- ENTIRE arrow dropped by runTracerA
+  * }}}
+  *
+  * Only `Emitting` produces visible effects when run. `Squelching` is a "ghost" arrow: it still
+  * composes with neighbours, but at `runTracerA` time it is replaced by `arr (const ())`. That
+  * collapse is why the library can offer lazy combinators (`contramapM`, `traceMaybe`, ...) that
+  * only pay their cost when some sink downstream is actually emitting.
+  *
+  * ==Composition algebra under `>>>`==
+  *
+  * {{{
+  *   g (upstream)     f (downstream)    g >>> f       intuition
+  *   ------------     --------------    -----------   ---------------------
+  *   Squelching       Squelching        Squelching    no emit anywhere
+  *   Emitting         Squelching        Emitting      emit, drop the tail
+  *   Squelching       Emitting          Emitting      squelch absorbed
+  *                                                     into emit's input
+  *   Emitting         Emitting          Emitting      both emits preserved
+  * }}}
+  *
+  * ==Fan-out via Semigroup `combine`==
+  *
+  * {{{
+  *                  x : A
+  *                    |
+  *           (xt.use &&& yt.use)    -- duplicates the input
+  *                    |
+  *                +---+---+
+  *                v       v
+  *              xt.use  yt.use      -- both sinks see the same A
+  *                |       |
+  *                v       v
+  *              (Unit, Unit) --discard--> Unit
+  * }}}
+  *
+  * ==Branching via `traceMaybe` (ArrowChoice `|||`)==
+  *
+  * {{{
+  *                  b : B
+  *                    |
+  *                classify  (Squelching: runs only if downstream emits)
+  *                    |
+  *             Either[Unit, A]
+  *               /         \
+  *           Left(())     Right(a)
+  *               |             |
+  *           squelch        this.use   <-- only emits on Right
+  *               |             |
+  *               v             v
+  *              Unit          Unit
+  * }}}
+  *
+  * Each test below is self-contained. Read them in order; the comments tell you what the test is
+  * demonstrating and which diagram it maps to.
+  */
+class ContraTracerDemo extends AnyFunSuite:
+
+    // --- helpers ------------------------------------------------------------
+
+    /** A leaf sink that appends every emitted string to `buf`. */
+    private def bufferSink(buf: ListBuffer[String]): ContraTracer[IO, String] =
+        ContraTracer.emit[IO, String](s => IO { val _ = buf += s })
+
+    /** Pattern-matches the underlying TracerA constructor — useful for verifying the composition
+      * algebra above without running anything.
+      */
+    private def tag[A](t: ContraTracer[IO, A]): String = t.runTracer match
+        case TracerA.Emitting(_, _) => "Emitting"
+        case TracerA.Squelching(_)  => "Squelching"
+
+    // --- Demo 1: leaf emit --------------------------------------------------
+
+    test("Demo 1 — leaf emit reaches the sink") {
+        // ContraTracer.emit lifts a `String => IO[Unit]` into an Emitting tracer.
+        // traceWith runs the underlying Kleisli on the given input.
+        val buf = ListBuffer.empty[String]
+        val sink = bufferSink(buf)
+
+        sink.traceWith("hello").unsafeRunSync()
+
+        assert(buf.toList == List("hello") && tag(sink) == "Emitting")
+    }
+
+    // --- Demo 2: nullTracer -------------------------------------------------
+
+    test("Demo 2 — nullTracer is silent (the Monoid identity)") {
+        // nullTracer is built from TracerA.squelch — the whole arrow is dropped
+        // by runTracerA, so traceWith is a no-op. It is also `Monoid.empty`.
+        val buf = ListBuffer.empty[String]
+        val sink: ContraTracer[IO, String] = nullTracer
+
+        sink.traceWith("ignored").unsafeRunSync()
+
+        assert(buf.isEmpty && tag(sink) == "Squelching")
+    }
+
+    // --- Demo 3: contramap --------------------------------------------------
+
+    test("Demo 3 — contramap adapts the input type") {
+        // Contravariant.contramap turns a ContraTracer[M, A] into a
+        // ContraTracer[M, B] using a pure `B => A`. Internally this is
+        //     compute(f) >>> tracer.use   (i.e. Squelching >>> Emitting)
+        // which the composition table tells us is Emitting.
+        val buf = ListBuffer.empty[String]
+        val stringSink = bufferSink(buf)
+        val intSink: ContraTracer[IO, Int] = stringSink.contramap(_.toString)
+
+        intSink.traceWith(42).unsafeRunSync()
+
+        // Squelching >>> Emitting = Emitting
+        assert(buf.toList == List("42") && tag(intSink) == "Emitting")
+    }
+
+    // --- Demo 4: Semigroup combine -----------------------------------------
+
+    test("Demo 4 — Semigroup combine fans out to both sinks") {
+        // tr1 |+| tr2 == ContraTracer((tr1.use &&& tr2.use) >>> arrDiscard).
+        // Both sinks see the same input, and the (Unit, Unit) pair is dropped.
+        val bufA = ListBuffer.empty[String]
+        val bufB = ListBuffer.empty[String]
+        val fanout = bufferSink(bufA) |+| bufferSink(bufB)
+
+        fanout.traceWith("once").unsafeRunSync()
+
+        assert(bufA.toList == List("once") && bufB.toList == List("once"))
+    }
+
+    // --- Demo 5: laziness proof  (Learn by Doing) --------------------------
+
+    test("Demo 5 — laziness proof (your contribution)") {
+        // We instrument the upstream stage's effect with a counter so we can
+        // observe *whether the body actually ran*. The Emitting/Squelching
+        // tag controls whether `runTracerA` keeps or drops the whole arrow.
+        val upstreamSideEffects = new AtomicInteger(0)
+        val sinkBuf = ListBuffer.empty[String]
+
+        val liveSink: ContraTracer[IO, String] =
+            ContraTracer.emit(s => IO { val _ = sinkBuf += s })
+
+        // Stage that adapts `Int => String` via an IO effect. Crucially, this
+        // is built from `TracerA.effect(...)` which is *Squelching*. When
+        // composed with a Squelching downstream the whole chain stays
+        // Squelching and `runTracerA` drops it. When composed with an
+        // Emitting downstream, the squelch is absorbed and the chain emits.
+        def withUpstream(downstream: ContraTracer[IO, String]): ContraTracer[IO, Int] =
+            downstream.contramapM[Int](i =>
+                IO { val _ = upstreamSideEffects.incrementAndGet(); i.toString }
+            )
+
+        val liveChain = withUpstream(liveSink)
+        val nullChain = withUpstream(nullTracer[IO, String])
+
+        // Live downstream: the chain is Emitting, so the upstream body runs (counter -> 1)
+        // and its output reaches the sink.
+        liveChain.traceWith(42).unsafeRunSync()
+        val liveEmitted =
+            sinkBuf.toList == List("42") && upstreamSideEffects.get == 1 &&
+                tag(liveChain) == "Emitting"
+
+        // Squelching downstream: the whole chain is Squelching, so runTracerA drops it and the
+        // contramapM body is never run — the counter does NOT advance (stays 1). This is the
+        // guarantee SLF4J cannot make: a squelched tracer evaluates none of its upstream work.
+        nullChain.traceWith(99).unsafeRunSync()
+        val squelchedNothing = upstreamSideEffects.get == 1 && tag(nullChain) == "Squelching"
+
+        assert(liveEmitted && squelchedNothing)
+    }
+
+    // --- Demo 6: traceAll over a Foldable ----------------------------------
+
+    test("Demo 6 — traceAll fans out across a Foldable") {
+        // traceAll(f: B => T[A]) = traceTraversable contramap f.
+        // For each element of the resulting collection, the sink fires once.
+        val buf = ListBuffer.empty[String]
+        val sink = bufferSink(buf)
+
+        // Pass each element of a List[String] to `sink`.
+        val listSink: ContraTracer[IO, List[String]] = sink.traceAll(identity)
+        listSink.traceWith(List("a", "b", "c")).unsafeRunSync()
+
+        // The Foldable variant has an explicit Squelching short-circuit:
+        // a null upstream collapses to nullTracer rather than iterating.
+        val nullList: ContraTracer[IO, List[String]] =
+            nullTracer[IO, String].traceAll(identity)
+        assert(buf.toList == List("a", "b", "c") && tag(nullList) == "Squelching")
+    }
+
+    // --- Demo 7: composition algebra --------------------------------------
+
+    test("Demo 7 — the composition table holds in practice") {
+        // Verify each row of the algebra by pattern-matching the resulting
+        // TracerA constructor after composing in the four configurations.
+        val buf = ListBuffer.empty[String]
+        val emittingSink: ContraTracer[IO, String] = bufferSink(buf)
+        val squelchingSink: ContraTracer[IO, String] = nullTracer
+
+        // contramap is `Squelching >>> tracer`, so its output tag mirrors the
+        // tag of `tracer`. Use this to construct each cell of the table.
+        val sqOverSq: ContraTracer[IO, Int] = squelchingSink.contramap(_.toString)
+        val sqOverEm: ContraTracer[IO, Int] = emittingSink.contramap(_.toString)
+
+        // For the "Emitting upstream" rows, build an emitting stage via
+        // ContraTracer.emit and `|+|` with a downstream sink — combine
+        // produces Emitting whenever *either* branch is Emitting.
+        val emittingStage: ContraTracer[IO, String] =
+            ContraTracer.emit(_ => IO.unit)
+
+        assert(
+          tag(sqOverSq) == "Squelching" && // Sq >>> Sq = Sq
+              tag(sqOverEm) == "Emitting" && // Sq >>> Em = Em
+              tag(emittingStage |+| squelchingSink) == "Emitting" && // Em + Sq
+              tag(emittingStage |+| emittingSink) == "Emitting" // Em + Em
+        )
+    }
+
+    // --- Demo 8 (bonus): natTracer ----------------------------------------
+
+    test("Demo 8 — natTracer changes the underlying monad") {
+        // natTracer applies a natural transformation `M ~> N` to every
+        // Kleisli inside the arrow. Here we lift an IO tracer through the
+        // identity natural transformation IO ~> IO just to show the
+        // mechanics; in real code you might lift IO into a Kleisli/Reader
+        // stack with IO at the base.
+        val buf = ListBuffer.empty[String]
+        val sink = bufferSink(buf)
+        val ioToIo: IO ~> IO = new (IO ~> IO) { def apply[A](fa: IO[A]): IO[A] = fa }
+        val lifted: ContraTracer[IO, String] = sink.natTracer(ioToIo)
+
+        lifted.traceWith("through-nat").unsafeRunSync()
+
+        assert(buf.toList == List("through-nat"))
+    }

--- a/src/test/scala/hydrozoa/lib/logging/Slf4jTracerTest.scala
+++ b/src/test/scala/hydrozoa/lib/logging/Slf4jTracerTest.scala
@@ -1,0 +1,48 @@
+package hydrozoa.lib.logging
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import cats.syntax.all.*
+import java.util.concurrent.atomic.AtomicInteger
+import org.scalatest.funsuite.AnyFunSuite
+import scala.collection.mutable.ListBuffer
+
+/** The level gate: [[Slf4jTracer.sink]] forces a [[LogEvent]]'s deferred `render` — the message
+  * interpolation and any `toString` inside it — only when the routing key's logger has the event's
+  * level enabled. See `logback-test.xml` for the `hydrozoa.test.gated.*` fixtures.
+  */
+class Slf4jTracerTest extends AnyFunSuite:
+
+    test("a disabled level forces no rendering; an enabled level does") {
+        val renders = new AtomicInteger(0)
+        def event(routingKey: String): LogEvent =
+            LogEvent(
+              Level.Debug,
+              { val _ = renders.incrementAndGet(); "message" }, // by-name: runs only if forced
+              routingKey = Some(routingKey)
+            )
+
+        // OFF in logback-test.xml -> isDebugEnabled == false -> the sink squelches, render not forced.
+        Slf4jTracer.sink.traceWith(event("hydrozoa.test.gated.off")).unsafeRunSync()
+        val afterOff = renders.get
+
+        // DEBUG in logback-test.xml -> isDebugEnabled == true -> render forced exactly once.
+        Slf4jTracer.sink.traceWith(event("hydrozoa.test.gated.on")).unsafeRunSync()
+        val afterOn = renders.get
+
+        assert(afterOff == 0 && afterOn == 1)
+    }
+
+    test("the gate wraps only the slf4j leg: a composed capture sink still fires") {
+        val captured = ListBuffer.empty[Int]
+        val capture: ContraTracer[IO, Int] = ContraTracer.emit(i => IO { val _ = captured += i })
+
+        // The slf4j leg formats to a LogEvent at a disabled level; the capture leg is separate.
+        val slf4jLeg: ContraTracer[IO, Int] =
+            Slf4jTracer.sink.contramap(i =>
+                LogEvent(Level.Debug, i.toString, routingKey = Some("hydrozoa.test.gated.off"))
+            )
+
+        (slf4jLeg |+| capture).traceWith(7).unsafeRunSync()
+        assert(captured.toList == List(7)) // capture fired even though the slf4j leg was gated off
+    }


### PR DESCRIPTION
Stacked on #685 (bases on `peter/logging-level-gate`). Final piece of the logging overhaul.

## Why

Events that pre-render a domain object to a `String` at construction (e.g. `RequestDecoded(request.toString)`, `CurrentL1State(state.prettyDump)`) do the expensive work **eagerly, before `traceWith`** — so the level gate from #685 can't help. Carrying the raw object and rendering it in the `*EventFormat` (whose message is by-name, hence gated) means the `toString` / `prettyDump` / hex runs only when the level is enabled.

## What

Converted every pre-rendering event that carries a real domain object:
- **Transport** — `DroppingNonWireRequest`, `UnexpectedInboundWire` carry the raw request/payload.
- **CardanoLiaison** — 9 events carry raw `State` / `TransactionHash` / `TransactionInput` / `QuantizedInstant` / `Action`. **`Action` is relocated from the actor trait into the companion object** (matching the code's own TODO) so the event can reference it; its `msg` renderer moves into the format.
- **JointLedger** — `BlockCompleting` carries the raw `DepositsMap.Split` (its verbose multi-line dump was built eagerly).
- **PeerLiaison** — `BatchRequested`/`BatchReceived` carry the describe-callback result as `Eval[String]`, so the per-batch describe runs only when the level is on.
- **Limiter** — `HoldingMsg` carries `Class[?]` (defers `getSimpleName`).
- **SlowConsensus** — `StackHandedOff` carries a `Boolean` not a phase String.
- **RuleBasedActor** — `Treasury.Found` → `Value`; `Evacuation.{ResolvedKzg,EvacuationAnchor,CandidateMaps}` → `KzgCommitment`/`TransactionHash`/`Set[KzgCommitment]`.
- **`From.{trace,debug,info,warn,error}`** build the deferred `Rendered` directly, so the message is captured, not run.

## Deliberately left as-is (with reasons)

- Cheap constants that never touch the hex/dump path: `FastConsensus` ack/block-type strings; `BlockWeaver.BecameState` (its `name` is already computed for the state-dedup check).
- `JointLedger.L2CommandFailed` / `RequestInvalidated` — the strings double as an exception message / are a union type; not a memory concern.
- `RuleBasedActor.CandidateMapSources` — a composed description string, not one domain object.
- **Extra log context stays eager varargs** — it only ever carries cheap primitives (block/stack numbers, request ids); deferring it would mean wrapping ~10 call sites in `Seq(...)` for no memory benefit.

## Tests

`ContraTracerDemo` + `Slf4jTracerTest` (from #685) still pass. `just precommit` + `just build-werror` green; capture-based event tests unaffected (they see the typed event, not a rendered string).

The subagent-assisted note: the RuleBasedActor conversion was done in parallel with the `From` change (disjoint files).