### PR TITLE
DO NOT MERGE UNTIL AFTER COMPETITION — feat(config): compute headParamsHash over the whole head config

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -472,7 +472,7 @@ inThisBuild(
   List(
     // Release version — drives the Docker image tag, `hydrozoa.BuildInfo.version`, and `GET
     // /version`. Bump here for a release (see RELEASE.md), then tag `v<version>`.
-    version := "0.1.12",
+    version := "0.1.13",
     scalaVersion := "3.3.7",
     semanticdbEnabled := true,
     semanticdbVersion := scalafixSemanticdb.revision

--- a/build.sbt
+++ b/build.sbt
@@ -472,7 +472,7 @@ inThisBuild(
   List(
     // Release version — drives the Docker image tag, `hydrozoa.BuildInfo.version`, and `GET
     // /version`. Bump here for a release (see RELEASE.md), then tag `v<version>`.
-    version := "0.1.13",
+    version := "0.1.14",
     scalaVersion := "3.3.7",
     semanticdbEnabled := true,
     semanticdbVersion := scalafixSemanticdb.revision

--- a/design/head-params-hash.md
+++ b/design/head-params-hash.md
@@ -1,0 +1,501 @@
+# The head parameters hash
+
+For anyone changing `HeadParameters`, `HeadConfig`, or the multisig treasury datum: this
+document defines `headParamsHash` — the digest that pins a head's agreed configuration — and
+where it is checked.
+
+## What it is for
+
+Head peers never exchange their configuration. Each node loads its own `head-config.json`
+and starts; there is no handshake and no runtime key exchange. Some disagreements are caught
+today as a side effect of construction — peer verification keys, their numbering, and
+`coilQuorum` all feed `HeadMultisigScript`, so a peer with a different roster derives a
+different policy id, a different head address, and rejects the initialization transaction.
+
+Most of the configuration is not pinned by anything. Two peers can differ on
+`depositMaturityDuration`, `maxRequestsPerBlock`, `votingDuration`, the fallback contingency
+split, or which L2 ledger they run, and both will start, sign block zero, and diverge later —
+at deposit absorption, at block packing, or at fallback, when the divergence is unrecoverable.
+
+`headParamsHash` closes that gap at the only agreement gate that exists. It is carried in the
+multisig treasury datum, which `InitializationTx.Parse` compares against the transaction it was
+handed. **A peer whose configuration differs cannot sign the initialization transaction**, so
+the head does not start rather than starting split.
+
+The multisig treasury sits under a native script, so no on-chain validator reads this datum.
+The enforcement is entirely off-chain. That is the right place: after initialization the
+configuration cannot change, and after fallback there is no consensus left to agree.
+
+## One digest, one nested leaf
+
+```
+multisig treasury datum
+  └── headParamsHash = blake2b_256("gummiworm-head-params-v1" || <the whole agreed config>)
+        └── l2ParamsHash — reported by the L2 ledger, 32 bytes, opaque to the head
+```
+
+`headParamsHash` covers the whole head config, not only the `HeadParameters` case class. The
+name is the one the code and the whitepaper already use, and there is no second digest: a
+nested digest earns its place only when something needs it standalone, and nothing compares,
+reports, or transmits a parameters-only value.
+
+`l2ParamsHash` is the one nesting that does earn it, on a different ground: **the head cannot
+compute it.** The L2 ledger is the only party that knows its own parameters, so the value
+arrives from outside, is compared against the ledger's report on its own (check 4), and is
+folded in as an opaque leaf.
+
+### Where it lives
+
+The digest needs `initialEquityContributions`, `blockBrief`, `coilPeers`, and
+`scriptReferenceUtxos` as well as `HeadParameters`, so it lives on `HeadConfig.Section` — a
+`lazy val` on the `HeadConfig` case class, delegated to by the trait. The layout itself is
+`config/head/HeadParamsHash.scala`; `HeadParamsHashTest` mutates every covered field one at a
+time and asserts the digest moves, and asserts it does **not** move for `webSocketAddress`.
+
+`InitializationTx.Parse` must **not** compute it. Its `Config` is a deliberately minimal
+intersection —
+
+```scala
+type Config = CardanoNetwork.Section & HeadPeers.Section & FallbackContingency.Section &
+    TxTiming.Section & InitializationParameters.Section
+```
+
+— and widening that to the whole config to hash it would work directly against the
+rule of least knowledge. Compute the digest once in the `HeadConfig` decoder, where everything
+is already in hand, and pass it into `Parse` as an opaque 32 bytes alongside
+`blockCreationEndTime`. `Parse` compares bytes; it does not need to know what they cover.
+
+## Encoding primitives
+
+The digest is `blake2b_256` over a domain-tagged, explicitly framed byte string. The layout
+below is normative — not a serialization of any JSON or CBOR encoder. Circe codecs for
+`QuantizedFiniteDuration`, `Coin`, and `PositiveInt` each have their own quirks, and a codec
+tweak that silently moved a hash already written into a treasury datum would leave a live head
+unable to parse its own initialization transaction.
+
+| notation | bytes |
+|---|---|
+| `u8(n)` | 1 byte |
+| `u32(n)` | 4 bytes, big-endian unsigned |
+| `u64(n)` | 8 bytes, big-endian; signed values two's-complement |
+| `f64(x)` | 8 bytes, big-endian IEEE-754 bits (`doubleToLongBits`, so every NaN is one pattern) |
+| `bool(b)` | 1 byte, `0x00` false / `0x01` true |
+| `framed(b)` | `u32(length)` ‖ the bytes |
+| `raw(b)` | the bytes, no framing — fixed-width fields only |
+
+The domain tag is ASCII with no terminator; the fixed-width field that follows makes the
+boundary unambiguous. Value types map as:
+
+| type | as |
+|---|---|
+| `QuantizedFiniteDuration` | `u64` milliseconds (`.toMillis`) |
+| `QuantizedInstant` | `u64` milliseconds since the Unix epoch (`.toEpochMilli`) |
+| `Coin` | `u64` lovelace |
+| `PositiveInt`, `Int`, `HeadPeerNumber`, `CoilPeerNumber` | `u32` |
+| `Double` | `f64` |
+| `Boolean` | `bool` |
+| `Hash32`, `EvacuationMapHash` | `raw`, 32 bytes |
+| `ScriptHash` | `raw`, 28 bytes |
+| `TransactionInput` | `raw` 32-byte transaction id ‖ `u32(index)` |
+| `L2LedgerKind` | `framed` config string — `cardano-eutxo` or `any-remote` |
+
+`L2LedgerKind` folds in its own config string rather than an ordinal, so the digest reuses the
+name already on the wire and in every config file instead of inventing a parallel numbering.
+
+## The layout
+
+```
+headParamsHash = blake2b_256(
+     "gummiworm-head-params-v1"
+
+  -- HeadParameters.txTiming
+  || u64(minSettlementDuration)      || u64(inactivityMarginDuration)
+  || u64(silenceDuration)            || u64(depositSubmissionDuration)
+  || u64(depositMaturityDuration)    || u64(depositAbsorptionDuration)
+
+  -- HeadParameters.fallbackContingency.collectiveContingency
+  || u64(publicVoteDeposit)          || u64(fallbackTxFee)
+  || u64(minAdaForTreasury)          || u64(minAdaForRegime)
+
+  -- HeadParameters.fallbackContingency.individualContingency
+  || u64(collateralDeposit)          || u64(tallyTxFee)
+  || u64(voteDeposit)                || u64(voteTxFee)
+
+  -- HeadParameters: disputeResolutionConfig / settlementConfig / blockConfig
+  || u64(votingDuration)
+  || u32(maxDepositsAbsorbedPerBlock)
+  || u32(maxRequestsPerBlock)        || u32(backpressureCoefficient)
+
+
+  -- HeadParameters: the rest
+  || u32(coilQuorum)
+  || raw(l2ParamsHash)
+  || framed(l2Ledger)
+  || bool(identityIsomorphism)
+
+  -- cardanoNetwork
+  || u64(protocolMagic) || u8(networkId)
+  || u64(slotConfig.zeroTime) || u64(slotConfig.zeroSlot) || u64(slotConfig.slotLength)
+
+  -- initialEquityContributions, ascending by HeadPeerNumber
+  || u32(entryCount)
+  || for each: u32(headPeerNumber) || u64(coin)
+
+  -- scriptReferences
+  || raw(HydrozoaBlueprint.treasuryScriptHash)
+  || raw(HydrozoaBlueprint.disputeScriptHash)
+  || raw(setupLadderAnchor.transactionId) || u32(setupLadderAnchor.index)
+
+  -- initialBlockTiming, from blockBrief.header
+  || u64(startTime) || u64(endTime) || u64(fallbackTxStartTime)
+  || u64(forcedMajorBlockWakeupTime)
+  || bool(hasDepositDecisionWakeupTime) [|| u64(mDepositDecisionWakeupTime)]
+
+  -- coilHubTopology, ascending by CoilPeerNumber
+  || u32(coilPeerCount)
+  || for each: u32(hubHeadPeerNumber)
+)
+```
+
+The `HeadParameters` fields come first, in declaration order, and the rest of the head config
+follows. That grouping is for review, not for meaning — it is one flat preimage and no prefix
+of it is separately checked.
+
+### Notes on individual fields
+
+**`rateLimits` is not covered.** It stays in the per-node `NodeOperationMultisigConfig`, and
+the test that keeps it out is the one this whole digest exists to serve: *does a follower's
+validation depend on the value?*
+
+It does not. `rateLimits` bounds what a peer does to itself. A leader that shapes aggressively
+produces fewer, fatter blocks; one that shapes loosely produces more, thinner ones. A follower
+rebuilds from the leader's brief either way, so no value of these seven knobs makes two peers
+disagree about a block. There is nothing here for consensus to enforce.
+
+Covering it would cost three things. This digest is pinned in the treasury datum and therefore
+immutable for the head's life, so a badly chosen `blockGateSmoothing` could not be corrected
+without re-initializing the head — and five of the seven knobs have never been tuned under
+production load. It would force one set of values across head peers whose hardware may differ.
+And it would undo the reason `rateLimits` is node-local: the gate deploys as a binary swap
+against a head whose consensus parameters are already pinned.
+
+The bound that *does* belong here is a follower-enforceable one — a cap on what a peer must
+accept from another, such as the majors a stack may cover. See `docs/spec/rate-limiter.md` for
+what the limiter does, and GUM-326 for that cap.
+
+`coilQuorum` and the peer verification keys are already pinned by the native script.
+`coilQuorum` is folded in anyway because it is a `HeadParameters` field and the section is
+covered whole; the verification keys are not, because they are pinned by construction.
+
+`networkId` is scalus's own `Network.networkId` — the Cardano network id byte, defined for every
+case including `Network.Other`. `protocolMagic` alone does not determine it, because
+`CardanoNetwork.Custom` pairs an arbitrary `CardanoInfo` with an arbitrary magic. `cardanoProtocolParams` is deliberately absent: it is fetched from the
+chain and moves with hard forks, so it is not something peers agree on.
+
+`initialEquityContributions` contributes its per-peer split, not just its total. Only the total
+reaches the treasury value; the split decides who is paid what at finalization and is otherwise
+unpinned.
+
+The block-zero timing fields matter unevenly and are all included for that reason.
+`startTime` and `endTime` reach the initialization transaction's validity end, but
+`fallbackTxStartTime`, `forcedMajorBlockWakeupTime`, and `mDepositDecisionWakeupTime` reach no
+transaction at all.
+
+`hubHeadPeerNumber` decides which head peer relays a coil peer's hard acknowledgement and how
+many `HubHardAck` journals a recovering coil peer must read. It is not in the native script.
+Coil peer numbers are contiguous from zero, so their position in the sequence is their number
+and is not repeated.
+
+### Pin the outref where the chain pins the outref
+
+The three script references are pinned three different ways, and the rule behind that is worth
+stating: **pin an output reference exactly where the chain pins an output reference; pin the
+hash everywhere else.**
+
+| reference | pinned as | why |
+|---|---|---|
+| `rulebasedTreasuryScriptUtxo` | `HydrozoaBlueprint.treasuryScriptHash` | determines the rule-based treasury address the fallback transaction pays to |
+| `disputeResolutionScriptUtxo` | `HydrozoaBlueprint.disputeScriptHash` | determines the dispute gate |
+| `setupLadderUtxos` | rung 0's `TransactionInput` | verbatim what `RuleBasedRegimeOutput.datum` writes as `setupG2Ladder` |
+
+The two Plutus script hashes are build constants, not configuration: `ScriptReferenceUtxos`
+already rejects a reference utxo whose script hash is not the blueprint's. Folding them in
+therefore catches nothing about a *config* mismatch — it catches a **build** mismatch, which
+nothing else does. Two peers on hydrozoa builds with different compiled validators each decode
+their own config happily and then build different fallback transactions.
+
+Their output references are not pinned, and must not be: a reference input is chosen by
+whoever builds the spending transaction, so the outref is deployment detail and redeploying a
+reference script must not brick a live head.
+
+The setup ladder inverts both halves. Its **content** is already verified offchain —
+`SetupLadderUtxos` checks every rung's inline datum against the locally computed
+`SetupLadder.rungDatum(i)`, so a peer with a different trusted setup cannot decode its config
+at all — and a content hash would add nothing. Its **outref** is what is unpinned and
+load-bearing: `RuleBasedRegimeOutput.datum` writes rung 0's outref into the regime datum as
+`setupG2Ladder`, and Evacuate uses it on-chain to authenticate the setup reference input. Two
+peers holding correct but differently deployed ladders build different fallback transactions,
+and discover it at fallback. Only the anchor is folded in; `SetupLadderUtxos` already requires
+the remaining rungs to be outputs `0..rungCount-1` of that one transaction.
+
+## `l2ParamsHash`
+
+The digest an L2 ledger reports over its own agreed parameters. 32 bytes, opaque to the head,
+and **the same contract for every backend** — the built-in EUTXO ledger meets it exactly as a
+remote sidecar does, through the same `L2Ledger` method, and nothing in the head branches on
+`l2Ledger` to obtain or check it.
+
+There is no head-side layout, deliberately: the L2 ledger is a black box, and the head's only
+interest is that every peer runs a ledger reporting the same value. What goes into it is the
+ledger's business — its rules version, its fee schedule, its asset policy, whatever it and its
+operators agree matters.
+
+**It covers parameters, never state.** No evacuation map goes into it. Parameters are fixed for
+the head's lifetime; an evacuation map changes with every applied command, and a moving value
+has no business inside a digest that the treasury datum pins forever. Keeping state out is also
+what lets one definition serve both backends: the moment state enters, a ledger with a
+different state model needs a different rule.
+
+The initial evacuation map loses nothing by being kept out, because it is already committed
+three times over: the initialization transaction's treasury **value** must back it, the same
+transaction's treasury **datum** carries its KZG `commit`, and check 3 compares it against the
+ledger's own at a cold anchor. A fourth commitment — a blake2b digest folded into the hash field
+of the very datum whose neighbouring field is already the KZG of the same object — would be
+redundant with something sitting inches away.
+
+The built-in EUTXO ledger has no negotiable parameters yet: its rules are the hydrozoa code, and
+its only agreed knobs — `identityIsomorphism` and the `headId` pin — already sit in
+`HeadParameters`, so folding them in here would hash the configuration against itself. It
+therefore reports a digest over an empty parameter set, which following `EvacuationMap.digest`'s
+precedent hashes its domain tag to a **defined value rather than an absence**. That keeps
+`l2ParamsHash` a plain `Hash32` — no `Option`, no special case in the layout or the checks — and
+the constant becomes a real digest as soon as the ledger grows parameters worth agreeing on.
+
+### What this does and does not prove
+
+The head cannot verify that a ledger implements particular rules. It can only check that the
+ledger reports a matching value, and a lying implementation defeats that entirely. What protects
+the head is topological: every node runs its **own private** ledger instance
+(`sugar-rush-ledger/DEPLOYMENT.md`), so a divergent ledger surfaces as consensus divergence
+between peers rather than as a silent loss. This digest catches misconfiguration, which is the
+failure mode that actually occurs.
+
+Operators get the two sides to agree by generating the config from the ledger rather than by
+hand, exactly as with the initial evacuation map: the ledger prints its `l2ParamsHash`
+out-of-band and the bootstrap copies it in.
+
+## What is deliberately excluded
+
+| field | why |
+|---|---|
+| `initializationTx` | circular — it carries the datum that carries `headParamsHash` |
+| `resolvedUtxos` | a cache so the head can parse the initialization transaction without a backend query; derived from that transaction's inputs, not negotiated |
+| `headId` | derived from the initialization transaction's seed utxo and re-derived and checked by `InitializationTx.Parse` |
+| `initialEvacuationMap` | already committed on-chain twice in the same transaction — as the treasury value it backs, and as the KZG `commit` in the same datum — and checked by check 1 |
+| head and coil peer verification keys, and their numbering | pinned by the native script's ordered `IndexedSeq` → policy id → beacon token name → treasury address |
+| `headPeers[*].webSocketAddress` | see below |
+| `cardanoProtocolParams` | fetched from the chain, moves with hard forks |
+
+### Why `webSocketAddress` is not in the hash
+
+Folding the address in would prove that every peer holds the same string. It would not prove
+that the node answering at that string is the intended peer, so it does not answer the question
+an operator actually has. A typo pointing at a live but wrong node, a moved proxy, or a changed
+DNS record all survive a matching hash.
+
+It would also make every relocation a head re-initialization. The advertised address is
+mutable infrastructure by design — see `peerBindHost` on `NodePrivateConfig`, which exists
+precisely because the address the head is dialed at and the address a node binds are different
+things.
+
+What the head does have is payload authentication: consensus messages carry `HeaderSignature`
+and `TxSignature`, verified against the statically configured verification keys, so a stranger
+at the wrong address cannot forge a hard acknowledgement or a settlement signature. What it
+does not have is connection authentication — `CoilFrame.Hello` carries a bare `coilNum` and
+`HubWsTransport` accepts it on nothing more than "is this a coil peer I hub". Closing that is a
+signed handshake over the already-pinned verification keys, and is tracked separately from this
+document.
+
+## The checks
+
+Five checks, at four moments. Every one reuses a comparison point the code already has, and
+**none of them branches on the backend.**
+
+| # | when | who | compares | on mismatch |
+|---|---|---|---|---|
+| 1 | config decode, every boot | every head and coil peer | the initialization tx's treasury datum against the datum rebuilt from local config | refuse to decode the config |
+| 2 | store open, every boot | every head and coil peer | the store's `Cf.Meta` identity stamp against `headParamsHash`, `headId`, and own `PeerId` | refuse to open the store |
+| 3 | every `restoreTo` anchor | `JointLedger` | the ledger's reported `evacuationMapHash` against the head's map at that anchor | refuse to boot |
+| 4 | every `restoreTo` anchor | `JointLedger` | the ledger's reported `l2ParamsHash` against the config's | refuse to boot |
+| 5 | every major block | every head and coil peer | the settlement tx's treasury datum `headParamsHash` against the local one | refuse to sign the block |
+
+Check 3 exists today. The rest are new, but checks 1 and 2 slot into comparison points that
+already exist — `InitializationTx.Parse`'s datum equality and `RocksDbBackendStore`'s
+`versionCheck`.
+
+### 1. The initialization transaction matches the hash
+
+The load-bearing one. `InitializationTx.Parse` already rebuilds the expected treasury datum
+from local config and compares it whole:
+
+```scala
+expectedTreasuryDatum = MultisigTreasuryUtxo.mkInitMultisigTreasuryDatum(config.initialEvacuationMap)
+...
+if decodedTreasuryDatum == expectedTreasuryDatum then Right(()) else Left(InvalidTransactionError(...))
+```
+
+Adding `headParamsHash` to the datum makes that comparison cover the whole configuration for
+free. Everything folded into the preimage becomes self-verifying against a value committed
+on-chain: a peer whose `depositMaturityDuration`, `maxRequestsPerBlock`, fallback contingency
+split, hub topology, or setup-ladder anchor differs from the one the initialization transaction
+was built for cannot parse that transaction, so it never signs block zero and the head does not
+start split.
+
+**Split the comparison into per-field checks.** A whole-datum equality reports
+`"actual treasury datum does not match the expected initial treasury datum"` for three
+completely different operator problems: a wrong initial evacuation map (`commit`), a stale
+version (`versionMajor`), and a configuration disagreement (`headParamsHash`). The third is the
+one an operator can actually act on, and it needs to say so.
+
+Two properties fall out of where this check sits, and both are worth relying on deliberately:
+
+- **It re-runs on every boot, not just at initialization.** `NodeConfig.load` re-reads
+  `head-config.json` and re-decodes it each time the node starts, and decoding runs
+  `InitializationTx.Parse`. An operator who hand-edits a live head's config is caught at the
+  next restart rather than at the next divergence.
+- **It is the cross-peer check, and one instance of it suffices.** Peers never compare configs
+  with each other, and do not need to: every peer compares against the *same* transaction, so
+  agreeing with the transaction implies agreeing with each other. No handshake, no gossip, no
+  quorum on config.
+
+### 2. The store belongs to this config, and to this peer
+
+A node's persistent store is built for one head, under one configuration, by one peer. Point it
+at a different one and it does not fail — it proceeds on a store that means something else.
+
+The check is a **stamp in `Cf.Meta`**, written when a fresh store is initialized and compared on
+every subsequent open. Three keys, flat and name-keyed like the `store_version` key that is
+already there:
+
+| key | value | catches |
+|---|---|---|
+| `head_params_hash` | `raw(headParamsHash)` | a store built under a different configuration |
+| `head_id` | the head's treasury token name | a store built for a different head — and makes the error message actionable |
+| `own_peer_id` | `PeerId.toWireInt`, 4 bytes big-endian | a store built by a *different peer of the same head* |
+
+`own_peer_id` is the one that cannot come from `headParamsHash`, and the one whose absence is
+most dangerous. Which peer a node is comes from `NodePrivateConfig`, not the head config, so
+every peer of a head has the identical `headParamsHash`. Opening head peer 0's store as head
+peer 1 therefore passes every other check while adopting peer 0's own-author journals as this
+peer's own — which is exactly the state equivocation avoidance exists to prevent. Reuse
+`PeerId.toWireInt`, already the author discriminant in the `HardAck` CF name, rather than
+inventing a second encoding.
+
+`head_id` is redundant against `head_params_hash` and is stamped anyway, because a bare hash
+mismatch tells an operator nothing they can act on. "This store belongs to head `0134…6b10`,
+this config is head `8f2a…c401`" names the mistake.
+
+**Where it runs, and what it costs.** `RocksDbBackendStore.openInternal` already runs
+`versionCheck` at open, and `StoreVersion.Check` already has the right three-way shape —
+`Fresh` / `Compatible` / `Incompatible`. The identity stamp is a sibling of that, with the same
+semantics: a writable open stamps a fresh store; a **read-only** open — the mode
+`hydrozoa evacuate` uses — treats a missing stamp as a hard error, because it cannot stamp and
+an unstamped store cannot be served; an incompatible stamp refuses the open, naming which of
+the three fields differs. It runs **after** the version check, because a store whose schema this
+build does not understand should not have its metadata interpreted at all, and **before** any
+recovery read. The cost is one point lookup per key on an already-open handle at startup, the
+same as the version check.
+
+**What this catches that nothing catches today.** `Cf.mkAll` derives the column-family set from
+head and coil membership, and `RocksDbBackendStore` opens RocksDB with
+`setCreateMissingColumnFamilies(true)`. So pointing a node at a store built for a different
+roster does not fail at open: the missing per-author CFs are **created empty**, and the node
+proceeds as though it had no history. That is the shape of the worst persistence failure seen in
+practice — a store that reads as empty re-bootstraps from stack 0, the peer can never rejoin the
+head, and the symptom surfaces much later and far from the cause, as an out-of-bounds journal
+cursor rather than as a refusal to open.
+
+**Why this does not replace check 1.** The two run in opposite directions and neither implies
+the other. Check 1 compares the config against the **chain** — is this configuration the one the
+head was initialized with? Check 2 compares the config against the **store** — is this the store
+that this configuration, run by this peer, has been writing? A config and a store can each be
+individually valid and still belong to different heads; a config can be edited between restarts
+while the store is untouched; a store can be copied between peers while the config is correct.
+
+### 3, 4. The ledger is the one the config describes
+
+`JointLedger` calls `restoreTo` on every boot including a cold one, and already compares the
+ledger's reported `evacuationMapHash` against its own map at the anchor (check 3, defined in
+`docs/spec/l2-ledger-command-coordination.md`). Check 4 adds `l2ParamsHash` to the `Restored`
+reply and compares it against the config's, so `L2Ledger.restoreTo` returns the pair
+`(EvacuationMapHash, Hash32)` rather than the map digest alone.
+
+The two answer different questions, and the difference is why both exist:
+
+- **`l2ParamsHash` never moves.** It is fixed for the head's lifetime, so it is comparable at
+  every anchor, warm or cold, against a config value that is equally fixed.
+- **`evacuationMapHash` moves with every applied command.** At a warm anchor it is compared
+  against the head's *current* map, not the initial one — so nothing but check 4 keeps asking
+  whether this is still the right *ledger* rather than merely a ledger holding the right state.
+
+Both run against every backend, with no conditional. `L2Ledger.restoreTo` is deliberately
+backend-agnostic — one signature, and check 3 already runs against the in-process ledger — so a
+branch here would be the only one in that contract.
+
+Check 4 is not vacuous for the built-in ledger, even while its parameter set is empty. The
+config's value was written by whichever build's tooling produced it; the reported value comes
+from the build now running. Once the ledger's domain tag carries a rules version, that
+comparison is what stops two peers on hydrozoa builds with divergent L2 semantics from booting
+against the same head.
+
+**A mismatch on 3 or 4 is fatal: the node refuses to boot.** Not recoverable at runtime and not
+safe to run through — either the on-chain commitment is already wrong, or the ledger is the
+wrong one. Same rule the evacuation map digest already follows.
+
+### 5. Every major block re-checks it
+
+`SettlementTx` builds a fresh treasury datum for every major block:
+
+```scala
+datum = MultisigTreasuryUtxo.Datum(kzgCommitment, majorVersionProduced)
+```
+
+With a third field it must carry `headParamsHash` forward unchanged, and every peer verifies a
+settlement transaction before signing it. So the configuration agreement is re-checked once per
+major block for the life of the head, by the machinery that already verifies settlements — a
+peer whose configuration drifts after initialization stops being able to get blocks signed.
+
+This is why `headParamsHash` belongs in the datum rather than in the initialization
+transaction's metadata: metadata is written once, the datum is rewritten and re-verified
+forever.
+
+### What is deliberately not checked
+
+- **Whether a ledger's `l2ParamsHash` honestly describes its rules.** The head cannot verify a
+  black box, only that it reports a matching value.
+- **Which node answers at a peer's `webSocketAddress`.** Not a hash problem; see above.
+- **The initialization transaction's witnesses.** `Parse` establishes structure; signatures are
+  collected and verified by initial-block consensus.
+
+### Migration
+
+Adding a field to `MultisigTreasuryUtxo.Datum` changes its `Data` arity, so
+`Data.fromData[MultisigTreasuryUtxo.Datum]` fails on every datum written before the change —
+on-chain and in persisted state alike. **A running head cannot be upgraded across this
+change.** It applies to heads initialized afterwards; existing heads keep the two-field datum
+and the build that understands it. This belongs in the release notes of the release that ships
+it, with the configuration-change procedure below.
+
+## Changing any of this
+
+The layout is a wire break and an on-chain break at once. A head whose treasury datum holds a
+`headParamsHash` computed under one layout cannot be parsed by a node computing the next.
+Changing the layout means a new domain tag, and heads initialized under the old one keep the
+old tag for life.
+
+Adding a field anywhere the preimage covers — `HeadParameters` or the wider head config —
+changes `headParamsHash`, and so changes the treasury datum of every head initialized
+afterwards. Follow the configuration-change procedure: state which files change, whether
+existing configs still decode, verify both decoders (`HeadParameters` and
+`Bootstrap.BootstrapHeadParams`), and carry the migration into the release notes of the release
+that ships it.

--- a/docs/user-guide/DEPLOYMENT.md
+++ b/docs/user-guide/DEPLOYMENT.md
@@ -124,13 +124,13 @@ under it. Then load the CLI alias and check you are on the version you expect:
 source ./hydrozoa.sh   # sets the `hydrozoa` alias + HYDROZOA_HOME (this folder, an absolute path)
 
 hydrozoa version       # verify the image you are running
-#   hydrozoa 0.1.12
-#   git:   v0.1.12
+#   hydrozoa 0.1.13
+#   git:   v0.1.13
 #   built: 2026-07-28 14:00:37.834-0600
 ```
 
-(The `git:` line is `git describe` provenance; a published image built from the `v0.1.12` tag reads a
-clean `v0.1.12`. A locally built image between releases shows the distance from the newest tag, e.g.
+(The `git:` line is `git describe` provenance; a published image built from the `v0.1.13` tag reads a
+clean `v0.1.13`. A locally built image between releases shows the distance from the newest tag, e.g.
 `v0.1.0-10-gaa9d7c69`.)
 
 Need a version that isn't in the registry? Build it from this repo — see §3.
@@ -425,8 +425,8 @@ finalization) appears in the same section as the head progresses.
 build (§3) is already tagged `…:latest`, so it is picked up without either:
 
 ```bash
-HYDROZOA_VERSION=0.1.12 just head-up                          # a specific published release
-HYDROZOA_IMAGE=cardano-hydrozoa/hydrozoa:0.1.12 just head-up  # a specific/other image name
+HYDROZOA_VERSION=0.1.13 just head-up                          # a specific published release
+HYDROZOA_IMAGE=cardano-hydrozoa/hydrozoa:0.1.13 just head-up  # a specific/other image name
 ```
 
 **Another head** — each head directory carries its own `docker-compose.yml`, so switch heads by

--- a/docs/user-guide/DEPLOYMENT.md
+++ b/docs/user-guide/DEPLOYMENT.md
@@ -124,13 +124,13 @@ under it. Then load the CLI alias and check you are on the version you expect:
 source ./hydrozoa.sh   # sets the `hydrozoa` alias + HYDROZOA_HOME (this folder, an absolute path)
 
 hydrozoa version       # verify the image you are running
-#   hydrozoa 0.1.13
-#   git:   v0.1.13
+#   hydrozoa 0.1.14
+#   git:   v0.1.14
 #   built: 2026-07-28 14:00:37.834-0600
 ```
 
-(The `git:` line is `git describe` provenance; a published image built from the `v0.1.13` tag reads a
-clean `v0.1.13`. A locally built image between releases shows the distance from the newest tag, e.g.
+(The `git:` line is `git describe` provenance; a published image built from the `v0.1.14` tag reads a
+clean `v0.1.14`. A locally built image between releases shows the distance from the newest tag, e.g.
 `v0.1.0-10-gaa9d7c69`.)
 
 Need a version that isn't in the registry? Build it from this repo — see §3.
@@ -425,8 +425,8 @@ finalization) appears in the same section as the head progresses.
 build (§3) is already tagged `…:latest`, so it is picked up without either:
 
 ```bash
-HYDROZOA_VERSION=0.1.13 just head-up                          # a specific published release
-HYDROZOA_IMAGE=cardano-hydrozoa/hydrozoa:0.1.13 just head-up  # a specific/other image name
+HYDROZOA_VERSION=0.1.14 just head-up                          # a specific published release
+HYDROZOA_IMAGE=cardano-hydrozoa/hydrozoa:0.1.14 just head-up  # a specific/other image name
 ```
 
 **Another head** — each head directory carries its own `docker-compose.yml`, so switch heads by

--- a/integration/src/test/scala/hydrozoa/integration/harness/MultiPeerHeadHarness.scala
+++ b/integration/src/test/scala/hydrozoa/integration/harness/MultiPeerHeadHarness.scala
@@ -26,6 +26,7 @@ import hydrozoa.lib.cardano.scalus.QuantizedTime.{QuantizedFiniteDuration, quant
 import hydrozoa.lib.logging.{ContraTracer, LogEvent, Slf4jMsg, Slf4jMsgFormat, Slf4jTracer, info}
 import hydrozoa.multisig.backend.cardano.{CardanoBackend as L1Backend, CardanoBackendBlockfrost, CardanoBackendEvent, CardanoBackendEventFormat, CardanoBackendMock, FirewalledCardanoBackendEvent, MockState, yaciTestSauceGenesis}
 import hydrozoa.multisig.consensus.peer.{CoilPeerNumber, HeadPeerId, HeadPeerNumber, PeerId}
+import hydrozoa.multisig.consensus.pollresults.PollResults
 import hydrozoa.multisig.consensus.transport.*
 import hydrozoa.multisig.consensus.{CardanoLiaison, RequestSequencer}
 import hydrozoa.multisig.ledger.block.BlockVersion.Major.given_Conversion_Major_Int
@@ -87,6 +88,24 @@ object MultiPeerHeadHarness:
     ): IO[Option[Instant]] =
         if useTestControl then IO.pure(None)
         else IO.realTimeInstant.map(t => Some(t.plusSeconds(offset.toSeconds)))
+
+    /** The first L1 sample a regime manager boots from, read here as `Serve` reads it: before the
+      * manager starts, so `ReplayActor.replay` only has to queue it.
+      *
+      * No retry ladder, unlike production — the harness's backend is in-process and a failed read
+      * is a broken fixture, not a transient outage, so it should fail the test loudly.
+      */
+    def readFirstPollResults(
+        cardanoBackend: L1Backend[IO],
+        config: NodeConfig
+    ): IO[PollResults] =
+        cardanoBackend
+            .utxosAt(config.initializationTx.treasuryProduced.address)
+            .flatMap {
+                case Right(utxos) => IO.pure(PollResults(utxos.keySet))
+                case Left(err) =>
+                    IO.raiseError(new RuntimeException(s"harness boot L1 sample failed: $err"))
+            }
 
     /** Head initial-block-end-time generator anchored on [[mkTakeoffTime]]. When `takeoffTime` is
       * `Some`, quantize it to the peer's slot config. When `None`, generate a random Jan-1-2026 +
@@ -1571,9 +1590,13 @@ object MultiPeerHeadHarness:
                 // A real node runs the 1 Hz sampler for the whole life of the process
                 // (`Serve.scala`); without it the runtime gauges read their initial values.
                 _ <- metrics.sampler().background
+                // Read where `Serve` reads it: before the regime manager starts, so `replay` only
+                // has to queue it. See `ReplayActor.replay`.
+                firstPollResults <- Resource.eval(readFirstPollResults(cardanoBackend, nodeConfig))
                 mrm <- HeadMultisigRegimeManager.resource(
                   nodeConfig,
                   cardanoBackend,
+                  firstPollResults,
                   l2Ledger,
                   EutxoL2Screener(nodeConfig),
                   persistence,
@@ -1648,9 +1671,11 @@ object MultiPeerHeadHarness:
                 // A coil runs the 1 Hz sampler too, and for the same reason: without it the
                 // runtime gauges never leave their initial values.
                 _ <- metrics.sampler().background
+                firstPollResults <- Resource.eval(readFirstPollResults(cardanoBackend, coilConfig))
                 mrm <- CoilMultisigRegimeManager.resource(
                   coilConfig,
                   cardanoBackend,
+                  firstPollResults,
                   l2Ledger,
                   persistence,
                   metrics,

--- a/integration/src/test/scala/hydrozoa/integration/harness/MultiPeerHeadHarness.scala
+++ b/integration/src/test/scala/hydrozoa/integration/harness/MultiPeerHeadHarness.scala
@@ -719,14 +719,14 @@ object MultiPeerHeadHarness:
             peerConnections <- Resource.eval(
               peerMrms.toList
                   .traverse { case (peerNum, peerMrm) =>
-                      peerMrm.mrm.connectionsDeferred.get.map(peerNum -> _)
+                      peerMrm.mrm.connectionsDeferred.get.flatMap(IO.fromEither).map(peerNum -> _)
                   }
                   .map(_.toMap)
             )
             coilConnections <- Resource.eval(
               coilMrms.toList
                   .traverse { case (coilNum, coilMrm) =>
-                      coilMrm.mrm.connectionsDeferred.get.map(coilNum -> _)
+                      coilMrm.mrm.connectionsDeferred.get.flatMap(IO.fromEither).map(coilNum -> _)
                   }
                   .map(_.toMap)
             )
@@ -805,7 +805,7 @@ object MultiPeerHeadHarness:
                         .allocated
                         .map(_._1)
                     (mrm, ref) = spawned
-                    conns <- mrm.connectionsDeferred.get
+                    conns <- mrm.connectionsDeferred.get.flatMap(IO.fromEither)
                     // Cancel the victim's previous tick (its CardanoLiaison is now stopped), then
                     // start a fresh supervised tick against the new connections.
                     _ <- headTicks.get.flatMap(_.getOrElse(peerNum, IO.unit))
@@ -849,7 +849,7 @@ object MultiPeerHeadHarness:
                         .allocated
                         .map(_._1)
                     (mrm, ref) = spawned
-                    conns <- mrm.connectionsDeferred.get
+                    conns <- mrm.connectionsDeferred.get.flatMap(IO.fromEither)
                     _ <- coilTicks.get.flatMap(_.getOrElse(coilNum, IO.unit))
                     tickFib <- tickSupervisor.supervise(
                       Ticks.tickLoop(coilPollingPeriodOf(coilNum), conns)

--- a/integration/src/test/scala/hydrozoa/integration/stage1/Suite.scala
+++ b/integration/src/test/scala/hydrozoa/integration/stage1/Suite.scala
@@ -554,7 +554,7 @@ case class Suite(
                   // Derived from this peer's own store rather than assumed cold, so the actor
                   // recovers from whatever the suite has put there — the same bundle the regime
                   // manager would hand it in production.
-                  markers <- Markers.derive(persistence, nodeConfig.ownPeerId)(using nodeConfig)
+                  markers <- Markers.derive(persistence, nodeConfig.ownPeerId)
                   jointLedger <- system.actorOf(
                     JointLedger(
                       nodeConfig,

--- a/integration/src/test/scala/hydrozoa/integration/stage1/Suite.scala
+++ b/integration/src/test/scala/hydrozoa/integration/stage1/Suite.scala
@@ -32,7 +32,7 @@ import hydrozoa.multisig.ledger.event.RequestNumber
 import hydrozoa.multisig.ledger.joint.{JointLedger, JointLedgerEventFormat}
 import hydrozoa.multisig.ledger.l1.tx.RawTx
 import hydrozoa.multisig.metrics.PeerMetrics
-import hydrozoa.multisig.persistence.{InMemoryBackendStore, Persistence, PersistenceEventFormat}
+import hydrozoa.multisig.persistence.{InMemoryBackendStore, Markers, Persistence, PersistenceEventFormat}
 import java.util.concurrent.TimeUnit
 import org.scalacheck.commands.{ModelBasedSuite, ScenarioGen}
 import org.scalacheck.util.Pretty
@@ -551,6 +551,10 @@ case class Suite(
                     headPeerLiaisons = List(),
                   )
                   l2Ledger <- InMemoryL2Store.ledger(nodeConfig)
+                  // Derived from this peer's own store rather than assumed cold, so the actor
+                  // recovers from whatever the suite has put there — the same bundle the regime
+                  // manager would hand it in production.
+                  markers <- Markers.derive(persistence, nodeConfig.ownPeerId)(using nodeConfig)
                   jointLedger <- system.actorOf(
                     JointLedger(
                       nodeConfig,
@@ -558,7 +562,8 @@ case class Suite(
                       l2Ledger,
                       Slf4jTracer.sink.contramap(JointLedgerEventFormat.humanFormat(headPeerNum)),
                       persistence,
-                      PeerMetrics.create(0L, Vector.empty)
+                      PeerMetrics.create(0L, Vector.empty),
+                      markers
                     )
                   )
                   _ <- jointLedgerD.complete(jointLedger)

--- a/src/main/resources/scaffold/hydrozoa.sh
+++ b/src/main/resources/scaffold/hydrozoa.sh
@@ -13,7 +13,7 @@
 # scaffolded workspace — resolved to an absolute path, so the alias mounts correctly no matter which
 # directory you run it from. Override HYDROZOA_HOME (to an absolute path) or HYDROZOA_VERSION before
 # sourcing, or edit the defaults below.
-: "${HYDROZOA_VERSION:=0.1.12}"   # published image tag (ghcr.io/cardano-hydrozoa/hydrozoa)
+: "${HYDROZOA_VERSION:=0.1.13}"   # published image tag (ghcr.io/cardano-hydrozoa/hydrozoa)
 : "${HYDROZOA_HOME:=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)}"   # head directory (absolute)
 export HYDROZOA_VERSION HYDROZOA_HOME
 

--- a/src/main/resources/scaffold/hydrozoa.sh
+++ b/src/main/resources/scaffold/hydrozoa.sh
@@ -13,7 +13,7 @@
 # scaffolded workspace — resolved to an absolute path, so the alias mounts correctly no matter which
 # directory you run it from. Override HYDROZOA_HOME (to an absolute path) or HYDROZOA_VERSION before
 # sourcing, or edit the defaults below.
-: "${HYDROZOA_VERSION:=0.1.13}"   # published image tag (ghcr.io/cardano-hydrozoa/hydrozoa)
+: "${HYDROZOA_VERSION:=0.1.14}"   # published image tag (ghcr.io/cardano-hydrozoa/hydrozoa)
 : "${HYDROZOA_HOME:=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)}"   # head directory (absolute)
 export HYDROZOA_VERSION HYDROZOA_HOME
 

--- a/src/main/scala/hydrozoa/app/Main.scala
+++ b/src/main/scala/hydrozoa/app/Main.scala
@@ -1,11 +1,13 @@
 package hydrozoa.app
 
+import cats.effect.unsafe.IORuntimeConfig
 import cats.effect.{ExitCode, IO}
 import com.monovore.decline.effect.CommandIOApp
 import com.monovore.decline.{Command, Opts}
 import hydrozoa.BuildInfo
 import hydrozoa.app.cli.{Scaffold, SubmitDeposit, SubmitL2Transaction}
 import hydrozoa.bootstrap.{BuildHeadConfig, GenerateKeyPair, InitBootstrapFiles, KeygenFleet, Migrate, PrintHeadZeroAddress}
+import scala.concurrent.duration.DurationInt
 
 /** The `hydrozoa` command-line entry point: a single dispatcher over every deployment and runtime
   * command. Each subcommand is defined next to its logic and surfaced here as a `Command` value:
@@ -31,6 +33,22 @@ object Main
       header = "Hydrozoa — multi-party state channels for Cardano",
       version = BuildInfo.version
     ):
+
+    /** Bound how long shutdown may hang after a signal.
+      *
+      * cats-effect defaults `shutdownHookTimeout` to `Duration.Inf`, so a finalizer that cannot
+      * complete makes the process ignore SIGTERM outright — it then needs SIGKILL, and anything
+      * downstream of the stuck finalizer never releases. A wedged node holding its RocksDB LOCK is
+      * the case that bit us: `docker stop -t 120` waits the full two minutes and kills it anyway.
+      *
+      * A finite bound converts that into a slower-than-usual exit. Finalizers past the deadline are
+      * skipped, which is safe for the store specifically: the OS releases the lock on process death
+      * and RocksDB recovers from its WAL, which is the same path any crash takes.
+      *
+      * This is a backstop, not a fix — a shutdown that needs it has a bug worth finding.
+      */
+    override protected def runtimeConfig: IORuntimeConfig =
+        super.runtimeConfig.copy(shutdownHookTimeout = 30.seconds)
 
     /** The `version` subcommand: print the version, git revision, and build time baked in at
       * compile time (see [[BuildInfo]]).

--- a/src/main/scala/hydrozoa/app/Serve.scala
+++ b/src/main/scala/hydrozoa/app/Serve.scala
@@ -506,11 +506,11 @@ object Serve {
     /** Compare the chain's live protocol parameters against the ones this head's config asserts,
       * and REFUSE to start on a mismatch.
       *
-      * ⛔ Nothing verified this at start-up before, so a head built
-      * every L1 transaction — settlements, fallbacks, rollouts, refunds — against parameters it
-      * merely assumed, and would keep doing so across a parameter update it never noticed. Those
-      * parameters decide fees, `maxTxSize` and execution-unit budgets, so a drift shows up as
-      * transactions the chain rejects, at the worst possible moment.
+      * ⛔ Nothing verified this at start-up before, so a head built every L1 transaction —
+      * settlements, fallbacks, rollouts, refunds — against parameters it merely assumed, and would
+      * keep doing so across a parameter update it never noticed. Those parameters decide fees,
+      * `maxTxSize` and execution-unit budgets, so a drift shows up as transactions the chain
+      * rejects, at the worst possible moment.
       *
       * ⚠️ Not to be confused with `CardanoBackendBlockfrost.getStartupParams`, which is alive and
       * called from `integration/…/stage1/Suite.scala` — it returns the **compiled-in** constant

--- a/src/main/scala/hydrozoa/app/Serve.scala
+++ b/src/main/scala/hydrozoa/app/Serve.scala
@@ -2,6 +2,7 @@ package hydrozoa.app
 
 import cats.Monoid
 import cats.effect.{ExitCode, IO, Resource}
+import cats.syntax.applicativeError.*
 import cats.syntax.apply.*
 import cats.syntax.contravariant.*
 import cats.syntax.semigroup.*
@@ -13,9 +14,11 @@ import hydrozoa.BuildInfo
 import hydrozoa.config.head.network.CardanoNetwork
 import hydrozoa.config.head.parameters.L2LedgerKind
 import hydrozoa.config.node.NodeConfig
-import hydrozoa.lib.logging.{ContraTracer, Slf4jMsg, Slf4jMsgFormat, Slf4jTracer, info}
+import hydrozoa.lib.StartupRefusal
+import hydrozoa.lib.logging.{ContraTracer, Slf4jMsg, Slf4jMsgFormat, Slf4jTracer, error, info, warn}
 import hydrozoa.multisig.backend.cardano.CardanoBackend
 import hydrozoa.multisig.consensus.peer.{CoilPeerNumber, HeadPeerId, HeadPeerNumber, PeerId}
+import hydrozoa.multisig.consensus.pollresults.PollResults
 import hydrozoa.multisig.consensus.transport.{CoilPeerWsTransport, CoilPeerWsTransportEventFormat, CoilTransport, HubTransport, HubWsTransport, NodeWsServer, WsPeerTransport}
 import hydrozoa.multisig.ledger.eutxol2.store.RocksDbL2Store
 import hydrozoa.multisig.ledger.eutxol2.{EutxoL2Ledger, EutxoL2Screener}
@@ -32,7 +35,9 @@ import org.http4s.Uri
 import org.http4s.ember.client.EmberClientBuilder
 import org.http4s.jdkhttpclient.JdkWSClient
 import org.http4s.server.websocket.WebSocketBuilder2
+import org.rocksdb.RocksDBException
 import scala.concurrent.duration.*
+import scalus.cardano.address.ShelleyAddress
 
 /** The head-node server: the `serve` subcommand of the `hydrozoa` CLI.
   *
@@ -163,7 +168,11 @@ object Serve {
                   ),
                   persistenceTracer,
                 )
-                .handleErrorWith { case e: org.rocksdb.RocksDBException =>
+                // `recoverWith`, not `handleErrorWith`: this handles ONE error type, and a
+                // partial function passed to `handleErrorWith` eta-expands into a total one that
+                // throws `MatchError` on everything else — losing the original cause for, say, a
+                // failure to create the directory.
+                .recoverWith { case e: RocksDBException =>
                     Resource.eval(
                       IO.raiseError(
                         StartupRefusal(
@@ -219,6 +228,33 @@ object Serve {
                 )
             }
 
+            // ⛔ BOTH L1 boot facts are established HERE, before the ActorSystem, and for the same
+            // two reasons the transplant gate above is.
+            //
+            // 1. Cancellability. `preStartLocal` is the handler for a `PreStart` message the regime
+            //    manager posts to itself (`MultisigRegimeManagerBase`), so it runs inside
+            //    `ActorCell.invoke(...).uncancelable`. An unbounded retry there cannot be
+            //    interrupted: SIGTERM does nothing and the process survives to be force-killed by
+            //    `shutdownHookTimeout`. Out here, on the app fiber, a wait is ordinary cancelable
+            //    IO and the node stops when it is asked to.
+            // 2. Exit code. A `StartupRefusal` raised inside the actor system escalates to the
+            //    guardian, which terminates on its own path and exits 1 — which
+            //    `RestartPreventExitStatus=2` does not catch, so the refusal crash-loops. Raised
+            //    here it reaches `StartupRefusal.guard` and exits 2, as intended.
+            //
+            // Neither needs anything the actor system provides: one is a UTxO read, the other a
+            // parameter comparison.
+            firstPollResults <- Resource.eval(
+              waitForFirstPollResults(
+                backend,
+                nodeConfig.initializationTx.treasuryProduced.address
+              )
+            )
+            _ <- Resource.eval {
+                given CardanoNetwork.Section = nodeConfig
+                verifyProtocolParams(backend)
+            }
+
             system <- ActorSystem[IO]("Hydrozoa Demo")
 
             // ⛔ ORDER IS LOAD-BEARING. Resource finalizers run in reverse acquisition order, so
@@ -239,6 +275,7 @@ object Serve {
                     buildHeadNode(
                       nodeConfig,
                       backend,
+                      firstPollResults,
                       l2Ledger,
                       l2Screener,
                       l2QueryReader,
@@ -259,6 +296,7 @@ object Serve {
                     buildCoilNode(
                       nodeConfig,
                       backend,
+                      firstPollResults,
                       l2Ledger,
                       persistence,
                       metrics,
@@ -422,12 +460,120 @@ object Serve {
                 )
         }
 
+    /** Backoff for the boot L1 reads: doubles from 1s, capped at 30s. Capped rather than unbounded
+      * so a node that has been waiting for hours still reacts promptly when L1 returns.
+      */
+    private def l1BootBackoff(attempt: Int): FiniteDuration =
+        (1.second.toNanos * (1L << math.min(attempt, 5))).nanos.min(30.seconds)
+
+    /** Read the treasury address on L1 and produce the first [[PollResults]], WAITING for as long
+      * as it takes.
+      *
+      * ⛔ This is a GATE. `BlockWeaver` starts at `PollResults.empty`, which is structurally
+      * indistinguishable from "polled, and the address is genuinely empty" — there is no
+      * `NeverPolled` state. A head peer classifies deposit existence from its own poll
+      * (`DepositsMap.Existence.FromPoll`), so acting on that empty value would reject every mature
+      * deposit as `NotInPollResults`: terminal, and DEBUG-only in the logs. `ReplayActor` queues
+      * this value into BlockWeaver's mailbox before the start barrier opens, precisely so that
+      * cannot happen.
+      *
+      * It waits rather than failing because a node is useless without this fact either way, and a
+      * failed boot under `Restart=on-failure` becomes a restart loop that outlives the blip.
+      *
+      * ⚠️ The waiting belongs HERE and not in `ReplayActor`, which runs inside an uncancelable
+      * actor message handler — see the call site.
+      */
+    private def waitForFirstPollResults(
+        cardanoBackend: CardanoBackend[IO],
+        treasuryAddress: ShelleyAddress
+    ): IO[PollResults] = {
+        def attempt(n: Int): IO[PollResults] =
+            cardanoBackend.utxosAt(treasuryAddress).flatMap {
+                case Right(utxos) =>
+                    IO.whenA(n > 0)(
+                      log.info(s"boot L1 sample succeeded after ${n + 1} attempts; continuing")
+                    ).as(PollResults(utxos.keySet))
+                case Left(err) =>
+                    val wait = l1BootBackoff(n)
+                    log.warn(
+                      s"boot L1 sample failed (attempt ${n + 1}): $err. Cannot start consensus " +
+                          s"without it, so WAITING rather than failing the boot; retrying in $wait"
+                    ) >> IO.sleep(wait) >> attempt(n + 1)
+            }
+        attempt(0)
+    }
+
+    /** Compare the chain's live protocol parameters against the ones this head's config asserts,
+      * and REFUSE to start on a mismatch.
+      *
+      * ⛔ Nothing did this before: `getStartupParams` existed with zero callers, so a head built
+      * every L1 transaction — settlements, fallbacks, rollouts, refunds — against parameters it
+      * merely assumed, and would keep doing so across a parameter update it never noticed. Those
+      * parameters decide fees, `maxTxSize` and execution-unit budgets, so a drift shows up as
+      * transactions the chain rejects, at the worst possible moment.
+      *
+      * It is a [[StartupRefusal]] rather than a generic crash because it is deterministic: the
+      * config asserts what it asserts, and a restart re-derives the same verdict.
+      *
+      * ⚠️ On `mainnet`, `preprod` and `preview` the comparison is against a value compiled into the
+      * binary, not a config field: the head config carries only the network NAME, and
+      * `cardanoProtocolParams` resolves through `CardanoInfo.<net>` from Scalus. Only a `custom`
+      * network reads parameters from JSON. The remedy differs accordingly, and the message says so
+      * — telling an operator to "update the config" on preview would send them looking for a field
+      * that does not exist.
+      *
+      * Unreachable is NOT drift: it retries, because "cannot ask" and "asked, and the answer is
+      * wrong" are the two classes this whole start-up path exists to separate.
+      */
+    private def verifyProtocolParams(
+        cardanoBackend: CardanoBackend[IO]
+    )(using net: CardanoNetwork.Section): IO[Unit] = {
+        val remedy = net.cardanoNetwork match {
+            case CardanoNetwork.Custom(_, _) =>
+                "Update the `custom` network's protocolParams in the head config to the chain's " +
+                    "current parameters (both values are on the ERROR line above)."
+            case _ =>
+                "These parameters are NOT a config field on a named network — they are compiled " +
+                    "in from Scalus's CardanoInfo. Upgrade Scalus to a version carrying the " +
+                    "chain's current parameters and redeploy every peer; editing the config " +
+                    "cannot fix this."
+        }
+        def attempt(n: Int): IO[Unit] =
+            cardanoBackend.fetchLatestParams.flatMap {
+                case Right(onChain) =>
+                    val assumed = net.cardanoProtocolParams
+                    if onChain == assumed then
+                        log.info("protocol parameters on chain match the ones this config asserts")
+                    else
+                        log.error(
+                          "PROTOCOL PARAMETER MISMATCH: the chain's parameters differ from the " +
+                              "ones this head's config asserts. Refusing to start.\n" +
+                              s"  on chain: $onChain\n" +
+                              s"  config:   $assumed"
+                        ) >> IO.raiseError(
+                          StartupRefusal(
+                            "the chain's protocol parameters differ from the ones this head's " +
+                                "config asserts, so the L1 transactions it builds may be rejected " +
+                                s"by the chain. $remedy"
+                          )
+                        )
+                case Left(err) =>
+                    val wait = l1BootBackoff(n)
+                    log.warn(
+                      s"could not read protocol parameters (attempt ${n + 1}): $err. " +
+                          s"Retrying in $wait."
+                    ) >> IO.sleep(wait) >> attempt(n + 1)
+            }
+        attempt(0)
+    }
+
     /** Build the head-node transports (mesh + optional hub-coil), bind one shared `NodeWsServer`,
       * start dialers, and allocate the [[HeadMultisigRegimeManager]].
       */
     private def buildHeadNode(
         nodeConfig: NodeConfig,
         backend: CardanoBackend[IO],
+        firstPollResults: PollResults,
         l2Ledger: L2Ledger[IO],
         l2Screener: L2Screener[IO],
         l2QueryReader: Option[EutxoL2LedgerReader[IO]],
@@ -518,6 +664,7 @@ object Serve {
             mrm <- HeadMultisigRegimeManager.resource(
               nodeConfig,
               backend,
+              firstPollResults,
               l2Ledger,
               l2Screener,
               persistence,
@@ -536,6 +683,7 @@ object Serve {
     private def buildCoilNode(
         nodeConfig: NodeConfig,
         backend: CardanoBackend[IO],
+        firstPollResults: PollResults,
         l2Ledger: L2Ledger[IO],
         persistence: Persistence[IO],
         metrics: PeerMetrics,
@@ -572,6 +720,7 @@ object Serve {
             mrm <- CoilMultisigRegimeManager.resource(
               nodeConfig,
               backend,
+              firstPollResults,
               l2Ledger,
               persistence,
               metrics,

--- a/src/main/scala/hydrozoa/app/Serve.scala
+++ b/src/main/scala/hydrozoa/app/Serve.scala
@@ -506,11 +506,18 @@ object Serve {
     /** Compare the chain's live protocol parameters against the ones this head's config asserts,
       * and REFUSE to start on a mismatch.
       *
-      * ⛔ Nothing did this before: `getStartupParams` existed with zero callers, so a head built
+      * ⛔ Nothing verified this at start-up before, so a head built
       * every L1 transaction — settlements, fallbacks, rollouts, refunds — against parameters it
       * merely assumed, and would keep doing so across a parameter update it never noticed. Those
       * parameters decide fees, `maxTxSize` and execution-unit budgets, so a drift shows up as
       * transactions the chain rejects, at the worst possible moment.
+      *
+      * ⚠️ Not to be confused with `CardanoBackendBlockfrost.getStartupParams`, which is alive and
+      * called from `integration/…/stage1/Suite.scala` — it returns the **compiled-in** constant
+      * (`provider.cardanoInfo.protocolParams`), where this gate reads the **chain** via
+      * `fetchLatestParams`. Different questions; do not delete it. (An earlier note here claimed it
+      * had zero callers. It was written from a search of `src/` only, and `integration` is a
+      * separate sbt project.)
       *
       * It is a [[StartupRefusal]] rather than a generic crash because it is deterministic: the
       * config asserts what it asserts, and a restart re-derives the same verdict.

--- a/src/main/scala/hydrozoa/app/Serve.scala
+++ b/src/main/scala/hydrozoa/app/Serve.scala
@@ -152,7 +152,7 @@ object Serve {
             persistenceTracer = Slf4jTracer.sink.contramap(PersistenceEventFormat.humanFormat)
             // A held LOCK means another instance owns this store. Deterministic: restarting
             // re-derives the same answer for as long as the other process lives, so it is a
-            // refusal, not a crash. Measured: fails in ~3s with a clear message.
+            // refusal, not a crash. It fails fast, with a message naming the holder.
             backendStore <- RocksDbBackendStore
                 .open(
                   dataDir.resolve(s"peer-${nodeConfig.ownPeerLabel}/rocksdb"),
@@ -198,7 +198,6 @@ object Serve {
             // NOT `hardAckedStack`, which is an interpretation the regime manager must derive
             // exactly once and project into its children.
             _ <- Resource.eval {
-                given CardanoNetwork.Section = nodeConfig
                 nodeConfig.transplantStackNumber.fold(IO.unit)(tag =>
                     Markers
                         .derive(persistence, nodeConfig.ownPeerId)

--- a/src/main/scala/hydrozoa/app/Serve.scala
+++ b/src/main/scala/hydrozoa/app/Serve.scala
@@ -21,9 +21,10 @@ import hydrozoa.multisig.ledger.eutxol2.store.RocksDbL2Store
 import hydrozoa.multisig.ledger.eutxol2.{EutxoL2Ledger, EutxoL2Screener}
 import hydrozoa.multisig.ledger.l2.{EutxoL2LedgerReader, L2Ledger, L2Screener}
 import hydrozoa.multisig.ledger.remote.{RemoteL2Ledger, RemoteL2LedgerEventFormat, RemoteL2Screener, RemoteL2ScreenerEventFormat}
+import hydrozoa.multisig.ledger.stack.StackNumber
 import hydrozoa.multisig.metrics.PeerMetrics
 import hydrozoa.multisig.persistence.rocksdb.RocksDbBackendStore
-import hydrozoa.multisig.persistence.{Cf, ConsensusStoreReader, Persistence, PersistenceEventFormat}
+import hydrozoa.multisig.persistence.{Cf, ConsensusStoreReader, Markers, Persistence, PersistenceEventFormat}
 import hydrozoa.multisig.server.{HydrozoaHttpEvent, HydrozoaHttpEventFormat, HydrozoaServer}
 import hydrozoa.multisig.{CoilMultisigRegimeManager, CoilMultisigRegimeManagerEventFormat, CoilRegimeManagerEvent, HeadMultisigRegimeManager, HeadMultisigRegimeManagerEventFormat, HeadRegimeManagerEvent, MrmTracers}
 import java.nio.file.Path
@@ -176,6 +177,47 @@ object Serve {
             persistence <- Resource.eval {
                 given CardanoNetwork.Section = nodeConfig
                 Persistence.fromBackend(backendStore, persistenceTracer)
+            }
+
+            // ⛔ A transplant must contain the stack it is tagged with.
+            //
+            // `transplantStackNumber` names the stack this peer ELECTS TO ADOPT: everything at or
+            // below it is taken on trust from the donor committee and never verified, and only the
+            // stacks above it are checked. That makes the tag a partition of the store, chosen by
+            // the operator — any stack the store actually holds is a legitimate choice. A tag
+            // naming a stack the store does NOT hold is a different thing entirely: the config and
+            // the data have been mis-paired, and no amount of restarting will pair them.
+            //
+            // ⛔ This runs BEFORE the ActorSystem deliberately. The same verdict raised inside it
+            // escalates to the guardian, which terminates the system and exits 1 — and the unit's
+            // `RestartPreventExitStatus=2` does not catch a 1, so a mistyped tag would crash-loop.
+            // Here it is an ordinary `StartupRefusal` and exits 2. It needs nothing but the store
+            // and the config, so there is no reason for it to run any later.
+            //
+            // ⚠️ Reads `hardConfirmed` only — a plain `lastKey`, safe to derive more than once.
+            // NOT `hardAckedStack`, which is an interpretation the regime manager must derive
+            // exactly once and project into its children.
+            _ <- Resource.eval {
+                given CardanoNetwork.Section = nodeConfig
+                nodeConfig.transplantStackNumber.fold(IO.unit)(tag =>
+                    Markers
+                        .derive(persistence, nodeConfig.ownPeerId)
+                        .flatMap(markers =>
+                            IO.raiseUnless(
+                              markers.hardConfirmed.exists(Ordering[StackNumber].gteq(_, tag))
+                            )(
+                              StartupRefusal(
+                                s"transplantStackNumber is $tag, but the highest hard-confirmed " +
+                                    "stack in this store is " +
+                                    markers.hardConfirmed.fold("none — the store is empty")(
+                                      _.toString
+                                    ) +
+                                    ". A transplant must contain the stack it is tagged with; " +
+                                    "check that the store was copied and the tag read from that copy."
+                              )
+                            )
+                        )
+                )
             }
 
             system <- ActorSystem[IO]("Hydrozoa Demo")

--- a/src/main/scala/hydrozoa/app/Serve.scala
+++ b/src/main/scala/hydrozoa/app/Serve.scala
@@ -61,7 +61,14 @@ object Serve {
         Command(
           name = "serve",
           header = "Run a Hydrozoa head node from a generated config"
-        )((headConfigPathArg, privateConfigPathArg).mapN((h, p) => runNode(h, p)))
+        )(
+          (headConfigPathArg, privateConfigPathArg).mapN((h, p) =>
+              // A deterministic refusal exits with a distinct code so the unit's
+              // `RestartPreventExitStatus=` can stop a supervisor from re-deriving the same
+              // verdict forever. Everything transient waits instead of exiting at all.
+              StartupRefusal.guard(runNode(h, p))
+          )
+        )
 
     /** Run a Hydrozoa head node from a loaded config.
       *
@@ -142,15 +149,30 @@ object Serve {
             // BackendStore (byte-level primitive), then wrap it in the typed Persistence the
             // actor topology consumes.
             persistenceTracer = Slf4jTracer.sink.contramap(PersistenceEventFormat.humanFormat)
-            backendStore <- RocksDbBackendStore.open(
-              dataDir.resolve(s"peer-${nodeConfig.ownPeerLabel}/rocksdb"),
-              Cf.mkAll(
-                headPeers = nodeConfig.headConfig.headPeerNums.toList,
-                coilPeers = nodeConfig.headConfig.coilPeers.coilPeerNumbers,
-                hubs = nodeConfig.headConfig.coilPeers.hubHeadPeerNumbers
-              ),
-              persistenceTracer,
-            )
+            // A held LOCK means another instance owns this store. Deterministic: restarting
+            // re-derives the same answer for as long as the other process lives, so it is a
+            // refusal, not a crash. Measured: fails in ~3s with a clear message.
+            backendStore <- RocksDbBackendStore
+                .open(
+                  dataDir.resolve(s"peer-${nodeConfig.ownPeerLabel}/rocksdb"),
+                  Cf.mkAll(
+                    headPeers = nodeConfig.headConfig.headPeerNums.toList,
+                    coilPeers = nodeConfig.headConfig.coilPeers.coilPeerNumbers,
+                    hubs = nodeConfig.headConfig.coilPeers.hubHeadPeerNumbers
+                  ),
+                  persistenceTracer,
+                )
+                .handleErrorWith { case e: org.rocksdb.RocksDBException =>
+                    Resource.eval(
+                      IO.raiseError(
+                        StartupRefusal(
+                          s"cannot open the persistence store (${e.getMessage}). Another hydrozoa " +
+                              "instance is most likely holding it.",
+                          Some(e)
+                        )
+                      )
+                    )
+                }
             persistence <- Resource.eval {
                 given CardanoNetwork.Section = nodeConfig
                 Persistence.fromBackend(backendStore, persistenceTracer)

--- a/src/main/scala/hydrozoa/app/Serve.scala
+++ b/src/main/scala/hydrozoa/app/Serve.scala
@@ -547,7 +547,7 @@ object Serve {
 
             // The HTTP server needs the RequestSequencer, which only exists once connections
             // resolve, so wait for them before binding.
-            connections <- mrm.connectionsDeferred.get
+            connections <- mrm.connectionsDeferred.get.flatMap(IO.fromEither)
             _ <- log.info("Starting HTTP server...")
 
             // `surround`, not `start.void`: the server is bound for exactly as long as the node
@@ -598,7 +598,7 @@ object Serve {
             _ <- system.actorOf(mrm, "CoilMultisigRegimeManager")
             _ <- log.info("Hydrozoa coil node started successfully")
 
-            connections <- mrm.connectionsDeferred.get
+            connections <- mrm.connectionsDeferred.get.flatMap(IO.fromEither)
             _ <- log.info("Starting HTTP server (coil: read-only surface)...")
 
             // `surround` binds the server for the node's lifetime and releases it when the actor

--- a/src/main/scala/hydrozoa/app/Serve.scala
+++ b/src/main/scala/hydrozoa/app/Serve.scala
@@ -135,7 +135,7 @@ object Serve {
             // `remoteLedgerUri`. Only the EUTXO ledger is also an EutxoL2LedgerReader, so only it
             // yields a reader for the server's L2-query endpoints (a remote node hands it None).
             l2 <- mkL2Ledger(nodeConfig, dataDir)
-            (l2Ledger, l2Screener, l2QueryReader) = l2
+            (l2Ledger, l2Screener, l2QueryReader, signalL2Shutdown) = l2
 
             // Per-peer persistence store. Default path; later milestones will surface this
             // through NodeConfig (P1 skeleton; see design §7). Open the RocksDB-backed
@@ -157,6 +157,14 @@ object Serve {
             }
 
             system <- ActorSystem[IO]("Hydrozoa Demo")
+
+            // ⛔ ORDER IS LOAD-BEARING. Resource finalizers run in reverse acquisition order, so
+            // acquiring this AFTER the ActorSystem makes it release BEFORE the system is torn down.
+            // A remote L2 ledger retries transport failure forever from inside a cats-actors message
+            // handler, and `ActorCell` wraps handlers in `.uncancelable` — so the system cannot stop
+            // that actor, and without this signal SIGTERM does not shut the node down at all. Move
+            // this line above the ActorSystem and the node stops exiting cleanly.
+            _ <- Resource.onFinalize(signalL2Shutdown)
 
             wsClient <- Resource.eval(JdkWSClient.simple[IO])
 
@@ -283,7 +291,7 @@ object Serve {
     private def mkL2Ledger(
         nodeConfig: NodeConfig,
         dataDir: Path,
-    ): Resource[IO, (L2Ledger[IO], L2Screener[IO], Option[EutxoL2LedgerReader[IO]])] =
+    ): Resource[IO, (L2Ledger[IO], L2Screener[IO], Option[EutxoL2LedgerReader[IO]], IO[Unit])] =
         nodeConfig.headConfig.l2Ledger match {
             case L2LedgerKind.CardanoEutxo =>
                 for {
@@ -292,7 +300,7 @@ object Serve {
                       dataDir.resolve(s"peer-${nodeConfig.ownPeerLabel}/l2-rocksdb")
                     )
                     ledger <- Resource.eval(EutxoL2Ledger(nodeConfig, store))
-                } yield (ledger, EutxoL2Screener(nodeConfig), Some(ledger))
+                } yield (ledger, EutxoL2Screener(nodeConfig), Some(ledger), IO.unit)
             case L2LedgerKind.AnyRemote =>
                 val tracer = Slf4jTracer.sink.contramap(RemoteL2LedgerEventFormat.humanFormat)
                 val wsUri = nodeConfig.remoteLedgerUri.getOrElse(
@@ -308,7 +316,12 @@ object Serve {
                       tracer = tracer,
                     )
                     screener <- mkRemoteScreener(nodeConfig)
-                } yield (ledger, screener, Option.empty[EutxoL2LedgerReader[IO]])
+                } yield (
+                  ledger,
+                  screener,
+                  Option.empty[EutxoL2LedgerReader[IO]],
+                  ledger.signalShutdown
+                )
         }
 
     /** The screener for a remote-ledger node: the stateless check every request must pass before it

--- a/src/main/scala/hydrozoa/app/StartupRefusal.scala
+++ b/src/main/scala/hydrozoa/app/StartupRefusal.scala
@@ -1,0 +1,45 @@
+package hydrozoa.app
+
+import cats.effect.{ExitCode, IO}
+
+/** A deliberate, deterministic refusal to start: something about THIS node is wrong, and starting
+  * it again will reach the same conclusion.
+  *
+  * ⛔ The distinction this carries is the whole point. A node that cannot reach Cardano, its ledger
+  * or its peers now **waits** — indefinitely, visibly, and without exiting — because the world may
+  * yet become ready. A node whose config is malformed, whose script reference UTxOs are not on
+  * chain, or whose store is held by another instance is in a state no amount of retrying can fix,
+  * and it must fail loudly and STAY failed.
+  *
+  * Conflating the two is what produces an infinite `Restart=on-failure` loop: the supervisor
+  * answers a permanent verdict by re-deriving it every `RestartSec`, forever, learning nothing. So
+  * a refusal exits with [[StartupRefusal.exitCode]] and the unit sets `RestartPreventExitStatus=`
+  * to match.
+  *
+  * ⚠️ Do NOT reach for this to make an unavailable dependency fail faster. If a human could fix it
+  * by waiting, it is not a refusal.
+  */
+final case class StartupRefusal(reason: String, cause: Option[Throwable] = None)
+    extends RuntimeException(reason, cause.orNull)
+
+object StartupRefusal:
+
+    /** Distinct from 1 (a generic failure) so a supervisor can tell "do not restart me" from "I
+      * crashed and a restart might help". Mirrored by `RestartPreventExitStatus=2` in the unit.
+      */
+    val exitCode: ExitCode = ExitCode(2)
+
+    /** Run `io`, turning a refusal into [[exitCode]] rather than an unhandled crash. Anything else
+      * propagates unchanged: an unexpected throwable is not a considered verdict and a restart may
+      * well be the right answer to it.
+      */
+    def guard(io: IO[ExitCode]): IO[ExitCode] =
+        io.handleErrorWith {
+            case r: StartupRefusal =>
+                IO.println(
+                  s"hydrozoa refuses to start: ${r.reason}\n" +
+                      "This is a deliberate refusal, not a transient failure — restarting will " +
+                      "reach the same conclusion. Fix the cause and start again."
+                ).as(exitCode)
+            case other => IO.raiseError(other)
+        }

--- a/src/main/scala/hydrozoa/bootstrap/Bootstrap.scala
+++ b/src/main/scala/hydrozoa/bootstrap/Bootstrap.scala
@@ -19,7 +19,7 @@ import hydrozoa.config.head.network.{CardanoNetwork, StandardCardanoNetwork}
 import hydrozoa.config.head.parameters.{HeadParameters, L2LedgerKind}
 import hydrozoa.config.head.peers.{HeadPeerData, HeadPeers}
 import hydrozoa.config.head.rulebased.dispute.DisputeResolutionConfig
-import hydrozoa.config.node.NodeConfig
+import hydrozoa.config.node.{NodeConfig, PrivateSecrets}
 import hydrozoa.lib.cardano.cip116.JsonCodecs.CIP0116.Conway.given
 import hydrozoa.lib.cardano.scalus.QuantizedTime.QuantizedInstant.realTimeQuantizedInstant
 import hydrozoa.lib.cardano.scalus.QuantizedTime.quantize
@@ -37,8 +37,9 @@ import hydrozoa.multisig.ledger.l1.tx.RawTx
 import hydrozoa.multisig.ledger.l1.txseq.InitializationTxSeq
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import io.circe.syntax.*
-import io.circe.{Decoder, DecodingFailure, Encoder, Json, parser}
+import io.circe.{Decoder, DecodingFailure, Encoder, Json, JsonObject, parser}
 import java.nio.charset.StandardCharsets
+import java.nio.file.attribute.PosixFilePermissions
 import java.nio.file.{Files, Path}
 import java.security.SecureRandom
 import org.bouncycastle.crypto.generators.Ed25519KeyPairGenerator
@@ -817,14 +818,22 @@ object GenerateKeyPair:
     ): IO[Unit] = for {
         templateStr <- IO.blocking(Files.readString(templatePath))
         template <- IO.fromEither(parser.parse(templateStr))
-        filled <- IO.fromEither(
+        result <- IO.fromEither(
           fillPrivateConfig(template, role, vKeyHex, sKeyHex).left.map(
             new IllegalArgumentException(_)
           )
         )
+        (filled, secrets) = result
+        envPath = outPath.resolveSibling(PrivateSecrets.defaultFileName)
         _ <- IO.blocking {
             Option(outPath.getParent).foreach(Files.createDirectories(_))
             Files.writeString(outPath, filled.spaces2)
+            Files.writeString(
+              envPath,
+              secrets.map((k, v) => s"$k=$v").toList.sorted.mkString("", "\n", "\n")
+            )
+            // The config beside it is meant to be shareable; this file is the reason that is safe.
+            Files.setPosixFilePermissions(envPath, PosixFilePermissions.fromString("rw-------"))
         }
     } yield ()
 
@@ -839,24 +848,52 @@ object GenerateKeyPair:
         role: Role,
         vKeyHex: String,
         sKeyHex: String
-    ): Either[String, Json] = {
-        def mkWallet(v: String, s: String): Json = Json.obj(
-          "verificationKey" -> Json.fromString(v),
-          "signingKey" -> Json.fromString(s)
-        )
+    ): Either[String, (Json, Map[String, String])] = {
         val walletField = role match {
             case Role.Head => "ownHeadWallet"
             case Role.Coil => "ownCoilWallet"
         }
+        // The generated signing key never enters the config; only its public half does, and the
+        // node re-pairs the two at boot and refuses if they disagree.
+        val ownWallet = Json.obj("verificationKey" -> Json.fromString(vKeyHex))
+
+        /** Lift a secret the template still carries out of the config and into the env map. */
+        def lift(obj: JsonObject, field: String): (JsonObject, Option[String]) =
+            obj(field).flatMap(_.asString) match
+                case Some(v) if v.nonEmpty => (obj.remove(field), Some(v))
+                case _                     => (obj, None)
+
         for {
             obj <- template.asObject.toRight("template is not a JSON object")
-            withWallet = obj
-                .add("ownPeerPrivate", Json.obj(walletField -> mkWallet(vKeyHex, sKeyHex)))
-            filled = role match {
+            withWallet = obj.add("ownPeerPrivate", Json.obj(walletField -> ownWallet))
+            roleFixed = role match {
                 case Role.Head => withWallet
                 case Role.Coil => withWallet.remove("remoteScreenerUri")
             }
-        } yield Json.fromJsonObject(filled)
+            (noBlockfrost, bfKey) = lift(roleFixed, "blockfrostApiKey")
+            (noAdmin, adminPw) = lift(noBlockfrost, "adminPassword")
+            evac = noAdmin("nodeOperationEvacuationConfig").flatMap(_.asObject)
+            ruleBased = evac.flatMap(_.apply("ruleBasedWallet")).flatMap(_.asObject)
+            ruleKey = ruleBased
+                .flatMap(_.apply("signingKey"))
+                .flatMap(_.asString)
+                .filter(_.nonEmpty)
+            cleaned = (evac, ruleBased) match
+                case (Some(e), Some(rb)) =>
+                    noAdmin.add(
+                      "nodeOperationEvacuationConfig",
+                      Json.fromJsonObject(
+                        e.add("ruleBasedWallet", Json.fromJsonObject(rb.remove("signingKey")))
+                      )
+                    )
+                case _ => noAdmin
+            secrets = List(
+              Some("HYDROZOA_SIGNING_KEY" -> sKeyHex),
+              bfKey.map("HYDROZOA_BLOCKFROST_API_KEY" -> _),
+              adminPw.map("HYDROZOA_ADMIN_PASSWORD" -> _),
+              ruleKey.map("HYDROZOA_RULE_BASED_SIGNING_KEY" -> _)
+            ).flatten.toMap
+        } yield (Json.fromJsonObject(cleaned), secrets)
     }
 
     private def mkHex(bytes: Array[Byte]): String = bytes.map("%02x".format(_)).mkString

--- a/src/main/scala/hydrozoa/config/head/HeadConfig.scala
+++ b/src/main/scala/hydrozoa/config/head/HeadConfig.scala
@@ -50,6 +50,8 @@ final case class HeadConfig private (
 ) extends HeadConfig.Section {
     override transparent inline def headConfig: HeadConfig = this
 
+    override lazy val headParamsHash: Hash32 = HeadParamsHash(this)
+
     override def headConfigBootstrap: HeadConfig.Bootstrap = {
         val initTx = initialBlock.effects.initializationTx
 
@@ -242,16 +244,21 @@ object HeadConfig {
     trait Section extends HeadConfig.Bootstrap.Section, InitialBlock.Section {
         def headConfig: HeadConfig
 
+        /** The digest pinning this whole configuration — see [[HeadParamsHash]] and
+          * `design/head-params-hash.md`.
+          */
+        def headParamsHash: Hash32 = headConfig.headParamsHash
+
         override def headConfigBootstrap: Bootstrap = headConfig.headConfigBootstrap
         def initialBlockSection: InitialBlock = headConfig.initialBlockSection
     }
 
     /** @param coilPeers
       *   The coil peers keyed by explicit [[CoilPeerNumber]] (verification key + hub head peer).
-      * @param l2Params
-      *   a black-box, L2-specific blake2b-256 hash of parameters that the peers must agree on
-      *   before initialization.
       */
+    // TODO: the L2 parameters hash is `HeadParameters.l2ParamsHash` and is documented there.
+    //  Keep that single name — `l2Params` is not a field of anything. See
+    //  design/head-params-hash.md for what the hash covers per backend.
     final case class Bootstrap private[head] (
         override val cardanoNetwork: CardanoNetwork,
         override val headParameters: HeadParameters,

--- a/src/main/scala/hydrozoa/config/head/HeadParamsHash.scala
+++ b/src/main/scala/hydrozoa/config/head/HeadParamsHash.scala
@@ -1,0 +1,193 @@
+package hydrozoa.config.head
+
+import hydrozoa.config.HydrozoaBlueprint
+import hydrozoa.config.head.multisig.timing.TxTiming.BlockTimes.given
+import hydrozoa.config.head.multisig.timing.TxTiming.Durations.given
+import hydrozoa.lib.cardano.scalus.QuantizedTime.{QuantizedFiniteDuration, QuantizedInstant}
+import java.io.ByteArrayOutputStream
+import java.lang.Double.doubleToLongBits
+import java.nio.charset.StandardCharsets.UTF_8
+import scala.concurrent.duration.FiniteDuration
+import scalus.cardano.ledger.{Blake2b_256, Coin, Hash, Hash32, ScriptHash, TransactionInput}
+import scalus.uplc.builtin.{ByteString, platform}
+
+/** The digest that pins a head's agreed configuration, as defined in `design/head-params-hash.md`.
+  *
+  * It covers the **whole head config**, not only the [[parameters.HeadParameters]] case class: the
+  * head parameters, the L1 network, the per-peer equity split, the script references, block zero's
+  * timing, and the coil hub topology. Peers never exchange their configs, so this is what makes a
+  * disagreement visible — the multisig treasury datum carries it, and a peer that computes a
+  * different value cannot parse the initialization transaction and so never signs block zero.
+  *
+  * ```
+  * headParamsHash = blake2b_256(
+  *      "gummiworm-head-params-v1"
+  *   || <HeadParameters, in declaration order>
+  *   || <cardanoNetwork> || <initialEquityContributions> || <scriptReferences>
+  *   || <initialBlockTiming> || <coilHubTopology>
+  * )
+  * ```
+  *
+  * The layout is written out byte by byte rather than delegating to a JSON or CBOR encoder.
+  * `QuantizedFiniteDuration`, `Coin` and `PositiveInt` each have their own codec quirks, and a
+  * codec tweak that silently moved this value — once it is written into a treasury datum — would
+  * leave a live head unable to parse its own initialization transaction.
+  *
+  * See `design/head-params-hash.md` for what each field is doing here, what is deliberately left
+  * out, and the checks that compare this value.
+  */
+object HeadParamsHash {
+
+    /** Mixed in before anything else so this digest can never collide with a hash of the same bytes
+      * taken for another purpose. ASCII, no terminator — the fixed-width field that follows makes
+      * the boundary unambiguous.
+      */
+    val domainTag: Array[Byte] = "gummiworm-head-params-v1".getBytes(UTF_8)
+
+    def apply(config: HeadConfig.Section): Hash32 = {
+        val out = Buffer()
+        out.raw(domainTag)
+
+        // -- HeadParameters.txTiming
+        out.duration(config.minSettlementDuration.convert)
+        out.duration(config.inactivityMarginDuration.convert)
+        out.duration(config.silenceDuration.convert)
+        out.duration(config.depositSubmissionDuration.convert)
+        out.duration(config.depositMaturityDuration.convert)
+        out.duration(config.depositAbsorptionDuration.convert)
+
+        // -- HeadParameters.fallbackContingency
+        val collective = config.collectiveContingency
+        out.coin(collective.publicVoteDeposit)
+        out.coin(collective.fallbackTxFee)
+        out.coin(collective.minAdaForTreasury)
+        out.coin(collective.minAdaForRegime)
+        val individual = config.individualContingency
+        out.coin(individual.collateralDeposit)
+        out.coin(individual.tallyTxFee)
+        out.coin(individual.voteDeposit)
+        out.coin(individual.voteTxFee)
+
+        // -- HeadParameters: disputeResolutionConfig / settlementConfig / blockConfig
+        out.duration(config.votingDuration)
+        out.u32(config.maxDepositsAbsorbedPerBlock.convert)
+        out.u32(config.maxRequestsPerBlock.convert)
+        out.u32(config.backpressureCoefficient.convert)
+
+        // `rateLimits` is deliberately absent: it is node-local, and nothing a follower validates
+        // depends on it. See design/head-params-hash.md, "What is left out".
+
+        // -- HeadParameters: the rest
+        out.u32(config.coilQuorum)
+        out.hash32(config.l2ParamsHash)
+        out.framed(config.l2Ledger.configString.getBytes(UTF_8))
+        out.bool(config.identityIsomorphism)
+
+        // -- cardanoNetwork. `networkId` is scalus's own id byte, which covers `Network.Other` too;
+        // `protocolMagic` alone does not determine it, because `CardanoNetwork.Custom` pairs an
+        // arbitrary `CardanoInfo` with an arbitrary magic. The protocol params are absent on
+        // purpose: they are fetched from the chain and move with hard forks, so they are not
+        // something the peers agree on.
+        out.u64(config.protocolMagic)
+        out.u8(config.network.networkId)
+        val slotConfig = config.slotConfig
+        out.u64(slotConfig.zeroTime)
+        out.u64(slotConfig.zeroSlot)
+        out.u64(slotConfig.slotLength)
+
+        // -- initialEquityContributions, ascending by HeadPeerNumber. The per-peer split, not just
+        // the total: only the total reaches the treasury value.
+        val equity = config.initialEquityContributions.toSortedMap
+        out.u32(equity.size)
+        equity.foreach { (peer, coin) =>
+            out.u32(peer.convert)
+            out.coin(coin)
+        }
+
+        // -- scriptReferences. Pin an output reference exactly where the chain pins one, and the
+        // hash everywhere else: the two Plutus scripts contribute their hashes (a build mismatch
+        // nothing else catches), the setup ladder its rung-0 outref (what the regime datum
+        // records as `setupG2Ladder`).
+        out.scriptHash(HydrozoaBlueprint.treasuryScriptHash)
+        out.scriptHash(HydrozoaBlueprint.disputeScriptHash)
+        out.transactionInput(config.setupLadderAnchor)
+
+        // -- initialBlockTiming. Only `startTime` and `endTime` reach the initialization
+        // transaction's validity end; the other three reach no transaction at all.
+        val header = config.initialBlock.blockBrief.header
+        out.instant(header.startTime.convert)
+        out.instant(header.endTime.convert)
+        out.instant(header.fallbackTxStartTime.convert)
+        out.instant(header.forcedMajorBlockWakeupTime.convert)
+        header.mDepositDecisionWakeupTime match {
+            case None => out.bool(false)
+            case Some(wakeup) =>
+                out.bool(true)
+                out.instant(wakeup.convert)
+        }
+
+        // -- coilHubTopology, ascending by CoilPeerNumber. Coil peer numbers are contiguous from
+        // zero, so a hub's position in the sequence is its coil peer number and is not repeated.
+        val coilPeers = config.coilPeers
+        val hubs = coilPeers.coilPeerNumbers.flatMap(coilPeers.hubHeadPeerNumber)
+        out.u32(hubs.size)
+        hubs.foreach(hub => out.u32(hub.convert))
+
+        Hash[Blake2b_256, Any](platform.blake2b_256(ByteString.unsafeFromArray(out.bytes)))
+    }
+
+    /** Accumulates the preimage. Variable-width values are length-framed and fixed-width ones are
+      * not, so no two distinct configs can produce the same byte string.
+      */
+    private final class Buffer {
+        private val buffer = ByteArrayOutputStream()
+
+        def bytes: Array[Byte] = buffer.toByteArray
+
+        def raw(value: Array[Byte]): Unit = buffer.write(value)
+
+        def framed(value: Array[Byte]): Unit = {
+            u32(value.length)
+            buffer.write(value)
+        }
+
+        def u8(value: Int): Unit = buffer.write(value & 0xff)
+
+        def u32(value: Int): Unit = {
+            buffer.write((value >>> 24) & 0xff)
+            buffer.write((value >>> 16) & 0xff)
+            buffer.write((value >>> 8) & 0xff)
+            buffer.write(value & 0xff)
+        }
+
+        def u64(value: Long): Unit = {
+            u32((value >>> 32).toInt)
+            u32(value.toInt)
+        }
+
+        def bool(value: Boolean): Unit = u8(if value then 0x01 else 0x00)
+
+        /** IEEE-754 bits, big-endian. `doubleToLongBits` rather than the raw variant, so every NaN
+          * collapses to one canonical bit pattern and the digest cannot depend on which NaN a
+          * decoder happened to produce.
+          */
+        def f64(value: Double): Unit = u64(doubleToLongBits(value))
+
+        def coin(value: Coin): Unit = u64(value.value)
+
+        def duration(value: QuantizedFiniteDuration): Unit = finiteDuration(value.finiteDuration)
+
+        def finiteDuration(value: FiniteDuration): Unit = u64(value.toMillis)
+
+        def instant(value: QuantizedInstant): Unit = u64(value.instant.toEpochMilli)
+
+        def hash32(value: Hash32): Unit = raw(value.bytes)
+
+        def scriptHash(value: ScriptHash): Unit = raw(value.bytes)
+
+        def transactionInput(value: TransactionInput): Unit = {
+            raw(value.transactionId.bytes)
+            u32(value.index)
+        }
+    }
+}

--- a/src/main/scala/hydrozoa/config/head/parameters/HeadParameters.scala
+++ b/src/main/scala/hydrozoa/config/head/parameters/HeadParameters.scala
@@ -63,8 +63,6 @@ object HeadParameters {
 
         def coilQuorum: Int = headParameters.coilQuorum
 
-        final def headParamsHash: Hash32 = ???
-
         def txTiming: TxTiming = headParameters.txTiming
 
         def fallbackContingency: FallbackContingency =

--- a/src/main/scala/hydrozoa/config/head/parameters/L2LedgerKind.scala
+++ b/src/main/scala/hydrozoa/config/head/parameters/L2LedgerKind.scala
@@ -18,10 +18,16 @@ object L2LedgerKind {
     private val cardanoEutxo = "cardano-eutxo"
     private val anyRemote = "any-remote"
 
-    given Encoder[L2LedgerKind] = Encoder.encodeString.contramap {
-        case L2LedgerKind.CardanoEutxo => cardanoEutxo
-        case L2LedgerKind.AnyRemote    => anyRemote
-    }
+    extension (self: L2LedgerKind)
+        /** The name this kind carries in every config file and on the wire. Single-sourced here so
+          * the JSON codec and [[hydrozoa.config.head.HeadParamsHash]] agree by construction.
+          */
+        def configString: String = self match {
+            case L2LedgerKind.CardanoEutxo => cardanoEutxo
+            case L2LedgerKind.AnyRemote    => anyRemote
+        }
+
+    given Encoder[L2LedgerKind] = Encoder.encodeString.contramap(_.configString)
 
     given Decoder[L2LedgerKind] = Decoder.decodeString.emap {
         case `cardanoEutxo` => Right(L2LedgerKind.CardanoEutxo)

--- a/src/main/scala/hydrozoa/config/node/NodeConfig.scala
+++ b/src/main/scala/hydrozoa/config/node/NodeConfig.scala
@@ -3,6 +3,7 @@ package hydrozoa.config.node
 import cats.data.EitherT
 import cats.effect.*
 import cats.syntax.contravariant.*
+import hydrozoa.app.StartupRefusal
 import hydrozoa.config.ScriptReferenceUtxos
 import hydrozoa.config.head.HeadConfig
 import hydrozoa.config.head.coil.CoilPeers
@@ -195,7 +196,13 @@ object NodeConfig {
               NodeConfig.fromJson(headStr, privateStr, backendOverride).value
             ).flatMap {
                 case Left(err) =>
-                    IO.raiseError(new RuntimeException(s"Failed to load NodeConfig: $err"))
+                    // Reached only for a DETERMINISTIC failure: `isWorthRetrying` retries a
+                    // backend error forever, so anything arriving here is a malformed config or a
+                    // script reference UTxO that is not on chain. Re-deriving that verdict on a
+                    // supervisor restart loop teaches nobody anything.
+                    IO.raiseError(
+                      StartupRefusal(s"failed to load NodeConfig: $err")
+                    )
                 case Right(ok) => IO.pure(ok)
             }
         } yield loaded

--- a/src/main/scala/hydrozoa/config/node/NodeConfig.scala
+++ b/src/main/scala/hydrozoa/config/node/NodeConfig.scala
@@ -207,12 +207,23 @@ object NodeConfig {
       * a process supervisor answers by starting it again, immediately, into the same failure. That
       * turns a brief loss of egress into a crash loop that outlives it.
       *
-      * The total wait is a little under two minutes. Long enough to ride out a DNS or upstream
-      * blip; short enough that a genuinely wrong config still fails while someone is watching the
-      * deploy.
+      * ⛔ UNBOUNDED, deliberately, and this is the whole point. The ladder used to stop after ~112
+      * seconds, which meant any loss of egress longer than two minutes ended in exactly the crash
+      * loop the paragraph above set out to prevent. A node that cannot reach Cardano cannot do
+      * anything useful, so exiting buys nothing and costs an endless restart cycle; waiting is
+      * strictly better and is visible on the dashboard.
+      *
+      * ⚠️ This does NOT make a wrong config wait: [[isWorthRetrying]] retries only
+      * `CardanoBackendError`. A malformed config or an unresolvable script UTxO still fails
+      * immediately, because re-reading the same bytes gives the same answer. That split is the
+      * difference between "the world is not ready yet" and "this node is misconfigured", and the
+      * two must never be treated alike.
+      *
+      * It backs off 2s, 5s, 15s, 30s and then every 60s forever — capped so a node that has been
+      * waiting for hours still reacts promptly when egress returns.
       */
-    private val backendReadRetryWaits: List[FiniteDuration] =
-        List(2.seconds, 5.seconds, 15.seconds, 30.seconds, 60.seconds)
+    private val backendReadRetryWaits: LazyList[FiniteDuration] =
+        LazyList(2.seconds, 5.seconds, 15.seconds, 30.seconds) #::: LazyList.continually(60.seconds)
 
     /** Whether a failed load is worth another attempt. Anything that reached the Cardano backend is
       * — including an error the backend classified, since a DNS failure surfaces as a resolve error
@@ -230,11 +241,11 @@ object NodeConfig {
       * can drive the same loop without waiting minutes.
       */
     private[node] def retryingBackendReads[A](
-        waits: List[FiniteDuration],
+        waits: LazyList[FiniteDuration],
         attempt: IO[Either[ScriptReferenceUtxos.Error | io.circe.Error, A]]
     ): IO[Either[ScriptReferenceUtxos.Error | io.circe.Error, A]] =
         def go(
-            remaining: List[FiniteDuration]
+            remaining: LazyList[FiniteDuration]
         ): IO[Either[ScriptReferenceUtxos.Error | io.circe.Error, A]] =
             // A raised throwable gets the same treatment as a backend error: building the backend
             // is itself a network operation, and it reports failure by raising rather than by a
@@ -251,10 +262,13 @@ object NodeConfig {
                         case Right(Left(e)) => isWorthRetrying(e)
                         case _              => false
                     (remaining, retryable) match
-                        case (wait :: rest, true) =>
+                        case (wait #:: rest, true) =>
+                            // ⛔ Do NOT report "attempts left" here: `remaining` is an
+                            // infinite LazyList in production and forcing its length hangs.
                             log.warn(
                               s"Config load failed against the Cardano backend ($reason); " +
-                                  s"retrying in $wait (${rest.length} attempts left after this)."
+                                  s"retrying in $wait. The node cannot start without this, so it " +
+                                  "WAITS rather than exiting into a restart loop."
                             ) >> IO.sleep(wait) >> go(rest)
                         case _ =>
                             other match

--- a/src/main/scala/hydrozoa/config/node/NodeConfig.scala
+++ b/src/main/scala/hydrozoa/config/node/NodeConfig.scala
@@ -3,7 +3,6 @@ package hydrozoa.config.node
 import cats.data.EitherT
 import cats.effect.*
 import cats.syntax.contravariant.*
-import hydrozoa.lib.StartupRefusal
 import hydrozoa.config.ScriptReferenceUtxos
 import hydrozoa.config.head.HeadConfig
 import hydrozoa.config.head.coil.CoilPeers
@@ -16,6 +15,7 @@ import hydrozoa.config.node.NodePrivateConfig.given
 import hydrozoa.config.node.operation.evacuation.NodeOperationEvacuationConfig
 import hydrozoa.config.node.operation.multisig.NodeOperationMultisigConfig
 import hydrozoa.config.node.owninfo.{OwnCoilPeerPrivate, OwnHeadPeerPrivate}
+import hydrozoa.lib.StartupRefusal
 import hydrozoa.lib.logging.{ContraTracer, Slf4jMsg, Slf4jMsgFormat, Slf4jTracer, warn}
 import hydrozoa.multisig.backend.cardano.{CardanoBackend, CardanoBackendBlockfrost, CardanoBackendEventFormat}
 import hydrozoa.multisig.consensus.peer.PeerId.isCoil

--- a/src/main/scala/hydrozoa/config/node/NodeConfig.scala
+++ b/src/main/scala/hydrozoa/config/node/NodeConfig.scala
@@ -3,7 +3,7 @@ package hydrozoa.config.node
 import cats.data.EitherT
 import cats.effect.*
 import cats.syntax.contravariant.*
-import hydrozoa.app.StartupRefusal
+import hydrozoa.lib.StartupRefusal
 import hydrozoa.config.ScriptReferenceUtxos
 import hydrozoa.config.head.HeadConfig
 import hydrozoa.config.head.coil.CoilPeers

--- a/src/main/scala/hydrozoa/config/node/NodeConfig.scala
+++ b/src/main/scala/hydrozoa/config/node/NodeConfig.scala
@@ -190,7 +190,20 @@ object NodeConfig {
     ): IO[(NodeConfig, CardanoBackend[IO])] =
         for {
             headStr <- IO.blocking(Files.readString(headConfigPath))
-            privateStr <- IO.blocking(Files.readString(privateConfigPath))
+            privateRaw <- IO.blocking(Files.readString(privateConfigPath))
+            // Credentials come from the environment, not from the config file, so they are spliced
+            // in before decoding and the decoders below are unchanged. A missing or mismatched one
+            // is a `StartupRefusal` raised here — deliberately ahead of the backend reads, since it
+            // is a verdict about this node alone and no amount of retrying changes it.
+            privateJson <- IO.fromEither(
+              io.circe.parser
+                  .parse(privateRaw)
+                  .left
+                  .map(e =>
+                      StartupRefusal(s"$privateConfigPath is not valid JSON: ${e.getMessage}")
+                  )
+            )
+            privateStr <- PrivateSecrets.overlay(privateConfigPath, privateJson).map(_.noSpaces)
             loaded <- retryingBackendReads(
               backendReadRetryWaits,
               NodeConfig.fromJson(headStr, privateStr, backendOverride).value

--- a/src/main/scala/hydrozoa/config/node/PrivateSecrets.scala
+++ b/src/main/scala/hydrozoa/config/node/PrivateSecrets.scala
@@ -1,0 +1,257 @@
+package hydrozoa.config.node
+
+import cats.effect.IO
+import hydrozoa.app.StartupRefusal
+import io.circe.{Json, JsonObject}
+import java.nio.file.{Files, Path}
+import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters
+
+/** The credentials a node needs to run, sourced from the environment rather than from
+  * `private.json`.
+  *
+  * Splitting them out is what lets `private.json` be treated as an ordinary configuration file: it
+  * can be templated, diffed, committed to a deployment repo, and handed to an operator who is not
+  * trusted with the head's signing key. Everything secret arrives through the environment, which is
+  * how every deployment target already wants to supply one — a Kubernetes `Secret` projected as env
+  * vars, systemd's `EnvironmentFile=`, `docker run --env-file`.
+  *
+  * ⛔ A missing credential is a REFUSAL, not a wait. No amount of retrying conjures a signing key,
+  * and a node that started without one would fail much later and much more obscurely: the signing
+  * key in particular surfaces as a `BadSignature` while the node verifies its own stack-0 hard ack,
+  * deep inside consensus, with nothing pointing back at the config.
+  */
+object PrivateSecrets:
+
+    /** Where a credential comes from and where the decoder expects to find it.
+      *
+      * `path` is the JSON location the value is spliced into; the decoders are unchanged and still
+      * read the field they always read.
+      */
+    final case class Secret(
+        envName: String,
+        path: List[String],
+        describe: String,
+        /** True for an Ed25519 signing key, whose public half sits beside it in the config and must
+          * agree with it.
+          */
+        pairedWithVerificationKey: Boolean = false
+    )
+
+    /** The env file read when `HYDROZOA_PRIVATE_ENV` is unset: a sibling of `private.json`. */
+    val defaultFileName: String = "private.env"
+
+    private val ruleBasedPath: List[String] =
+        List("nodeOperationEvacuationConfig", "ruleBasedWallet", "signingKey")
+
+    /** Credentials that are not the peer's own signing key, whose JSON path does not depend on
+      * whether this node is a head or a coil peer.
+      */
+    private val fixedSecrets: List[Secret] = List(
+      Secret(
+        "HYDROZOA_RULE_BASED_SIGNING_KEY",
+        ruleBasedPath,
+        "the rule-based (dispute/evacuation) wallet's signing key",
+        pairedWithVerificationKey = true
+      ),
+      Secret("HYDROZOA_BLOCKFROST_API_KEY", List("blockfrostApiKey"), "the Blockfrost project id"),
+      Secret("HYDROZOA_ADMIN_PASSWORD", List("adminPassword"), "the admin API password")
+    )
+
+    /** Parse the `KEY=value` subset systemd's `EnvironmentFile=` and `docker --env-file` share.
+      *
+      * Blank lines and `#` comments are skipped, a leading `export ` is tolerated so the file can
+      * also be `source`d by a shell, and one layer of matching quotes is stripped. Deliberately not
+      * a shell parser: no interpolation, no continuations, no `$(…)`. A credentials file that
+      * executes anything is a credentials file that can surprise you.
+      */
+    def parseEnvFile(contents: String): Map[String, String] =
+        contents.linesIterator
+            .map(_.trim)
+            .filter(l => l.nonEmpty && !l.startsWith("#"))
+            .map(l => if l.startsWith("export ") then l.drop("export ".length).trim else l)
+            .flatMap { line =>
+                line.split("=", 2) match
+                    case Array(k, v) if k.trim.nonEmpty =>
+                        val raw = v.trim
+                        val unquoted =
+                            if raw.length >= 2 &&
+                                ((raw.startsWith("\"") && raw.endsWith("\"")) ||
+                                    (raw.startsWith("'") && raw.endsWith("'")))
+                            then raw.substring(1, raw.length - 1)
+                            else raw
+                        Some(k.trim -> unquoted)
+                    case _ => None
+            }
+            .toMap
+
+    /** The peer's own signing key lives under whichever wallet field this node's role puts it in,
+      * and that is the same field the decoder dispatches on.
+      */
+    private def ownWalletSecret(json: Json): Either[String, Secret] =
+        val cursor = json.hcursor.downField("ownPeerPrivate")
+        val field =
+            if cursor.downField("ownHeadWallet").succeeded then Some("ownHeadWallet")
+            else if cursor.downField("ownCoilWallet").succeeded then Some("ownCoilWallet")
+            else None
+        field
+            .toRight(
+              "ownPeerPrivate carries neither ownHeadWallet nor ownCoilWallet"
+            )
+            .map(f =>
+                Secret(
+                  "HYDROZOA_SIGNING_KEY",
+                  List("ownPeerPrivate", f, "signingKey"),
+                  "this peer's own signing key",
+                  pairedWithVerificationKey = true
+                )
+            )
+
+    private def at(json: Json, path: List[String]): Option[Json] =
+        path.foldLeft(Option(json))((acc, k) => acc.flatMap(_.asObject).flatMap(_.apply(k)))
+
+    /** Set `path` to `value`, creating intermediate objects as needed. */
+    private def splice(json: Json, path: List[String], value: Json): Json =
+        path match
+            case Nil => value
+            case head :: rest =>
+                val obj = json.asObject.getOrElse(JsonObject.empty)
+                val child = obj(head).getOrElse(Json.obj())
+                Json.fromJsonObject(obj.add(head, splice(child, rest, value)))
+
+    /** ⛔ An all-zeros placeholder is what the config ENCODER writes in place of a real signing key.
+      * Finding one is expected and harmless — it is overwritten. Finding anything else means a live
+      * credential is sitting in a file this split exists to make shareable.
+      */
+    private def isPlaceholder(j: Json): Boolean =
+        j.asString.exists(s => s.isEmpty || s.forall(_ == '0'))
+
+    /** Resolve every credential and splice it into `json`, ready for the ordinary decoders.
+      *
+      * Precedence is the real environment first, then the env file. That ordering is what lets a
+      * Kubernetes deployment override one value without rewriting the file the rest come from.
+      */
+    def overlay(privateConfigPath: Path, json: Json): IO[Json] =
+        for {
+            envPath <- IO.delay(
+              sys.env
+                  .get("HYDROZOA_PRIVATE_ENV")
+                  .map(Path.of(_))
+                  .getOrElse(privateConfigPath.resolveSibling(defaultFileName))
+            )
+            fromFile <- IO.blocking {
+                if Files.isReadable(envPath) then parseEnvFile(Files.readString(envPath))
+                else Map.empty[String, String]
+            }
+            provided = fromFile ++ sys.env.view.filterKeys(fromFile.keySet ++ allEnvNames).toMap
+            resolved <- IO.fromEither(
+              applySecrets(json, provided, s"$privateConfigPath (credentials from $envPath)")
+            )
+        } yield resolved
+
+    /** Every credential name this loader knows about. */
+    def allEnvNames: Set[String] =
+        (Set("HYDROZOA_SIGNING_KEY") ++ fixedSecrets.map(_.envName)).toSet
+
+    /** The pure core: check, pair and splice, given credentials from wherever.
+      *
+      * Separating it from the file and environment reads is what lets the round trip be tested
+      * directly — `GenerateKeyPair` writes the config and the credentials as a pair, and this
+      * reassembles them.
+      */
+    def applySecrets(
+        json: Json,
+        provided: Map[String, String],
+        source: String
+    ): Either[StartupRefusal, Json] =
+        ownWalletSecret(json).left
+            .map(m => StartupRefusal(s"$source: $m"))
+            .flatMap(own => resolve(own :: fixedSecrets, provided, source, json))
+
+    private def resolve(
+        secrets: List[Secret],
+        fromFile: Map[String, String],
+        source: String,
+        json: Json
+    ): Either[StartupRefusal, Json] =
+        val leaked = secrets.filter(s => at(json, s.path).exists(v => !isPlaceholder(v)))
+        if leaked.nonEmpty then
+            Left(
+              StartupRefusal(
+                s"$source still contains credentials that are now read from the environment: " +
+                    s"${leaked.map(_.path.mkString(".")).mkString(", ")}. Move each value out and " +
+                    "delete the field, so the config file carries no secrets."
+              )
+            )
+        else
+            // A signing key is required only where its public half is: a config with no rule-based
+            // wallet at all is a different (and self-reporting) problem, and demanding a key for a
+            // wallet that is not there would turn the decoder's clear message into a confusing one.
+            val applicable = secrets.filter(s =>
+                !s.pairedWithVerificationKey || at(json, s.path.init :+ "verificationKey").isDefined
+            )
+            val missing = applicable.filter(s => value(s, fromFile).isEmpty)
+            if missing.nonEmpty then
+                Left(
+                  StartupRefusal(
+                    "missing credentials: " +
+                        missing
+                            .map(s => s"${s.envName} (${s.describe})")
+                            .mkString(", ") +
+                        s". Set them in the environment, or in the private.env beside $source."
+                  )
+                )
+            else
+                val spliced = applicable.foldLeft(json)((acc, s) =>
+                    splice(acc, s.path, Json.fromString(value(s, fromFile).get))
+                )
+                pairingErrors(applicable, spliced) match
+                    case Nil => Right(spliced)
+                    case errs =>
+                        Left(
+                          StartupRefusal(
+                            "credential does not match the config it is paired with: " +
+                                errs.mkString("; ") +
+                                ". A signing key whose public half disagrees with the config is " +
+                                "not caught at load — the node signs with a key its own " +
+                                "verification key does not match, and dies verifying its own " +
+                                "stack-0 hard ack, deep in consensus."
+                          )
+                        )
+
+    /** Every signing key must agree with the `verificationKey` sitting beside it.
+      *
+      * ⛔ This is the check whose absence is expensive. The two halves are supplied from different
+      * places by design — the public half from the config file, the private half from the
+      * environment — so nothing else in the system is positioned to notice they were paired wrong.
+      */
+    private def pairingErrors(secrets: List[Secret], json: Json): List[String] =
+        secrets.filter(_.pairedWithVerificationKey).flatMap { s =>
+            val vkeyPath = s.path.init :+ "verificationKey"
+            val where = s.path.init.mkString(".")
+            (at(json, s.path).flatMap(_.asString), at(json, vkeyPath).flatMap(_.asString)) match
+                case (Some(skeyHex), Some(vkeyHex)) =>
+                    derivePublicKeyHex(skeyHex) match
+                        case Left(why) => Some(s"$where: ${s.envName} $why")
+                        case Right(derived) =>
+                            Option.when(!derived.equalsIgnoreCase(vkeyHex))(
+                              s"$where: ${s.envName} derives verification key $derived, but the " +
+                                  s"config declares $vkeyHex"
+                            )
+                case (_, None) => Some(s"$where: no verificationKey in the config to check against")
+                case (None, _) => Some(s"$where: no signing key resolved")
+        }
+
+    /** Ed25519 public half of a 32-byte signing key, as lowercase hex. */
+    private def derivePublicKeyHex(skeyHex: String): Either[String, String] =
+        val cleaned = skeyHex.trim
+        if cleaned.length != 64 || !cleaned.forall(c => "0123456789abcdefABCDEF".contains(c)) then
+            Left(s"is not 32 bytes of hex (got ${cleaned.length} characters)")
+        else
+            try
+                val bytes = cleaned.grouped(2).map(Integer.parseInt(_, 16).toByte).toArray
+                val pub = Ed25519PrivateKeyParameters(bytes, 0).generatePublicKey().getEncoded
+                Right(pub.map("%02x".format(_)).mkString)
+            catch case e: Exception => Left(s"could not be read as an Ed25519 key: ${e.getMessage}")
+
+    private def value(s: Secret, provided: Map[String, String]): Option[String] =
+        provided.get(s.envName).filter(_.nonEmpty)

--- a/src/main/scala/hydrozoa/config/node/PrivateSecrets.scala
+++ b/src/main/scala/hydrozoa/config/node/PrivateSecrets.scala
@@ -1,7 +1,7 @@
 package hydrozoa.config.node
 
 import cats.effect.IO
-import hydrozoa.app.StartupRefusal
+import hydrozoa.lib.StartupRefusal
 import io.circe.{Json, JsonObject}
 import java.nio.file.{Files, Path}
 import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters

--- a/src/main/scala/hydrozoa/config/node/operation/multisig/NodeOperationMultisigConfig.scala
+++ b/src/main/scala/hydrozoa/config/node/operation/multisig/NodeOperationMultisigConfig.scala
@@ -2,6 +2,8 @@ package hydrozoa.config.node.operation.multisig
 
 import hydrozoa.lib.cardano.scalus.QuantizedTime.given
 import hydrozoa.lib.number.PositiveInt
+import hydrozoa.multisig.ledger.stack.StackNumber
+import hydrozoa.multisig.ledger.stack.StackNumber.given
 import io.circe.*
 import io.circe.generic.semiauto.*
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
@@ -11,6 +13,7 @@ final case class NodeOperationMultisigConfig(
     override val peerLiaisonMaxRequestsPerBatch: PositiveInt,
     override val peerLiaisonOutboxCap: PositiveInt,
     override val peerLiaisonResendInterval: FiniteDuration,
+    override val transplantStackNumber: Option[StackNumber],
     override val rateLimits: RateLimits
 ) extends NodeOperationMultisigConfig.Section {
     override transparent inline def nodeOperationMultisigConfig: NodeOperationMultisigConfig = this
@@ -45,6 +48,30 @@ object NodeOperationMultisigConfig {
         def peerLiaisonResendInterval: FiniteDuration =
             nodeOperationMultisigConfig.peerLiaisonResendInterval
 
+        /** The stack a transplanted store was seeded at, when this peer is being seeded from
+          * another peer's store. At boot, and **only when this equals the store's own
+          * `hardConfirmed`**, recovery takes `hardConfirmed` as this peer's acked floor.
+          *
+          * A seeded peer inherits the donor's confirmed history but not its own hard-ack journal,
+          * so the two disagree by construction: `hardConfirmed` names a stack this peer never
+          * acked. Recovery then either refuses (`confirmed > acked`) or, on an empty journal, takes
+          * the stack-0 re-bootstrap path against a head long past it.
+          *
+          * Tagging it with the stack rather than making it a boolean is what keeps it one-shot
+          * without the operator having to take it back out. `hardConfirmed` is monotonic, so it
+          * passes through the tagged value exactly once: the adopting boot matches and adopts, and
+          * every later restart finds `hardConfirmed` past it and behaves as if unset. A boot that
+          * dies before acking leaves `hardConfirmed` where it was, so a retry still matches — the
+          * adoption is idempotent, not single-attempt. A stale tag can neither re-arm nor fail a
+          * restart.
+          *
+          * Node-local, like [[peerLiaisonOutboxCap]]: it moves this peer's own replay floor and
+          * changes nothing it sends, so it cannot make peers diverge. Absent is the only correct
+          * value for a peer that has always run its own store.
+          */
+        def transplantStackNumber: Option[StackNumber] =
+            nodeOperationMultisigConfig.transplantStackNumber
+
         override def rateLimits: RateLimits = nodeOperationMultisigConfig.rateLimits
     }
 
@@ -59,6 +86,7 @@ object NodeOperationMultisigConfig {
       peerLiaisonMaxRequestsPerBatch = PositiveInt.unsafeApply(500),
       peerLiaisonOutboxCap = defaultPeerLiaisonOutboxCap,
       peerLiaisonResendInterval = 5.seconds,
+      transplantStackNumber = None,
       rateLimits = RateLimits.default
     )
 
@@ -74,12 +102,14 @@ object NodeOperationMultisigConfig {
             maxRequestsPerBatch <- c.downField("peerLiaisonMaxRequestsPerBatch").as[PositiveInt]
             outboxCap <- c.downField("peerLiaisonOutboxCap").as[Option[PositiveInt]]
             resendInterval <- c.downField("peerLiaisonResendInterval").as[FiniteDuration]
+            transplantStack <- c.downField("transplantStackNumber").as[Option[StackNumber]]
             limits <- c.downField("rateLimits").as[RateLimits]
         } yield NodeOperationMultisigConfig(
           cardanoLiaisonPollingPeriod = pollingPeriod,
           peerLiaisonMaxRequestsPerBatch = maxRequestsPerBatch,
           peerLiaisonOutboxCap = outboxCap.getOrElse(defaultPeerLiaisonOutboxCap),
           peerLiaisonResendInterval = resendInterval,
+          transplantStackNumber = transplantStack,
           rateLimits = limits
         )
     )

--- a/src/main/scala/hydrozoa/lib/QuietRelease.scala
+++ b/src/main/scala/hydrozoa/lib/QuietRelease.scala
@@ -1,0 +1,30 @@
+package hydrozoa.lib
+
+// `_root_.` because `hydrozoa.lib.cats` shadows the top-level `cats` package from here.
+import _root_.cats.effect.{IO, Resource}
+
+/** Make a resource's RELEASE non-throwing, leaving acquire and use untouched.
+  *
+  * ⛔ Why this exists. `JdkWSClient`'s close path hands the observed close status straight to the
+  * JDK's `WebSocket.sendClose`, which rejects the RFC 6455 reserved codes 1005 (No Status Received)
+  * and 1006 (Abnormal Closure) with `IllegalArgumentException: statusCode` — and those are exactly
+  * the codes reported for a socket that closed WITHOUT a close handshake, i.e. every peer that
+  * crashed, was killed, or vanished. Reproduced twice: once when the remote ledger was killed
+  * mid-run, once at node shutdown.
+  *
+  * The throw escapes from a finalizer, where cats-effect can only report it to `reportFailure` and
+  * drop it. That is bad in two ways: it prints a bare stack trace with no logger context (so it
+  * reads like a crash), and a finalizer that throws stops being a reliable part of an orderly
+  * teardown. Neither is acceptable on the shutdown path, which is precisely where a peer is most
+  * likely to have gone away.
+  *
+  * ⚠️ Deliberately narrow: only the release is swallowed. An acquire failure still propagates — a
+  * connection that cannot be opened is real news, and callers retry on it.
+  */
+object QuietRelease:
+    def apply[A](resource: Resource[IO, A]): Resource[IO, A] =
+        Resource.applyFull { poll =>
+            poll(resource.allocated).map { case (a, release) =>
+                (a, (_: Resource.ExitCase) => release.attempt.void)
+            }
+        }

--- a/src/main/scala/hydrozoa/lib/StartupRefusal.scala
+++ b/src/main/scala/hydrozoa/lib/StartupRefusal.scala
@@ -1,6 +1,7 @@
-package hydrozoa.app
+package hydrozoa.lib
 
-import cats.effect.{ExitCode, IO}
+// `_root_.` because `hydrozoa.lib.cats` shadows the top-level `cats` package from here.
+import _root_.cats.effect.{ExitCode, IO}
 
 /** A deliberate, deterministic refusal to start: something about THIS node is wrong, and starting
   * it again will reach the same conclusion.

--- a/src/main/scala/hydrozoa/multisig/CoilMultisigRegimeManager.scala
+++ b/src/main/scala/hydrozoa/multisig/CoilMultisigRegimeManager.scala
@@ -75,22 +75,12 @@ trait CoilMultisigRegimeManager(
             // each child actor. Deriving per-actor let two paths interpret the same journal
             // independently, which is how a seeded store could satisfy one and not the other.
             derived <- Markers.derive(persistence, config.ownPeerId)
-            // Adopting a store seeded from another peer. The tag names the stack it was seeded at
-            // and the floor applies only while that is still this store's `hardConfirmed`, so it
-            // matches on the adopting boot and is inert ever after (`hardConfirmed` is monotonic).
-            // Applied to the ONE bundle, so the gate, the replay cursors, the in-flight handoff and
-            // the stack composer all move together — the alternative is the divergence that made
-            // this necessary.
-            // It RAISES the floor and never lowers it: a peer mid-flight has acked one stack beyond
-            // its confirmation, and clamping that down to the tag would discard the in-flight
-            // handoff `ReplayActor` rebuilds from it.
-            markers = config.transplantStackNumber
-                .filter(tag => derived.hardConfirmed.contains(tag))
-                .fold(derived)(tag =>
-                    derived.copy(hardAckedStack = Some(derived.hardAckedStack.fold(tag) { own =>
-                        if Ordering[StackNumber].gteq(own, tag) then own else tag
-                    }))
-                )
+            // Adopting a store seeded from another peer: raise the trusted-history floor to the
+            // stack the transplant was tagged with. Applied to the ONE bundle, so the gate, the
+            // replay cursors, the in-flight handoff and the stack composer all move together — the
+            // alternative is the divergence that made this necessary. See `Markers.adopt` for the
+            // comparison and why it must be the same one `Serve`'s boot gate uses.
+            markers = Markers.adopt(derived, config.transplantStackNumber)
             core <- spawnCoreActors(
               config,
               cardanoBackend,

--- a/src/main/scala/hydrozoa/multisig/CoilMultisigRegimeManager.scala
+++ b/src/main/scala/hydrozoa/multisig/CoilMultisigRegimeManager.scala
@@ -12,6 +12,7 @@ import hydrozoa.multisig.backend.cardano.CardanoBackend
 import hydrozoa.multisig.consensus.*
 import hydrozoa.multisig.consensus.peer.PeerId
 import hydrozoa.multisig.consensus.peer.PeerId.{Coil, Head}
+import hydrozoa.multisig.consensus.pollresults.PollResults
 import hydrozoa.multisig.consensus.transport.{CoilTransport, RemoteHubProxy}
 import hydrozoa.multisig.ledger.l2.L2Ledger
 import hydrozoa.multisig.ledger.stack.StackNumber
@@ -33,6 +34,10 @@ import hydrozoa.rulebased.RuleBasedRegimeManager
 trait CoilMultisigRegimeManager(
     config: NodeConfig,
     cardanoBackend: CardanoBackend[IO],
+    /** The first L1 sample, read by `Serve` before the actor system exists. See
+      * [[ReplayActor.replay]] for why the read cannot happen inside this actor.
+      */
+    firstPollResults: PollResults,
     l2Ledger: L2Ledger[IO],
     persistence: Persistence[IO],
     override protected val metrics: PeerMetrics,
@@ -135,7 +140,7 @@ trait CoilMultisigRegimeManager(
             // and drains in order once the barrier opens. Cold store ⇒ near-no-op.
             _ <- ReplayActor.replay(
               persistence,
-              cardanoBackend,
+              firstPollResults,
               ReplayActor.Targets(
                 blockWeaver = core.blockWeaver,
                 fastConsensusActor = core.consensusActor,
@@ -148,7 +153,6 @@ trait CoilMultisigRegimeManager(
               // A coil peer is never a hub, so it re-feeds no coil-ack gap (its Targets carries no
               // CoilAckSequencer either — the gap step is a no-op).
               coils = Nil,
-              treasuryAddress = config.initializationTx.treasuryProduced.address,
               leadsFastBlock = config.canLeadFast,
               markers = markers
             )(using config)
@@ -209,6 +213,7 @@ object CoilMultisigRegimeManager {
     def resource(
         config: NodeConfig,
         cardanoBackend: CardanoBackend[IO],
+        firstPollResults: PollResults,
         virtualLedger: L2Ledger[IO],
         persistence: Persistence[IO],
         metrics: PeerMetrics,
@@ -221,6 +226,7 @@ object CoilMultisigRegimeManager {
                 new CoilMultisigRegimeManager(
                   config,
                   cardanoBackend,
+                  firstPollResults,
                   virtualLedger,
                   persistence,
                   metrics,

--- a/src/main/scala/hydrozoa/multisig/CoilMultisigRegimeManager.scala
+++ b/src/main/scala/hydrozoa/multisig/CoilMultisigRegimeManager.scala
@@ -1,6 +1,6 @@
 package hydrozoa.multisig
 
-import cats.effect.{Deferred, IO, Ref, Resource}
+import cats.effect.{IO, Ref, Resource}
 import cats.syntax.all.*
 import com.suprnation.actor.ActorContext
 import com.suprnation.actor.ActorRef.NoSendActorRef
@@ -65,7 +65,6 @@ trait CoilMultisigRegimeManager(
                 .getOrElse(
                   throw new IllegalStateException(s"No hub configured for coil $ownCoilNum")
                 )
-            pendingConnections <- Deferred[IO, Connections]
 
             // Every recovery marker this peer boots from, derived ONCE here and projected into
             // each child actor. Deriving per-actor let two paths interpret the same journal
@@ -154,8 +153,8 @@ trait CoilMultisigRegimeManager(
               markers = markers
             )(using config)
 
-            _ <- pendingConnections.complete(connections)
-            _ <- connectionsDeferred.complete(connections)
+            _ <- pendingConnections.complete(Right(connections))
+            _ <- connectionsDeferred.complete(Right(connections))
 
             _ <- tracer.traceWith(WatchingActors)
 

--- a/src/main/scala/hydrozoa/multisig/CoilMultisigRegimeManager.scala
+++ b/src/main/scala/hydrozoa/multisig/CoilMultisigRegimeManager.scala
@@ -14,6 +14,7 @@ import hydrozoa.multisig.consensus.peer.PeerId
 import hydrozoa.multisig.consensus.peer.PeerId.{Coil, Head}
 import hydrozoa.multisig.consensus.transport.{CoilTransport, RemoteHubProxy}
 import hydrozoa.multisig.ledger.l2.L2Ledger
+import hydrozoa.multisig.ledger.stack.StackNumber
 import hydrozoa.multisig.metrics.PeerMetrics
 import hydrozoa.multisig.persistence.{Markers, Persistence}
 import hydrozoa.rulebased.RuleBasedRegimeManager
@@ -69,7 +70,23 @@ trait CoilMultisigRegimeManager(
             // Every recovery marker this peer boots from, derived ONCE here and projected into
             // each child actor. Deriving per-actor let two paths interpret the same journal
             // independently, which is how a seeded store could satisfy one and not the other.
-            markers <- Markers.derive(persistence, config.ownPeerId)(using config)
+            derived <- Markers.derive(persistence, config.ownPeerId)(using config)
+            // Adopting a store seeded from another peer. The tag names the stack it was seeded at
+            // and the floor applies only while that is still this store's `hardConfirmed`, so it
+            // matches on the adopting boot and is inert ever after (`hardConfirmed` is monotonic).
+            // Applied to the ONE bundle, so the gate, the replay cursors, the in-flight handoff and
+            // the stack composer all move together — the alternative is the divergence that made
+            // this necessary.
+            // It RAISES the floor and never lowers it: a peer mid-flight has acked one stack beyond
+            // its confirmation, and clamping that down to the tag would discard the in-flight
+            // handoff `ReplayActor` rebuilds from it.
+            markers = config.transplantStackNumber
+                .filter(tag => derived.hardConfirmed.contains(tag))
+                .fold(derived)(tag =>
+                    derived.copy(hardAckedStack = Some(derived.hardAckedStack.fold(tag) { own =>
+                        if Ordering[StackNumber].gteq(own, tag) then own else tag
+                    }))
+                )
             core <- spawnCoreActors(
               config,
               cardanoBackend,

--- a/src/main/scala/hydrozoa/multisig/CoilMultisigRegimeManager.scala
+++ b/src/main/scala/hydrozoa/multisig/CoilMultisigRegimeManager.scala
@@ -15,7 +15,7 @@ import hydrozoa.multisig.consensus.peer.PeerId.{Coil, Head}
 import hydrozoa.multisig.consensus.transport.{CoilTransport, RemoteHubProxy}
 import hydrozoa.multisig.ledger.l2.L2Ledger
 import hydrozoa.multisig.metrics.PeerMetrics
-import hydrozoa.multisig.persistence.Persistence
+import hydrozoa.multisig.persistence.{Markers, Persistence}
 import hydrozoa.rulebased.RuleBasedRegimeManager
 
 /** Coil-peer counterpart to [[HeadMultisigRegimeManager]]. A coil runs the same multisig-regime
@@ -66,12 +66,17 @@ trait CoilMultisigRegimeManager(
                 )
             pendingConnections <- Deferred[IO, Connections]
 
+            // Every recovery marker this peer boots from, derived ONCE here and projected into
+            // each child actor. Deriving per-actor let two paths interpret the same journal
+            // independently, which is how a seeded store could satisfy one and not the other.
+            markers <- Markers.derive(persistence, config.ownPeerId)(using config)
             core <- spawnCoreActors(
               config,
               cardanoBackend,
               l2Ledger,
               persistence,
               pendingConnections,
+              markers,
             )
 
             // Exactly one liaison, toward the hub head peer (§5.5) [doc-ref]. Register it on the
@@ -128,7 +133,8 @@ trait CoilMultisigRegimeManager(
               // CoilAckSequencer either — the gap step is a no-op).
               coils = Nil,
               treasuryAddress = config.initializationTx.treasuryProduced.address,
-              leadsFastBlock = config.canLeadFast
+              leadsFastBlock = config.canLeadFast,
+              markers = markers
             )(using config)
 
             _ <- pendingConnections.complete(connections)

--- a/src/main/scala/hydrozoa/multisig/CoilMultisigRegimeManager.scala
+++ b/src/main/scala/hydrozoa/multisig/CoilMultisigRegimeManager.scala
@@ -69,7 +69,7 @@ trait CoilMultisigRegimeManager(
             // Every recovery marker this peer boots from, derived ONCE here and projected into
             // each child actor. Deriving per-actor let two paths interpret the same journal
             // independently, which is how a seeded store could satisfy one and not the other.
-            derived <- Markers.derive(persistence, config.ownPeerId)(using config)
+            derived <- Markers.derive(persistence, config.ownPeerId)
             // Adopting a store seeded from another peer. The tag names the stack it was seeded at
             // and the floor applies only while that is still this store's `hardConfirmed`, so it
             // matches on the adopting boot and is inert ever after (`hardConfirmed` is monotonic).

--- a/src/main/scala/hydrozoa/multisig/CoilMultisigRegimeManager.scala
+++ b/src/main/scala/hydrozoa/multisig/CoilMultisigRegimeManager.scala
@@ -15,7 +15,6 @@ import hydrozoa.multisig.consensus.peer.PeerId.{Coil, Head}
 import hydrozoa.multisig.consensus.pollresults.PollResults
 import hydrozoa.multisig.consensus.transport.{CoilTransport, RemoteHubProxy}
 import hydrozoa.multisig.ledger.l2.L2Ledger
-import hydrozoa.multisig.ledger.stack.StackNumber
 import hydrozoa.multisig.metrics.PeerMetrics
 import hydrozoa.multisig.persistence.{Markers, Persistence}
 import hydrozoa.rulebased.RuleBasedRegimeManager

--- a/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManager.scala
+++ b/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManager.scala
@@ -17,7 +17,7 @@ import hydrozoa.multisig.consensus.transport.{HubTransport, PeerTransport, Remot
 import hydrozoa.multisig.ledger.joint.JointLedger
 import hydrozoa.multisig.ledger.l2.{L2Ledger, L2Screener}
 import hydrozoa.multisig.metrics.PeerMetrics
-import hydrozoa.multisig.persistence.Persistence
+import hydrozoa.multisig.persistence.{Markers, Persistence}
 import hydrozoa.rulebased.RuleBasedRegimeManager
 
 trait HeadMultisigRegimeManager(
@@ -50,12 +50,17 @@ trait HeadMultisigRegimeManager(
 
             pendingConnections <- Deferred[IO, HeadMultisigRegimeManager.Connections]
 
+            // Every recovery marker this peer boots from, derived ONCE here and projected into
+            // each child actor. Deriving per-actor let two paths interpret the same journal
+            // independently, which is how a seeded store could satisfy one and not the other.
+            markers <- Markers.derive(persistence, config.ownPeerId)(using config)
             core <- spawnCoreActors(
               config,
               cardanoBackend,
               l2Ledger,
               persistence,
               pendingConnections,
+              markers,
             )
 
             // Throttles the FastConsensusActor → BlockWeaver soft-block-confirmation lane (see
@@ -82,7 +87,8 @@ trait HeadMultisigRegimeManager(
                 l2Screener,
                 tracers.eventSequencer,
                 persistence,
-                metrics
+                metrics,
+                markers
               )
             )
 
@@ -245,7 +251,8 @@ trait HeadMultisigRegimeManager(
               hubs = config.hubHeadPeerNumbers,
               coils = hubbedCoilPeers,
               treasuryAddress = config.initializationTx.treasuryProduced.address,
-              leadsFastBlock = config.canLeadFast
+              leadsFastBlock = config.canLeadFast,
+              markers = markers
             )(using config)
 
             _ <- pendingConnections.complete(connections)

--- a/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManager.scala
+++ b/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManager.scala
@@ -52,7 +52,7 @@ trait HeadMultisigRegimeManager(
             // Every recovery marker this peer boots from, derived ONCE here and projected into
             // each child actor. Deriving per-actor let two paths interpret the same journal
             // independently, which is how a seeded store could satisfy one and not the other.
-            derived <- Markers.derive(persistence, config.ownPeerId)(using config)
+            derived <- Markers.derive(persistence, config.ownPeerId)
             // Adopting a store seeded from another peer. The tag names the stack it was seeded at
             // and the floor applies only while that is still this store's `hardConfirmed`, so it
             // matches on the adopting boot and is inert ever after (`hardConfirmed` is monotonic).

--- a/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManager.scala
+++ b/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManager.scala
@@ -16,6 +16,7 @@ import hydrozoa.multisig.consensus.peer.{CoilPeerNumber, HeadPeerNumber, PeerId}
 import hydrozoa.multisig.consensus.transport.{HubTransport, PeerTransport, RemoteCoilProxy, RemotePeerProxy}
 import hydrozoa.multisig.ledger.joint.JointLedger
 import hydrozoa.multisig.ledger.l2.{L2Ledger, L2Screener}
+import hydrozoa.multisig.ledger.stack.StackNumber
 import hydrozoa.multisig.metrics.PeerMetrics
 import hydrozoa.multisig.persistence.{Markers, Persistence}
 import hydrozoa.rulebased.RuleBasedRegimeManager
@@ -53,7 +54,23 @@ trait HeadMultisigRegimeManager(
             // Every recovery marker this peer boots from, derived ONCE here and projected into
             // each child actor. Deriving per-actor let two paths interpret the same journal
             // independently, which is how a seeded store could satisfy one and not the other.
-            markers <- Markers.derive(persistence, config.ownPeerId)(using config)
+            derived <- Markers.derive(persistence, config.ownPeerId)(using config)
+            // Adopting a store seeded from another peer. The tag names the stack it was seeded at
+            // and the floor applies only while that is still this store's `hardConfirmed`, so it
+            // matches on the adopting boot and is inert ever after (`hardConfirmed` is monotonic).
+            // Applied to the ONE bundle, so the gate, the replay cursors, the in-flight handoff and
+            // the stack composer all move together — the alternative is the divergence that made
+            // this necessary.
+            // It RAISES the floor and never lowers it: a peer mid-flight has acked one stack beyond
+            // its confirmation, and clamping that down to the tag would discard the in-flight
+            // handoff `ReplayActor` rebuilds from it.
+            markers = config.transplantStackNumber
+                .filter(tag => derived.hardConfirmed.contains(tag))
+                .fold(derived)(tag =>
+                    derived.copy(hardAckedStack = Some(derived.hardAckedStack.fold(tag) { own =>
+                        if Ordering[StackNumber].gteq(own, tag) then own else tag
+                    }))
+                )
             core <- spawnCoreActors(
               config,
               cardanoBackend,

--- a/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManager.scala
+++ b/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManager.scala
@@ -58,22 +58,12 @@ trait HeadMultisigRegimeManager(
             // each child actor. Deriving per-actor let two paths interpret the same journal
             // independently, which is how a seeded store could satisfy one and not the other.
             derived <- Markers.derive(persistence, config.ownPeerId)
-            // Adopting a store seeded from another peer. The tag names the stack it was seeded at
-            // and the floor applies only while that is still this store's `hardConfirmed`, so it
-            // matches on the adopting boot and is inert ever after (`hardConfirmed` is monotonic).
-            // Applied to the ONE bundle, so the gate, the replay cursors, the in-flight handoff and
-            // the stack composer all move together — the alternative is the divergence that made
-            // this necessary.
-            // It RAISES the floor and never lowers it: a peer mid-flight has acked one stack beyond
-            // its confirmation, and clamping that down to the tag would discard the in-flight
-            // handoff `ReplayActor` rebuilds from it.
-            markers = config.transplantStackNumber
-                .filter(tag => derived.hardConfirmed.contains(tag))
-                .fold(derived)(tag =>
-                    derived.copy(hardAckedStack = Some(derived.hardAckedStack.fold(tag) { own =>
-                        if Ordering[StackNumber].gteq(own, tag) then own else tag
-                    }))
-                )
+            // Adopting a store seeded from another peer: raise the trusted-history floor to the
+            // stack the transplant was tagged with. Applied to the ONE bundle, so the gate, the
+            // replay cursors, the in-flight handoff and the stack composer all move together — the
+            // alternative is the divergence that made this necessary. See `Markers.adopt` for the
+            // comparison and why it must be the same one `Serve`'s boot gate uses.
+            markers = Markers.adopt(derived, config.transplantStackNumber)
             core <- spawnCoreActors(
               config,
               cardanoBackend,

--- a/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManager.scala
+++ b/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManager.scala
@@ -13,6 +13,7 @@ import hydrozoa.multisig.backend.cardano.CardanoBackend
 import hydrozoa.multisig.consensus.*
 import hydrozoa.multisig.consensus.limiter.{Limiter, LimiterControl}
 import hydrozoa.multisig.consensus.peer.{CoilPeerNumber, HeadPeerNumber, PeerId}
+import hydrozoa.multisig.consensus.pollresults.PollResults
 import hydrozoa.multisig.consensus.transport.{HubTransport, PeerTransport, RemoteCoilProxy, RemotePeerProxy}
 import hydrozoa.multisig.ledger.joint.JointLedger
 import hydrozoa.multisig.ledger.l2.{L2Ledger, L2Screener}
@@ -24,6 +25,10 @@ import hydrozoa.rulebased.RuleBasedRegimeManager
 trait HeadMultisigRegimeManager(
     config: NodeConfig,
     cardanoBackend: CardanoBackend[IO],
+    /** The first L1 sample, read by `Serve` before the actor system exists. See
+      * [[ReplayActor.replay]] for why the read cannot happen inside this actor.
+      */
+    firstPollResults: PollResults,
     l2Ledger: L2Ledger[IO],
     l2Screener: L2Screener[IO],
     persistence: Persistence[IO],
@@ -253,7 +258,7 @@ trait HeadMultisigRegimeManager(
             // L1 sample.
             _ <- ReplayActor.replay(
               persistence,
-              cardanoBackend,
+              firstPollResults,
               ReplayActor.Targets(
                 blockWeaver = core.blockWeaver,
                 fastConsensusActor = core.consensusActor,
@@ -265,7 +270,6 @@ trait HeadMultisigRegimeManager(
               peers = config.headPeerIds.map(_.peerNum).toList,
               hubs = config.hubHeadPeerNumbers,
               coils = hubbedCoilPeers,
-              treasuryAddress = config.initializationTx.treasuryProduced.address,
               leadsFastBlock = config.canLeadFast,
               markers = markers
             )(using config)
@@ -386,6 +390,7 @@ object HeadMultisigRegimeManager {
     def resource(
         config: NodeConfig,
         cardanoBackend: CardanoBackend[IO],
+        firstPollResults: PollResults,
         virtualLedger: L2Ledger[IO],
         l2Screener: L2Screener[IO],
         persistence: Persistence[IO],
@@ -403,6 +408,7 @@ object HeadMultisigRegimeManager {
                 new HeadMultisigRegimeManager(
                   config,
                   cardanoBackend,
+                  firstPollResults,
                   virtualLedger,
                   l2Screener,
                   persistence,

--- a/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManager.scala
+++ b/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManager.scala
@@ -49,8 +49,6 @@ trait HeadMultisigRegimeManager(
         for {
             _ <- tracer.traceWith(StartingActors)
 
-            pendingConnections <- Deferred[IO, HeadMultisigRegimeManager.Connections]
-
             // Every recovery marker this peer boots from, derived ONCE here and projected into
             // each child actor. Deriving per-actor let two paths interpret the same journal
             // independently, which is how a seeded store could satisfy one and not the other.
@@ -272,8 +270,8 @@ trait HeadMultisigRegimeManager(
               markers = markers
             )(using config)
 
-            _ <- pendingConnections.complete(connections)
-            _ <- connectionsDeferred.complete(connections)
+            _ <- pendingConnections.complete(Right(connections))
+            _ <- connectionsDeferred.complete(Right(connections))
 
             _ <- tracer.traceWith(WatchingActors)
 
@@ -383,7 +381,7 @@ object HeadMultisigRegimeManager {
         coilPeerLiaisons: List[liaison.PeerLiaisonHubToCoil.Handle] = Nil,
     )
 
-    type PendingConnections = Deferred[IO, Connections]
+    type PendingConnections = Deferred[IO, Either[Throwable, Connections]]
 
     def resource(
         config: NodeConfig,

--- a/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManager.scala
+++ b/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManager.scala
@@ -17,7 +17,6 @@ import hydrozoa.multisig.consensus.pollresults.PollResults
 import hydrozoa.multisig.consensus.transport.{HubTransport, PeerTransport, RemoteCoilProxy, RemotePeerProxy}
 import hydrozoa.multisig.ledger.joint.JointLedger
 import hydrozoa.multisig.ledger.l2.{L2Ledger, L2Screener}
-import hydrozoa.multisig.ledger.stack.StackNumber
 import hydrozoa.multisig.metrics.PeerMetrics
 import hydrozoa.multisig.persistence.{Markers, Persistence}
 import hydrozoa.rulebased.RuleBasedRegimeManager

--- a/src/main/scala/hydrozoa/multisig/MultisigRegimeManagerBase.scala
+++ b/src/main/scala/hydrozoa/multisig/MultisigRegimeManagerBase.scala
@@ -54,7 +54,21 @@ trait MultisigRegimeManagerBase[E >: LifecycleEvent <: RegimeManagerEvent]
     /** Completed by the subclass's [[preStartLocal]] once every actor is spawned and the
       * `Connections` slots are populated.
       */
-    val connectionsDeferred: Deferred[IO, Connections] = Deferred.unsafe[IO, Connections]
+    val connectionsDeferred: Deferred[IO, Either[Throwable, Connections]] =
+        Deferred.unsafe[IO, Either[Throwable, Connections]]
+
+    /** The inner barrier every child actor parks on until this manager has populated `Connections`.
+      *
+      * Held here rather than created inside [[preStartLocal]] so that a boot which never reaches
+      * the completion still has something to complete: a failure there used to leave both barriers
+      * empty forever, and the process could not exit. The children stayed parked inside
+      * `ActorCell.invoke(...).uncancelable`, the actor system's `Supervisor(await = true)` waited
+      * on them rather than cancelling, the store's release sat downstream of that wait, and the app
+      * fiber itself never reached `waitForTermination` — so SIGTERM had nothing to cancel and the
+      * node needed SIGKILL with its RocksDB LOCK still held.
+      */
+    val pendingConnections: HeadMultisigRegimeManager.PendingConnections =
+        Deferred.unsafe[IO, Either[Throwable, Connections]]
 
     /** Node lifecycle status backing the user-facing server's `/ready` endpoint. Advanced
       * monotonically (via [[NodeStatus.advanceTo]]) by [[CardanoLiaison]] as the L1 target state
@@ -105,7 +119,13 @@ trait MultisigRegimeManagerBase[E >: LifecycleEvent <: RegimeManagerEvent]
     override def receive: Receive[IO, Request] = PartialFunction.fromFunction(receiveTotal)
 
     private def receiveTotal(req: Request): IO[Unit] = req match {
-        case PreStart => preStartLocal
+        // A boot failure must reach both barriers, or nothing parked on them can ever unpark.
+        // `complete` is idempotent-by-outcome here: on the happy path `preStartLocal` has already
+        // filled them and these are no-ops.
+        case PreStart =>
+            preStartLocal.onError(e =>
+                (pendingConnections.complete(Left(e)) >> connectionsDeferred.complete(Left(e))).void
+            )
         case TerminatedChild(childType, _) =>
             tracer.traceWith(LifecycleEvent.TerminatedActor(childType))
         case TerminatedDependency(dependencyType, _) =>
@@ -144,7 +164,7 @@ trait MultisigRegimeManagerBase[E >: LifecycleEvent <: RegimeManagerEvent]
         cardanoBackend: CardanoBackend[IO],
         l2Ledger: L2Ledger[IO],
         persistence: Persistence[IO],
-        pendingConnections: Deferred[IO, Connections],
+        pendingConnections: HeadMultisigRegimeManager.PendingConnections,
         markers: Markers,
     ): IO[CoreActors] =
         for {

--- a/src/main/scala/hydrozoa/multisig/MultisigRegimeManagerBase.scala
+++ b/src/main/scala/hydrozoa/multisig/MultisigRegimeManagerBase.scala
@@ -16,7 +16,7 @@ import hydrozoa.multisig.consensus.*
 import hydrozoa.multisig.ledger.joint.JointLedger
 import hydrozoa.multisig.ledger.l2.L2Ledger
 import hydrozoa.multisig.metrics.PeerMetrics
-import hydrozoa.multisig.persistence.Persistence
+import hydrozoa.multisig.persistence.{Markers, Persistence}
 import scala.concurrent.duration.DurationInt
 
 /** Shared scaffolding for [[HeadMultisigRegimeManager]] and [[CoilMultisigRegimeManager]]: the
@@ -145,10 +145,18 @@ trait MultisigRegimeManagerBase[E >: LifecycleEvent <: RegimeManagerEvent]
         l2Ledger: L2Ledger[IO],
         persistence: Persistence[IO],
         pendingConnections: Deferred[IO, Connections],
+        markers: Markers,
     ): IO[CoreActors] =
         for {
             blockWeaver <- context.actorOf(
-              BlockWeaver(config, pendingConnections, tracers.blockWeaver, metrics, persistence)
+              BlockWeaver(
+                config,
+                pendingConnections,
+                tracers.blockWeaver,
+                metrics,
+                persistence,
+                markers
+              )
             )
             cardanoLiaison <- context.actorOf(
               CardanoLiaison(
@@ -181,7 +189,8 @@ trait MultisigRegimeManagerBase[E >: LifecycleEvent <: RegimeManagerEvent]
                 l2Ledger,
                 tracers.jointLedger,
                 persistence,
-                metrics
+                metrics,
+                markers
               )
             )
             stackComposer <- context.actorOf(
@@ -190,7 +199,8 @@ trait MultisigRegimeManagerBase[E >: LifecycleEvent <: RegimeManagerEvent]
                 pendingConnections,
                 tracers.stackComposer,
                 persistence,
-                metrics
+                metrics,
+                markers
               )
             )
             slowConsensusActor <- context.actorOf(
@@ -199,7 +209,8 @@ trait MultisigRegimeManagerBase[E >: LifecycleEvent <: RegimeManagerEvent]
                 pendingConnections,
                 tracers.slowConsensusActor,
                 persistence,
-                metrics
+                metrics,
+                markers
               )
             )
         } yield CoreActors(

--- a/src/main/scala/hydrozoa/multisig/backend/cardano/CardanoBackendBlockfrost.scala
+++ b/src/main/scala/hydrozoa/multisig/backend/cardano/CardanoBackendBlockfrost.scala
@@ -20,7 +20,6 @@ import java.net.URI
 import java.net.http.{HttpClient, HttpRequest, HttpResponse}
 import scala.collection.mutable
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
 import scala.jdk.CollectionConverters.*
 import scala.util.Try
 import scalus.cardano.address.{Address, ShelleyAddress}
@@ -45,7 +44,10 @@ import scalus.uplc.builtin.{ByteString, Data}
 class CardanoBackendBlockfrost private (
     private val backendService: BackendService,
     private val pageSize: Int,
-    private val blockfrostProviderFuture: Future[BlockfrostProvider],
+    /** Builds a FRESH provider. Called again after a failure -- see [[provider]]. */
+    private val mkProvider: IO[BlockfrostProvider],
+    /** Memoises the provider ON SUCCESS ONLY. */
+    private val providerRef: Ref[IO, Option[BlockfrostProvider]],
     protected val tracer: ContraTracer[IO, CardanoBackendEvent],
     // Base URL + project id for the raw tx-utxos read in [[continuingTx]] — BloxBean's
     // `TxContentUtxoInputs` model drops the per-input tx_hash/output_index/collateral/reference we
@@ -53,6 +55,27 @@ class CardanoBackendBlockfrost private (
     private val baseUrl: String,
     private val apiKey: String
 ) extends CardanoBackend[IO] {
+
+    /** The Scalus provider, built on first use and memoised **only if it succeeds**.
+      *
+      * ⛔ This used to be a plain `Future[BlockfrostProvider]` created eagerly at construction. A
+      * Scala `Future` memoises its outcome — including its failure — so a single Blockfrost blip at
+      * the moment the backend was built poisoned every later `fetchLatestParams` for the entire
+      * life of the process, with no retry and no way back short of a restart. The node looked
+      * healthy: it polled L1 fine, because `utxosAt` goes through BloxBean's service and never
+      * touches this.
+      *
+      * That is disqualifying for a start-up gate built on protocol parameters — one blip and the
+      * gate could never be satisfied. So: retry on failure, memoise on success.
+      *
+      * ⚠️ Two concurrent first-callers may each build one; the loser's is discarded. Harmless (the
+      * provider is a stateless HTTP wrapper) and cheaper than serialising every access.
+      */
+    private def provider: IO[BlockfrostProvider] =
+        providerRef.get.flatMap {
+            case Some(p) => IO.pure(p)
+            case None    => mkProvider.flatTap(p => providerRef.set(Some(p)))
+        }
 
     private val httpClient: HttpClient = HttpClient.newHttpClient()
 
@@ -683,8 +706,8 @@ class CardanoBackendBlockfrost private (
 
     override def fetchLatestParams: IO[Either[Error, ProtocolParams]] =
         (for
-            provider <- IO.fromFuture(IO.pure(blockfrostProviderFuture))
-            result <- IO.fromFuture(IO.pure(provider.fetchLatestParams))
+            p <- provider
+            result <- IO.fromFuture(IO.pure(p.fetchLatestParams))
         yield Right(result))
             .handleError(e =>
                 Left(Unexpected(s"${e.getMessage}, caused by: ${
@@ -693,8 +716,8 @@ class CardanoBackendBlockfrost private (
             )
 
     def getStartupParams: IO[Either[Error, ProtocolParams]] =
-        (for provider <- IO.fromFuture(IO.pure(blockfrostProviderFuture))
-        yield Right(provider.cardanoInfo.protocolParams))
+        (for p <- provider
+        yield Right(p.cardanoInfo.protocolParams))
             .handleError(e =>
                 Left(Unexpected(s"${e.getMessage}, caused by: ${
                         if e.getCause != null then e.getCause.getMessage else "N/A"
@@ -720,32 +743,33 @@ object CardanoBackendBlockfrost:
         // NB: Bloxbean requires the trailing slash
         val backendService = BFBackendService(s"$baseUrl/", apiKey)
 
-        // 2. Scalus blockfrost provider
-        val blockfrostProviderFuture =
-            network match {
-                case Left(std) =>
-                    std match {
-                        case CardanoNetwork.Mainnet =>
-                            BlockfrostProvider.mainnet(apiKey)
-                        case CardanoNetwork.Preprod =>
-                            BlockfrostProvider.preprod(apiKey)
-                        case CardanoNetwork.Preview =>
-                            BlockfrostProvider.preview(apiKey)
+        // 2. Scalus blockfrost provider, as a RETRYABLE IO rather than an eager Future: each
+        //    evaluation starts a fresh fetch, so a failure is not memoised. See `provider`.
+        val mkProvider: IO[BlockfrostProvider] = IO.defer(IO.fromFuture(IO.delay(network match {
+            case Left(std) =>
+                std match {
+                    case CardanoNetwork.Mainnet =>
+                        BlockfrostProvider.mainnet(apiKey)
+                    case CardanoNetwork.Preprod =>
+                        BlockfrostProvider.preprod(apiKey)
+                    case CardanoNetwork.Preview =>
+                        BlockfrostProvider.preview(apiKey)
 
-                    }
-                case Right(custom, customBaseUrl) =>
-                    BlockfrostProvider.create(
-                      apiKey = apiKey,
-                      baseUrl = customBaseUrl,
-                      network = custom.network,
-                      slotConfig = custom.cardanoInfo.slotConfig
-                    )
-            }
+                }
+            case Right(custom, customBaseUrl) =>
+                BlockfrostProvider.create(
+                  apiKey = apiKey,
+                  baseUrl = customBaseUrl,
+                  network = custom.network,
+                  slotConfig = custom.cardanoInfo.slotConfig
+                )
+        })))
 
         new CardanoBackendBlockfrost(
           backendService,
           pageSize,
-          blockfrostProviderFuture,
+          mkProvider,
+          Ref.unsafe[IO, Option[BlockfrostProvider]](None),
           tracer,
           baseUrl,
           apiKey

--- a/src/main/scala/hydrozoa/multisig/consensus/BlockWeaver.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/BlockWeaver.scala
@@ -87,7 +87,7 @@ final case class BlockWeaver(
     private def initializeConnections: IO[BlockWeaver.Connections] = pendingConnections match {
         case pc: HeadMultisigRegimeManager.PendingConnections =>
             for {
-                c <- pc.get
+                c <- pc.get.flatMap(IO.fromEither)
             } yield BlockWeaver.Connections(
               blockWeaver = context.self,
               jointLedger = c.jointLedger,

--- a/src/main/scala/hydrozoa/multisig/consensus/BlockWeaver.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/BlockWeaver.scala
@@ -35,6 +35,10 @@ final case class BlockWeaver(
       * block to resume on, and whether its predecessor is confirmed — and reads it in `PreStart`.
       */
     persistence: Persistence[IO],
+    /** The boot markers, derived once by the regime manager (§5.2). This actor projects
+      * `fastBlockMark` and `softConfirmed` out of them rather than re-reading the store.
+      */
+    markers: Markers,
 ) extends Actor[IO, BlockWeaver.Request] {
     import BlockWeaver.*
 
@@ -62,9 +66,16 @@ final case class BlockWeaver(
                 // Suspends on the start barrier, so the base below is in place before any
                 // replayed journal entry is processed (§5.6, §8).
                 connections <- initializeConnections
-                // Same anchor as `JointLedger.preStartLocal`: the two step the spine in lockstep.
-                fastBlockMark <- Markers.recoverFastBlockMark(persistence.backend)
-                recovered <- State.recover(config, connections, tracer, persistence, fastBlockMark)
+                // Same anchor as `JointLedger.preStartLocal`: the two step the spine in lockstep —
+                // now guaranteed, because both project the one bundle rather than each re-reading.
+                recovered <- State.recover(
+                  config,
+                  connections,
+                  tracer,
+                  persistence,
+                  markers.fastBlockMark,
+                  markers.softConfirmed
+                )
                 // `None`: the store says this head finalized, so the weaver retires rather than
                 // opening a block, as on the live path.
                 _ <- recovered.fold(context.self.stop)(become)
@@ -247,10 +258,10 @@ object BlockWeaver {
             connections: Connections,
             tracer: ContraTracer[IO, BlockWeaverEvent],
             persistence: Persistence[IO],
-            fastBlockMark: Option[BlockNumber]
+            fastBlockMark: Option[BlockNumber],
+            softConfirmed: Option[BlockNumber]
         ): IO[Option[Reactive]] =
             for {
-                softConfirmed <- Markers.recoverSoftConfirmed(persistence.backend)
                 opening <- start(config, connections, tracer, fastBlockMark)
                 // `filter(softConfirmed.contains)` is the "confirmed everything it applied" test.
                 resumed <- fastBlockMark

--- a/src/main/scala/hydrozoa/multisig/consensus/CardanoLiaison.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/CardanoLiaison.scala
@@ -523,7 +523,7 @@ trait CardanoLiaison(
     private def initializeConnections: IO[Unit] = pendingConnections match {
         case x: HeadMultisigRegimeManager.PendingConnections =>
             for {
-                _connections <- x.get
+                _connections <- x.get.flatMap(IO.fromEither)
                 _ <- connections.set(
                   Some(CardanoLiaison.Connections(blockWeaver = _connections.blockWeaver))
                 )

--- a/src/main/scala/hydrozoa/multisig/consensus/CoilAckSequencer.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/CoilAckSequencer.scala
@@ -75,11 +75,13 @@ trait CoilAckSequencer(
 
     private def initializeConnections: IO[Unit] = pendingConnections match {
         case x: HeadMultisigRegimeManager.PendingConnections =>
-            x.get.flatMap(c =>
-                connections.set(
-                  Some(Connections(liaisons = c.headPeerLiaisons, coilRelay = c.coilRelay))
+            x.get
+                .flatMap(IO.fromEither)
+                .flatMap(c =>
+                    connections.set(
+                      Some(Connections(liaisons = c.headPeerLiaisons, coilRelay = c.coilRelay))
+                    )
                 )
-            )
         case x: CoilAckSequencer.Connections => connections.set(Some(x))
     }
 

--- a/src/main/scala/hydrozoa/multisig/consensus/CoilRelay.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/CoilRelay.scala
@@ -84,7 +84,9 @@ abstract class CoilRelay(
 
     private def resolveConnections: IO[CoilRelay.Connections] = pendingConnections match {
         case shared: HeadMultisigRegimeManager.PendingConnections =>
-            shared.get.map(s => CoilRelay.Connections(coilPeerLiaisons = s.coilPeerLiaisons))
+            shared.get
+                .flatMap(IO.fromEither)
+                .map(s => CoilRelay.Connections(coilPeerLiaisons = s.coilPeerLiaisons))
         case own: CoilRelay.Connections => IO.pure(own)
     }
 

--- a/src/main/scala/hydrozoa/multisig/consensus/FastConsensusActor.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/FastConsensusActor.scala
@@ -181,7 +181,7 @@ class FastConsensusActor(
     private def initializeConnections: IO[Unit] = pendingConnections match {
         case x: HeadMultisigRegimeManager.PendingConnections =>
             for {
-                _connections <- x.get
+                _connections <- x.get.flatMap(IO.fromEither)
                 _ <- connections.set(
                   Some(
                     FastConsensusActor.Connections(

--- a/src/main/scala/hydrozoa/multisig/consensus/ReplayActor.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/ReplayActor.scala
@@ -2,10 +2,7 @@ package hydrozoa.multisig.consensus
 
 import cats.effect.IO
 import cats.syntax.all.*
-import hydrozoa.app.StartupRefusal
 import hydrozoa.config.head.network.CardanoNetwork
-import hydrozoa.lib.logging.{ContraTracer, Slf4jMsg, Slf4jMsgFormat, Slf4jTracer, error, info, warn}
-import hydrozoa.multisig.backend.cardano.CardanoBackend
 import hydrozoa.multisig.consensus.ack.{HardAck, HardAckNumber}
 import hydrozoa.multisig.consensus.peer.{CoilPeerNumber, HeadPeerNumber, PeerId}
 import hydrozoa.multisig.consensus.pollresults.PollResults
@@ -14,8 +11,6 @@ import hydrozoa.multisig.ledger.event.RequestNumber
 import hydrozoa.multisig.ledger.stack.StackNumber
 import hydrozoa.multisig.persistence.recovery.{ArrivalOrderedMerge, JournalScan, RawJournalEntry, ReplayCursors}
 import hydrozoa.multisig.persistence.{JournalKey, Markers, Persistence, StoreKey}
-import scala.concurrent.duration.*
-import scalus.cardano.address.ShelleyAddress
 
 /** The boot-time replay seam (R3 §8 step 3). Not a long-lived cats-actors `Actor`: it is the
   * one-shot routine `HeadMultisigRegimeManager` runs **inline** after spawning the consensus actors
@@ -27,9 +22,10 @@ import scalus.cardano.address.ShelleyAddress
   *
   * What it does, in order:
   *
-  *   1. Sample L1 directly (`CardanoBackend.utxosAt(treasuryAddress)`) and seed BlockWeaver's first
-  *      [[PollResults]], so deposit decisions proceed immediately rather than waiting on
-  *      CardanoLiaison's poll cadence (§5.5).
+  *   1. Seed BlockWeaver's first [[PollResults]], so deposit decisions proceed immediately rather
+  *      than waiting on CardanoLiaison's poll cadence (§5.5). The value is read from L1 by `Serve`
+  *      before the actor system exists and handed in — see [[replay]] for why the read cannot
+  *      happen here.
   *   2. Reconstruct the in-flight acked-but-unconfirmed stack — at most one (single-flight; the §9
   *      "crash mid-stack" case) — from its persisted `Stack.Unsigned` + this peer's hard-acks, and
   *      hand it to `SlowConsensusActor` so it re-forms its cell and re-aggregates. StackComposer
@@ -48,11 +44,6 @@ import scalus.cardano.address.ShelleyAddress
   */
 object ReplayActor:
 
-    private val log: ContraTracer[IO, Slf4jMsg] =
-        Slf4jTracer.sink.contramap(
-          Slf4jMsgFormat.humanFormat("hydrozoa.multisig.consensus.ReplayActor")
-        )
-
     /** The consensus actors the replay tail is routed into. `coilAckSequencer` is present only on a
       * hub — the boundary the received-but-unstamped coil-ack gap is re-fed to (see [[replay]]).
       */
@@ -64,25 +55,30 @@ object ReplayActor:
         coilAckSequencer: Option[CoilAckSequencer.Handle] = None
     )
 
-    /** Run the boot replay (see the object docstring), for either peer type. Pure over the store +
-      * a one-shot L1 read; all effects are mailbox sends to `targets`. The fast side and the slow
-      * side are now common to both peer types: the slow-side own-ack journal is the one
-      * `PeerId`-keyed `HardAck` journal, so `own: PeerId` flows straight into
-      * `JournalKey.HardAck(own, n)` with no peer-type branch (§10 Q10). `peers` is every head peer
-      * (own included on a head peer), `hubs` every hub head peer (their `HubHardAck` journals carry
-      * the coil quorum SCA aggregates, read by both peer types), `coils` the hubbed coils whose ack
-      * gap a hub re-feeds (`Nil` off a hub). `own`, `treasuryAddress` and `leadsFastBlock` — the
-      * fast-cycle leadership predicate, always false on a coil — come from the node config.
+    /** Run the boot replay (see the object docstring), for either peer type. Pure over the store;
+      * all effects are mailbox sends to `targets`. The fast side and the slow side are now common
+      * to both peer types: the slow-side own-ack journal is the one `PeerId`-keyed `HardAck`
+      * journal, so `own: PeerId` flows straight into `JournalKey.HardAck(own, n)` with no peer-type
+      * branch (§10 Q10). `peers` is every head peer (own included on a head peer), `hubs` every hub
+      * head peer (their `HubHardAck` journals carry the coil quorum SCA aggregates, read by both
+      * peer types), `coils` the hubbed coils whose ack gap a hub re-feeds (`Nil` off a hub). `own`
+      * and `leadsFastBlock` — the fast-cycle leadership predicate, always false on a coil — come
+      * from the node config.
+      *
+      * `firstPollResults` is read from L1 by the caller, NOT here. This runs inside an uncancelable
+      * actor message handler, so a read that retries would be uninterruptible; `Serve` establishes
+      * the fact on the app fiber and hands it down. Queuing it is still this function's job: it has
+      * to reach BlockWeaver's mailbox before the start barrier opens, or the weaver acts on
+      * `PollResults.empty` and rejects every mature deposit as `NotInPollResults`.
       */
     def replay(
         persistence: Persistence[IO],
-        cardanoBackend: CardanoBackend[IO],
+        firstPollResults: PollResults,
         targets: Targets,
         own: PeerId,
         peers: List[HeadPeerNumber],
         hubs: List[HeadPeerNumber],
         coils: List[CoilPeerNumber],
-        treasuryAddress: ShelleyAddress,
         leadsFastBlock: BlockNumber => Boolean,
         markers: Markers
     )(using CardanoNetwork.Section): IO[Unit] =
@@ -106,10 +102,7 @@ object ReplayActor:
               hardAckedStack
             )
             // 1. First L1 sample → BlockWeaver, so deposit decisions don't wait on the poll tick.
-            _ <- seedFirstPollResults(cardanoBackend, treasuryAddress, targets.blockWeaver)
-            // Same gate, same place: an L1 fact established once, on the app fiber, before the
-            // start barrier opens.
-            _ <- verifyProtocolParams(cardanoBackend)
+            _ <- targets.blockWeaver ! firstPollResults
             // 2. The in-flight acked-but-unconfirmed stack (≤1) → reconstructed handoff to SCA.
             _ <- inflight.traverse_(targets.slowConsensusActor ! _)
             // 3. Derive cursors, scan all lanes, total-order, route the tail into mailboxes.
@@ -198,109 +191,6 @@ object ReplayActor:
                 s"fastBlockMark=$fastBlockMark, hardAckedStack=$hardAckedStack"
           )
         )
-
-    /** Read L1 directly and send BlockWeaver the first [[PollResults]] (§5.5).
-      *
-      * ⛔ This is a GATE, and it must WAIT rather than fail. BlockWeaver starts at
-      * `PollResults.empty`, which is structurally indistinguishable from "polled, and the address
-      * is genuinely empty" — there is no `NeverPolled` state. A head peer classifies deposit
-      * existence from its OWN poll (`DepositsMap.Existence.FromPoll`), so acting on that empty
-      * value would reject every mature deposit as `NotInPollResults`: terminal, and DEBUG-only in
-      * the logs. The seed is queued before the start barrier opens precisely so that cannot happen.
-      *
-      * It previously raised on a failed L1 read, which closed the correctness hole but turned a
-      * transient Blockfrost blip into a failed boot — and `Restart=on-failure` turns a failed boot
-      * into an infinite restart loop that outlives the blip. Waiting is strictly better: the node
-      * is useless without this fact either way, and the retry is bounded by nothing but the
-      * operator's patience, which is what a dashboard is for.
-      *
-      * ⚠️ Safe to retry here ONLY because `replay` runs INLINE at the regime manager, on the app
-      * fiber, outside the actor system. The same loop inside a cats-actors message handler would be
-      * uncancelable (`ActorCell` wraps handlers in `.uncancelable`) and would make the process
-      * unkillable — measured. Do not move this into an actor.
-      */
-    private def seedFirstPollResults(
-        cardanoBackend: CardanoBackend[IO],
-        treasuryAddress: ShelleyAddress,
-        blockWeaver: BlockWeaver.Handle
-    ): IO[Unit] = {
-        def attempt(n: Int): IO[Unit] =
-            cardanoBackend.utxosAt(treasuryAddress).flatMap {
-                case Right(utxos) =>
-                    IO.whenA(n > 0)(
-                      log.info(
-                        s"boot L1 sample succeeded after ${n + 1} attempts; continuing start-up"
-                      )
-                    ) >> (blockWeaver ! PollResults(utxos.keySet))
-                case Left(err) =>
-                    val wait = l1SampleBackoff(n)
-                    log.warn(
-                      s"boot L1 sample failed (attempt ${n + 1}): $err. Cannot start consensus " +
-                          s"without it, so WAITING rather than failing the boot; retrying in $wait"
-                    ) >> IO.sleep(wait) >> attempt(n + 1)
-            }
-        attempt(0)
-    }
-
-    /** Compare the chain's live protocol parameters against the ones this head's config asserts.
-      *
-      * ⛔ Nothing did this before: `getStartupParams` existed with **zero callers**, so a head built
-      * every L1 transaction — settlements, fallbacks, rollouts, refunds — against parameters it
-      * merely assumed, and would keep doing so across a parameter update it never noticed. Those
-      * parameters decide fees, `maxTxSize` and execution-unit budgets, so a drift shows up as
-      * transactions the chain rejects, at the worst possible moment.
-      *
-      * ⛔ **A mismatch REFUSES the boot.** A head building transactions against parameters the chain
-      * has moved past emits txs the chain rejects — silently, at settlement time, under load.
-      *
-      * It is a `StartupRefusal` rather than a generic crash because it is **deterministic**: the
-      * config asserts what it asserts, and a restart re-derives the same verdict, so a supervisor
-      * loop would learn nothing. ⇒ Operationally, an on-chain parameter update stops every peer
-      * until its config is updated. That is intended: the alternative is peers quietly emitting
-      * invalid transactions. If a benign field ever proves to differ in practice, narrow the
-      * comparison to the fields that govern tx validity — do not weaken it back to a warning.
-      *
-      * Unreachable is NOT drift: it retries like the L1 sample, because "cannot ask" and "asked and
-      * the answer is wrong" are the two classes this whole start-up path is built to separate.
-      */
-    private def verifyProtocolParams(
-        cardanoBackend: CardanoBackend[IO]
-    )(using net: CardanoNetwork.Section): IO[Unit] = {
-        def attempt(n: Int): IO[Unit] =
-            cardanoBackend.fetchLatestParams.flatMap {
-                case Right(onChain) =>
-                    val assumed = net.cardanoProtocolParams
-                    if onChain == assumed then
-                        log.info("protocol parameters on chain match the ones this config asserts")
-                    else
-                        log.error(
-                          "PROTOCOL PARAMETER MISMATCH: the chain's parameters differ from the " +
-                              "ones this head's config asserts. Refusing to start.\n" +
-                              s"  on chain: $onChain\n" +
-                              s"  config:   $assumed"
-                        ) >> IO.raiseError(
-                          StartupRefusal(
-                            "the chain's protocol parameters differ from the ones this head's " +
-                                "config asserts, so the L1 transactions it builds may be rejected " +
-                                "by the chain. Update the config to the chain's current parameters " +
-                                "(both values are on the ERROR line above)."
-                          )
-                        )
-                case Left(err) =>
-                    val wait = l1SampleBackoff(n)
-                    log.warn(
-                      s"could not read protocol parameters (attempt ${n + 1}): $err. " +
-                          s"Retrying in $wait."
-                    ) >> IO.sleep(wait) >> attempt(n + 1)
-            }
-        attempt(0)
-    }
-
-    /** Backoff for the boot L1 sample: doubles from 1s, capped at 30s. Capped rather than unbounded
-      * so a node that has been waiting for hours still reacts promptly when L1 returns.
-      */
-    private def l1SampleBackoff(attempt: Int): FiniteDuration =
-        (1.second.toNanos * (1L << math.min(attempt, 5))).nanos.min(30.seconds)
 
     /** Reconstruct the handoff for the in-flight stack — the last own-acked stack, **iff** it is
       * not yet hard-confirmed (`hardConfirmed < hardAckedStack`). Its `Stack.Unsigned` was

--- a/src/main/scala/hydrozoa/multisig/consensus/ReplayActor.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/ReplayActor.scala
@@ -106,6 +106,9 @@ object ReplayActor:
             )
             // 1. First L1 sample → BlockWeaver, so deposit decisions don't wait on the poll tick.
             _ <- seedFirstPollResults(cardanoBackend, treasuryAddress, targets.blockWeaver)
+            // Same gate, same place: an L1 fact established once, on the app fiber, before the
+            // start barrier opens.
+            _ <- verifyProtocolParams(cardanoBackend)
             // 2. The in-flight acked-but-unconfirmed stack (≤1) → reconstructed handoff to SCA.
             _ <- inflight.traverse_(targets.slowConsensusActor ! _)
             // 3. Derive cursors, scan all lanes, total-order, route the tail into mailboxes.
@@ -233,6 +236,54 @@ object ReplayActor:
                     log.warn(
                       s"boot L1 sample failed (attempt ${n + 1}): $err. Cannot start consensus " +
                           s"without it, so WAITING rather than failing the boot; retrying in $wait"
+                    ) >> IO.sleep(wait) >> attempt(n + 1)
+            }
+        attempt(0)
+    }
+
+    /** Compare the chain's live protocol parameters against the ones this head's config asserts.
+      *
+      * ⛔ Nothing did this before: `getStartupParams` existed with **zero callers**, so a head built
+      * every L1 transaction — settlements, fallbacks, rollouts, refunds — against parameters it
+      * merely assumed, and would keep doing so across a parameter update it never noticed. Those
+      * parameters decide fees, `maxTxSize` and execution-unit budgets, so a drift shows up as
+      * transactions the chain rejects, at the worst possible moment.
+      *
+      * ⚠️ **Reports, does not refuse — deliberately, and this is a decision to revisit.** A refusal
+      * needs a comparison we trust, and we do not yet know which fields differ benignly in practice
+      * (a config may legitimately pin a subset, or lag a harmless update). Refusing on a brittle
+      * equality check would brick every node on the first benign difference, which is far worse
+      * than the gap it closes. So this establishes the signal first: match ⇒ one INFO line; drift ⇒
+      * a loud WARN carrying both values, which is what tells us what a safe comparison should be. ⇒
+      * Escalating to a `StartupRefusal` (and gating hard-confirmation on it) is the intended next
+      * step, once real drift has been observed.
+      *
+      * Unreachable is NOT drift: it retries like the L1 sample, because "cannot ask" and "asked and
+      * the answer is wrong" are the two classes this whole start-up path is built to separate.
+      */
+    private def verifyProtocolParams(
+        cardanoBackend: CardanoBackend[IO]
+    )(using net: CardanoNetwork.Section): IO[Unit] = {
+        def attempt(n: Int): IO[Unit] =
+            cardanoBackend.fetchLatestParams.flatMap {
+                case Right(onChain) =>
+                    val assumed = net.cardanoProtocolParams
+                    if onChain == assumed then
+                        log.info("protocol parameters on chain match the ones this config asserts")
+                    else
+                        log.warn(
+                          "PROTOCOL PARAMETER DRIFT: the chain's parameters differ from the ones " +
+                              "this head's config asserts. Every L1 transaction this node builds " +
+                              "uses the config's values, so a real drift will surface as txs the " +
+                              "chain rejects.\n" +
+                              s"  on chain: $onChain\n" +
+                              s"  config:   $assumed"
+                        )
+                case Left(err) =>
+                    val wait = l1SampleBackoff(n)
+                    log.warn(
+                      s"could not read protocol parameters (attempt ${n + 1}): $err. " +
+                          s"Retrying in $wait."
                     ) >> IO.sleep(wait) >> attempt(n + 1)
             }
         attempt(0)

--- a/src/main/scala/hydrozoa/multisig/consensus/ReplayActor.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/ReplayActor.scala
@@ -3,6 +3,7 @@ package hydrozoa.multisig.consensus
 import cats.effect.IO
 import cats.syntax.all.*
 import hydrozoa.config.head.network.CardanoNetwork
+import hydrozoa.lib.logging.{ContraTracer, Slf4jMsg, Slf4jMsgFormat, Slf4jTracer, info, warn}
 import hydrozoa.multisig.backend.cardano.CardanoBackend
 import hydrozoa.multisig.consensus.ack.{HardAck, HardAckNumber}
 import hydrozoa.multisig.consensus.peer.{CoilPeerNumber, HeadPeerNumber, PeerId}
@@ -12,6 +13,7 @@ import hydrozoa.multisig.ledger.event.RequestNumber
 import hydrozoa.multisig.ledger.stack.StackNumber
 import hydrozoa.multisig.persistence.recovery.{ArrivalOrderedMerge, JournalScan, RawJournalEntry, ReplayCursors}
 import hydrozoa.multisig.persistence.{JournalKey, Markers, Persistence, StoreKey}
+import scala.concurrent.duration.*
 import scalus.cardano.address.ShelleyAddress
 
 /** The boot-time replay seam (R3 §8 step 3). Not a long-lived cats-actors `Actor`: it is the
@@ -44,6 +46,11 @@ import scalus.cardano.address.ShelleyAddress
   * is the single place that re-feeds the consensus actors from the persisted lane tail.
   */
 object ReplayActor:
+
+    private val log: ContraTracer[IO, Slf4jMsg] =
+        Slf4jTracer.sink.contramap(
+          Slf4jMsgFormat.humanFormat("hydrozoa.multisig.consensus.ReplayActor")
+        )
 
     /** The consensus actors the replay tail is routed into. `coilAckSequencer` is present only on a
       * hub — the boundary the received-but-unstamped coil-ack gap is re-fed to (see [[replay]]).
@@ -188,17 +195,54 @@ object ReplayActor:
           )
         )
 
-    /** Read L1 directly and send BlockWeaver the first [[PollResults]] (§5.5). */
+    /** Read L1 directly and send BlockWeaver the first [[PollResults]] (§5.5).
+      *
+      * ⛔ This is a GATE, and it must WAIT rather than fail. BlockWeaver starts at
+      * `PollResults.empty`, which is structurally indistinguishable from "polled, and the address
+      * is genuinely empty" — there is no `NeverPolled` state. A head peer classifies deposit
+      * existence from its OWN poll (`DepositsMap.Existence.FromPoll`), so acting on that empty
+      * value would reject every mature deposit as `NotInPollResults`: terminal, and DEBUG-only in
+      * the logs. The seed is queued before the start barrier opens precisely so that cannot happen.
+      *
+      * It previously raised on a failed L1 read, which closed the correctness hole but turned a
+      * transient Blockfrost blip into a failed boot — and `Restart=on-failure` turns a failed boot
+      * into an infinite restart loop that outlives the blip. Waiting is strictly better: the node
+      * is useless without this fact either way, and the retry is bounded by nothing but the
+      * operator's patience, which is what a dashboard is for.
+      *
+      * ⚠️ Safe to retry here ONLY because `replay` runs INLINE at the regime manager, on the app
+      * fiber, outside the actor system. The same loop inside a cats-actors message handler would be
+      * uncancelable (`ActorCell` wraps handlers in `.uncancelable`) and would make the process
+      * unkillable — measured. Do not move this into an actor.
+      */
     private def seedFirstPollResults(
         cardanoBackend: CardanoBackend[IO],
         treasuryAddress: ShelleyAddress,
         blockWeaver: BlockWeaver.Handle
-    ): IO[Unit] =
-        cardanoBackend.utxosAt(treasuryAddress).flatMap {
-            case Left(err) =>
-                IO.raiseError(new RuntimeException(s"ReplayActor L1 sample failed: $err"))
-            case Right(utxos) => blockWeaver ! PollResults(utxos.keySet)
-        }
+    ): IO[Unit] = {
+        def attempt(n: Int): IO[Unit] =
+            cardanoBackend.utxosAt(treasuryAddress).flatMap {
+                case Right(utxos) =>
+                    IO.whenA(n > 0)(
+                      log.info(
+                        s"boot L1 sample succeeded after ${n + 1} attempts; continuing start-up"
+                      )
+                    ) >> (blockWeaver ! PollResults(utxos.keySet))
+                case Left(err) =>
+                    val wait = l1SampleBackoff(n)
+                    log.warn(
+                      s"boot L1 sample failed (attempt ${n + 1}): $err. Cannot start consensus " +
+                          s"without it, so WAITING rather than failing the boot; retrying in $wait"
+                    ) >> IO.sleep(wait) >> attempt(n + 1)
+            }
+        attempt(0)
+    }
+
+    /** Backoff for the boot L1 sample: doubles from 1s, capped at 30s. Capped rather than unbounded
+      * so a node that has been waiting for hours still reacts promptly when L1 returns.
+      */
+    private def l1SampleBackoff(attempt: Int): FiniteDuration =
+        (1.second.toNanos * (1L << math.min(attempt, 5))).nanos.min(30.seconds)
 
     /** Reconstruct the handoff for the in-flight stack — the last own-acked stack, **iff** it is
       * not yet hard-confirmed (`hardConfirmed < hardAckedStack`). Its `Stack.Unsigned` was

--- a/src/main/scala/hydrozoa/multisig/consensus/ReplayActor.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/ReplayActor.scala
@@ -75,16 +75,21 @@ object ReplayActor:
         hubs: List[HeadPeerNumber],
         coils: List[CoilPeerNumber],
         treasuryAddress: ShelleyAddress,
-        leadsFastBlock: BlockNumber => Boolean
+        leadsFastBlock: BlockNumber => Boolean,
+        markers: Markers
     )(using CardanoNetwork.Section): IO[Unit] =
         val backend = persistence.backend
+        // `hardAckedStack` is a marker like the rest now, and the bundle is the manager's, derived
+        // once: `StackComposer` reads the same value, so the two cannot disagree — which is the
+        // whole point, since an adjustment applied to the bundle has to reach both.
+        val hardAckedStack = markers.hardAckedStack
         for
-            markers <- Markers.derive(backend, own)
-            // The slow-side own-ack journal is the one `PeerId`-keyed `HardAck` journal — both the
-            // acked stack (the StackComposer/aggregator floor) and the in-flight handoff's own acks
-            // come from it, for either peer type (§10 Q10).
-            ownAck <- recoverOwnAck(persistence, own, markers.hardConfirmed, markers.hardAcked)
-            (hardAckedStack, inflight) = ownAck
+            inflight <- reconstructInflightHandoff(
+              persistence,
+              own,
+              markers.hardConfirmed,
+              hardAckedStack
+            )
             // Fail-safe (CR6/CR7): refuse to start on an inconsistent store (confirmed > acked).
             _ <- validateInvariants(
               markers.softConfirmed,
@@ -154,20 +159,6 @@ object ReplayActor:
       * so this avoids re-scanning the own `HardAck` CF. The own ack journal is the one
       * `PeerId`-keyed `HardAck` journal, so `own: PeerId` works for both peer types (§10 Q10).
       */
-    private def recoverOwnAck(
-        persistence: Persistence[IO],
-        own: PeerId,
-        hardConfirmed: Option[StackNumber],
-        hardAcked: Option[HardAckNumber]
-    )(using
-        CardanoNetwork.Section
-    ): IO[(Option[StackNumber], Option[SlowConsensusActor.StackHandoff])] =
-        for
-            hardAckedStack <- hardAcked.traverse(n =>
-                persistence.getOrFail(JournalKey.HardAck(own, n)).map(_.payload.stackNum)
-            )
-            inflight <- reconstructInflightHandoff(persistence, own, hardConfirmed, hardAckedStack)
-        yield (hardAckedStack, inflight)
 
     /** Boot-time consistency fail-safe (CR6/CR7): a confirmed mark must never exceed its acked mark
       * (`confirmed ≤ acked` — we confirm only what we have acked). A violation means a torn or

--- a/src/main/scala/hydrozoa/multisig/consensus/ReplayActor.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/ReplayActor.scala
@@ -2,8 +2,9 @@ package hydrozoa.multisig.consensus
 
 import cats.effect.IO
 import cats.syntax.all.*
+import hydrozoa.app.StartupRefusal
 import hydrozoa.config.head.network.CardanoNetwork
-import hydrozoa.lib.logging.{ContraTracer, Slf4jMsg, Slf4jMsgFormat, Slf4jTracer, info, warn}
+import hydrozoa.lib.logging.{ContraTracer, Slf4jMsg, Slf4jMsgFormat, Slf4jTracer, error, info, warn}
 import hydrozoa.multisig.backend.cardano.CardanoBackend
 import hydrozoa.multisig.consensus.ack.{HardAck, HardAckNumber}
 import hydrozoa.multisig.consensus.peer.{CoilPeerNumber, HeadPeerNumber, PeerId}
@@ -249,14 +250,19 @@ object ReplayActor:
       * parameters decide fees, `maxTxSize` and execution-unit budgets, so a drift shows up as
       * transactions the chain rejects, at the worst possible moment.
       *
-      * ⚠️ **Reports, does not refuse — deliberately, and this is a decision to revisit.** A refusal
-      * needs a comparison we trust, and we do not yet know which fields differ benignly in practice
-      * (a config may legitimately pin a subset, or lag a harmless update). Refusing on a brittle
-      * equality check would brick every node on the first benign difference, which is far worse
-      * than the gap it closes. So this establishes the signal first: match ⇒ one INFO line; drift ⇒
-      * a loud WARN carrying both values, which is what tells us what a safe comparison should be. ⇒
-      * Escalating to a `StartupRefusal` (and gating hard-confirmation on it) is the intended next
-      * step, once real drift has been observed.
+      * ⛔ **A mismatch REFUSES the boot** (George, 2026-09-01): *"it should raise an escalated error
+      * if protocol parameters don't match, because it likely means that the head can't produce
+      * valid L1 txs in some cases."* A head building transactions against parameters the chain has
+      * moved past emits txs the chain rejects — silently, at settlement time, under load.
+      *
+      * It is a `StartupRefusal` rather than a generic crash because it is **deterministic**: the
+      * config asserts what it asserts, and a restart re-derives the same verdict, so a supervisor
+      * loop would learn nothing. ⇒ Operationally, an on-chain parameter update stops every peer
+      * until its config is updated. That is intended: the alternative is peers quietly emitting
+      * invalid transactions. ⚠️ Measured on preview 2026-09-01: the config's parameters equal the
+      * chain's **exactly**, so this is not a hair-trigger. If a benign field ever proves to differ
+      * in practice, narrow the comparison to the fields that govern tx validity — do not weaken it
+      * back to a warning.
       *
       * Unreachable is NOT drift: it retries like the L1 sample, because "cannot ask" and "asked and
       * the answer is wrong" are the two classes this whole start-up path is built to separate.
@@ -271,13 +277,18 @@ object ReplayActor:
                     if onChain == assumed then
                         log.info("protocol parameters on chain match the ones this config asserts")
                     else
-                        log.warn(
-                          "PROTOCOL PARAMETER DRIFT: the chain's parameters differ from the ones " +
-                              "this head's config asserts. Every L1 transaction this node builds " +
-                              "uses the config's values, so a real drift will surface as txs the " +
-                              "chain rejects.\n" +
+                        log.error(
+                          "PROTOCOL PARAMETER MISMATCH: the chain's parameters differ from the " +
+                              "ones this head's config asserts. Refusing to start.\n" +
                               s"  on chain: $onChain\n" +
                               s"  config:   $assumed"
+                        ) >> IO.raiseError(
+                          StartupRefusal(
+                            "the chain's protocol parameters differ from the ones this head's " +
+                                "config asserts, so the L1 transactions it builds may be rejected " +
+                                "by the chain. Update the config to the chain's current parameters " +
+                                "(both values are on the ERROR line above)."
+                          )
                         )
                 case Left(err) =>
                     val wait = l1SampleBackoff(n)

--- a/src/main/scala/hydrozoa/multisig/consensus/ReplayActor.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/ReplayActor.scala
@@ -250,19 +250,15 @@ object ReplayActor:
       * parameters decide fees, `maxTxSize` and execution-unit budgets, so a drift shows up as
       * transactions the chain rejects, at the worst possible moment.
       *
-      * ⛔ **A mismatch REFUSES the boot** (George, 2026-09-01): *"it should raise an escalated error
-      * if protocol parameters don't match, because it likely means that the head can't produce
-      * valid L1 txs in some cases."* A head building transactions against parameters the chain has
-      * moved past emits txs the chain rejects — silently, at settlement time, under load.
+      * ⛔ **A mismatch REFUSES the boot.** A head building transactions against parameters the chain
+      * has moved past emits txs the chain rejects — silently, at settlement time, under load.
       *
       * It is a `StartupRefusal` rather than a generic crash because it is **deterministic**: the
       * config asserts what it asserts, and a restart re-derives the same verdict, so a supervisor
       * loop would learn nothing. ⇒ Operationally, an on-chain parameter update stops every peer
       * until its config is updated. That is intended: the alternative is peers quietly emitting
-      * invalid transactions. ⚠️ Measured on preview 2026-09-01: the config's parameters equal the
-      * chain's **exactly**, so this is not a hair-trigger. If a benign field ever proves to differ
-      * in practice, narrow the comparison to the fields that govern tx validity — do not weaken it
-      * back to a warning.
+      * invalid transactions. If a benign field ever proves to differ in practice, narrow the
+      * comparison to the fields that govern tx validity — do not weaken it back to a warning.
       *
       * Unreachable is NOT drift: it retries like the L1 sample, because "cannot ask" and "asked and
       * the answer is wrong" are the two classes this whole start-up path is built to separate.

--- a/src/main/scala/hydrozoa/multisig/consensus/RequestSequencer.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/RequestSequencer.scala
@@ -37,7 +37,11 @@ trait RequestSequencer(
     l2Screener: L2Screener[IO],
     tracer: ContraTracer[IO, EventSequencerEvent],
     persistence: Persistence[IO],
-    metrics: PeerMetrics
+    metrics: PeerMetrics,
+    /** The boot markers, derived once by the regime manager (§5.2); this actor projects
+      * `nextRequestNumber` rather than re-reading its own Request spine.
+      */
+    markers: Markers
 ) extends Actor[IO, Request] {
     private val connections = Ref.unsafe[IO, Option[RequestSequencer.Connections]](None)
     private val state = State()
@@ -186,7 +190,7 @@ trait RequestSequencer(
             _ <- initializeConnections
             // R3: continue the request counter from `max(own Request) + 1` (CR3, no re-issue);
             // empty store -> RequestNumber(0), the same cold value.
-            next <- Markers.recoverNextRequestNumber(persistence.backend, ownHeadPeerNum)
+            next = markers.nextRequestNumber
             _ <- state.seedNextRequestNum(next)
             // Seed the confirmed high-water from the highest already-assigned own request (next - 1).
             // Treating assigned-as-confirmed opens the backpressure window optimistically after a
@@ -253,7 +257,8 @@ object RequestSequencer {
         l2Screener: L2Screener[IO],
         tracer: ContraTracer[IO, EventSequencerEvent],
         persistence: Persistence[IO],
-        metrics: PeerMetrics
+        metrics: PeerMetrics,
+        markers: Markers
     ): IO[RequestSequencer] =
         IO(
           new RequestSequencer(
@@ -262,7 +267,8 @@ object RequestSequencer {
             l2Screener,
             tracer,
             persistence,
-            metrics
+            metrics,
+            markers
           ) {}
         )
 

--- a/src/main/scala/hydrozoa/multisig/consensus/RequestSequencer.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/RequestSequencer.scala
@@ -72,7 +72,7 @@ trait RequestSequencer(
     private def initializeConnections: IO[Unit] = pendingConnections match {
         case x: HeadMultisigRegimeManager.PendingConnections =>
             for {
-                _connections <- x.get
+                _connections <- x.get.flatMap(IO.fromEither)
                 _ <- connections.set(
                   Some(
                     Connections(

--- a/src/main/scala/hydrozoa/multisig/consensus/SlowConsensusActor.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/SlowConsensusActor.scala
@@ -61,7 +61,11 @@ final case class SlowConsensusActor(
         SlowConsensusActor.Connections,
     tracer: ContraTracer[IO, SlowConsensusActorEvent],
     persistence: Persistence[IO],
-    metrics: PeerMetrics
+    metrics: PeerMetrics,
+    /** The boot markers, derived once by the regime manager (§5.2); this actor projects
+      * `hardConfirmed` rather than re-reading the spine `StackComposer` also reads.
+      */
+    markers: Markers
 ) extends Actor[IO, SlowConsensusActor.Request] {
     import SlowConsensusActor.*
 
@@ -118,8 +122,7 @@ final case class SlowConsensusActor(
                 // than dropped — orphans `clearOrphans` never reaches, since no cell is re-created
                 // for a confirmed stack. The hard-ack journals scan from key 0, so the buffer would
                 // retain every remote ack the head ever produced, on every restart.
-                hardConfirmed <- Markers.recoverHardConfirmed(persistence.backend)
-                _ <- stateRef.update(_.withLastConfirmed(hardConfirmed))
+                _ <- stateRef.update(_.withLastConfirmed(markers.hardConfirmed))
             } yield ()
         case h: StackHandoff =>
             handleStackHandoff(h)

--- a/src/main/scala/hydrozoa/multisig/consensus/SlowConsensusActor.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/SlowConsensusActor.scala
@@ -515,7 +515,7 @@ final case class SlowConsensusActor(
     private def initializeConnections: IO[Unit] = pendingConnections match {
         case x: HeadMultisigRegimeManager.PendingConnections =>
             for {
-                c <- x.get
+                c <- x.get.flatMap(IO.fromEither)
                 _ <- connections.set(
                   Some(
                     Connections(

--- a/src/main/scala/hydrozoa/multisig/consensus/StackComposer.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/StackComposer.scala
@@ -51,7 +51,13 @@ final case class StackComposer(
     pendingConnections: HeadMultisigRegimeManager.PendingConnections | StackComposer.Connections,
     tracer: ContraTracer[IO, StackComposerEvent],
     persistence: Persistence[IO],
-    metrics: PeerMetrics
+    metrics: PeerMetrics,
+    /** The boot markers, derived once by the regime manager (§5.2). `hardAckedStack` in particular
+      * is projected, not re-derived: this actor and `ReplayActor` used to unpack it from the
+      * own-ack journal independently, so a store whose journal disagrees with its confirmations (a
+      * seeded one) could satisfy the replay gate and still anchor this actor at the wrong stack.
+      */
+    markers: Markers
 ) extends Actor[IO, StackComposer.Request] {
     import StackComposer.*
 
@@ -103,9 +109,12 @@ final case class StackComposer(
       */
     private def recoverOrBootstrap: IO[Unit] =
         for {
-            hardAcked <- Markers.recoverHardAcked(persistence.backend, config.ownPeerId)
-            hardConfirmed <- Markers.recoverHardConfirmed(persistence.backend)
-            recovered <- State.recover(persistence, hardAcked, hardConfirmed, config.ownPeerId)
+            recovered <- State.recover(
+              persistence,
+              markers.hardAcked,
+              markers.hardConfirmed,
+              markers.hardAckedStack
+            )
             _ <- recovered match {
                 case Some(recoveredState) => state.set(recoveredState)
                 case None                 => bootstrapInitialStack
@@ -1042,18 +1051,16 @@ object StackComposer {
             persistence: Persistence[IO],
             hardAcked: Option[HardAckNumber],
             hardConfirmed: Option[StackNumber],
-            own: PeerId
+            hardAckedStack: Option[StackNumber]
         )(using config: HeadConfig.Bootstrap.Section): IO[Option[State]] =
-            hardAcked match
-                case None => IO.pure(None)
-                case Some(hardAckNum) =>
+            (hardAcked, hardAckedStack) match
+                case (None, _) | (_, None) => IO.pure(None)
+                case (Some(hardAckNum), Some(hardAckedStack)) =>
                     for {
-                        // No peer-type branch: the own hard-ack lives in the one `PeerId`-keyed
-                        // `HardAck` journal, and the closing stack's `lastBlockNum` comes from the
-                        // `UnsignedStack` every peer persists on every close (atomic with the
-                        // hard-ack, so always present for a hard-acked stack).
-                        lastHardAck <- persistence.getOrFail(JournalKey.HardAck(own, hardAckNum))
-                        hardAckedStack = lastHardAck.payload.stackNum
+                        // The closing stack's `lastBlockNum` comes from the `UnsignedStack` every
+                        // peer persists on every close (atomic with the hard-ack, so always present
+                        // for a stack this peer itself acked). `hardAckedStack` is projected from
+                        // the one marker bundle, so this anchor and the replay gate cannot disagree.
                         unsignedStack <- persistence.getOrFail(
                           StoreKey.UnsignedStack(hardAckedStack)
                         )

--- a/src/main/scala/hydrozoa/multisig/consensus/StackComposer.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/StackComposer.scala
@@ -1053,9 +1053,20 @@ object StackComposer {
             hardConfirmed: Option[StackNumber],
             hardAckedStack: Option[StackNumber]
         )(using config: HeadConfig.Bootstrap.Section): IO[Option[State]] =
-            (hardAcked, hardAckedStack) match
-                case (None, _) | (_, None) => IO.pure(None)
-                case (Some(hardAckNum), Some(hardAckedStack)) =>
+            // The anchor is `hardAckedStack`; the ack NUMBER only says what to assign next. They can
+            // come apart in exactly one situation: a store seeded from another peer, where the floor
+            // supplies the stack from `hardConfirmed` while this peer's own ack journal is empty
+            // because the donor never recorded an ack from it. `Markers.derive` unpacks the stack
+            // FROM the number, so `(None, Some(_))` is unreachable by reading a store — only the
+            // transplant floor can construct it, which is why treating it as a cold ack counter
+            // cannot change normal operation.
+            //
+            // Zero is the right counter there for the same reason a coil must never be handed fewer
+            // acks than its hub recorded: the donor recorded none, so the hub's cursor for this
+            // peer's ack lane is at zero, which is exactly what it will ask for.
+            hardAckedStack match
+                case None => IO.pure(None)
+                case Some(hardAckedStack) =>
                     for {
                         // The closing stack's `lastBlockNum` comes from the `UnsignedStack` every
                         // peer persists on every close (atomic with the hard-ack, so always present
@@ -1095,7 +1106,7 @@ object StackComposer {
                           lastClosedBlockNum = lastBlockNum,
                           previousStackHardConfirmed =
                               hardConfirmed.exists(Ordering[StackNumber].gteq(_, hardAckedStack)),
-                          nextOwnHardAckNum = hardAckNum.increment,
+                          nextOwnHardAckNum = hardAcked.fold(HardAckNumber.zero)(_.increment),
                           treasury = treasury,
                           evacuationMap = evacuationMap
                         )

--- a/src/main/scala/hydrozoa/multisig/consensus/StackComposer.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/StackComposer.scala
@@ -813,7 +813,7 @@ final case class StackComposer(
     private def initializeConnections: IO[Unit] = pendingConnections match {
         case x: HeadMultisigRegimeManager.PendingConnections =>
             for {
-                c <- x.get
+                c <- x.get.flatMap(IO.fromEither)
                 _ <- connections.set(
                   Some(
                     Connections(

--- a/src/main/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonCoilToHub.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonCoilToHub.scala
@@ -55,23 +55,25 @@ abstract class PeerLiaisonCoilToHub(
     private def resolveConnections: IO[PeerLiaisonCoilToHub.Connections] =
         pendingConnections match {
             case shared: HeadMultisigRegimeManager.PendingConnections =>
-                shared.get.flatMap(s =>
-                    s.remoteHubLiaison.fold(
-                      IO.raiseError(
-                        IllegalStateException("Coil→hub liaison requires a hub liaison handle.")
-                      )
-                    )(hub =>
-                        IO.pure(
-                          PeerLiaisonCoilToHub.Connections(
-                            blockWeaver = s.blockWeaver,
-                            consensusActor = s.consensusActor,
-                            stackComposer = s.stackComposer,
-                            slowConsensusActor = s.slowConsensusActor,
-                            remote = hub
+                shared.get
+                    .flatMap(IO.fromEither)
+                    .flatMap(s =>
+                        s.remoteHubLiaison.fold(
+                          IO.raiseError(
+                            IllegalStateException("Coil→hub liaison requires a hub liaison handle.")
                           )
+                        )(hub =>
+                            IO.pure(
+                              PeerLiaisonCoilToHub.Connections(
+                                blockWeaver = s.blockWeaver,
+                                consensusActor = s.consensusActor,
+                                stackComposer = s.stackComposer,
+                                slowConsensusActor = s.slowConsensusActor,
+                                remote = hub
+                              )
+                            )
                         )
                     )
-                )
             case own: PeerLiaisonCoilToHub.Connections => IO.pure(own)
         }
 

--- a/src/main/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonHeadToHead.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonHeadToHead.scala
@@ -67,16 +67,18 @@ abstract class PeerLiaisonHeadToHead(
     private def resolveConnections: IO[PeerLiaisonHeadToHead.Connections] =
         pendingConnections match {
             case shared: HeadMultisigRegimeManager.PendingConnections =>
-                shared.get.map(s =>
-                    PeerLiaisonHeadToHead.Connections(
-                      blockWeaver = s.blockWeaver,
-                      consensusActor = s.consensusActor,
-                      stackComposer = s.stackComposer,
-                      slowConsensusActor = s.slowConsensusActor,
-                      remote = s.remoteHeadLiaisons(remoteHead.peerNum),
-                      coilRelay = s.coilRelay
+                shared.get
+                    .flatMap(IO.fromEither)
+                    .map(s =>
+                        PeerLiaisonHeadToHead.Connections(
+                          blockWeaver = s.blockWeaver,
+                          consensusActor = s.consensusActor,
+                          stackComposer = s.stackComposer,
+                          slowConsensusActor = s.slowConsensusActor,
+                          remote = s.remoteHeadLiaisons(remoteHead.peerNum),
+                          coilRelay = s.coilRelay
+                        )
                     )
-                )
             case own: PeerLiaisonHeadToHead.Connections => IO.pure(own)
         }
 

--- a/src/main/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonHubToCoil.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonHubToCoil.scala
@@ -53,21 +53,23 @@ abstract class PeerLiaisonHubToCoil(
     private def resolveConnections: IO[PeerLiaisonHubToCoil.Connections] =
         pendingConnections match {
             case shared: HeadMultisigRegimeManager.PendingConnections =>
-                shared.get.flatMap(s =>
-                    s.coilAckSequencer.fold(
-                      IO.raiseError(
-                        IllegalStateException("Hub→coil liaison requires a CoilAckSequencer.")
-                      )
-                    )(seq =>
-                        IO.pure(
-                          PeerLiaisonHubToCoil.Connections(
-                            slowConsensusActor = s.slowConsensusActor,
-                            coilAckSequencer = seq,
-                            remote = s.remoteCoilLiaisons(coil)
+                shared.get
+                    .flatMap(IO.fromEither)
+                    .flatMap(s =>
+                        s.coilAckSequencer.fold(
+                          IO.raiseError(
+                            IllegalStateException("Hub→coil liaison requires a CoilAckSequencer.")
                           )
+                        )(seq =>
+                            IO.pure(
+                              PeerLiaisonHubToCoil.Connections(
+                                slowConsensusActor = s.slowConsensusActor,
+                                coilAckSequencer = seq,
+                                remote = s.remoteCoilLiaisons(coil)
+                              )
+                            )
                         )
                     )
-                )
             case own: PeerLiaisonHubToCoil.Connections => IO.pure(own)
         }
 

--- a/src/main/scala/hydrozoa/multisig/consensus/transport/CoilPeerWsTransport.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/transport/CoilPeerWsTransport.scala
@@ -4,6 +4,7 @@ import cats.effect.std.Queue
 import cats.effect.{IO, Ref, Resource}
 import cats.syntax.all.*
 import hydrozoa.config.head.network.CardanoNetwork
+import hydrozoa.lib.QuietRelease
 import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.consensus.liaison.BatchMessages.{OwnHardAck, Population}
 import hydrozoa.multisig.consensus.liaison.{LiaisonProtocol, PeerLiaisonCoilToHub}
@@ -85,7 +86,7 @@ final class CoilPeerWsTransport private (
         // Low-level `connect`, not `connectHighLevel`: the dialer needs to see the hub's keep-alive
         // Ping to know the link is alive (see WsDuplex).
         def once: IO[Unit] =
-            client.connect(request).use { conn =>
+            QuietRelease(client.connect(request)).use { conn =>
                 val helloLine = CoilFrame.encode(CoilFrame.Hello(ownCoilNum.convert))
                 tracer.traceWith(DialerConnected(hubUri)) >>
                     conn.send(WSFrame.Text(helloLine)) >>

--- a/src/main/scala/hydrozoa/multisig/consensus/transport/CoilPeerWsTransport.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/transport/CoilPeerWsTransport.scala
@@ -1,7 +1,7 @@
 package hydrozoa.multisig.consensus.transport
 
 import cats.effect.std.Queue
-import cats.effect.{IO, Ref, Resource}
+import cats.effect.{Deferred, FiberIO, IO, Ref, Resource}
 import cats.syntax.all.*
 import hydrozoa.config.head.network.CardanoNetwork
 import hydrozoa.lib.QuietRelease
@@ -71,9 +71,10 @@ final class CoilPeerWsTransport private (
             case Left(err)                     => tracer.traceWith(DecodeError(err))
         }
 
-    /** How long one dial attempt may sit in the WebSocket handshake before it is abandoned. Long
-      * enough not to give up on an ordinarily slow hub, short enough that a stalled one does not
-      * stop this peer reconnecting.
+    /** How long one dial attempt may sit in the WebSocket **handshake** before it is abandoned.
+      * Long enough not to give up on an ordinarily slow hub, short enough that a stalled one does
+      * not stop this peer reconnecting. Bounds the handshake alone: an established connection is
+      * unbounded, and [[WsDuplex.defaultReadIdleTimeout]] is what catches a half-open one.
       */
     private val handshakeBudget: FiniteDuration = 30.seconds
 
@@ -85,34 +86,68 @@ final class CoilPeerWsTransport private (
 
         // Low-level `connect`, not `connectHighLevel`: the dialer needs to see the hub's keep-alive
         // Ping to know the link is alive (see WsDuplex).
-        def once: IO[Unit] =
+        // `handshook` arbitrates between this attempt and the loop's budget: whoever completes it
+        // first decides whether the socket is used or dropped. `complete` has exactly one winner,
+        // so a handshake landing on the deadline cannot leave both a live connection and a redial.
+        def once(handshook: Deferred[IO, Unit]): IO[Unit] =
             QuietRelease(client.connect(request)).use { conn =>
                 val helloLine = CoilFrame.encode(CoilFrame.Hello(ownCoilNum.convert))
-                tracer.traceWith(DialerConnected(hubUri)) >>
-                    conn.send(WSFrame.Text(helloLine)) >>
-                    WsDuplex.run(conn, outbox, onLine)
+                handshook.complete(()).flatMap {
+                    case true =>
+                        tracer.traceWith(DialerConnected(hubUri)) >>
+                            conn.send(WSFrame.Text(helloLine)) >>
+                            WsDuplex.run(conn, outbox, onLine)
+                    // Lost the claim: the budget expired and the loop has already redialed. Return
+                    // instead, so `use` closes this socket rather than leaving a second live
+                    // connection draining the shared outbox.
+                    case false => tracer.traceWith(DialerHandshakeLate(hubUri))
+                }
             }
 
-        val attempt: IO[Unit] =
-            (once >> tracer.traceWith(DialerDisconnected(hubUri)))
+        def attempt(handshook: Deferred[IO, Unit]): IO[Unit] =
+            (once(handshook) >> tracer.traceWith(DialerDisconnected(hubUri)))
                 .handleErrorWith(e => tracer.traceWith(DialerFailed(e)))
 
-        // Bound each attempt and ABANDON a stalled one rather than awaiting it. `JdkWSClient`
-        // builds its socket inside `Resource.make`'s acquire, which is uncancelable, and
-        // `fromCompletableFuture` is cooperative-only — so a hub that accepts the TCP connection and
-        // never answers the handshake blocks `once` forever. Without this the loop never iterates
-        // and the peer stops reconnecting entirely: not slow to recover, never retrying.
+        // Wait out a connection this loop owns. `onCancel` is what keeps teardown closing the
+        // socket: the attempt runs on its own fiber, so cancelling this loop cancels the JOIN and
+        // not the attempt behind it, and a live `WsDuplex.run` would otherwise outlive
+        // `startDialer`'s release with its connection still open. Safe to cancel here and only
+        // here — past the claim the uncancelable acquire is long finished.
+        def own(f: FiberIO[Unit]): IO[Unit] = f.join.void.onCancel(f.cancel)
+
+        // Bound the HANDSHAKE, and only the handshake. `JdkWSClient` builds its socket inside
+        // `Resource.make`'s acquire, which is uncancelable, and `fromCompletableFuture` is
+        // cooperative-only — so a hub that accepts the TCP connection and never answers the
+        // handshake blocks the attempt forever, the loop never iterates, and the peer stops
+        // reconnecting entirely: not slow to recover, never retrying.
         //
-        // `race` cancels the losing `join`, not the attempt behind it, which is exactly what is
-        // wanted here — the stalled fiber is left to finish or not, and the loop moves on.
+        // What must NOT be bounded is what comes after. `WsDuplex.run` occupies the attempt for the
+        // whole life of a healthy link — the hub pings well inside the read deadline, so it never
+        // returns on its own — and timing the attempt as a whole therefore abandons a *working*
+        // connection every `handshakeBudget` and dials a second one on top of it.
+        //
+        // A stalled attempt is abandoned, not cancelled: the acquire it is stuck in cannot be
+        // interrupted. It disowns itself through `handshook` if it ever does complete.
         val bounded: IO[Unit] =
-            attempt.start.flatMap(f =>
-                IO.race(f.join, IO.sleep(handshakeBudget)).flatMap {
-                    case Left(_) => IO.unit
+            for {
+                handshook <- Deferred[IO, Unit]
+                f <- attempt(handshook).start
+                _ <- IO.race(IO.race(handshook.get, f.join), IO.sleep(handshakeBudget)).flatMap {
+                    // Connected inside the budget: this attempt owns the dialer until the link
+                    // ends, and waiting on it is the point.
+                    case Left(Left(_)) => own(f)
+                    // Ended before it ever connected — refused, DNS, TLS. Redial.
+                    case Left(Right(_)) => IO.unit
                     case Right(_) =>
-                        tracer.traceWith(DialerHandshakeStalled(hubUri, handshakeBudget))
+                        handshook.complete(()).flatMap {
+                            case true =>
+                                tracer.traceWith(DialerHandshakeStalled(hubUri, handshakeBudget))
+                            // It handshook on the deadline and claimed first after all, so it owns
+                            // the link and there is nothing to redial.
+                            case false => own(f)
+                        }
                 }
-            )
+            } yield ()
 
         (bounded >> IO.sleep(1.second)).foreverM
     }

--- a/src/main/scala/hydrozoa/multisig/consensus/transport/CoilPeerWsTransport.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/transport/CoilPeerWsTransport.scala
@@ -70,6 +70,15 @@ final class CoilPeerWsTransport private (
             case Left(err)                     => tracer.traceWith(DecodeError(err))
         }
 
+    /** How long one dial attempt may sit in the WebSocket handshake before it is abandoned. Long
+      * enough not to give up on an ordinarily slow hub, short enough that a stalled one does not
+      * stop this peer reconnecting.
+      */
+    private val handshakeBudget: FiniteDuration = 30.seconds
+
+    /** How long teardown waits for the dialer to acknowledge cancellation before proceeding. */
+    private val dialerCancelBudget: FiniteDuration = 5.seconds
+
     private def dialerLoop(client: WSClient[IO], hubUri: Uri): IO[Nothing] = {
         val request = WSRequest(hubUri)
 
@@ -87,14 +96,41 @@ final class CoilPeerWsTransport private (
             (once >> tracer.traceWith(DialerDisconnected(hubUri)))
                 .handleErrorWith(e => tracer.traceWith(DialerFailed(e)))
 
-        (attempt >> IO.sleep(1.second)).foreverM
+        // Bound each attempt and ABANDON a stalled one rather than awaiting it. `JdkWSClient`
+        // builds its socket inside `Resource.make`'s acquire, which is uncancelable, and
+        // `fromCompletableFuture` is cooperative-only — so a hub that accepts the TCP connection and
+        // never answers the handshake blocks `once` forever. Without this the loop never iterates
+        // and the peer stops reconnecting entirely: not slow to recover, never retrying.
+        //
+        // `race` cancels the losing `join`, not the attempt behind it, which is exactly what is
+        // wanted here — the stalled fiber is left to finish or not, and the loop moves on.
+        val bounded: IO[Unit] =
+            attempt.start.flatMap(f =>
+                IO.race(f.join, IO.sleep(handshakeBudget)).flatMap {
+                    case Left(_) => IO.unit
+                    case Right(_) =>
+                        tracer.traceWith(DialerHandshakeStalled(hubUri, handshakeBudget))
+                }
+            )
+
+        (bounded >> IO.sleep(1.second)).foreverM
     }
 
     /** Launch the hub dialer fiber; torn down when the resource is released. The hub URI is passed
       * at dial-start time so the caller can discover the hub's OS-assigned port after binding.
       */
     def startDialer(client: WSClient[IO], hubUri: Uri): Resource[IO, Unit] =
-        Resource.make(dialerLoop(client, hubUri).start)(_.cancel).void
+        Resource
+            .make(dialerLoop(client, hubUri).start)(fiber =>
+                // `cancel` waits for the fiber to finalize and is itself uncancelable, so a dialer
+                // stuck in an uncancelable handshake acquire would hang teardown — the same shape as
+                // the boot barriers. Run the cancel on its own fiber and bound the JOIN, which IS
+                // cancelable. A healthy dialer sits in `IO.sleep` and completes this immediately.
+                fiber.cancel.start
+                    .flatMap(_.join.timeoutTo(dialerCancelBudget, IO.unit))
+                    .void
+            )
+            .void
 }
 
 object CoilPeerWsTransport {

--- a/src/main/scala/hydrozoa/multisig/consensus/transport/CoilPeerWsTransportEvent.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/transport/CoilPeerWsTransportEvent.scala
@@ -2,6 +2,7 @@ package hydrozoa.multisig.consensus.transport
 
 import hydrozoa.multisig.consensus.liaison.LiaisonProtocol
 import org.http4s.Uri
+import scala.concurrent.duration.FiniteDuration
 
 /** Typed events emitted by [[CoilPeerWsTransport]]. Pure data; formatters in
   * [[CoilPeerWsTransportEventFormat]] decide how each variant is rendered to a particular sink.
@@ -34,6 +35,16 @@ object CoilPeerWsTransportEvent:
 
     /** A dialer attempt to the hub failed. */
     final case class DialerFailed(cause: Throwable) extends CoilPeerWsTransportEvent
+
+    /** A dial attempt sat in the WebSocket handshake past its budget and was abandoned.
+      *
+      * Distinct from [[DialerFailed]] because nothing failed: the hub accepted the TCP connection
+      * and then never answered. That attempt cannot be cancelled (the client builds its socket in
+      * an uncancelable acquire), so it is left running and the dialer moves on — which is the only
+      * way this peer keeps reconnecting at all.
+      */
+    final case class DialerHandshakeStalled(uri: Uri, after: FiniteDuration)
+        extends CoilPeerWsTransportEvent
 
     /** The connection to the hub ended without error — the peer closed cleanly, or the receive side
       * reached end of stream. A read-deadline expiry is an **error** and surfaces as

--- a/src/main/scala/hydrozoa/multisig/consensus/transport/CoilPeerWsTransportEvent.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/transport/CoilPeerWsTransportEvent.scala
@@ -46,6 +46,15 @@ object CoilPeerWsTransportEvent:
     final case class DialerHandshakeStalled(uri: Uri, after: FiniteDuration)
         extends CoilPeerWsTransportEvent
 
+    /** An abandoned dial attempt completed its handshake after the loop had given up on it, and
+      * dropped the socket instead of using it.
+      *
+      * The pair to [[DialerHandshakeStalled]]: seeing both for one attempt means the hub is merely
+      * slower than `handshakeBudget`, not black-holing, and the budget is the thing to raise.
+      * Seeing the stall alone means the handshake never landed at all.
+      */
+    final case class DialerHandshakeLate(uri: Uri) extends CoilPeerWsTransportEvent
+
     /** The connection to the hub ended without error — the peer closed cleanly, or the receive side
       * reached end of stream. A read-deadline expiry is an **error** and surfaces as
       * [[DialerFailed]], not here.

--- a/src/main/scala/hydrozoa/multisig/consensus/transport/CoilPeerWsTransportEventFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/transport/CoilPeerWsTransportEventFormat.scala
@@ -35,6 +35,11 @@ object CoilPeerWsTransportEventFormat:
                   s"dialer: handshake to hub at $uri stalled past $after and was abandoned; " +
                       "the hub accepted the connection but never completed it — redialing"
                 )
+            case DialerHandshakeLate(uri) =>
+                warn(
+                  s"dialer: handshake to hub at $uri completed after it was abandoned; " +
+                      "dropping the socket"
+                )
             case DialerDisconnected(uri) =>
                 warn(s"dialer: disconnected from hub at $uri; redialing")
         }

--- a/src/main/scala/hydrozoa/multisig/consensus/transport/CoilPeerWsTransportEventFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/transport/CoilPeerWsTransportEventFormat.scala
@@ -30,6 +30,11 @@ object CoilPeerWsTransportEventFormat:
                 // Class as well as message: getMessage is null for most connection exceptions,
                 // which made a live incident undiagnosable from the logs.
                 warn(s"dialer to hub failed: ${cause.getClass.getSimpleName}: ${cause.getMessage}")
+            case DialerHandshakeStalled(uri, after) =>
+                warn(
+                  s"dialer: handshake to hub at $uri stalled past $after and was abandoned; " +
+                      "the hub accepted the connection but never completed it — redialing"
+                )
             case DialerDisconnected(uri) =>
                 warn(s"dialer: disconnected from hub at $uri; redialing")
         }

--- a/src/main/scala/hydrozoa/multisig/consensus/transport/PeerTransport.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/transport/PeerTransport.scala
@@ -5,6 +5,7 @@ import cats.effect.{IO, Ref, Resource}
 import cats.syntax.all.*
 import fs2.Stream
 import hydrozoa.config.head.network.CardanoNetwork
+import hydrozoa.lib.QuietRelease
 import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.consensus.liaison.{LiaisonProtocol, PeerLiaisonHeadToHead}
 import hydrozoa.multisig.consensus.peer.HeadPeerId
@@ -115,7 +116,7 @@ final class WsPeerTransport private (
         // Low-level `connect`, not `connectHighLevel`: the dialer needs to see the remote's
         // keep-alive Ping to know the link is alive (see WsDuplex).
         def once: IO[Unit] =
-            client.connect(request).use { conn =>
+            QuietRelease(client.connect(request)).use { conn =>
                 val helloLine = HeadFrame.encode(HeadFrame.Hello(ownPeerId.peerNum))
                 tracer.traceWith(DialerConnected(remote, uri)) >>
                     conn.send(WSFrame.Text(helloLine)) >>

--- a/src/main/scala/hydrozoa/multisig/consensus/transport/PeerTransport.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/transport/PeerTransport.scala
@@ -126,7 +126,20 @@ final class WsPeerTransport private (
             (once >> tracer.traceWith(DialerDisconnected(remote, uri)))
                 .handleErrorWith(e => tracer.traceWith(DialerFailed(remote, e)))
 
-        (attempt >> IO.sleep(1.second)).foreverM
+        // Same bound as the coil dialer: `JdkWSClient` builds its socket in an uncancelable acquire,
+        // so a remote that accepts the connection and never answers the handshake blocks `once`
+        // forever and this loop stops retrying altogether. `race` cancels the losing join, not the
+        // attempt, so the stalled fiber is abandoned and the dialer moves on.
+        val bounded: IO[Unit] =
+            attempt.start.flatMap(f =>
+                IO.race(f.join, IO.sleep(handshakeBudget)).flatMap {
+                    case Left(_) => IO.unit
+                    case Right(_) =>
+                        tracer.traceWith(DialerHandshakeStalled(remote, uri, handshakeBudget))
+                }
+            )
+
+        (bounded >> IO.sleep(1.second)).foreverM
     }
 
     /** Server-side handler for an incoming WS connection. The first frame must be
@@ -178,6 +191,12 @@ final class WsPeerTransport private (
             serverHandler(wsb)
         }
 
+    /** How long one dial attempt may sit in the WebSocket handshake before it is abandoned. */
+    private val handshakeBudget: FiniteDuration = 30.seconds
+
+    /** How long teardown waits for a dialer to acknowledge cancellation before proceeding. */
+    private val dialerCancelBudget: FiniteDuration = 5.seconds
+
     /** Launch a dialer fiber for each remote with peerNum greater than ours (lower dials higher).
       * The fibers are torn down when the resource is released. URIs are passed at dial-start time
       * so the caller can bind on an OS-assigned ephemeral port and only build the URI map after
@@ -192,7 +211,13 @@ final class WsPeerTransport private (
             .traverse_ { case (rid, uri) =>
                 Resource
                     .make(dialerLoop(client, rid, uri).start)(fiber =>
-                        tracer.traceWith(DialerStopped(rid, uri)) >> fiber.cancel
+                        // Bounded for the same reason as the coil side: `cancel` waits for the
+                        // fiber to finalize and is itself uncancelable, so a dialer stuck in the
+                        // handshake would hang teardown. Bound the JOIN, which is cancelable.
+                        tracer.traceWith(DialerStopped(rid, uri)) >>
+                            fiber.cancel.start
+                                .flatMap(_.join.timeoutTo(dialerCancelBudget, IO.unit))
+                                .void
                     )
                     .void
             }

--- a/src/main/scala/hydrozoa/multisig/consensus/transport/PeerTransport.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/transport/PeerTransport.scala
@@ -1,7 +1,7 @@
 package hydrozoa.multisig.consensus.transport
 
 import cats.effect.std.Queue
-import cats.effect.{IO, Ref, Resource}
+import cats.effect.{Deferred, FiberIO, IO, Ref, Resource}
 import cats.syntax.all.*
 import fs2.Stream
 import hydrozoa.config.head.network.CardanoNetwork
@@ -115,30 +115,54 @@ final class WsPeerTransport private (
 
         // Low-level `connect`, not `connectHighLevel`: the dialer needs to see the remote's
         // keep-alive Ping to know the link is alive (see WsDuplex).
-        def once: IO[Unit] =
+        // `handshook` arbitrates between this attempt and the loop's budget — see the coil dialer
+        // in `CoilPeerWsTransport` for the full rationale; the shape here is identical.
+        def once(handshook: Deferred[IO, Unit]): IO[Unit] =
             QuietRelease(client.connect(request)).use { conn =>
                 val helloLine = HeadFrame.encode(HeadFrame.Hello(ownPeerId.peerNum))
-                tracer.traceWith(DialerConnected(remote, uri)) >>
-                    conn.send(WSFrame.Text(helloLine)) >>
-                    WsDuplex.run(conn, outboxes(remote), onLine(remote))
+                handshook.complete(()).flatMap {
+                    case true =>
+                        tracer.traceWith(DialerConnected(remote, uri)) >>
+                            conn.send(WSFrame.Text(helloLine)) >>
+                            WsDuplex.run(conn, outboxes(remote), onLine(remote))
+                    // Lost the claim: the budget expired and the loop has already redialed. Return
+                    // instead, so `use` closes this socket rather than leaving a second live
+                    // connection draining this remote's outbox.
+                    case false => tracer.traceWith(DialerHandshakeLate(remote, uri))
+                }
             }
 
-        val attempt: IO[Unit] =
-            (once >> tracer.traceWith(DialerDisconnected(remote, uri)))
+        def attempt(handshook: Deferred[IO, Unit]): IO[Unit] =
+            (once(handshook) >> tracer.traceWith(DialerDisconnected(remote, uri)))
                 .handleErrorWith(e => tracer.traceWith(DialerFailed(remote, e)))
 
-        // Same bound as the coil dialer: `JdkWSClient` builds its socket in an uncancelable acquire,
-        // so a remote that accepts the connection and never answers the handshake blocks `once`
-        // forever and this loop stops retrying altogether. `race` cancels the losing join, not the
-        // attempt, so the stalled fiber is abandoned and the dialer moves on.
+        // `onCancel` is what keeps teardown closing the socket: the attempt runs on its own fiber,
+        // so cancelling this loop cancels the JOIN and not the attempt behind it. Safe past the
+        // claim and only there — by then the uncancelable acquire has finished.
+        def own(f: FiberIO[Unit]): IO[Unit] = f.join.void.onCancel(f.cancel)
+
+        // Same bound as the coil dialer, and bounding the same thing: the HANDSHAKE only.
+        // `JdkWSClient` builds its socket in an uncancelable acquire, so a remote that accepts the
+        // connection and never answers blocks the attempt forever and this loop stops retrying
+        // altogether. But `WsDuplex.run` holds the attempt for the whole life of a healthy link, so
+        // bounding the attempt as a whole abandons working connections on a timer instead.
         val bounded: IO[Unit] =
-            attempt.start.flatMap(f =>
-                IO.race(f.join, IO.sleep(handshakeBudget)).flatMap {
-                    case Left(_) => IO.unit
+            for {
+                handshook <- Deferred[IO, Unit]
+                f <- attempt(handshook).start
+                _ <- IO.race(IO.race(handshook.get, f.join), IO.sleep(handshakeBudget)).flatMap {
+                    case Left(Left(_))  => own(f)
+                    case Left(Right(_)) => IO.unit
                     case Right(_) =>
-                        tracer.traceWith(DialerHandshakeStalled(remote, uri, handshakeBudget))
+                        handshook.complete(()).flatMap {
+                            case true =>
+                                tracer.traceWith(
+                                  DialerHandshakeStalled(remote, uri, handshakeBudget)
+                                )
+                            case false => own(f)
+                        }
                 }
-            )
+            } yield ()
 
         (bounded >> IO.sleep(1.second)).foreverM
     }

--- a/src/main/scala/hydrozoa/multisig/consensus/transport/PeerTransportEvent.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/transport/PeerTransportEvent.scala
@@ -49,6 +49,12 @@ object PeerTransportEvent:
     final case class DialerHandshakeStalled(remote: HeadPeerId, uri: Uri, after: FiniteDuration)
         extends PeerTransportEvent
 
+    /** An abandoned dial attempt completed its handshake after the loop had given up on it, and
+      * dropped the socket instead of using it. The pair to [[DialerHandshakeStalled]]: both for one
+      * attempt means the remote is merely slower than `handshakeBudget`, not black-holing.
+      */
+    final case class DialerHandshakeLate(remote: HeadPeerId, uri: Uri) extends PeerTransportEvent
+
     /** A frame received on an active dialer connection could not be decoded. */
     final case class ClientDecodeError(remote: HeadPeerId, cause: Throwable)
         extends PeerTransportEvent

--- a/src/main/scala/hydrozoa/multisig/consensus/transport/PeerTransportEvent.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/transport/PeerTransportEvent.scala
@@ -2,6 +2,7 @@ package hydrozoa.multisig.consensus.transport
 
 import hydrozoa.multisig.consensus.peer.HeadPeerId
 import org.http4s.Uri
+import scala.concurrent.duration.FiniteDuration
 
 /** Typed events emitted by [[PeerTransport]]. Pure data; formatters in [[PeerTransportEventFormat]]
   * decide how each variant is rendered to a particular sink.
@@ -39,6 +40,14 @@ object PeerTransportEvent:
 
     /** The dialer fiber for a remote peer was cancelled (resource release). */
     final case class DialerStopped(remote: HeadPeerId, uri: Uri) extends PeerTransportEvent
+
+    /** A dial attempt sat in the WebSocket handshake past its budget and was abandoned. Nothing
+      * failed: the remote accepted the TCP connection and never answered. The attempt cannot be
+      * cancelled (the client builds its socket in an uncancelable acquire), so it is left running
+      * and the dialer moves on — which is what keeps this peer reconnecting at all.
+      */
+    final case class DialerHandshakeStalled(remote: HeadPeerId, uri: Uri, after: FiniteDuration)
+        extends PeerTransportEvent
 
     /** A frame received on an active dialer connection could not be decoded. */
     final case class ClientDecodeError(remote: HeadPeerId, cause: Throwable)

--- a/src/main/scala/hydrozoa/multisig/consensus/transport/PeerTransportEventFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/transport/PeerTransportEventFormat.scala
@@ -37,6 +37,11 @@ object PeerTransportEventFormat:
                       s"$after and was abandoned; the remote accepted the connection but never " +
                       "completed it — redialing"
                 )
+            case DialerHandshakeLate(remote, uri) =>
+                warn(
+                  s"dialer: handshake to remote=${remote.peerNum: Int} at $uri completed after " +
+                      "it was abandoned; dropping the socket"
+                )
             case ClientDecodeError(remote, cause) =>
                 warn(
                   s"failed to decode frame from remote=${remote.peerNum: Int}: ${cause.getMessage}"

--- a/src/main/scala/hydrozoa/multisig/consensus/transport/PeerTransportEventFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/transport/PeerTransportEventFormat.scala
@@ -31,6 +31,18 @@ object PeerTransportEventFormat:
                 warn(s"dialer: disconnected from remote=${remote.peerNum: Int} at $uri; redialing")
             case DialerStopped(remote, uri) =>
                 info(s"dialer: stopped for remote=${remote.peerNum: Int} at $uri")
+            case DialerHandshakeStalled(remote, uri, after) =>
+                warn(
+                  s"dialer: handshake to remote=${remote.peerNum: Int} at $uri stalled past " +
+                      s"$after and was abandoned; the remote accepted the connection but never " +
+                      "completed it — redialing"
+                )
+            case DialerHandshakeStalled(remote, uri, after) =>
+                warn(
+                  s"dialer: handshake to remote=${remote.peerNum: Int} at $uri stalled past " +
+                      s"$after and was abandoned; the remote accepted the connection but never " +
+                      "completed it — redialing"
+                )
             case ClientDecodeError(remote, cause) =>
                 warn(
                   s"failed to decode frame from remote=${remote.peerNum: Int}: ${cause.getMessage}"

--- a/src/main/scala/hydrozoa/multisig/consensus/transport/PeerTransportEventFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/transport/PeerTransportEventFormat.scala
@@ -37,12 +37,6 @@ object PeerTransportEventFormat:
                       s"$after and was abandoned; the remote accepted the connection but never " +
                       "completed it — redialing"
                 )
-            case DialerHandshakeStalled(remote, uri, after) =>
-                warn(
-                  s"dialer: handshake to remote=${remote.peerNum: Int} at $uri stalled past " +
-                      s"$after and was abandoned; the remote accepted the connection but never " +
-                      "completed it — redialing"
-                )
             case ClientDecodeError(remote, cause) =>
                 warn(
                   s"failed to decode frame from remote=${remote.peerNum: Int}: ${cause.getMessage}"

--- a/src/main/scala/hydrozoa/multisig/ledger/joint/JointLedger.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/joint/JointLedger.scala
@@ -549,8 +549,8 @@ final case class JointLedger(
                   rejectedDeposits = decisions.rejected.requestIds
                 )
 
-            // The command number the deposit-decisions command takes when this block issues it
-            // (regular/major only); the number is carried unchanged when no command is issued.
+            // The command number the deposit-decisions command takes when a block issues it;
+            // carried unchanged when none is issued.
             assigned = p.commandNumber.increment
 
             // Block header
@@ -581,13 +581,16 @@ final case class JointLedger(
                     } yield (newJLState, headerIntermediate, evacDiffs)
                 else {
                     for {
-                        newL2State <- applyDepositDecisionsOrPanic(
-                          p,
-                          assigned,
-                          depositRequestDecisions
-                        )
-                        evacDiffs = newL2State.diffs
-                        newJLState = p.setL2LedgerState(newL2State).incrementCommandNumber
+                        // Also reached for a block made major by a withdrawal, which has no
+                        // decisions to apply -- and applying two empty lists is a no-op that
+                        // would still consume a command number.
+                        newJLState <-
+                            if decisions.absorbed.isEmpty && decisions.rejected.isEmpty
+                            then IO.pure(p)
+                            else
+                                applyDepositDecisionsOrPanic(p, assigned, depositRequestDecisions)
+                                    .map(s => p.setL2LedgerState(s).incrementCommandNumber)
+                        evacDiffs = newJLState.l2LedgerState.diffs
 
                         headerIntermediate <- previousHeader.nextHeaderMajor(bhTracer)(
                           txTiming,

--- a/src/main/scala/hydrozoa/multisig/ledger/joint/JointLedger.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/joint/JointLedger.scala
@@ -127,7 +127,7 @@ final case class JointLedger(
     private def initializeConnections: IO[Unit] = pendingConnections match {
         case x: HeadMultisigRegimeManager.PendingConnections =>
             for {
-                _connections <- x.get
+                _connections <- x.get.flatMap(IO.fromEither)
                 _ <- connections.set(
                   Some(
                     Connections(

--- a/src/main/scala/hydrozoa/multisig/ledger/joint/JointLedger.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/joint/JointLedger.scala
@@ -49,7 +49,11 @@ final case class JointLedger(
     l2Ledger: L2Ledger[IO],
     tracer: ContraTracer[IO, JointLedgerEvent],
     persistence: Persistence[IO],
-    metrics: PeerMetrics
+    metrics: PeerMetrics,
+    /** The boot markers, derived once by the regime manager (§5.2): this actor projects
+      * `fastBlockMark` and `evacuationMapMark` rather than re-reading the store.
+      */
+    markers: Markers
 ) extends Actor[IO, Requests.Request] {
     import config.*
 
@@ -200,12 +204,12 @@ final case class JointLedger(
             // fast anchor is `fastBlockMark = max(BlockResult)` (§6), shared by head and coil peers:
             // on a head peer it coincides with `max(own SoftAck)` (both written in the same atomic
             // per-block batch); a coil peer authors no soft-ack and anchors on it directly.
-            fastBlockMark <- Markers.recoverFastBlockMark(persistence.backend)
             recovered <- State.recover(
               persistence,
               l2Ledger,
-              fastBlockMark,
-              config.initialEvacuationMap
+              markers.fastBlockMark,
+              config.initialEvacuationMap,
+              markers.evacuationMapMark
             )
             _ <- recovered match {
                 case Some(done) =>
@@ -1078,7 +1082,8 @@ object JointLedger {
             persistence: Persistence[IO],
             l2Ledger: L2Ledger[IO],
             fastBlockMark: Option[BlockNumber],
-            initialEvacuationMap: EvacuationMap
+            initialEvacuationMap: EvacuationMap,
+            evacuationMapMark: Option[BlockNumber]
         )(using CardanoNetwork.Section): IO[Option[Done]] =
             fastBlockMark match
                 case None =>
@@ -1102,7 +1107,12 @@ object JointLedger {
                             .restoreTo(done.commandNumber)
                             .value
                             .flatMap(IO.fromEither)
-                        expected <- evacuationMapAt(persistence, blockNum, initialEvacuationMap)
+                        expected <- evacuationMapAt(
+                          persistence,
+                          blockNum,
+                          initialEvacuationMap,
+                          evacuationMapMark
+                        )
                         _ <- IO.raiseUnless(actual == expected.digest)(
                           RestoreError.EvacuationMapMismatch(
                             expected = expected.digest,
@@ -1128,10 +1138,10 @@ object JointLedger {
         private def evacuationMapAt(
             persistence: Persistence[IO],
             blockNum: BlockNumber,
-            initialEvacuationMap: EvacuationMap
+            initialEvacuationMap: EvacuationMap,
+            mapMark: Option[BlockNumber]
         ): IO[EvacuationMap] =
             for {
-                mapMark <- Markers.recoverEvacuationMapMark(persistence.backend)
                 base <- mapMark.fold(IO.pure(BlockNumber.zero -> initialEvacuationMap))(mark =>
                     persistence.getOrFail(StoreKey.EvacuationMap(mark)).map(mark -> _)
                 )

--- a/src/main/scala/hydrozoa/multisig/ledger/remote/RemoteL2Ledger.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/remote/RemoteL2Ledger.scala
@@ -3,9 +3,10 @@ package hydrozoa.multisig.ledger.remote
 import cats.Monad
 import cats.data.EitherT
 import cats.effect.std.{Mutex, Queue}
-import cats.effect.{Async, FiberIO, IO, Ref, Resource}
+import cats.effect.{Async, Deferred, FiberIO, IO, Ref, Resource}
 import cats.syntax.all.*
 import hydrozoa.config.head.network.CardanoNetwork
+import hydrozoa.lib.QuietRelease
 import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.ledger.joint.EvacuationMapHash
 import hydrozoa.multisig.ledger.l2.{ApplyDepositDecisionsResponse, ApplyTransactionResponse, L2CommandNumber, L2Ledger, L2LedgerCommand, L2LedgerResponse, RegisterDepositResponse, RestoreError}
@@ -25,6 +26,16 @@ import scala.concurrent.duration.*
   * returned as a response.
   */
 final case class RemoteL2LedgerError(message: String) extends RuntimeException(message)
+
+/** Raised to break an in-flight exchange out of its retry loop when the node is shutting down.
+  *
+  * ⛔ This exists because a cats-actors message handler runs inside `ActorCell`'s `.uncancelable`
+  * region, so an actor parked in an unbounded retry CANNOT be cancelled and the actor system can
+  * never terminate — measured: SIGTERM did not shut the node down at all, and the process survived
+  * only to be force-killed by cats-effect's `shutdownHookTimeout` (whose default is `Duration.Inf`,
+  * i.e. never). The handler must therefore RETURN of its own accord, and this is how it does so.
+  */
+final case class RemoteL2LedgerShuttingDown(message: String) extends RuntimeException(message)
 
 /** A remote [[L2Ledger]] that drives a black-box ledger over one long-lived WebSocket connection,
   * one synchronous request/response at a time.
@@ -79,6 +90,8 @@ class RemoteL2Ledger private (
     restoreTimeout: FiniteDuration,
     initialBackoff: FiniteDuration,
     maxBackoff: FiniteDuration,
+    handshakeBudget: FiniteDuration,
+    stopping: Deferred[IO, Unit],
     config: RemoteL2Ledger.Config,
     tracer: ContraTracer[IO, RemoteL2LedgerEvent]
 ) extends L2Ledger[IO] {
@@ -267,7 +280,26 @@ class RemoteL2Ledger private (
                             }
                             tracer.traceWith(event) >> IO.sleep(wait) >> attempt(n + 1)
                     }
-            attempt(0)
+            // ⛔ The ESCAPE HATCH. `attempt` retries transport failure forever, by design — that is
+            // what makes a node tolerate an absent ledger. But it runs inside a cats-actors message
+            // handler, which `ActorCell` wraps in `.uncancelable`, so nothing outside can interrupt
+            // it: on SIGTERM the actor system cannot terminate and the process has to be
+            // force-killed. Racing an internal signal works where cancellation cannot, because the
+            // race is *inside* the uncancelable region rather than outside it.
+            //
+            // `stopping` is completed by a Resource acquired AFTER the ActorSystem, so its finalizer
+            // runs BEFORE the system is torn down — the loop is already unwinding by the time the
+            // system asks its actors to stop.
+            IO.race(stopping.get, attempt(0)).flatMap {
+                case Right(response) => IO.pure(response)
+                case Left(_) =>
+                    IO.raiseError(
+                      RemoteL2LedgerShuttingDown(
+                        "node is shutting down; abandoning the exchange for command " +
+                            s"${request.commandNumber}"
+                      )
+                    )
+            }
         }
     }
 
@@ -291,36 +323,75 @@ class RemoteL2Ledger private (
 
     /** Open a connection, cache it, and trace the outcome. A failure to connect propagates so
       * [[exchange]] backs off and retries.
+      *
+      * ⛔ The handshake is BOUNDED and a stalled attempt is ABANDONED rather than awaited.
+      * `JdkWSClient` builds its socket inside `Resource.make`'s acquire, which cats-effect runs
+      * uncancelable, so neither `.timeout` nor a `poll` around `allocated` can interrupt it. A
+      * remote that accepts the TCP connection and never completes the WebSocket upgrade therefore
+      * blocks the FIRST attempt forever — and because that attempt never returns, the retry ladder
+      * in [[exchange]] never engages. Measured: one connection, one log line, then silence
+      * indefinitely, while the node still serves HTTP and looks healthy. This is the same defect
+      * fixed for the peer transport in `41ddf732`, and `IO.race` cancels only the losing *join*,
+      * not the attempt behind it — which is exactly what is wanted.
       */
     private def open: IO[Conn] =
         tracer.traceWith(Connecting(wsUri)) >>
-            // Allocate-then-cache must be atomic w.r.t. cancellation: `poll` keeps the connect itself
-            // interruptible, but once `allocated` yields the (connection, release) pair, caching the
-            // release handle in `connRef` runs uninterruptibly. Otherwise a cancellation landing
-            // between the fd opening and the cache would strand the release handle and leak the
-            // connection — the exact fd leak this class exists to prevent.
-            IO.uncancelable { poll =>
-                poll(wsClient.connectHighLevel(WSRequest(wsUri)).allocated).flatMap {
-                    case (connection, release) =>
-                        for {
-                            // A per-connection queue fed by a background fiber that pulls
-                            // `receiveStream` without pause. Draining it continuously keeps the JDK
-                            // WebSocket's read-demand (`request(n)`) open, so a response is never left
-                            // unread in the socket — the receive-stall failure mode of re-pulling
-                            // `receiveStream.head` afresh per exchange.
-                            incoming <- Queue.unbounded[IO, String]
-                            receiveFiber <- connection.receiveStream
-                                .collect { case WSFrame.Text(t, _) => t }
-                                .foreach(incoming.offer)
-                                .compile
-                                .drain
-                                .start
-                            conn = Conn(connection, incoming, receiveFiber, release)
-                            _ <- connRef.set(Some(conn))
-                            _ <- tracer.traceWith(Connected(wsUri))
-                        } yield conn
-                }
-            }
+            QuietRelease(wsClient.connectHighLevel(WSRequest(wsUri))).allocated.start
+                .flatMap(f =>
+                    IO.race(f.joinWithNever, IO.sleep(handshakeBudget)).flatMap {
+                        case Left(pair) => cacheConnection(pair)
+                        case Right(_)   => abandon(f)
+                    }
+                )
+
+    /** Give up on a stalled handshake. The attempt is left running — it cannot be cancelled — so
+      * anything it eventually produces must still be closed by someone, or it is the exact fd leak
+      * this class exists to prevent. A cleanup fiber joins the abandoned attempt and releases
+      * whatever it yields; if it never yields, the fiber simply never runs.
+      */
+    private def abandon(f: FiberIO[(WSConnectionHighLevel[IO], IO[Unit])]): IO[Nothing] =
+        f.joinWithNever.flatMap((_, release) => release.attempt.void).start.void >>
+            tracer.traceWith(HandshakeStalled(wsUri, handshakeBudget)) >>
+            IO.raiseError(
+              RemoteL2LedgerError(
+                s"WebSocket handshake to $wsUri did not complete within $handshakeBudget"
+              )
+            )
+
+    /** Install a freshly-allocated connection: start its drain fiber and cache it.
+      *
+      * Uncancelable: once `allocated` has yielded the (connection, release) pair, a cancellation
+      * landing before the release handle reaches `connRef` would strand it and leak the connection.
+      */
+    private def cacheConnection(pair: (WSConnectionHighLevel[IO], IO[Unit])): IO[Conn] =
+        IO.uncancelable { _ =>
+            val (connection, release) = pair
+            for {
+                // A per-connection queue fed by a background fiber that pulls `receiveStream`
+                // without pause. Draining it continuously keeps the JDK WebSocket's read-demand
+                // (`request(n)`) open, so a response is never left unread in the socket — the
+                // receive-stall failure mode of re-pulling `receiveStream.head` afresh per exchange.
+                incoming <- Queue.unbounded[IO, String]
+                receiveFiber <- connection.receiveStream
+                    .collect { case WSFrame.Text(t, _) => t }
+                    .foreach(incoming.offer)
+                    .compile
+                    .drain
+                    .start
+                conn = Conn(connection, incoming, receiveFiber, release)
+                _ <- connRef.set(Some(conn))
+                _ <- tracer.traceWith(Connected(wsUri))
+            } yield conn
+        }
+
+    /** Tell any in-flight exchange to stop retrying and return.
+      *
+      * ⛔ Must be invoked from a `Resource` acquired **after** the `ActorSystem`, so that its
+      * finalizer runs **before** the system is torn down. Acquired earlier, it would fire after the
+      * system had already tried (and failed) to stop the actor parked in the retry loop, which is
+      * the deadlock it exists to prevent.
+      */
+    def signalShutdown: IO[Unit] = stopping.complete(()).void
 
     /** Discard a connection believed broken: clear it from the cache (if still current) and release
       * its resources, ignoring any close error.
@@ -443,17 +514,29 @@ object RemoteL2Ledger {
         config: Config,
         tracer: ContraTracer[IO, RemoteL2LedgerEvent],
         requestTimeout: FiniteDuration = 5.seconds,
-        // A remote ledger answers a Restore by replaying its **whole** event log — there is no
-        // snapshot — so this bound has to exceed a full rebuild, and a rebuild grows linearly with
-        // the head's lifetime. Measured 2026-08-20 on the production box: ~8 minutes over ~42M
-        // events, growing ~2-3 minutes per day at that traffic. The old 10-minute default was
-        // therefore about two minutes from expiring, and an expiry here is terminal: `restoreTo`
-        // is deliberately not retried (a retry restarts the rebuild), and every boot calls it, so
-        // the node simply fails to start. Raised to leave room while the log keeps growing;
-        // the real fix is a ledger snapshot, which makes the rebuild bounded instead of linear.
+        // An expiry here is terminal: `restoreTo` is deliberately not retried (a retry restarts
+        // the rebuild), and every boot calls it, so the node simply fails to start.
+        //
+        // ⚠️ This value was sized when a Restore replayed the remote's **whole** event log, which
+        // grew linearly with the head's lifetime — measured 2026-08-20 at ~8 minutes over ~42M
+        // events. That is no longer how it works: the remote now seeds from its newest snapshot
+        // and replays only the commands above it, capped by its snapshot interval (20,000 by
+        // default), so a rebuild is seconds and does not grow with the head's age. Measured
+        // 2026-09-01: 9,096 commands in 15 ms.
+        //
+        // ⇒ The bound is therefore now enormously oversized rather than marginal. It is left as-is
+        // deliberately: it costs nothing when nothing is wrong, and the failure it guards against
+        // (a boot that never completes) is worse than a boot that takes too long to give up. Do not
+        // re-derive a rebuild estimate from the old figure — that is how a stale constant in a
+        // comment produced a stale conclusion two steps away.
         restoreTimeout: FiniteDuration = 60.minutes,
         initialBackoff: FiniteDuration = 1.second,
         maxBackoff: FiniteDuration = 30.seconds,
+        // Bounds the WebSocket handshake. Generous, because a slow-but-healthy remote must not be
+        // abandoned: a ledger rebuilding from its newest snapshot answers in well under this, and
+        // the point of the bound is only to stop an attempt that will NEVER complete from parking
+        // the connect forever. See `open`.
+        handshakeBudget: FiniteDuration = 30.seconds,
     ): Resource[IO, RemoteL2Ledger] =
         for {
             uri <- Resource.eval(IO.fromEither(Uri.fromString(wsUri)))
@@ -463,6 +546,8 @@ object RemoteL2Ledger {
                 ref.get.flatMap(_.traverse_(c => c.receiveFiber.cancel >> c.release.attempt.void))
             )
             mutex <- Resource.eval(Mutex[IO])
+            // Completed by `stopOnShutdown`, which the caller must acquire AFTER the ActorSystem.
+            stopping <- Resource.eval(Deferred[IO, Unit])
         } yield new RemoteL2Ledger(
           uri,
           wsClient,
@@ -472,6 +557,8 @@ object RemoteL2Ledger {
           restoreTimeout,
           initialBackoff,
           maxBackoff,
+          handshakeBudget,
+          stopping,
           config,
           tracer
         )

--- a/src/main/scala/hydrozoa/multisig/ledger/remote/RemoteL2Ledger.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/remote/RemoteL2Ledger.scala
@@ -517,18 +517,17 @@ object RemoteL2Ledger {
         // An expiry here is terminal: `restoreTo` is deliberately not retried (a retry restarts
         // the rebuild), and every boot calls it, so the node simply fails to start.
         //
-        // ⚠️ This value was sized when a Restore replayed the remote's **whole** event log, which
-        // grew linearly with the head's lifetime — measured 2026-08-20 at ~8 minutes over ~42M
-        // events. That is no longer how it works: the remote now seeds from its newest snapshot
-        // and replays only the commands above it, capped by its snapshot interval (20,000 by
-        // default), so a rebuild is seconds and does not grow with the head's age. Measured
-        // 2026-09-01: 9,096 commands in 15 ms.
+        // ⚠️ This value was sized when a Restore replayed the remote's **whole** event log, so the
+        // rebuild grew linearly with the head's lifetime. That is no longer how it works: the remote
+        // seeds from its newest snapshot and replays only the commands above it, capped by its
+        // snapshot interval (20,000 by default), so a rebuild does not grow with the head's age.
         //
-        // ⇒ The bound is therefore now enormously oversized rather than marginal. It is left as-is
+        // ⇒ The bound is therefore enormously oversized rather than marginal. It is left as-is
         // deliberately: it costs nothing when nothing is wrong, and the failure it guards against
-        // (a boot that never completes) is worse than a boot that takes too long to give up. Do not
-        // re-derive a rebuild estimate from the old figure — that is how a stale constant in a
-        // comment produced a stale conclusion two steps away.
+        // (a boot that never completes) is worse than a boot that takes too long to give up.
+        // ⛔ Do not re-derive a rebuild estimate from any figure quoted near this constant: the
+        // rebuild cost depends on the snapshot interval and the state's size, and a number measured
+        // on one head does not transfer to another.
         restoreTimeout: FiniteDuration = 60.minutes,
         initialBackoff: FiniteDuration = 1.second,
         maxBackoff: FiniteDuration = 30.seconds,

--- a/src/main/scala/hydrozoa/multisig/ledger/remote/RemoteL2LedgerEvent.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/remote/RemoteL2LedgerEvent.scala
@@ -17,6 +17,14 @@ object RemoteL2LedgerEvent:
     /** A WebSocket connection to the remote ledger succeeded. */
     final case class Connected(uri: Uri) extends RemoteL2LedgerEvent
 
+    /** The WebSocket handshake did not complete within [[budget]], so the attempt was ABANDONED
+      * rather than awaited. A remote that accepts the TCP connection and never answers the upgrade
+      * would otherwise block the connect forever: `JdkWSClient` builds its socket inside
+      * `Resource.make`'s acquire, which is uncancelable, so neither a `timeout` nor a `poll` can
+      * interrupt it and the retry ladder never engages.
+      */
+    final case class HandshakeStalled(uri: Uri, budget: FiniteDuration) extends RemoteL2LedgerEvent
+
     /** A request errored; reconnecting after [[backoff]] on attempt [[attempt]] (zero-indexed). */
     final case class ConnectionError(attempt: Int, backoff: FiniteDuration, cause: Throwable)
         extends RemoteL2LedgerEvent

--- a/src/main/scala/hydrozoa/multisig/ledger/remote/RemoteL2LedgerEventFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/remote/RemoteL2LedgerEventFormat.scala
@@ -15,6 +15,13 @@ object RemoteL2LedgerEventFormat:
                 info(s"Connecting to WebSocket at $uri")
             case Connected(uri) =>
                 info(s"Successfully connected to $uri")
+            case HandshakeStalled(uri, budget) =>
+                LogEvent(
+                  Level.Warn,
+                  s"WebSocket handshake to $uri did not complete within $budget; " +
+                      "abandoning this attempt and retrying",
+                  routingKey = Some("RemoteL2Ledger")
+                )
             case ConnectionError(attempt, backoff, cause) =>
                 LogEvent(
                   Level.Warn,

--- a/src/main/scala/hydrozoa/multisig/persistence/Markers.scala
+++ b/src/main/scala/hydrozoa/multisig/persistence/Markers.scala
@@ -48,6 +48,35 @@ object Markers:
       */
     val cold: Markers = Markers(None, None, None, None, RequestNumber(0), None, None)
 
+    /** Apply a `transplantStackNumber` to a freshly derived marker bundle, raising this peer's
+      * trusted-history floor to the stack the transplant was tagged with.
+      *
+      * ⛔ The comparison is **`hardConfirmed >= tag`**, deliberately the same one
+      * `Serve`'s boot gate uses. It used to be exact equality here while the gate accepted `>=`, so
+      * a tag naming any stack BELOW the store's tip passed the gate and was then **silently
+      * dropped** — the operator got no adoption and no error. A tag is a partition of the store
+      * chosen by the operator, and any stack the store actually holds is a legitimate choice, so
+      * below-tip must adopt. (George's ruling, 2026-09-02.)
+      *
+      * It RAISES the floor and never lowers it: a peer mid-flight has acked one stack beyond its
+      * confirmation, and clamping that down to the tag would discard the in-flight handoff
+      * `ReplayActor` rebuilds from it. So once the peer has moved past the tag the `max` is a
+      * no-op, which is what keeps a tag left in the config after adoption harmless.
+      *
+      * Applied to the ONE bundle, so the gate, the replay cursors, the in-flight handoff and the
+      * stack composer all move together — the alternative is the divergence that made this
+      * necessary. Lives here rather than in each regime manager because it was duplicated verbatim
+      * in both, which is how the comparison came to disagree with the gate in the first place.
+      */
+    def adopt(derived: Markers, tag: Option[StackNumber]): Markers =
+        tag
+            .filter(t => derived.hardConfirmed.exists(Ordering[StackNumber].gteq(_, t)))
+            .fold(derived)(t =>
+                derived.copy(hardAckedStack = Some(derived.hardAckedStack.fold(t) { own =>
+                    if Ordering[StackNumber].gteq(own, t) then own else t
+                }))
+            )
+
     /** Read all five markers from `backend`, scoping the `hardAcked` and `nextRequestNumber`
       * derivations to `own`. With the per-author CF split each satellite CF holds exactly one
       * author's journal, so the own `hardAcked` mark is just `lastKey` of the own-author `HardAck`

--- a/src/main/scala/hydrozoa/multisig/persistence/Markers.scala
+++ b/src/main/scala/hydrozoa/multisig/persistence/Markers.scala
@@ -2,6 +2,8 @@ package hydrozoa.multisig.persistence
 
 import cats.effect.IO
 import cats.syntax.parallel.*
+import cats.syntax.traverse.*
+import hydrozoa.config.head.network.CardanoNetwork
 import hydrozoa.multisig.consensus.ack.HardAckNumber
 import hydrozoa.multisig.consensus.peer.{HeadPeerNumber, PeerId}
 import hydrozoa.multisig.ledger.block.BlockNumber
@@ -30,10 +32,23 @@ final case class Markers(
     fastBlockMark: Option[BlockNumber],
     hardConfirmed: Option[StackNumber],
     hardAcked: Option[HardAckNumber],
-    nextRequestNumber: RequestNumber
+    nextRequestNumber: RequestNumber,
+    evacuationMapMark: Option[BlockNumber],
+    /** The stack this peer's last own hard-ack covers — `hardAcked` dereferenced into the journal
+      * and unpacked. Unlike the six marks around it this is an *interpretation*, not a `lastKey`,
+      * which is exactly why it belongs here: derived twice it can be adjusted once and disagree
+      * everywhere. `None` on an empty own-ack journal.
+      */
+    hardAckedStack: Option[StackNumber]
 )
 
 object Markers:
+    /** The marker set of an empty store: every anchor absent, the request counter at zero. What
+      * [[derive]] returns for a cold store, spelled out so a caller that has no store to derive
+      * from (a test wiring an actor against an empty backend) need not fabricate one.
+      */
+    val cold: Markers = Markers(None, None, None, None, RequestNumber(0), None, None)
+
     /** Read all five markers from `backend`, scoping the `hardAcked` and `nextRequestNumber`
       * derivations to `own`. With the per-author CF split each satellite CF holds exactly one
       * author's journal, so the own `hardAcked` mark is just `lastKey` of the own-author `HardAck`
@@ -41,17 +56,29 @@ object Markers:
       * covers both peer types, and `nextRequestNumber` is `RequestNumber(0)` on a coil peer (the
       * user-request surface is head-only).
       */
-    def derive(backend: BackendStore[IO], own: PeerId): IO[Markers] =
+    def derive(persistence: Persistence[IO], own: PeerId)(using
+        CardanoNetwork.Section
+    ): IO[Markers] =
+        val backend = persistence.backend
         val nextRequest = own match
             case PeerId.Head(n) => recoverNextRequestNumber(backend, n)
             case PeerId.Coil(_) => IO.pure(RequestNumber(0))
-        (
-          backend.lastKey(Cf.SoftConfirmation).map(_.map(decodeBlockNum)),
-          recoverFastBlockMark(backend),
-          backend.lastKey(Cf.HardConfirmation).map(_.map(decodeStackNum)),
-          backend.lastKey(Cf.HardAck(own)).map(_.map(decodeSatelliteNumHard)),
-          nextRequest
-        ).parMapN(Markers.apply)
+        for {
+            base <- (
+              backend.lastKey(Cf.SoftConfirmation).map(_.map(decodeBlockNum)),
+              recoverFastBlockMark(backend),
+              backend.lastKey(Cf.HardConfirmation).map(_.map(decodeStackNum)),
+              backend.lastKey(Cf.HardAck(own)).map(_.map(decodeSatelliteNumHard)),
+              nextRequest,
+              recoverEvacuationMapMark(backend)
+            ).parTupled
+            (soft, fast, hardConf, hardAck, nextReq, evacMark) = base
+            // Sequenced after the parallel block: it is keyed BY `hardAcked`, so it cannot be read
+            // alongside the mark it depends on.
+            ackedStack <- hardAck.traverse(n =>
+                persistence.getOrFail(JournalKey.HardAck(own, n)).map(_.payload.stackNum)
+            )
+        } yield Markers(soft, fast, hardConf, hardAck, nextReq, evacMark, ackedStack)
 
     /** The next request number this peer will assign after recovery: `max(own Request) + 1`, or
       * `RequestNumber(0)` for an empty store — the last key of the own-author `Request` CF (an

--- a/src/main/scala/hydrozoa/multisig/persistence/Markers.scala
+++ b/src/main/scala/hydrozoa/multisig/persistence/Markers.scala
@@ -3,7 +3,6 @@ package hydrozoa.multisig.persistence
 import cats.effect.IO
 import cats.syntax.parallel.*
 import cats.syntax.traverse.*
-import hydrozoa.config.head.network.CardanoNetwork
 import hydrozoa.multisig.consensus.ack.HardAckNumber
 import hydrozoa.multisig.consensus.peer.{HeadPeerNumber, PeerId}
 import hydrozoa.multisig.ledger.block.BlockNumber
@@ -56,9 +55,7 @@ object Markers:
       * covers both peer types, and `nextRequestNumber` is `RequestNumber(0)` on a coil peer (the
       * user-request surface is head-only).
       */
-    def derive(persistence: Persistence[IO], own: PeerId)(using
-        CardanoNetwork.Section
-    ): IO[Markers] =
+    def derive(persistence: Persistence[IO], own: PeerId): IO[Markers] =
         val backend = persistence.backend
         val nextRequest = own match
             case PeerId.Head(n) => recoverNextRequestNumber(backend, n)

--- a/src/main/scala/hydrozoa/multisig/persistence/Markers.scala
+++ b/src/main/scala/hydrozoa/multisig/persistence/Markers.scala
@@ -51,12 +51,12 @@ object Markers:
     /** Apply a `transplantStackNumber` to a freshly derived marker bundle, raising this peer's
       * trusted-history floor to the stack the transplant was tagged with.
       *
-      * ⛔ The comparison is **`hardConfirmed >= tag`**, deliberately the same one
-      * `Serve`'s boot gate uses. It used to be exact equality here while the gate accepted `>=`, so
-      * a tag naming any stack BELOW the store's tip passed the gate and was then **silently
-      * dropped** — the operator got no adoption and no error. A tag is a partition of the store
-      * chosen by the operator, and any stack the store actually holds is a legitimate choice, so
-      * below-tip must adopt. (George's ruling, 2026-09-02.)
+      * ⛔ The comparison is **`hardConfirmed >= tag`**, deliberately the same one `Serve`'s boot
+      * gate uses. It used to be exact equality here while the gate accepted `>=`, so a tag naming
+      * any stack BELOW the store's tip passed the gate and was then **silently dropped** — the
+      * operator got no adoption and no error. A tag is a partition of the store chosen by the
+      * operator, and any stack the store actually holds is a legitimate choice, so below-tip must
+      * adopt. (George's ruling, 2026-09-02.)
       *
       * It RAISES the floor and never lowers it: a peer mid-flight has acked one stack beyond its
       * confirmation, and clamping that down to the tag would discard the in-flight handoff

--- a/src/main/scala/hydrozoa/rulebased/RuleBasedActor.scala
+++ b/src/main/scala/hydrozoa/rulebased/RuleBasedActor.scala
@@ -300,7 +300,7 @@ final case class RuleBasedActor(
         versionMajor: BigInt
     ): IO[List[StandaloneEvacuationCommitment.MultiSigned]] =
         for {
-            markers <- Markers.derive(persistence.backend, config.ownPeerId)
+            markers <- Markers.derive(persistence, config.ownPeerId)
             latest <- markers.hardConfirmed.liftTo[IO](
               MissingState("no hard-confirmed stack on disk")
             )
@@ -337,7 +337,7 @@ final case class RuleBasedActor(
       */
     private[rulebased] def loadEvacuationInputs(versionMajor: BigInt): IO[EvacuationInputs] =
         for {
-            markers <- Markers.derive(persistence.backend, config.ownPeerId)
+            markers <- Markers.derive(persistence, config.ownPeerId)
             latest <- markers.hardConfirmed.liftTo[IO](
               MissingState("no hard-confirmed stack on disk")
             )
@@ -440,7 +440,7 @@ final case class RuleBasedActor(
             IO.pure(config.initialEvacuationMap.kzgCommitment -> config.initialEvacuationMap)
         else
             for {
-                markers <- Markers.derive(persistence.backend, config.ownPeerId)
+                markers <- Markers.derive(persistence, config.ownPeerId)
                 latest <- markers.hardConfirmed.liftTo[IO](
                   MissingState("no hard-confirmed stack on disk")
                 )

--- a/src/test/scala/hydrozoa/app/MainSmokeTest.scala
+++ b/src/test/scala/hydrozoa/app/MainSmokeTest.scala
@@ -6,6 +6,7 @@ import hydrozoa.config.GenerateSampleConfig.{defaultSpec, testPeersSpec}
 import hydrozoa.config.head.HeadConfig.headConfigEncoder
 import hydrozoa.config.node.NodePrivateConfig.nodePrivateConfigEncoder
 import hydrozoa.config.node.{MultiNodeConfig, PrivateSecrets}
+import hydrozoa.lib.StartupRefusal
 import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.backend.cardano.{CardanoBackendMock, MockState}
 import hydrozoa.multisig.consensus.peer.HeadPeerNumber
@@ -297,7 +298,17 @@ class MainSmokeTest extends AnyFunSuite:
         val mnc: MultiNodeConfig = MultiNodeConfig
             .generate(testPeersSpec(spec))()
             .pureApply(Gen.Parameters.default, org.scalacheck.rng.Seed(spec.generationSeed))
-        val peerPrivate = mnc.nodePrivateConfigs(HeadPeerNumber(0)).copy(httpPort = "0")
+        val generatedPrivate = mnc.nodePrivateConfigs(HeadPeerNumber(0))
+        // ⛔ Clear the transplant tag, for the same reason the positive test does — and here it is
+        // load-bearing rather than tidy. The generator draws it from `Gen.option`, this store is
+        // empty, and the transplant gate runs in `Serve` BEFORE the parameter comparison. Left in,
+        // this test would refuse for the wrong reason and pass while never exercising the gate it
+        // exists to cover.
+        val peerPrivate = generatedPrivate.copy(
+          httpPort = "0",
+          nodeOperationMultisigConfig = generatedPrivate.nodeOperationMultisigConfig
+              .copy(transplantStackNumber = None)
+        )
         val printer = Printer.spaces2.copy(dropNullValues = true)
         val (_, peerSigningKey) = TestPeers.deriveScalusKeypair(spec.seedPhrase.mnemonic, 0)
         val runnablePrivateJson = peerPrivate.asJson.deepMerge(
@@ -331,7 +342,13 @@ class MainSmokeTest extends AnyFunSuite:
                   IO.raiseError(new AssertionError("runNode neither refused nor returned in 60s"))
                 )
             _ <- outcome match {
-                case Left(_: StartupRefusal) => IO.unit
+                // On the REASON, not the type: a node has several ways to refuse, and the whole
+                // point of this control is that it fails for this one.
+                case Left(r: StartupRefusal) if r.reason.contains("protocol parameters") => IO.unit
+                case Left(r: StartupRefusal) =>
+                    IO.raiseError(
+                      new AssertionError(s"refused, but for another reason: ${r.reason}")
+                    )
                 case Left(other) =>
                     IO.raiseError(
                       new AssertionError(s"expected a StartupRefusal, got: $other")

--- a/src/test/scala/hydrozoa/app/MainSmokeTest.scala
+++ b/src/test/scala/hydrozoa/app/MainSmokeTest.scala
@@ -56,9 +56,17 @@ class MainSmokeTest extends AnyFunSuite:
         // Both the inter-peer mesh server (which binds where the head config advertises this peer —
         // the test fixture uses port 0) and the HTTP admin server (httpPort) bind OS-ephemeral
         // ports, so the test doesn't collide with whatever holds the generator's defaults.
-        val peerPrivate = mnc
-            .nodePrivateConfigs(HeadPeerNumber(0))
-            .copy(httpPort = "0")
+        val generatedPrivate = mnc.nodePrivateConfigs(HeadPeerNumber(0))
+        // ⛔ Clear the transplant tag. `generateNodeOperationMultisigConfig` draws it from
+        // `Gen.option` on purpose — a codec round-trip has to cover both shapes of the field — but
+        // this test boots a NORMAL peer, and a normal peer carries no transplant tag. Left in, the
+        // config claims to be a transplant of a stack no empty store can hold, which is a refusal,
+        // and whether it appears at all depends on the generator seed.
+        val peerPrivate = generatedPrivate.copy(
+          httpPort = "0",
+          nodeOperationMultisigConfig = generatedPrivate.nodeOperationMultisigConfig
+              .copy(transplantStackNumber = None)
+        )
 
         val printer = Printer.spaces2.copy(dropNullValues = true)
 
@@ -149,6 +157,87 @@ class MainSmokeTest extends AnyFunSuite:
             // ⚠️ Do not await this. Cancelling a *live* node never returns, and `Fiber.cancel` is
             // itself uncancelable, so no timeout bounds it. The daemon threads go with the JVM.
             _ <- fiber.cancel.start.void
+        } yield ()
+
+        testIO.unsafeRunSync()
+    }
+
+    // A `transplantStackNumber` names the stack this peer elects to ADOPT: everything at or below it
+    // is taken on trust from the donor committee and never verified. So the tag has to name a stack
+    // the store actually holds. Here the store is empty, so no tag can be honoured -- the node must
+    // refuse rather than silently ignore the tag and boot as though none had been set.
+    //
+    // Asserting on the REASON, not just the type: this refusal has to be distinguishable from the
+    // other ways a node can refuse to start, or the test would pass on the wrong one.
+    test("Serve.runNode refuses a transplantStackNumber the store does not contain") {
+        val rootTmp = Files.createTempDirectory("hydrozoa-transplant-tag-")
+        val configDir = rootTmp.resolve("config")
+        val dataDir = rootTmp.resolve("data")
+        Files.createDirectories(configDir)
+        Files.createDirectories(dataDir)
+
+        val spec = defaultSpec.copy(outDir = configDir, nPeers = 1)
+        val headPath = configDir.resolve("head-config.json")
+        val privatePath = configDir.resolve("peer-0").resolve("private.json")
+        val mnc: MultiNodeConfig = MultiNodeConfig
+            .generate(testPeersSpec(spec))()
+            .pureApply(Gen.Parameters.default, org.scalacheck.rng.Seed(spec.generationSeed))
+        val peerPrivate = mnc.nodePrivateConfigs(HeadPeerNumber(0)).copy(httpPort = "0")
+        val printer = Printer.spaces2.copy(dropNullValues = true)
+        val (_, peerSigningKey) = TestPeers.deriveScalusKeypair(spec.seedPhrase.mnemonic, 0)
+        val runnablePrivateJson = peerPrivate.asJson
+            .deepMerge(
+              Json.obj(
+                "ownPeerPrivate" -> Json.obj(
+                  "ownHeadWallet" -> Json.obj(
+                    "signingKey" -> Json.fromString(
+                      scodec.bits.ByteVector(peerSigningKey.bytes).toHex
+                    )
+                  )
+                )
+              )
+            )
+            .deepMerge(
+              Json.obj(
+                "nodeOperationMultisigConfig" -> Json.obj(
+                  "transplantStackNumber" -> Json.fromInt(999999)
+                )
+              )
+            )
+
+        val testIO = for {
+            _ <- IO.blocking(Files.writeString(headPath, printer.print(mnc.headConfig.asJson)))
+            _ <- IO.blocking(Files.createDirectories(privatePath.getParent))
+            _ <- IO.blocking(Files.writeString(privatePath, printer.print(runnablePrivateJson)))
+            mockBackend <- CardanoBackendMock.mockIO(
+              MockState(initialUtxos =
+                  mnc.headConfig.initializationTx.resolvedUtxos.utxos
+                      ++ Map.from(mnc.headConfig.scriptReferenceUtxos.toList.map(_.toTuple))
+              )
+            )
+            outcome <- Serve
+                .runNode(headPath, privatePath, dataDir, backendOverride = Some(mockBackend))
+                .attempt
+                .timeoutTo(
+                  60.seconds,
+                  IO.raiseError(new AssertionError("runNode neither refused nor returned in 60s"))
+                )
+            _ <- outcome match {
+                case Left(r: StartupRefusal) if r.reason.contains("transplantStackNumber") =>
+                    IO.unit
+                case Left(r: StartupRefusal) =>
+                    IO.raiseError(
+                      new AssertionError(s"refused, but for another reason: ${r.reason}")
+                    )
+                case Left(other) =>
+                    IO.raiseError(new AssertionError(s"expected a StartupRefusal, got: $other"))
+                case Right(code) =>
+                    IO.raiseError(
+                      new AssertionError(
+                        s"expected a StartupRefusal, but the node started and exited $code"
+                      )
+                    )
+            }
         } yield ()
 
         testIO.unsafeRunSync()

--- a/src/test/scala/hydrozoa/app/MainSmokeTest.scala
+++ b/src/test/scala/hydrozoa/app/MainSmokeTest.scala
@@ -88,7 +88,7 @@ class MainSmokeTest extends AnyFunSuite:
 
         val testIO = for {
             _ <- IO.blocking(
-              Files.writeString(headPath, printer.print(mnc.headConfig.asJson))
+              Files.writeString(headPath, printer.print(mnc.headConfig.asJson)): Unit
             )
             _ <- IO.blocking(writePrivatePair(runnablePrivateJson, privatePath))
 
@@ -192,11 +192,11 @@ class MainSmokeTest extends AnyFunSuite:
         val stripped = paths.foldLeft(json)((acc, kv) => drop(acc, kv._2))
         val printer = Printer.spaces2.copy(dropNullValues = true)
         Files.createDirectories(privatePath.getParent)
-        Files.writeString(privatePath, printer.print(stripped))
+        Files.writeString(privatePath, printer.print(stripped)): Unit
         Files.writeString(
           privatePath.resolveSibling(PrivateSecrets.defaultFileName),
           found.map((k, v) => s"$k=$v").mkString("", "\n", "\n")
-        )
+        ): Unit
     }
 
     // A `transplantStackNumber` names the stack this peer elects to ADOPT: everything at or below it

--- a/src/test/scala/hydrozoa/app/MainSmokeTest.scala
+++ b/src/test/scala/hydrozoa/app/MainSmokeTest.scala
@@ -91,7 +91,12 @@ class MainSmokeTest extends AnyFunSuite:
               MockState(initialUtxos =
                   mnc.headConfig.initializationTx.resolvedUtxos.utxos
                       ++ Map.from(mnc.headConfig.scriptReferenceUtxos.toList.map(_.toTuple))
-              )
+              ),
+              // The node refuses to start when the chain's protocol parameters differ from the ones
+              // its config asserts, so the mock must report the config's. Without this it reports
+              // scalus's `UtxoEnv.testMainnet` fixture, which matches no real network's CardanoInfo
+              // -- the boot then refuses, correctly, on an incoherent fixture.
+              reportedParams = Some(mnc.headConfig.cardanoProtocolParams)
             )
 
             startedD <- Deferred[IO, Unit]
@@ -144,6 +149,76 @@ class MainSmokeTest extends AnyFunSuite:
             // ⚠️ Do not await this. Cancelling a *live* node never returns, and `Fiber.cancel` is
             // itself uncancelable, so no timeout bounds it. The daemon threads go with the JVM.
             _ <- fiber.cancel.start.void
+        } yield ()
+
+        testIO.unsafeRunSync()
+    }
+
+    // The positive test above hands the mock the config's own protocol parameters, so the boot-time
+    // comparison always agrees. That would leave the REFUSAL path untested -- a check that cannot
+    // fail is not a check -- so this is its negative control: the same node, booted against a chain
+    // that reports DIFFERENT parameters, must refuse rather than start and quietly build L1
+    // transactions the chain may reject.
+    test("Serve.runNode refuses to start when the chain's protocol parameters differ") {
+        val rootTmp = Files.createTempDirectory("hydrozoa-pparams-mismatch-")
+        val configDir = rootTmp.resolve("config")
+        val dataDir = rootTmp.resolve("data")
+        Files.createDirectories(configDir)
+        Files.createDirectories(dataDir)
+
+        val spec = defaultSpec.copy(outDir = configDir, nPeers = 1)
+        val headPath = configDir.resolve("head-config.json")
+        val privatePath = configDir.resolve("peer-0").resolve("private.json")
+        val mnc: MultiNodeConfig = MultiNodeConfig
+            .generate(testPeersSpec(spec))()
+            .pureApply(Gen.Parameters.default, org.scalacheck.rng.Seed(spec.generationSeed))
+        val peerPrivate = mnc.nodePrivateConfigs(HeadPeerNumber(0)).copy(httpPort = "0")
+        val printer = Printer.spaces2.copy(dropNullValues = true)
+        val (_, peerSigningKey) = TestPeers.deriveScalusKeypair(spec.seedPhrase.mnemonic, 0)
+        val runnablePrivateJson = peerPrivate.asJson.deepMerge(
+          Json.obj(
+            "ownPeerPrivate" -> Json.obj(
+              "ownHeadWallet" -> Json.obj(
+                "signingKey" -> Json.fromString(scodec.bits.ByteVector(peerSigningKey.bytes).toHex)
+              )
+            )
+          )
+        )
+
+        val testIO = for {
+            _ <- IO.blocking(Files.writeString(headPath, printer.print(mnc.headConfig.asJson)))
+            _ <- IO.blocking(Files.createDirectories(privatePath.getParent))
+            _ <- IO.blocking(Files.writeString(privatePath, printer.print(runnablePrivateJson)))
+
+            // No `reportedParams`: the mock falls back to scalus's `UtxoEnv.testMainnet` fixture,
+            // which matches no real network's `CardanoInfo`. That IS the mismatch under test.
+            mockBackend <- CardanoBackendMock.mockIO(
+              MockState(initialUtxos =
+                  mnc.headConfig.initializationTx.resolvedUtxos.utxos
+                      ++ Map.from(mnc.headConfig.scriptReferenceUtxos.toList.map(_.toTuple))
+              )
+            )
+
+            outcome <- Serve
+                .runNode(headPath, privatePath, dataDir, backendOverride = Some(mockBackend))
+                .attempt
+                .timeoutTo(
+                  60.seconds,
+                  IO.raiseError(new AssertionError("runNode neither refused nor returned in 60s"))
+                )
+            _ <- outcome match {
+                case Left(_: StartupRefusal) => IO.unit
+                case Left(other) =>
+                    IO.raiseError(
+                      new AssertionError(s"expected a StartupRefusal, got: $other")
+                    )
+                case Right(code) =>
+                    IO.raiseError(
+                      new AssertionError(
+                        s"expected a StartupRefusal, but the node started and exited $code"
+                      )
+                    )
+            }
         } yield ()
 
         testIO.unsafeRunSync()

--- a/src/test/scala/hydrozoa/app/MainSmokeTest.scala
+++ b/src/test/scala/hydrozoa/app/MainSmokeTest.scala
@@ -4,15 +4,15 @@ import cats.effect.unsafe.implicits.global
 import cats.effect.{Deferred, IO}
 import hydrozoa.config.GenerateSampleConfig.{defaultSpec, testPeersSpec}
 import hydrozoa.config.head.HeadConfig.headConfigEncoder
-import hydrozoa.config.node.MultiNodeConfig
 import hydrozoa.config.node.NodePrivateConfig.nodePrivateConfigEncoder
+import hydrozoa.config.node.{MultiNodeConfig, PrivateSecrets}
 import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.backend.cardano.{CardanoBackendMock, MockState}
 import hydrozoa.multisig.consensus.peer.HeadPeerNumber
 import hydrozoa.multisig.server.HydrozoaHttpEvent
 import io.circe.syntax.*
 import io.circe.{Json, Printer}
-import java.nio.file.Files
+import java.nio.file.{Files, Path}
 import org.scalacheck.Gen
 import org.scalatest.funsuite.AnyFunSuite
 import scala.concurrent.duration.DurationInt
@@ -90,10 +90,7 @@ class MainSmokeTest extends AnyFunSuite:
             _ <- IO.blocking(
               Files.writeString(headPath, printer.print(mnc.headConfig.asJson))
             )
-            _ <- IO.blocking(Files.createDirectories(privatePath.getParent))
-            _ <- IO.blocking(
-              Files.writeString(privatePath, printer.print(runnablePrivateJson))
-            )
+            _ <- IO.blocking(writePrivatePair(runnablePrivateJson, privatePath))
 
             mockBackend <- CardanoBackendMock.mockIO(
               MockState(initialUtxos =
@@ -162,6 +159,46 @@ class MainSmokeTest extends AnyFunSuite:
         testIO.unsafeRunSync()
     }
 
+    /** Split a private config into the file a node reads and the credentials beside it.
+      *
+      * Credentials no longer live in `private.json` — the node reads them from the environment or
+      * from a `private.env` sibling — so a test that writes a runnable config has to write both
+      * halves. Doing it here rather than hand-rolling per test keeps every test on the real path.
+      */
+    private def writePrivatePair(json: Json, privatePath: Path): Unit = {
+        val walletField =
+            if json.hcursor.downField("ownPeerPrivate").downField("ownHeadWallet").succeeded then
+                "ownHeadWallet"
+            else "ownCoilWallet"
+        val paths = List(
+          "HYDROZOA_SIGNING_KEY" -> List("ownPeerPrivate", walletField, "signingKey"),
+          "HYDROZOA_RULE_BASED_SIGNING_KEY" ->
+              List("nodeOperationEvacuationConfig", "ruleBasedWallet", "signingKey"),
+          "HYDROZOA_BLOCKFROST_API_KEY" -> List("blockfrostApiKey"),
+          "HYDROZOA_ADMIN_PASSWORD" -> List("adminPassword")
+        )
+        def get(j: Json, path: List[String]): Option[String] =
+            path.foldLeft(Option(j))((acc, k) => acc.flatMap(_.asObject).flatMap(_.apply(k)))
+                .flatMap(_.asString)
+        def drop(j: Json, path: List[String]): Json = path match {
+            case Nil         => j
+            case last :: Nil => j.asObject.fold(j)(o => Json.fromJsonObject(o.remove(last)))
+            case head :: rest =>
+                j.asObject.fold(j)(o =>
+                    Json.fromJsonObject(o.add(head, drop(o(head).getOrElse(Json.obj()), rest)))
+                )
+        }
+        val found = paths.flatMap((env, path) => get(json, path).map(env -> _))
+        val stripped = paths.foldLeft(json)((acc, kv) => drop(acc, kv._2))
+        val printer = Printer.spaces2.copy(dropNullValues = true)
+        Files.createDirectories(privatePath.getParent)
+        Files.writeString(privatePath, printer.print(stripped))
+        Files.writeString(
+          privatePath.resolveSibling(PrivateSecrets.defaultFileName),
+          found.map((k, v) => s"$k=$v").mkString("", "\n", "\n")
+        )
+    }
+
     // A `transplantStackNumber` names the stack this peer elects to ADOPT: everything at or below it
     // is taken on trust from the donor committee and never verified. So the tag has to name a stack
     // the store actually holds. Here the store is empty, so no tag can be honoured -- the node must
@@ -207,8 +244,7 @@ class MainSmokeTest extends AnyFunSuite:
 
         val testIO = for {
             _ <- IO.blocking(Files.writeString(headPath, printer.print(mnc.headConfig.asJson)))
-            _ <- IO.blocking(Files.createDirectories(privatePath.getParent))
-            _ <- IO.blocking(Files.writeString(privatePath, printer.print(runnablePrivateJson)))
+            _ <- IO.blocking(writePrivatePair(runnablePrivateJson, privatePath))
             mockBackend <- CardanoBackendMock.mockIO(
               MockState(initialUtxos =
                   mnc.headConfig.initializationTx.resolvedUtxos.utxos
@@ -276,8 +312,7 @@ class MainSmokeTest extends AnyFunSuite:
 
         val testIO = for {
             _ <- IO.blocking(Files.writeString(headPath, printer.print(mnc.headConfig.asJson)))
-            _ <- IO.blocking(Files.createDirectories(privatePath.getParent))
-            _ <- IO.blocking(Files.writeString(privatePath, printer.print(runnablePrivateJson)))
+            _ <- IO.blocking(writePrivatePair(runnablePrivateJson, privatePath))
 
             // No `reportedParams`: the mock falls back to scalus's `UtxoEnv.testMainnet` fixture,
             // which matches no real network's `CardanoInfo`. That IS the mismatch under test.

--- a/src/test/scala/hydrozoa/bootstrap/GenerateKeyPairOutputsTest.scala
+++ b/src/test/scala/hydrozoa/bootstrap/GenerateKeyPairOutputsTest.scala
@@ -4,12 +4,13 @@ import cats.data.NonEmptyMap
 import hydrozoa.bootstrap.GenerateKeyPair.Role
 import hydrozoa.config.head.coil.{CoilPeerData, CoilPeers}
 import hydrozoa.config.head.peers.{HeadPeerData, HeadPeers}
-import hydrozoa.config.node.NodePrivateConfig
 import hydrozoa.config.node.NodePrivateConfig.nodePrivateConfigDecoder
 import hydrozoa.config.node.owninfo.{OwnCoilPeerPrivate, OwnHeadPeerPrivate}
+import hydrozoa.config.node.{NodePrivateConfig, PrivateSecrets}
 import hydrozoa.multisig.consensus.peer.HeadPeerNumber
 import io.circe.parser
 import java.nio.file.{Files, Path}
+import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters
 import org.http4s.Uri
 import org.scalatest.funsuite.AnyFunSuite
 import scala.collection.immutable.SortedMap
@@ -25,10 +26,24 @@ import scalus.uplc.builtin.ByteString
   */
 class GenerateKeyPairOutputsTest extends AnyFunSuite {
 
+    /** A signing key: an arbitrary but valid 32-byte Ed25519 seed. */
     private def hex(digit: Char): String = digit.toString * 64
 
+    /** The verification key that ACTUALLY belongs to `hex(digit)`.
+      *
+      * Derived rather than invented, because the config loader re-derives it and refuses a pair
+      * that does not agree. A fixture pairing an arbitrary "vkey" with an unrelated "skey" builds a
+      * config no node would accept, and would test the decoder against something unreachable.
+      */
+    private def vkeyHex(digit: Char): String =
+        Ed25519PrivateKeyParameters(ByteString.fromHex(hex(digit)).bytes, 0)
+            .generatePublicKey()
+            .getEncoded
+            .map("%02x".format(_))
+            .mkString
+
     private def vkey(digit: Char): VerificationKey =
-        VerificationKey.unsafeFromByteString(ByteString.fromHex(hex(digit)))
+        VerificationKey.unsafeFromByteString(ByteString.fromHex(vkeyHex(digit)))
 
     private val wsUri: Uri = Uri.unsafeFromString("ws://head-0:4001")
 
@@ -94,12 +109,19 @@ class GenerateKeyPairOutputsTest extends AnyFunSuite {
         given HeadPeers = headPeers
         given CoilPeers = coilPeers
 
-        val filled = GenerateKeyPair
-            .fillPrivateConfig(template, Role.Head, hex('1'), hex('a'))
+        // The round trip the split creates: `fillPrivateConfig` writes the config and the
+        // credentials as a pair, and the loader reassembles them. Decoding the config alone is
+        // supposed to be impossible now, which the dedicated test below asserts.
+        val (filled, secrets) = GenerateKeyPair
+            .fillPrivateConfig(template, Role.Head, vkeyHex('1'), hex('1'))
             .fold(e => fail(s"fill failed: $e"), identity)
 
+        val reassembled = PrivateSecrets
+            .applySecrets(filled, secrets, "test")
+            .fold(e => fail(s"credentials rejected: ${e.reason}"), identity)
+
         val decoded = parser
-            .decode[NodePrivateConfig](filled.spaces2)(using nodePrivateConfigDecoder)
+            .decode[NodePrivateConfig](reassembled.spaces2)(using nodePrivateConfigDecoder)
             .fold(e => fail(s"decode failed: $e"), identity)
 
         decoded.ownPeerPrivate match {
@@ -114,11 +136,13 @@ class GenerateKeyPairOutputsTest extends AnyFunSuite {
 
     test("the screener uri survives a head fill and is dropped from a coil's") {
         val head = GenerateKeyPair
-            .fillPrivateConfig(template, Role.Head, hex('1'), hex('a'))
+            .fillPrivateConfig(template, Role.Head, vkeyHex('1'), hex('1'))
             .fold(e => fail(s"fill failed: $e"), identity)
+            ._1
         val coil = GenerateKeyPair
-            .fillPrivateConfig(template, Role.Coil, hex('3'), hex('a'))
+            .fillPrivateConfig(template, Role.Coil, vkeyHex('3'), hex('3'))
             .fold(e => fail(s"fill failed: $e"), identity)
+            ._1
 
         // The template has to carry it, or the head check passes vacuously.
         val inTemplate = template.hcursor.downField("remoteScreenerUri").succeeded
@@ -134,12 +158,16 @@ class GenerateKeyPairOutputsTest extends AnyFunSuite {
         given HeadPeers = headPeers
         given CoilPeers = coilPeers
 
-        val filled = GenerateKeyPair
-            .fillPrivateConfig(template, Role.Coil, hex('3'), hex('a'))
+        val (filled, secrets) = GenerateKeyPair
+            .fillPrivateConfig(template, Role.Coil, vkeyHex('3'), hex('3'))
             .fold(e => fail(s"fill failed: $e"), identity)
 
+        val reassembled = PrivateSecrets
+            .applySecrets(filled, secrets, "test")
+            .fold(e => fail(s"credentials rejected: ${e.reason}"), identity)
+
         val decoded = parser
-            .decode[NodePrivateConfig](filled.spaces2)(using nodePrivateConfigDecoder)
+            .decode[NodePrivateConfig](reassembled.spaces2)(using nodePrivateConfigDecoder)
             .fold(e => fail(s"decode failed: $e"), identity)
 
         decoded.ownPeerPrivate match {

--- a/src/test/scala/hydrozoa/config/head/HeadParamsHashTest.scala
+++ b/src/test/scala/hydrozoa/config/head/HeadParamsHashTest.scala
@@ -1,0 +1,171 @@
+package hydrozoa.config.head
+
+import cats.data.Validated
+import hydrozoa.config.head.initialization.InitializationParameters
+import hydrozoa.config.head.multisig.block.BlockConfig
+import hydrozoa.config.head.multisig.settlement.SettlementConfig
+import hydrozoa.config.head.multisig.timing.TxTiming
+import hydrozoa.config.head.parameters.{HeadParameters, L2LedgerKind}
+import hydrozoa.config.head.peers.{HeadPeerData, HeadPeers}
+import hydrozoa.config.head.rulebased.dispute.DisputeResolutionConfig
+import hydrozoa.lib.number.PositiveInt
+import org.http4s.Uri
+import org.scalacheck.Prop.propBoolean
+import org.scalacheck.{Prop, Properties}
+import scalus.cardano.ledger.{Blake2b_256, Coin, Hash}
+import scalus.uplc.builtin.ByteString
+import test.{TestPeers, TestPeersSpec}
+
+/** [[HeadParamsHash]] must be stable for a given config and must move when any covered field moves.
+  *
+  * A field that silently falls out of the preimage is invisible in production — every peer simply
+  * agrees on a hash that does not constrain the thing that differs — so each covered field gets its
+  * own mutation here. [[hydrozoa.config.head.peers.HeadPeerData.webSocketAddress]] gets the
+  * opposite check: it is deliberately excluded, and folding it in would make every peer relocation
+  * a head re-initialization.
+  */
+object HeadParamsHashTest extends Properties("HeadParamsHash") {
+
+    private val generateConfig =
+        TestPeersSpec.generate().flatMap(TestPeers.generate).flatMap(generateHeadConfig().run(_))
+
+    /** Rebuild a config with `headParameters` replaced, keeping everything else identical. */
+    private def withParameters(hc: HeadConfig, params: HeadParameters): HeadConfig =
+        rebuild(hc, params, hc.headConfigBootstrap.initializationParameters, hc.headPeers)
+
+    private def rebuild(
+        hc: HeadConfig,
+        params: HeadParameters,
+        initParams: InitializationParameters,
+        headPeers: HeadPeers
+    ): HeadConfig = {
+        val bootstrap = HeadConfig.Bootstrap(
+          cardanoNetwork = hc.cardanoNetwork,
+          headParams = params,
+          headPeers = headPeers,
+          coilPeers = hc.coilPeers,
+          initializationParams = initParams,
+          scriptReferenceUtxos = hc.scriptReferenceUtxos
+        ) match {
+            case Validated.Valid(b)   => b
+            case Validated.Invalid(e) => throw RuntimeException(s"bootstrap rebuild failed: $e")
+        }
+        HeadConfig(bootstrap, hc.initialBlockSection) match {
+            case Validated.Valid(c)   => c
+            case Validated.Invalid(e) => throw RuntimeException(s"config rebuild failed: $e")
+        }
+    }
+
+    /** One mutation per covered [[HeadParameters]] field. `txTiming` is absent because its
+      * constructor is private — it gets its own whole-section swap below.
+      */
+    private val parameterMutations: List[(String, HeadParameters => HeadParameters)] = List(
+      "l2ParamsHash" -> (p =>
+          p.copy(l2ParamsHash =
+              Hash[Blake2b_256, Any](ByteString.fromArray(Array.fill[Byte](32)(0x5a)))
+          )
+      ),
+      "l2Ledger" -> (p =>
+          p.copy(l2Ledger =
+              if p.l2Ledger == L2LedgerKind.CardanoEutxo then L2LedgerKind.AnyRemote
+              else L2LedgerKind.CardanoEutxo
+          )
+      ),
+      "identityIsomorphism" -> (p => p.copy(identityIsomorphism = !p.identityIsomorphism)),
+      "coilQuorum" -> (p => p.copy(coilQuorum = p.coilQuorum + 1)),
+      "settlementConfig.maxDepositsAbsorbedPerBlock" -> (p =>
+          p.copy(settlementConfig =
+              SettlementConfig(bump(p.settlementConfig.maxDepositsAbsorbedPerBlock))
+          )
+      ),
+      "blockConfig.maxRequestsPerBlock" -> (p =>
+          p.copy(blockConfig =
+              p.blockConfig.copy(maxRequestsPerBlock = bump(p.maxRequestsPerBlock))
+          )
+      ),
+      "blockConfig.backpressureCoefficient" -> (p =>
+          p.copy(blockConfig =
+              p.blockConfig.copy(backpressureCoefficient = bump(p.backpressureCoefficient))
+          )
+      ),
+      "fallbackContingency.collective" -> (p =>
+          p.copy(fallbackContingency =
+              p.fallbackContingency.copy(collectiveContingency =
+                  p.collectiveContingency
+                      .copy(fallbackTxFee = Coin(p.collectiveContingency.fallbackTxFee.value + 1))
+              )
+          )
+      ),
+      "fallbackContingency.individual" -> (p =>
+          p.copy(fallbackContingency =
+              p.fallbackContingency.copy(individualContingency =
+                  p.individualContingency
+                      .copy(voteDeposit = Coin(p.individualContingency.voteDeposit.value + 1))
+              )
+          )
+      ),
+      "disputeResolutionConfig.votingDuration" -> (p =>
+          p.copy(disputeResolutionConfig =
+              DisputeResolutionConfig(p.votingDuration + p.votingDuration)
+          )
+      )
+    )
+
+    private def bump(n: PositiveInt): PositiveInt = PositiveInt.unsafeApply(n.convert + 1)
+
+    val _ = property("is deterministic") = Prop.forAll(generateConfig) { hc =>
+        hc.headParamsHash == HeadParamsHash(hc)
+    }
+
+    /** `txTiming`'s constructor is private, so it cannot be mutated field by field like the rest.
+      * Swapping the whole section for [[TxTiming.demo]] covers it instead.
+      */
+    val _ = property("covers txTiming") = Prop.forAll(generateConfig) { hc =>
+        val demo = TxTiming.demo(hc.cardanoNetwork.slotConfig)
+        (demo != hc.txTiming) ==> {
+            withParameters(hc, hc.headParameters.copy(txTiming = demo)).headParamsHash
+                != hc.headParamsHash
+        }
+    }
+
+    parameterMutations.foreach { (name, mutate) =>
+        val _ = property(s"covers $name") = Prop.forAll(generateConfig) { hc =>
+            val mutated = withParameters(hc, mutate(hc.headParameters))
+            mutated.headParamsHash != hc.headParamsHash
+        }
+    }
+
+    val _ = property("covers initialEquityContributions") = Prop.forAll(generateConfig) { hc =>
+        val initParams = hc.headConfigBootstrap.initializationParameters
+        val (peer, coin) = initParams.initialEquityContributions.toSortedMap.head
+        val mutated = rebuild(
+          hc,
+          hc.headParameters,
+          initParams.copy(initialEquityContributions =
+              initParams.initialEquityContributions.add(peer -> Coin(coin.value + 1))
+          ),
+          hc.headPeers
+        )
+        mutated.headParamsHash != hc.headParamsHash
+    }
+
+    val _ = property("excludes webSocketAddress") = Prop.forAll(generateConfig) { hc =>
+        val data = hc.headPeers.headPeerData
+        val (peer, peerData) = data.toSortedMap.head
+        val moved = HeadPeers(
+          data.add(
+            peer -> HeadPeerData(
+              peerData.verificationKey,
+              Uri.unsafeFromString("ws://relocated.example:9999")
+            )
+          )
+        ).getOrElse(throw RuntimeException("head peers rebuild failed"))
+        val mutated = rebuild(
+          hc,
+          hc.headParameters,
+          hc.headConfigBootstrap.initializationParameters,
+          moved
+        )
+        mutated.headParamsHash == hc.headParamsHash
+    }
+}

--- a/src/test/scala/hydrozoa/config/node/NodeConfigRetryTest.scala
+++ b/src/test/scala/hydrozoa/config/node/NodeConfigRetryTest.scala
@@ -23,7 +23,9 @@ class NodeConfigRetryTest extends AnyFunSuite {
     private val badConfig: io.circe.Error =
         io.circe.DecodingFailure("not a config", Nil)
 
-    private val waits = List(1.milli, 1.milli, 1.milli)
+    // Finite on purpose: production passes an INFINITE ladder (a transient backend failure must
+    // never end in an exit), so the "gives up" cases below can only be expressed with a bounded one.
+    private val waits = LazyList(1.milli, 1.milli, 1.milli)
 
     /** An attempt that fails `failures` times with `error`, then succeeds. */
     private def failing(

--- a/src/test/scala/hydrozoa/config/node/PrivateSecretsTest.scala
+++ b/src/test/scala/hydrozoa/config/node/PrivateSecretsTest.scala
@@ -1,0 +1,166 @@
+package hydrozoa.config.node
+
+import io.circe.{Json, parser}
+import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters
+import org.scalatest.funsuite.AnyFunSuite
+
+class PrivateSecretsTest extends AnyFunSuite {
+
+    private def skey(digit: Char): String = digit.toString * 64
+
+    private def vkeyOf(skeyHex: String): String =
+        Ed25519PrivateKeyParameters(
+          skeyHex.grouped(2).map(Integer.parseInt(_, 16).toByte).toArray,
+          0
+        ).generatePublicKey().getEncoded.map("%02x".format(_)).mkString
+
+    /** A config in the shape the split produces: public halves present, secrets absent. */
+    private def config(ownVkey: String, ruleVkey: String): Json =
+        parser
+            .parse(s"""{
+              "ownPeerPrivate": { "ownHeadWallet": { "verificationKey": "$ownVkey" } },
+              "nodeOperationEvacuationConfig": {
+                "ruleBasedWallet": { "verificationKey": "$ruleVkey" }
+              },
+              "httpPort": "8080"
+            }""")
+            .fold(e => fail(s"bad fixture: $e"), identity)
+
+    private def credentials(own: String, rule: String): Map[String, String] = Map(
+      "HYDROZOA_SIGNING_KEY" -> own,
+      "HYDROZOA_RULE_BASED_SIGNING_KEY" -> rule,
+      "HYDROZOA_BLOCKFROST_API_KEY" -> "previewXXXX",
+      "HYDROZOA_ADMIN_PASSWORD" -> "hunter2"
+    )
+
+    test("a complete, matching credential set is spliced into the config") {
+        val json = config(vkeyOf(skey('1')), vkeyOf(skey('2')))
+        val out = PrivateSecrets
+            .applySecrets(json, credentials(skey('1'), skey('2')), "test")
+            .fold(e => fail(s"unexpectedly refused: ${e.reason}"), identity)
+
+        val c = out.hcursor
+        assert(
+          c.downField("ownPeerPrivate")
+              .downField("ownHeadWallet")
+              .downField("signingKey")
+              .as[String] == Right(skey('1'))
+        )
+        assert(c.downField("blockfrostApiKey").as[String] == Right("previewXXXX"))
+        assert(c.downField("adminPassword").as[String] == Right("hunter2"))
+    }
+
+    test("a missing credential is refused, and the message names it") {
+        val json = config(vkeyOf(skey('1')), vkeyOf(skey('2')))
+        val refusal = PrivateSecrets
+            .applySecrets(
+              json,
+              credentials(skey('1'), skey('2')) - "HYDROZOA_ADMIN_PASSWORD",
+              "test"
+            )
+            .swap
+            .fold(_ => fail("expected a refusal"), identity)
+        assert(refusal.reason.contains("HYDROZOA_ADMIN_PASSWORD"))
+    }
+
+    // The check that earns this module its place: the two halves of a keypair now arrive from
+    // different places, so nothing else in the system is positioned to notice they were paired
+    // wrong. Unchecked it surfaces as a BadSignature deep in consensus.
+    test("a signing key that does not match its verification key is refused") {
+        val json = config(vkeyOf(skey('1')), vkeyOf(skey('2')))
+        val refusal = PrivateSecrets
+            .applySecrets(json, credentials(skey('9'), skey('2')), "test")
+            .swap
+            .fold(_ => fail("expected a refusal"), identity)
+        assert(refusal.reason.contains("derives verification key"))
+        assert(refusal.reason.contains("ownPeerPrivate.ownHeadWallet"))
+    }
+
+    test("the rule-based wallet is paired too, not just the peer's own") {
+        val json = config(vkeyOf(skey('1')), vkeyOf(skey('2')))
+        val refusal = PrivateSecrets
+            .applySecrets(json, credentials(skey('1'), skey('9')), "test")
+            .swap
+            .fold(_ => fail("expected a refusal"), identity)
+        assert(refusal.reason.contains("ruleBasedWallet"))
+    }
+
+    // The whole point of the split is that the config file becomes shareable. A live key left in
+    // it would defeat that silently, so it is refused rather than overwritten.
+    test("a credential left behind in the config is refused") {
+        val json = config(vkeyOf(skey('1')), vkeyOf(skey('2')))
+            .deepMerge(Json.obj("blockfrostApiKey" -> Json.fromString("previewLEFTBEHIND")))
+        val refusal = PrivateSecrets
+            .applySecrets(json, credentials(skey('1'), skey('2')), "test")
+            .swap
+            .fold(_ => fail("expected a refusal"), identity)
+        assert(refusal.reason.contains("blockfrostApiKey"))
+    }
+
+    // The encoder writes an all-zeros stand-in where a signing key would go. That is not a leak
+    // and must not be treated as one -- it is simply overwritten.
+    test("the encoder's all-zeros placeholder is overwritten, not treated as a leak") {
+        val json = config(vkeyOf(skey('1')), vkeyOf(skey('2'))).deepMerge(
+          Json.obj(
+            "ownPeerPrivate" -> Json.obj(
+              "ownHeadWallet" -> Json.obj("signingKey" -> Json.fromString("0" * 64))
+            )
+          )
+        )
+        val out = PrivateSecrets
+            .applySecrets(json, credentials(skey('1'), skey('2')), "test")
+            .fold(e => fail(s"unexpectedly refused: ${e.reason}"), identity)
+        assert(
+          out.hcursor
+              .downField("ownPeerPrivate")
+              .downField("ownHeadWallet")
+              .downField("signingKey")
+              .as[String] == Right(skey('1'))
+        )
+    }
+
+    test("a config with no rule-based wallet does not demand its key") {
+        val json = parser
+            .parse(s"""{
+              "ownPeerPrivate": { "ownHeadWallet": { "verificationKey": "${vkeyOf(skey('1'))}" } }
+            }""")
+            .fold(e => fail(s"bad fixture: $e"), identity)
+        val creds = Map(
+          "HYDROZOA_SIGNING_KEY" -> skey('1'),
+          "HYDROZOA_BLOCKFROST_API_KEY" -> "previewXXXX",
+          "HYDROZOA_ADMIN_PASSWORD" -> "hunter2"
+        )
+        assert(PrivateSecrets.applySecrets(json, creds, "test").isRight)
+    }
+
+    test("a malformed signing key is refused rather than parsed into nonsense") {
+        val json = config(vkeyOf(skey('1')), vkeyOf(skey('2')))
+        val refusal = PrivateSecrets
+            .applySecrets(json, credentials("nothex", skey('2')), "test")
+            .swap
+            .fold(_ => fail("expected a refusal"), identity)
+        assert(refusal.reason.contains("32 bytes of hex"))
+    }
+
+    test("the env file parser handles comments, quotes, blanks and export") {
+        val parsed = PrivateSecrets.parseEnvFile("""
+          |# a comment
+          |
+          |HYDROZOA_SIGNING_KEY=abc123
+          |export HYDROZOA_ADMIN_PASSWORD="quoted value"
+          |HYDROZOA_BLOCKFROST_API_KEY='single'
+          |  SPACED  =  padded
+          |not a pair
+          |""".stripMargin)
+
+        assert(parsed("HYDROZOA_SIGNING_KEY") == "abc123")
+        assert(parsed("HYDROZOA_ADMIN_PASSWORD") == "quoted value")
+        assert(parsed("HYDROZOA_BLOCKFROST_API_KEY") == "single")
+        assert(parsed("SPACED") == "padded")
+        assert(!parsed.contains("not a pair"))
+    }
+
+    test("a value containing '=' survives the split") {
+        assert(PrivateSecrets.parseEnvFile("K=a=b=c")("K") == "a=b=c")
+    }
+}

--- a/src/test/scala/hydrozoa/config/node/PrivateSecretsTest.scala
+++ b/src/test/scala/hydrozoa/config/node/PrivateSecretsTest.scala
@@ -45,9 +45,9 @@ class PrivateSecretsTest extends AnyFunSuite {
               .downField("ownHeadWallet")
               .downField("signingKey")
               .as[String] == Right(skey('1'))
-        )
-        assert(c.downField("blockfrostApiKey").as[String] == Right("previewXXXX"))
-        assert(c.downField("adminPassword").as[String] == Right("hunter2"))
+        ): Unit
+        assert(c.downField("blockfrostApiKey").as[String] == Right("previewXXXX")): Unit
+        assert(c.downField("adminPassword").as[String] == Right("hunter2")): Unit
     }
 
     test("a missing credential is refused, and the message names it") {
@@ -60,7 +60,7 @@ class PrivateSecretsTest extends AnyFunSuite {
             )
             .swap
             .fold(_ => fail("expected a refusal"), identity)
-        assert(refusal.reason.contains("HYDROZOA_ADMIN_PASSWORD"))
+        assert(refusal.reason.contains("HYDROZOA_ADMIN_PASSWORD")): Unit
     }
 
     // The check that earns this module its place: the two halves of a keypair now arrive from
@@ -72,8 +72,8 @@ class PrivateSecretsTest extends AnyFunSuite {
             .applySecrets(json, credentials(skey('9'), skey('2')), "test")
             .swap
             .fold(_ => fail("expected a refusal"), identity)
-        assert(refusal.reason.contains("derives verification key"))
-        assert(refusal.reason.contains("ownPeerPrivate.ownHeadWallet"))
+        assert(refusal.reason.contains("derives verification key")): Unit
+        assert(refusal.reason.contains("ownPeerPrivate.ownHeadWallet")): Unit
     }
 
     test("the rule-based wallet is paired too, not just the peer's own") {
@@ -82,7 +82,7 @@ class PrivateSecretsTest extends AnyFunSuite {
             .applySecrets(json, credentials(skey('1'), skey('9')), "test")
             .swap
             .fold(_ => fail("expected a refusal"), identity)
-        assert(refusal.reason.contains("ruleBasedWallet"))
+        assert(refusal.reason.contains("ruleBasedWallet")): Unit
     }
 
     // The whole point of the split is that the config file becomes shareable. A live key left in
@@ -94,7 +94,7 @@ class PrivateSecretsTest extends AnyFunSuite {
             .applySecrets(json, credentials(skey('1'), skey('2')), "test")
             .swap
             .fold(_ => fail("expected a refusal"), identity)
-        assert(refusal.reason.contains("blockfrostApiKey"))
+        assert(refusal.reason.contains("blockfrostApiKey")): Unit
     }
 
     // The encoder writes an all-zeros stand-in where a signing key would go. That is not a leak
@@ -116,7 +116,7 @@ class PrivateSecretsTest extends AnyFunSuite {
               .downField("ownHeadWallet")
               .downField("signingKey")
               .as[String] == Right(skey('1'))
-        )
+        ): Unit
     }
 
     test("a config with no rule-based wallet does not demand its key") {
@@ -130,7 +130,7 @@ class PrivateSecretsTest extends AnyFunSuite {
           "HYDROZOA_BLOCKFROST_API_KEY" -> "previewXXXX",
           "HYDROZOA_ADMIN_PASSWORD" -> "hunter2"
         )
-        assert(PrivateSecrets.applySecrets(json, creds, "test").isRight)
+        assert(PrivateSecrets.applySecrets(json, creds, "test").isRight): Unit
     }
 
     test("a malformed signing key is refused rather than parsed into nonsense") {
@@ -139,7 +139,7 @@ class PrivateSecretsTest extends AnyFunSuite {
             .applySecrets(json, credentials("nothex", skey('2')), "test")
             .swap
             .fold(_ => fail("expected a refusal"), identity)
-        assert(refusal.reason.contains("32 bytes of hex"))
+        assert(refusal.reason.contains("32 bytes of hex")): Unit
     }
 
     test("the env file parser handles comments, quotes, blanks and export") {
@@ -153,14 +153,14 @@ class PrivateSecretsTest extends AnyFunSuite {
           |not a pair
           |""".stripMargin)
 
-        assert(parsed("HYDROZOA_SIGNING_KEY") == "abc123")
-        assert(parsed("HYDROZOA_ADMIN_PASSWORD") == "quoted value")
-        assert(parsed("HYDROZOA_BLOCKFROST_API_KEY") == "single")
-        assert(parsed("SPACED") == "padded")
-        assert(!parsed.contains("not a pair"))
+        assert(parsed("HYDROZOA_SIGNING_KEY") == "abc123"): Unit
+        assert(parsed("HYDROZOA_ADMIN_PASSWORD") == "quoted value"): Unit
+        assert(parsed("HYDROZOA_BLOCKFROST_API_KEY") == "single"): Unit
+        assert(parsed("SPACED") == "padded"): Unit
+        assert(!parsed.contains("not a pair")): Unit
     }
 
     test("a value containing '=' survives the split") {
-        assert(PrivateSecrets.parseEnvFile("K=a=b=c")("K") == "a=b=c")
+        assert(PrivateSecrets.parseEnvFile("K=a=b=c")("K") == "a=b=c"): Unit
     }
 }

--- a/src/test/scala/hydrozoa/config/node/operation/multisig/NodeOperationMultisigConfigGen.scala
+++ b/src/test/scala/hydrozoa/config/node/operation/multisig/NodeOperationMultisigConfigGen.scala
@@ -1,6 +1,7 @@
 package hydrozoa.config.node.operation.multisig
 
 import hydrozoa.lib.number.PositiveInt
+import hydrozoa.multisig.ledger.stack.StackNumber
 import org.scalacheck.Gen
 import scala.concurrent.duration.{DurationInt, DurationLong, FiniteDuration}
 
@@ -21,10 +22,13 @@ def generateNodeOperationMultisigConfig(
         maxRequestsPerBatch <- Gen.choose(1, 100)
         outboxCap <- Gen.choose(1, 4096)
         millis <- Gen.choose(1L, maxPollingPeriod.toMillis)
+        // Present and absent, so a codec round-trip covers both shapes of the field.
+        transplantStack <- Gen.option(Gen.choose(0, 100000).map(StackNumber.apply))
     } yield NodeOperationMultisigConfig(
       cardanoLiaisonPollingPeriod = millis.millis,
       peerLiaisonMaxRequestsPerBatch = PositiveInt(maxRequestsPerBatch).get,
       peerLiaisonOutboxCap = PositiveInt(outboxCap).get,
       peerLiaisonResendInterval = 5.seconds,
+      transplantStackNumber = transplantStack,
       rateLimits = rateLimits
     )

--- a/src/test/scala/hydrozoa/multisig/backend/cardano/CardanoBackendMock.scala
+++ b/src/test/scala/hydrozoa/multisig/backend/cardano/CardanoBackendMock.scala
@@ -37,7 +37,16 @@ type MockStateF[A] = State[MockState, A]
 // It should be ReaderT over those vals, though I don't think it buys anything but extra lifts.
 class CardanoBackendMock private (
     private val mutator: Mutator,
-    private val mkContext: Long => Context
+    private val mkContext: Long => Context,
+    /** What this mock reports as the chain's protocol parameters.
+      *
+      * ⛔ Defaults to the context's, which is scalus's `UtxoEnv.testMainnet` FIXTURE — unrelated to
+      * the `CardanoInfo` parameters a head's config asserts, for ANY network. A node now refuses to
+      * start when those two disagree, so a test booting a real node must hand the mock the config's
+      * parameters; otherwise the fixture is claiming the chain runs parameters the head was never
+      * configured for, and the refusal is correct rather than a bug.
+      */
+    private val reportedParams: Option[ProtocolParams]
 ) extends CardanoBackend[MockStateF] {
     import State.*
 
@@ -203,7 +212,7 @@ class CardanoBackendMock private (
 
     def fetchLatestParams: MockStateF[Either[Error, ProtocolParams]] = {
         // As long as paramters don't depend on the slot number it's fine
-        State.pure(Right(mkContext(0).env.params))
+        State.pure(Right(reportedParams.getOrElse(mkContext(0).env.params)))
     }
 
     def setSlot(currentSlot: Slot): MockStateF[Unit] = {
@@ -221,9 +230,10 @@ object CardanoBackendMock {
     def mockIO(
         initialState: MockState,
         mutator: Mutator = CardanoMutator,
-        mkContext: Long => Context = Context.testMainnet
+        mkContext: Long => Context = Context.testMainnet,
+        reportedParams: Option[ProtocolParams] = None
     ): IO[CardanoBackend[IO]] =
-        mockIOWithSnapshot(initialState, mutator, mkContext).map(_._1)
+        mockIOWithSnapshot(initialState, mutator, mkContext, reportedParams).map(_._1)
 
     /** Like [[mockIO]] but also returns an `IO[Utxos]` that reads the current UTxO set from the
       * shared state ref. Useful for inspecting the terminal ledger state after actors finish.
@@ -231,7 +241,8 @@ object CardanoBackendMock {
     def mockIOWithSnapshot(
         initialState: MockState,
         mutator: Mutator = CardanoMutator,
-        mkContext: Long => Context = Context.testMainnet
+        mkContext: Long => Context = Context.testMainnet,
+        reportedParams: Option[ProtocolParams] = None
     ): IO[(CardanoBackend[IO], IO[Utxos])] = {
         val ioLog: ContraTracer[IO, CardanoBackendEvent] =
             Slf4jTracer.sink.contramap(CardanoBackendEventFormat.humanFormat)
@@ -243,7 +254,7 @@ object CardanoBackendMock {
             )
             stateRef <- Ref.of[IO, MockState](initialState)
         } yield {
-            val mock = new CardanoBackendMock(mutator, mkContext)
+            val mock = new CardanoBackendMock(mutator, mkContext, reportedParams)
             // TODO: this is awkward, but this requires the mending of Scalus
             //  - Context is not a case class
             //  - Context is not returned by CardanoMutator

--- a/src/test/scala/hydrozoa/multisig/consensus/BlockWeaverTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/BlockWeaverTest.scala
@@ -26,12 +26,7 @@ import hydrozoa.multisig.ledger.event.RequestId.ValidityFlag
 import hydrozoa.multisig.ledger.joint.JointLedger
 import hydrozoa.multisig.ledger.joint.JointLedger.Requests.{CompleteBlockFinal, CompleteBlockRegular, StartBlock}
 import hydrozoa.multisig.metrics.PeerMetrics
-import hydrozoa.multisig.persistence.{
-  InMemoryBackendStore,
-  Markers,
-  Persistence,
-  PersistenceEventFormat
-}
+import hydrozoa.multisig.persistence.{InMemoryBackendStore, Markers, Persistence, PersistenceEventFormat}
 import java.time.Instant
 import java.util.concurrent.atomic.AtomicReference
 import org.scalacheck.{Gen, Properties, PropertyM, Test}

--- a/src/test/scala/hydrozoa/multisig/consensus/BlockWeaverTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/BlockWeaverTest.scala
@@ -26,7 +26,12 @@ import hydrozoa.multisig.ledger.event.RequestId.ValidityFlag
 import hydrozoa.multisig.ledger.joint.JointLedger
 import hydrozoa.multisig.ledger.joint.JointLedger.Requests.{CompleteBlockFinal, CompleteBlockRegular, StartBlock}
 import hydrozoa.multisig.metrics.PeerMetrics
-import hydrozoa.multisig.persistence.{InMemoryBackendStore, Persistence, PersistenceEventFormat}
+import hydrozoa.multisig.persistence.{
+  InMemoryBackendStore,
+  Markers,
+  Persistence,
+  PersistenceEventFormat
+}
 import java.time.Instant
 import java.util.concurrent.atomic.AtomicReference
 import org.scalacheck.{Gen, Properties, PropertyM, Test}
@@ -128,7 +133,9 @@ object BlockWeaverTestHelpers {
             backend <- lift(InMemoryBackendStore.open(persistenceTracer).allocated.map(_._1))
             persistence <- lift(Persistence.fromBackend(backend, persistenceTracer)(using config))
             actor <- lift(
-              env.system.actorOf(BlockWeaver(config, connections, tracer, metrics, persistence))
+              env.system.actorOf(
+                BlockWeaver(config, connections, tracer, metrics, persistence, Markers.cold)
+              )
             )
         } yield (actor, seen)
 
@@ -187,7 +194,9 @@ object BlockWeaverTestHelpers {
             backend <- lift(InMemoryBackendStore.open(persistenceTracer).allocated.map(_._1))
             persistence <- lift(Persistence.fromBackend(backend, persistenceTracer)(using config))
             actor <- lift(
-              env.system.actorOf(BlockWeaver(config, connections, tracer, metrics, persistence))
+              env.system.actorOf(
+                BlockWeaver(config, connections, tracer, metrics, persistence, Markers.cold)
+              )
             )
         } yield actor
 

--- a/src/test/scala/hydrozoa/multisig/consensus/CoilLiaisonTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/CoilLiaisonTest.scala
@@ -164,7 +164,10 @@ object CoilLiaisonTest extends Properties("Coil liaison plumbing") {
                 Persistence.fromBackend(backend, persistenceTracer).flatMap { persistence =>
                     ActorSystem[IO]("coil-liaison-test").use { system =>
                         for {
-                            headPending <- Deferred[IO, Either[Throwable, HeadMultisigRegimeManager.Connections]]
+                            headPending <- Deferred[IO, Either[
+                              Throwable,
+                              HeadMultisigRegimeManager.Connections
+                            ]]
                             hubSeen <- Ref[IO].of(Vector.empty[HardAck])
                             hubSlowConsensus <- system.actorOf(new HardAckRecorder(hubSeen))
                             sequencer <- system.actorOf(
@@ -181,7 +184,10 @@ object CoilLiaisonTest extends Properties("Coil liaison plumbing") {
                                         )
                                 }
                                 for {
-                                    pending <- Deferred[IO, Either[Throwable, HeadMultisigRegimeManager.Connections]]
+                                    pending <- Deferred[IO, Either[
+                                      Throwable,
+                                      HeadMultisigRegimeManager.Connections
+                                    ]]
                                     coilSeen <- Ref[IO].of(Vector.empty[HardAck])
                                     coilSlowConsensus <- system.actorOf(
                                       new HardAckRecorder(coilSeen)

--- a/src/test/scala/hydrozoa/multisig/consensus/CoilLiaisonTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/CoilLiaisonTest.scala
@@ -138,7 +138,7 @@ object CoilLiaisonTest extends Properties("Coil liaison plumbing") {
     /** Per-coil actors + the Ref recording what its slow-consensus slot receives. */
     private final case class CoilParts(
         coilNum: CoilPeerNumber,
-        pending: Deferred[IO, HeadMultisigRegimeManager.Connections],
+        pending: HeadMultisigRegimeManager.PendingConnections,
         coilSeen: Ref[IO, Vector[HardAck]],
         coilSlowConsensus: SlowConsensusActor.Handle,
         coilLiaison: PeerLiaisonCoilToHub.Handle,
@@ -164,7 +164,7 @@ object CoilLiaisonTest extends Properties("Coil liaison plumbing") {
                 Persistence.fromBackend(backend, persistenceTracer).flatMap { persistence =>
                     ActorSystem[IO]("coil-liaison-test").use { system =>
                         for {
-                            headPending <- Deferred[IO, HeadMultisigRegimeManager.Connections]
+                            headPending <- Deferred[IO, Either[Throwable, HeadMultisigRegimeManager.Connections]]
                             hubSeen <- Ref[IO].of(Vector.empty[HardAck])
                             hubSlowConsensus <- system.actorOf(new HardAckRecorder(hubSeen))
                             sequencer <- system.actorOf(
@@ -181,7 +181,7 @@ object CoilLiaisonTest extends Properties("Coil liaison plumbing") {
                                         )
                                 }
                                 for {
-                                    pending <- Deferred[IO, HeadMultisigRegimeManager.Connections]
+                                    pending <- Deferred[IO, Either[Throwable, HeadMultisigRegimeManager.Connections]]
                                     coilSeen <- Ref[IO].of(Vector.empty[HardAck])
                                     coilSlowConsensus <- system.actorOf(
                                       new HardAckRecorder(coilSeen)
@@ -238,7 +238,7 @@ object CoilLiaisonTest extends Properties("Coil liaison plumbing") {
                                         coilPeers.map(c => c.coilNum -> c.coilLiaison).toMap,
                                   )
                                 )
-                            _ <- headPending.complete(headConnections)
+                            _ <- headPending.complete(Right(headConnections))
                             _ <- coilPeers.traverse_ { c =>
                                 baseConnections(system, slowConsensus = c.coilSlowConsensus)
                                     .map(
@@ -247,7 +247,7 @@ object CoilLiaisonTest extends Properties("Coil liaison plumbing") {
                                         remoteHubLiaison = Some(c.hubLiaison),
                                       )
                                     )
-                                    .flatMap(c.pending.complete)
+                                    .flatMap(conns => c.pending.complete(Right(conns)))
                             }
 
                             // Let the initial population/own-hard-ack handshakes settle, then

--- a/src/test/scala/hydrozoa/multisig/consensus/ReplayActorTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/ReplayActorTest.scala
@@ -209,7 +209,14 @@ class ReplayActorTest extends AnyFunSuite:
                 ActorSystem[IO]("replay-test").use(system =>
                     for {
                         persistence <- Persistence.fromBackend(backend, persistenceTracer)
-                        cardanoBackend <- CardanoBackendMock.mockIO(MockState(Map.empty))
+                        cardanoBackend <- CardanoBackendMock.mockIO(
+                          MockState(Map.empty),
+                          // `replay` now verifies the chain's protocol parameters against the
+                          // config's and REFUSES on a mismatch, so the mock must report the
+                          // config's. Its default is scalus's `UtxoEnv.testMainnet` fixture, which
+                          // matches no real network's `CardanoInfo`.
+                          reportedParams = Some(config.cardanoProtocolParams)
+                        )
                         bwSink <- Ref.of[IO, Vector[BlockWeaver.Request]](Vector.empty)
                         fcaSink <- Ref.of[IO, Vector[FastConsensusActor.Request]](Vector.empty)
                         scaSink <- Ref.of[IO, Vector[SlowConsensusActor.Request]](Vector.empty)
@@ -261,7 +268,14 @@ class ReplayActorTest extends AnyFunSuite:
                 ActorSystem[IO]("replay-coil-test").use(system =>
                     for {
                         persistence <- Persistence.fromBackend(backend, persistenceTracer)
-                        cardanoBackend <- CardanoBackendMock.mockIO(MockState(Map.empty))
+                        cardanoBackend <- CardanoBackendMock.mockIO(
+                          MockState(Map.empty),
+                          // `replay` now verifies the chain's protocol parameters against the
+                          // config's and REFUSES on a mismatch, so the mock must report the
+                          // config's. Its default is scalus's `UtxoEnv.testMainnet` fixture, which
+                          // matches no real network's `CardanoInfo`.
+                          reportedParams = Some(config.cardanoProtocolParams)
+                        )
                         bwSink <- Ref.of[IO, Vector[BlockWeaver.Request]](Vector.empty)
                         fcaSink <- Ref.of[IO, Vector[FastConsensusActor.Request]](Vector.empty)
                         scaSink <- Ref.of[IO, Vector[SlowConsensusActor.Request]](Vector.empty)

--- a/src/test/scala/hydrozoa/multisig/consensus/ReplayActorTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/ReplayActorTest.scala
@@ -21,7 +21,17 @@ import hydrozoa.multisig.ledger.block.{BlockBody, BlockBrief, BlockHeader, Block
 import hydrozoa.multisig.ledger.event.RequestNumber
 import hydrozoa.multisig.ledger.l1.tx.TxSignature
 import hydrozoa.multisig.ledger.stack.{PartitionEffects, Stack, StackBrief, StackEffects, StackNumber, StandaloneEvacuationCommitment}
-import hydrozoa.multisig.persistence.{ArrivalStamp, Cf, InMemoryBackendStore, JournalKey, JournalValue, Persistence, PersistenceEventFormat, StoreKey}
+import hydrozoa.multisig.persistence.{
+  ArrivalStamp,
+  Cf,
+  InMemoryBackendStore,
+  JournalKey,
+  JournalValue,
+  Markers,
+  Persistence,
+  PersistenceEventFormat,
+  StoreKey
+}
 import org.scalacheck.Gen
 import org.scalatest.funsuite.AnyFunSuite
 import scala.concurrent.duration.DurationInt
@@ -221,6 +231,7 @@ class ReplayActorTest extends AnyFunSuite:
                         seqSink <- Ref.of[IO, Vector[CoilAckSequencer.Request]](Vector.empty)
                         seq <- system.actorOf(Recorder[CoilAckSequencer.Request](seqSink))
                         _ <- seed(persistence)
+                        markers <- Markers.derive(persistence, PeerId.Head(own))
                         outcome <- ReplayActor
                             .replay(
                               persistence,
@@ -231,7 +242,8 @@ class ReplayActorTest extends AnyFunSuite:
                               hubs,
                               coils,
                               treasuryAddress,
-                              leadsFastBlock = ownLeadsFastBlock
+                              leadsFastBlock = ownLeadsFastBlock,
+                              markers = markers
                             )
                             .attempt
                         _ <- IO.sleep(1.second) // let the probe fibers drain their mailboxes
@@ -269,6 +281,7 @@ class ReplayActorTest extends AnyFunSuite:
                         sca <- system.actorOf(Recorder[SlowConsensusActor.Request](scaSink))
                         sc <- system.actorOf(Recorder[StackComposer.Request](scSink))
                         _ <- seed(persistence)
+                        markers <- Markers.derive(persistence, PeerId.Coil(CoilPeerNumber(0)))
                         outcome <- ReplayActor
                             .replay(
                               persistence,
@@ -280,7 +293,8 @@ class ReplayActorTest extends AnyFunSuite:
                               Nil,
                               treasuryAddress,
                               // A coil peer never leads a fast block.
-                              leadsFastBlock = _ => false
+                              leadsFastBlock = _ => false,
+                              markers = markers
                             )
                             .attempt
                         _ <- IO.sleep(1.second) // let the probe fibers drain their mailboxes

--- a/src/test/scala/hydrozoa/multisig/consensus/ReplayActorTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/ReplayActorTest.scala
@@ -13,7 +13,6 @@ import hydrozoa.config.head.network.CardanoNetwork
 import hydrozoa.config.node.{MultiNodeConfig, NodeConfig}
 import hydrozoa.lib.cardano.scalus.QuantizedTime.QuantizedInstant.realTimeQuantizedInstant
 import hydrozoa.lib.logging.Slf4jTracer
-import hydrozoa.multisig.backend.cardano.{CardanoBackendMock, MockState}
 import hydrozoa.multisig.consensus.ack.{HardAck, HardAckId, HardAckNumber, HardAckWithId, HubHardAckNumber}
 import hydrozoa.multisig.consensus.peer.{CoilPeerNumber, HeadPeerNumber, PeerId}
 import hydrozoa.multisig.consensus.pollresults.PollResults
@@ -201,7 +200,6 @@ class ReplayActorTest extends AnyFunSuite:
     ): Captured =
         val own = ownNum
         val peers = config.headPeerIds.map(_.peerNum).toList
-        val treasuryAddress = config.initializationTx.treasuryProduced.address
         val persistenceTracer = Slf4jTracer.sink.contramap(PersistenceEventFormat.humanFormat)
         InMemoryBackendStore
             .open(persistenceTracer)
@@ -209,14 +207,6 @@ class ReplayActorTest extends AnyFunSuite:
                 ActorSystem[IO]("replay-test").use(system =>
                     for {
                         persistence <- Persistence.fromBackend(backend, persistenceTracer)
-                        cardanoBackend <- CardanoBackendMock.mockIO(
-                          MockState(Map.empty),
-                          // `replay` now verifies the chain's protocol parameters against the
-                          // config's and REFUSES on a mismatch, so the mock must report the
-                          // config's. Its default is scalus's `UtxoEnv.testMainnet` fixture, which
-                          // matches no real network's `CardanoInfo`.
-                          reportedParams = Some(config.cardanoProtocolParams)
-                        )
                         bwSink <- Ref.of[IO, Vector[BlockWeaver.Request]](Vector.empty)
                         fcaSink <- Ref.of[IO, Vector[FastConsensusActor.Request]](Vector.empty)
                         scaSink <- Ref.of[IO, Vector[SlowConsensusActor.Request]](Vector.empty)
@@ -232,13 +222,12 @@ class ReplayActorTest extends AnyFunSuite:
                         outcome <- ReplayActor
                             .replay(
                               persistence,
-                              cardanoBackend,
+                              PollResults.empty,
                               ReplayActor.Targets(bw, fca, sca, sc, Some(seq)),
                               PeerId.Head(own),
                               peers,
                               hubs,
                               coils,
-                              treasuryAddress,
                               leadsFastBlock = ownLeadsFastBlock,
                               markers = markers
                             )
@@ -260,7 +249,6 @@ class ReplayActorTest extends AnyFunSuite:
     private def runReplayCoil(seed: Persistence[IO] => IO[Unit]): Captured =
         val peers = config.headPeerIds.map(_.peerNum).toList
         val hubs = List(HeadPeerNumber(1))
-        val treasuryAddress = config.initializationTx.treasuryProduced.address
         val persistenceTracer = Slf4jTracer.sink.contramap(PersistenceEventFormat.humanFormat)
         InMemoryBackendStore
             .open(persistenceTracer)
@@ -268,14 +256,6 @@ class ReplayActorTest extends AnyFunSuite:
                 ActorSystem[IO]("replay-coil-test").use(system =>
                     for {
                         persistence <- Persistence.fromBackend(backend, persistenceTracer)
-                        cardanoBackend <- CardanoBackendMock.mockIO(
-                          MockState(Map.empty),
-                          // `replay` now verifies the chain's protocol parameters against the
-                          // config's and REFUSES on a mismatch, so the mock must report the
-                          // config's. Its default is scalus's `UtxoEnv.testMainnet` fixture, which
-                          // matches no real network's `CardanoInfo`.
-                          reportedParams = Some(config.cardanoProtocolParams)
-                        )
                         bwSink <- Ref.of[IO, Vector[BlockWeaver.Request]](Vector.empty)
                         fcaSink <- Ref.of[IO, Vector[FastConsensusActor.Request]](Vector.empty)
                         scaSink <- Ref.of[IO, Vector[SlowConsensusActor.Request]](Vector.empty)
@@ -289,13 +269,12 @@ class ReplayActorTest extends AnyFunSuite:
                         outcome <- ReplayActor
                             .replay(
                               persistence,
-                              cardanoBackend,
+                              PollResults.empty,
                               ReplayActor.Targets(bw, fca, sca, sc),
                               PeerId.Coil(CoilPeerNumber(0)),
                               peers,
                               hubs,
                               Nil,
-                              treasuryAddress,
                               // A coil peer never leads a fast block.
                               leadsFastBlock = _ => false,
                               markers = markers

--- a/src/test/scala/hydrozoa/multisig/consensus/ReplayActorTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/ReplayActorTest.scala
@@ -21,17 +21,7 @@ import hydrozoa.multisig.ledger.block.{BlockBody, BlockBrief, BlockHeader, Block
 import hydrozoa.multisig.ledger.event.RequestNumber
 import hydrozoa.multisig.ledger.l1.tx.TxSignature
 import hydrozoa.multisig.ledger.stack.{PartitionEffects, Stack, StackBrief, StackEffects, StackNumber, StandaloneEvacuationCommitment}
-import hydrozoa.multisig.persistence.{
-  ArrivalStamp,
-  Cf,
-  InMemoryBackendStore,
-  JournalKey,
-  JournalValue,
-  Markers,
-  Persistence,
-  PersistenceEventFormat,
-  StoreKey
-}
+import hydrozoa.multisig.persistence.{ArrivalStamp, Cf, InMemoryBackendStore, JournalKey, JournalValue, Markers, Persistence, PersistenceEventFormat, StoreKey}
 import org.scalacheck.Gen
 import org.scalatest.funsuite.AnyFunSuite
 import scala.concurrent.duration.DurationInt

--- a/src/test/scala/hydrozoa/multisig/consensus/SlowConsensusActorRecoveryTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/SlowConsensusActorRecoveryTest.scala
@@ -14,7 +14,14 @@ import hydrozoa.multisig.consensus.peer.{HeadPeerNumber, PeerId}
 import hydrozoa.multisig.ledger.l1.tx.TxSignature
 import hydrozoa.multisig.ledger.stack.StackNumber
 import hydrozoa.multisig.metrics.PeerMetrics
-import hydrozoa.multisig.persistence.{Cf, InMemoryBackendStore, Persistence, PersistenceEventFormat, StoreKey}
+import hydrozoa.multisig.persistence.{
+  Cf,
+  InMemoryBackendStore,
+  Markers,
+  Persistence,
+  PersistenceEventFormat,
+  StoreKey
+}
 import org.scalacheck.Gen
 import org.scalatest.funsuite.AnyFunSuite
 import scala.concurrent.duration.DurationInt
@@ -68,6 +75,11 @@ class SlowConsensusActorRecoveryTest extends AnyFunSuite:
                           StoreKey.HardConfirmation(StackNumber(confirmed)).encode,
                           Array[Byte](0)
                         )
+                        // Derived from the SEEDED store, not `Markers.cold`: the fixture writes a
+                        // HardConfirmation key above, and a cold bundle would leave `lastConfirmed`
+                        // None — the surplus guard under test would never arm and the suite would
+                        // pass while asserting nothing.
+                        markers <- Markers.derive(persistence, config.ownPeerId)
                         seen <- Ref.of[IO, Vector[SlowConsensusActorEvent]](Vector.empty)
                         tracer = ContraTracer[IO, SlowConsensusActorEvent](e => seen.update(_ :+ e))
                         sc <- system.actorOf(SinkActor[StackComposer.Request]())
@@ -78,7 +90,8 @@ class SlowConsensusActorRecoveryTest extends AnyFunSuite:
                             SlowConsensusActor.Connections(sc, cl, Nil),
                             tracer,
                             persistence,
-                            PeerMetrics.create(0L, Vector.empty)
+                            PeerMetrics.create(0L, Vector.empty),
+                            markers
                           )
                         )
                         _ <- sca ! remoteAck(peer = 1, stack = ackStack)

--- a/src/test/scala/hydrozoa/multisig/consensus/SlowConsensusActorRecoveryTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/SlowConsensusActorRecoveryTest.scala
@@ -14,14 +14,7 @@ import hydrozoa.multisig.consensus.peer.{HeadPeerNumber, PeerId}
 import hydrozoa.multisig.ledger.l1.tx.TxSignature
 import hydrozoa.multisig.ledger.stack.StackNumber
 import hydrozoa.multisig.metrics.PeerMetrics
-import hydrozoa.multisig.persistence.{
-  Cf,
-  InMemoryBackendStore,
-  Markers,
-  Persistence,
-  PersistenceEventFormat,
-  StoreKey
-}
+import hydrozoa.multisig.persistence.{Cf, InMemoryBackendStore, Markers, Persistence, PersistenceEventFormat, StoreKey}
 import org.scalacheck.Gen
 import org.scalatest.funsuite.AnyFunSuite
 import scala.concurrent.duration.DurationInt

--- a/src/test/scala/hydrozoa/multisig/consensus/StackComposerRecoveryTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/StackComposerRecoveryTest.scala
@@ -20,16 +20,7 @@ import hydrozoa.multisig.ledger.l1.utxo.MultisigTreasuryUtxo
 import hydrozoa.multisig.ledger.stack.{PartitionEffects, Stack, StackBrief, StackEffects, StackNumber, StandaloneEvacuationCommitment}
 import hydrozoa.multisig.metrics.PeerMetrics
 import hydrozoa.multisig.persistence.codec.TreasuryFixture
-import hydrozoa.multisig.persistence.{
-  ArrivalStamp,
-  InMemoryBackendStore,
-  JournalKey,
-  JournalValue,
-  Markers,
-  Persistence,
-  PersistenceEventFormat,
-  StoreKey
-}
+import hydrozoa.multisig.persistence.{ArrivalStamp, InMemoryBackendStore, JournalKey, JournalValue, Markers, Persistence, PersistenceEventFormat, StoreKey}
 import org.scalacheck.Gen
 import org.scalatest.funsuite.AnyFunSuite
 import scala.concurrent.duration.DurationInt

--- a/src/test/scala/hydrozoa/multisig/consensus/StackComposerRecoveryTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/StackComposerRecoveryTest.scala
@@ -20,7 +20,16 @@ import hydrozoa.multisig.ledger.l1.utxo.MultisigTreasuryUtxo
 import hydrozoa.multisig.ledger.stack.{PartitionEffects, Stack, StackBrief, StackEffects, StackNumber, StandaloneEvacuationCommitment}
 import hydrozoa.multisig.metrics.PeerMetrics
 import hydrozoa.multisig.persistence.codec.TreasuryFixture
-import hydrozoa.multisig.persistence.{ArrivalStamp, InMemoryBackendStore, JournalKey, JournalValue, Persistence, PersistenceEventFormat, StoreKey}
+import hydrozoa.multisig.persistence.{
+  ArrivalStamp,
+  InMemoryBackendStore,
+  JournalKey,
+  JournalValue,
+  Markers,
+  Persistence,
+  PersistenceEventFormat,
+  StoreKey
+}
 import org.scalacheck.Gen
 import org.scalatest.funsuite.AnyFunSuite
 import scala.concurrent.duration.DurationInt
@@ -87,7 +96,7 @@ class StackComposerRecoveryTest extends AnyFunSuite:
                   p,
                   Some(HardAckNumber(0)),
                   None,
-                  PeerId.Head(ownNum)
+                  Some(StackNumber(1))
                 )
             } yield recovered match {
                 case Some(state) => assert(state.treasury == balancedTreasury)
@@ -105,7 +114,7 @@ class StackComposerRecoveryTest extends AnyFunSuite:
             for {
                 _ <- seedRecoverableWith(p, TreasuryFixture.sampleTreasury)
                 outcome <- StackComposer.State
-                    .recover(p, Some(HardAckNumber(0)), None, PeerId.Head(ownNum))
+                    .recover(p, Some(HardAckNumber(0)), None, Some(StackNumber(1)))
                     .attempt
             } yield outcome match {
                 case Left(e) =>
@@ -171,6 +180,9 @@ class StackComposerRecoveryTest extends AnyFunSuite:
                     for {
                         persistence <- Persistence.fromBackend(backend, persistenceTracer)
                         _ <- seed(persistence)
+                        // From the SEEDED store: this case is about recovering a real anchor, so a
+                        // cold bundle would make the actor bootstrap instead and assert nothing.
+                        markers <- Markers.derive(persistence, config.ownPeerId)
                         gotHandoff <- Deferred[IO, SlowConsensusActor.StackHandoff]
                         probe <- system.actorOf(HandoffProbe(gotHandoff))
                         jlSink <- system.actorOf(NoopSink[JointLedger.Requests.Request]())
@@ -186,7 +198,8 @@ class StackComposerRecoveryTest extends AnyFunSuite:
                             ),
                             ContraTracer.nullTracer[IO, StackComposerEvent],
                             persistence,
-                            PeerMetrics.create(0L, Vector.empty)
+                            PeerMetrics.create(0L, Vector.empty),
+                            markers
                           )
                         )
                         r <- check(gotHandoff)

--- a/src/test/scala/hydrozoa/multisig/consensus/transport/CoilDialerBudgetTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/transport/CoilDialerBudgetTest.scala
@@ -1,0 +1,117 @@
+package hydrozoa.multisig.consensus.transport
+
+import cats.effect.testkit.TestControl
+import cats.effect.{IO, Ref, Resource}
+import hydrozoa.config.head.network.CardanoNetwork
+import hydrozoa.lib.logging.ContraTracer
+import hydrozoa.multisig.consensus.peer.CoilPeerNumber
+import hydrozoa.multisig.consensus.transport.CoilPeerWsTransportEvent.*
+import org.http4s.Uri
+import org.http4s.client.websocket.{WSClient, WSConnection, WSFrame, WSRequest}
+import org.scalatest.funsuite.AnyFunSuite
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
+
+/** What the dialer's handshake budget may and may not cut short, on a virtual clock.
+  *
+  * The budget exists because `JdkWSClient` builds its socket inside an uncancelable acquire, so a
+  * hub that accepts the TCP connection and never answers can only be abandoned, never cancelled. It
+  * must bound the handshake and nothing past it: an established link is *supposed* to occupy the
+  * dialer for as long as it lives, so a budget that reaches beyond the handshake tears down working
+  * connections on a timer and dials a second one on top of each — every frame then goes to
+  * whichever of them the shared outbox happens to hand it to.
+  */
+class CoilDialerBudgetTest extends AnyFunSuite {
+
+    private given CardanoNetwork.Section = CardanoNetwork.Preview
+
+    private val hubUri = Uri.unsafeFromString("ws://hub.invalid:3001/ws")
+
+    /** A quiet-but-live link: a keep-alive Ping every `pingEvery`, which is what holds `WsDuplex`'s
+      * read deadline off a real idle connection (`NodeWsServer` pings every 10s).
+      *
+      * It closes after `pings` of them rather than running forever, only so `TestControl` has an
+      * end to reach: an eternal link leaves work scheduled at every future instant and `tickAll`
+      * chases it without terminating. Size it past the window under test.
+      */
+    private def pinging(pingEvery: FiniteDuration, pings: Int = 200): IO[WSConnection[IO]] =
+        Ref.of[IO, Int](pings).map { left =>
+            new WSConnection[IO] {
+                override def send(wsf: WSFrame): IO[Unit] = IO.unit
+                override def sendMany[G[_]: cats.Foldable, A <: WSFrame](wsfs: G[A]): IO[Unit] =
+                    IO.unit
+                override def receive: IO[Option[WSFrame]] =
+                    IO.sleep(pingEvery) >> left.modify(n => (n - 1, n)).map {
+                        case n if n > 0 => Some(WSFrame.Ping(scodec.bits.ByteVector.empty))
+                        // End of stream: the peer closed its receiving side.
+                        case _ => None
+                    }
+                override def subprotocol: Option[String] = None
+            }
+        }
+
+    /** Run the real dialer against `connect` for `forHowLong` of virtual time, and report how many
+      * dial attempts it made and what it traced.
+      */
+    private def dial(
+        connect: Resource[IO, WSConnection[IO]],
+        forHowLong: FiniteDuration
+    ): (Int, Vector[CoilPeerWsTransportEvent]) = {
+        val prog = for {
+            attempts <- Ref.of[IO, Int](0)
+            seen <- Ref.of[IO, Vector[CoilPeerWsTransportEvent]](Vector.empty)
+            tracer = ContraTracer[IO, CoilPeerWsTransportEvent](e => seen.update(_ :+ e))
+            transport <- CoilPeerWsTransport.create(CoilPeerNumber(0), tracer)
+            client = WSClient[IO](respondToPings = false) { (_: WSRequest) =>
+                Resource.eval(attempts.update(_ + 1)).flatMap(_ => connect)
+            }
+            _ <- transport.startDialer(client, hubUri).surround(IO.sleep(forHowLong))
+            n <- attempts.get
+            events <- seen.get
+        } yield (n, events)
+        TestControl.executeEmbed(prog).unsafeRunSync()(using cats.effect.unsafe.implicits.global)
+    }
+
+    private def stalls(events: Vector[CoilPeerWsTransportEvent]): Int =
+        events.count(_.isInstanceOf[DialerHandshakeStalled])
+
+    test("a live link holds the dialer: no redial and no stall for as long as it stays up") {
+        // Ten minutes is twenty budgets. The link is quiet but not silent, exactly as a real one is
+        // between blocks, so nothing about it should ever look like a stalled handshake.
+        val (attempts, events) = dial(Resource.eval(pinging(10.seconds)), 10.minutes)
+        assert(
+          (attempts, stalls(events)) == (1, 0),
+          s"the link never dropped, so the dialer must neither redial nor report a stall; " +
+              s"dialed $attempts times, traced $events"
+        )
+    }
+
+    test("a handshake that never completes is abandoned, and the dialer keeps redialing") {
+        // 30s budget + the 1s inter-attempt delay, so 65s covers three attempts and two expiries.
+        val (attempts, events) = dial(Resource.eval(IO.never[WSConnection[IO]]), 65.seconds)
+        assert(
+          (attempts, stalls(events)) == (3, 2),
+          s"expected a redial per expired budget, each announced; " +
+              s"dialed $attempts times, traced $events"
+        )
+    }
+
+    test(
+      "a handshake landing after the budget drops its socket rather than opening a second link"
+    ) {
+        // The deadline case the `handshook` claim exists for: the hub answers at 35s, five seconds
+        // after the loop gave up and one attempt into the redial. Exactly one of the two may win,
+        // so the late attempt must disown itself and never reach `DialerConnected`.
+        val late = Resource.eval(IO.sleep(35.seconds) >> pinging(10.seconds, pings = 2))
+        val (attempts, events) = dial(late, 40.seconds)
+        assert(
+          (
+            attempts,
+            stalls(events),
+            events.count(_.isInstanceOf[DialerHandshakeLate]),
+            events.count(_.isInstanceOf[DialerConnected])
+          ) == (2, 1, 1, 0),
+          s"the budget expired once and the late handshake disowned itself; " +
+              s"dialed $attempts times, traced $events"
+        )
+    }
+}

--- a/src/test/scala/hydrozoa/multisig/consensus/transport/CoilDialerBudgetTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/transport/CoilDialerBudgetTest.scala
@@ -80,7 +80,7 @@ class CoilDialerBudgetTest extends AnyFunSuite {
         val (attempts, events) = dial(Resource.eval(pinging(10.seconds)), 10.minutes)
         assert(
           (attempts, stalls(events)) == (1, 0),
-          s"the link never dropped, so the dialer must neither redial nor report a stall; " +
+          "the link never dropped, so the dialer must neither redial nor report a stall; " +
               s"dialed $attempts times, traced $events"
         )
     }
@@ -90,7 +90,7 @@ class CoilDialerBudgetTest extends AnyFunSuite {
         val (attempts, events) = dial(Resource.eval(IO.never[WSConnection[IO]]), 65.seconds)
         assert(
           (attempts, stalls(events)) == (3, 2),
-          s"expected a redial per expired budget, each announced; " +
+          "expected a redial per expired budget, each announced; " +
               s"dialed $attempts times, traced $events"
         )
     }
@@ -110,7 +110,7 @@ class CoilDialerBudgetTest extends AnyFunSuite {
             events.count(_.isInstanceOf[DialerHandshakeLate]),
             events.count(_.isInstanceOf[DialerConnected])
           ) == (2, 1, 1, 0),
-          s"the budget expired once and the late handshake disowned itself; " +
+          "the budget expired once and the late handshake disowned itself; " +
               s"dialed $attempts times, traced $events"
         )
     }

--- a/src/test/scala/hydrozoa/multisig/consensus/transport/HeadDialerBudgetTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/transport/HeadDialerBudgetTest.scala
@@ -1,0 +1,109 @@
+package hydrozoa.multisig.consensus.transport
+
+import cats.effect.testkit.TestControl
+import cats.effect.{IO, Ref, Resource}
+import hydrozoa.config.head.network.CardanoNetwork
+import hydrozoa.lib.logging.ContraTracer
+import hydrozoa.lib.number.PositiveInt
+import hydrozoa.multisig.consensus.peer.{HeadPeerId, HeadPeerNumber}
+import hydrozoa.multisig.consensus.transport.PeerTransportEvent.*
+import org.http4s.Uri
+import org.http4s.client.websocket.{WSClient, WSConnection, WSFrame, WSRequest}
+import org.scalatest.funsuite.AnyFunSuite
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
+
+/** The head-mesh mirror of [[CoilDialerBudgetTest]].
+  *
+  * `WsPeerTransport.dialerLoop` and `CoilPeerWsTransport.dialerLoop` are the same code twice over,
+  * and the budget defect was in both — so the fix needs a witness on both. Everything the coil
+  * suite pins is pinned here against `WsPeerTransport` instead: a live link must occupy the dialer
+  * for as long as it lives, a handshake that never lands must be abandoned and redialed, and one
+  * that lands after the budget must drop its socket rather than leave a second connection draining
+  * this remote's outbox.
+  */
+class HeadDialerBudgetTest extends AnyFunSuite {
+
+    private given CardanoNetwork.Section = CardanoNetwork.Preview
+
+    private val nPeers = PositiveInt.unsafeApply(2)
+    private val ownId = HeadPeerId(HeadPeerNumber(0), nPeers)
+    // Lower peerNum dials higher, so peer 0 is the dialer and peer 1 the remote.
+    private val remoteId = HeadPeerId(HeadPeerNumber(1), nPeers)
+    private val remoteUri = Uri.unsafeFromString("ws://peer1.invalid:3001/head")
+
+    /** A quiet-but-live link: a keep-alive Ping every `pingEvery`, which is what holds `WsDuplex`'s
+      * read deadline off a real idle connection. Ends after `pings` so `TestControl` has an end to
+      * reach.
+      */
+    private def pinging(pingEvery: FiniteDuration, pings: Int = 200): IO[WSConnection[IO]] =
+        Ref.of[IO, Int](pings).map { left =>
+            new WSConnection[IO] {
+                override def send(wsf: WSFrame): IO[Unit] = IO.unit
+                override def sendMany[G[_]: cats.Foldable, A <: WSFrame](wsfs: G[A]): IO[Unit] =
+                    IO.unit
+                override def receive: IO[Option[WSFrame]] =
+                    IO.sleep(pingEvery) >> left.modify(n => (n - 1, n)).map {
+                        case n if n > 0 => Some(WSFrame.Ping(scodec.bits.ByteVector.empty))
+                        case _          => None
+                    }
+                override def subprotocol: Option[String] = None
+            }
+        }
+
+    private def dial(
+        connect: Resource[IO, WSConnection[IO]],
+        forHowLong: FiniteDuration
+    ): (Int, Vector[PeerTransportEvent]) = {
+        val prog = for {
+            attempts <- Ref.of[IO, Int](0)
+            seen <- Ref.of[IO, Vector[PeerTransportEvent]](Vector.empty)
+            tracer = ContraTracer[IO, PeerTransportEvent](e => seen.update(_ :+ e))
+            transport <- WsPeerTransport.create(ownId, List(remoteId), tracer)
+            client = WSClient[IO](respondToPings = false) { (_: WSRequest) =>
+                Resource.eval(attempts.update(_ + 1)).flatMap(_ => connect)
+            }
+            _ <- transport
+                .startDialers(client, Map(remoteId -> remoteUri))
+                .surround(IO.sleep(forHowLong))
+            n <- attempts.get
+            events <- seen.get
+        } yield (n, events)
+        TestControl.executeEmbed(prog).unsafeRunSync()(using cats.effect.unsafe.implicits.global)
+    }
+
+    private def stalls(events: Vector[PeerTransportEvent]): Int =
+        events.count(_.isInstanceOf[DialerHandshakeStalled])
+
+    test("a live link holds the head dialer: no redial and no stall for as long as it stays up") {
+        val (attempts, events) = dial(Resource.eval(pinging(10.seconds)), 10.minutes)
+        assert(
+          (attempts, stalls(events)) == (1, 0),
+          "the link never dropped, so the dialer must neither redial nor report a stall; " +
+              s"dialed $attempts times, traced $events"
+        )
+    }
+
+    test("a head handshake that never completes is abandoned, and the dialer keeps redialing") {
+        val (attempts, events) = dial(Resource.eval(IO.never[WSConnection[IO]]), 65.seconds)
+        assert(
+          (attempts, stalls(events)) == (3, 2),
+          "expected a redial per expired budget, each announced; " +
+              s"dialed $attempts times, traced $events"
+        )
+    }
+
+    test("a head handshake landing after the budget drops its socket rather than opening a link") {
+        val late = Resource.eval(IO.sleep(35.seconds) >> pinging(10.seconds, pings = 2))
+        val (attempts, events) = dial(late, 40.seconds)
+        assert(
+          (
+            attempts,
+            stalls(events),
+            events.count(_.isInstanceOf[DialerHandshakeLate]),
+            events.count(_.isInstanceOf[DialerConnected])
+          ) == (2, 1, 1, 0),
+          "the budget expired once and the late handshake disowned itself; " +
+              s"dialed $attempts times, traced $events"
+        )
+    }
+}

--- a/src/test/scala/hydrozoa/multisig/ledger/JointLedgerTest.scala
+++ b/src/test/scala/hydrozoa/multisig/ledger/JointLedgerTest.scala
@@ -35,7 +35,12 @@ import hydrozoa.multisig.ledger.joint.{JointLedger, JointLedgerEventFormat}
 import hydrozoa.multisig.ledger.l1.deposits.map.DepositsMap
 import hydrozoa.multisig.ledger.l1.txseq.DepositRefundTxSeq
 import hydrozoa.multisig.metrics.PeerMetrics
-import hydrozoa.multisig.persistence.{InMemoryBackendStore, Persistence, PersistenceEventFormat}
+import hydrozoa.multisig.persistence.{
+  InMemoryBackendStore,
+  Markers,
+  Persistence,
+  PersistenceEventFormat
+}
 import java.util.concurrent.TimeUnit
 import monocle.Focus.focus
 import org.scalacheck.*
@@ -167,7 +172,10 @@ object JointLedgerTestHelpers {
                             JointLedgerEventFormat.humanFormat(HeadPeerNumber.zero)
                           ),
                           persistence,
-                          PeerMetrics.create(0L, Vector(HeadPeerNumber.zero: Int))
+                          PeerMetrics.create(0L, Vector(HeadPeerNumber.zero: Int)),
+                          // Nothing is seeded in this fixture, so the cold bundle is exactly what
+                          // deriving from this backend would return.
+                          Markers.cold
                         )
                       )
                     )

--- a/src/test/scala/hydrozoa/multisig/ledger/JointLedgerTest.scala
+++ b/src/test/scala/hydrozoa/multisig/ledger/JointLedgerTest.scala
@@ -35,12 +35,7 @@ import hydrozoa.multisig.ledger.joint.{JointLedger, JointLedgerEventFormat}
 import hydrozoa.multisig.ledger.l1.deposits.map.DepositsMap
 import hydrozoa.multisig.ledger.l1.txseq.DepositRefundTxSeq
 import hydrozoa.multisig.metrics.PeerMetrics
-import hydrozoa.multisig.persistence.{
-  InMemoryBackendStore,
-  Markers,
-  Persistence,
-  PersistenceEventFormat
-}
+import hydrozoa.multisig.persistence.{InMemoryBackendStore, Markers, Persistence, PersistenceEventFormat}
 import java.util.concurrent.TimeUnit
 import monocle.Focus.focus
 import org.scalacheck.*

--- a/src/test/scala/hydrozoa/multisig/persistence/MarkersAdoptTest.scala
+++ b/src/test/scala/hydrozoa/multisig/persistence/MarkersAdoptTest.scala
@@ -1,0 +1,64 @@
+package hydrozoa.multisig.persistence
+
+import hydrozoa.multisig.ledger.stack.StackNumber
+import org.scalatest.funsuite.AnyFunSuite
+
+/** What a `transplantStackNumber` does to a freshly derived marker bundle.
+  *
+  * The rule this pins is that `Markers.adopt` and `Serve`'s boot gate must use the **same**
+  * comparison. They did not: the gate accepted `hardConfirmed >= tag` while adoption required exact
+  * equality, so a tag naming a stack below the store's tip passed the gate and was then silently
+  * dropped — no adoption, no error, and an operator with no way to tell. The first test below is
+  * that case, and it fails on the old `hardConfirmed.contains(tag)`.
+  */
+class MarkersAdoptTest extends AnyFunSuite {
+
+    private def store(hardConfirmed: Int, hardAckedStack: Option[Int]): Markers =
+        Markers.cold.copy(
+          hardConfirmed = Some(StackNumber(hardConfirmed)),
+          hardAckedStack = hardAckedStack.map(StackNumber(_))
+        )
+
+    test("a tag BELOW the store's tip is adopted, not silently dropped") {
+        // The regression. The boot gate lets this through, so adoption must too — a tag is a
+        // partition of the store chosen by the operator, and any stack the store holds is a
+        // legitimate choice.
+        val adopted = Markers.adopt(store(hardConfirmed = 100, hardAckedStack = None), Some(StackNumber(42)))
+        assert(
+          adopted.hardAckedStack.contains(StackNumber(42)),
+          s"a below-tip tag must raise the floor; got ${adopted.hardAckedStack}"
+        )
+    }
+
+    test("a tag EQUAL to the store's tip is adopted") {
+        val adopted = Markers.adopt(store(hardConfirmed = 42, hardAckedStack = None), Some(StackNumber(42)))
+        assert(adopted.hardAckedStack.contains(StackNumber(42)))
+    }
+
+    test("a tag ABOVE the store's tip is not adopted — the gate refuses that boot anyway") {
+        val derived = store(hardConfirmed = 10, hardAckedStack = Some(7))
+        assert(Markers.adopt(derived, Some(StackNumber(99))) == derived)
+    }
+
+    test("no tag leaves the bundle untouched") {
+        val derived = store(hardConfirmed = 10, hardAckedStack = Some(7))
+        assert(Markers.adopt(derived, None) == derived)
+    }
+
+    test("an empty store adopts nothing, whatever the tag") {
+        assert(Markers.adopt(Markers.cold, Some(StackNumber(1))) == Markers.cold)
+    }
+
+    test("the floor is RAISED and never lowered") {
+        // A peer mid-flight has acked one stack beyond its confirmation; clamping that down to the
+        // tag would discard the in-flight handoff ReplayActor rebuilds from it.
+        val ahead = store(hardConfirmed = 100, hardAckedStack = Some(101))
+        assert(Markers.adopt(ahead, Some(StackNumber(42))).hardAckedStack.contains(StackNumber(101)))
+    }
+
+    test("adoption is idempotent — a tag left in the config after the fact changes nothing") {
+        val derived = store(hardConfirmed = 100, hardAckedStack = Some(60))
+        val once = Markers.adopt(derived, Some(StackNumber(42)))
+        assert(Markers.adopt(once, Some(StackNumber(42))) == once)
+    }
+}

--- a/src/test/scala/hydrozoa/multisig/persistence/MarkersAdoptTest.scala
+++ b/src/test/scala/hydrozoa/multisig/persistence/MarkersAdoptTest.scala
@@ -23,7 +23,8 @@ class MarkersAdoptTest extends AnyFunSuite {
         // The regression. The boot gate lets this through, so adoption must too — a tag is a
         // partition of the store chosen by the operator, and any stack the store holds is a
         // legitimate choice.
-        val adopted = Markers.adopt(store(hardConfirmed = 100, hardAckedStack = None), Some(StackNumber(42)))
+        val adopted =
+            Markers.adopt(store(hardConfirmed = 100, hardAckedStack = None), Some(StackNumber(42)))
         assert(
           adopted.hardAckedStack.contains(StackNumber(42)),
           s"a below-tip tag must raise the floor; got ${adopted.hardAckedStack}"
@@ -31,7 +32,8 @@ class MarkersAdoptTest extends AnyFunSuite {
     }
 
     test("a tag EQUAL to the store's tip is adopted") {
-        val adopted = Markers.adopt(store(hardConfirmed = 42, hardAckedStack = None), Some(StackNumber(42)))
+        val adopted =
+            Markers.adopt(store(hardConfirmed = 42, hardAckedStack = None), Some(StackNumber(42)))
         assert(adopted.hardAckedStack.contains(StackNumber(42)))
     }
 
@@ -53,7 +55,9 @@ class MarkersAdoptTest extends AnyFunSuite {
         // A peer mid-flight has acked one stack beyond its confirmation; clamping that down to the
         // tag would discard the in-flight handoff ReplayActor rebuilds from it.
         val ahead = store(hardConfirmed = 100, hardAckedStack = Some(101))
-        assert(Markers.adopt(ahead, Some(StackNumber(42))).hardAckedStack.contains(StackNumber(101)))
+        assert(
+          Markers.adopt(ahead, Some(StackNumber(42))).hardAckedStack.contains(StackNumber(101))
+        )
     }
 
     test("adoption is idempotent — a tag left in the config after the fact changes nothing") {

--- a/src/test/scala/hydrozoa/multisig/persistence/recovery/JournalScanTest.scala
+++ b/src/test/scala/hydrozoa/multisig/persistence/recovery/JournalScanTest.scala
@@ -97,7 +97,10 @@ class JournalScanTest extends AnyFunSuite:
               fastBlockMark = None,
               hardConfirmed = Some(StackNumber(1)), // stack floor 2
               hardAcked = Some(HardAckNumber(4)),
-              nextRequestNumber = RequestNumber(0)
+              nextRequestNumber = RequestNumber(0),
+              // Neither is read by cursor derivation; present only to complete the bundle.
+              evacuationMapMark = None,
+              hardAckedStack = None
             )
             val highWater = Map(
               HeadPeerNumber(0) -> RequestNumber(4), // request floor 5

--- a/src/test/scala/hydrozoa/multisig/persistence/recovery/RecoverSeamsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/persistence/recovery/RecoverSeamsTest.scala
@@ -79,11 +79,13 @@ class RecoverSeamsTest extends AnyFunSuite:
             for
                 store <- InMemoryL2Store.create
                 ledger <- EutxoL2Ledger(config, store)
+                emm <- Markers.recoverEvacuationMapMark(p.backend)
                 viaRecover <- JointLedger.State.recover(
                   p,
                   ledger,
                   None,
-                  config.initialEvacuationMap
+                  config.initialEvacuationMap,
+                  emm
                 )
                 viaState <- JointLedger.State.recoverState(p, None)
             yield assert(viaRecover.isEmpty && viaState.isEmpty)
@@ -131,11 +133,13 @@ class RecoverSeamsTest extends AnyFunSuite:
                         p.put(StoreKey.BlockResult(BlockNumber(n)))(br.persisted)
                     )
                 )
+                emm <- Markers.recoverEvacuationMapMark(p.backend)
                 done <- JointLedger.State.recover(
                   p,
                   ledger,
                   Some(BlockNumber(2)),
-                  config.initialEvacuationMap
+                  config.initialEvacuationMap,
+                  emm
                 )
                 anchored <- ledger.peekState.map(_.commandNumber)
             yield assert(done.isDefined && anchored == L2CommandNumber(2L))
@@ -168,11 +172,13 @@ class RecoverSeamsTest extends AnyFunSuite:
                         p.put(StoreKey.BlockResult(BlockNumber(n)))(br.persisted)
                     )
                 )
+                emm <- Markers.recoverEvacuationMapMark(p.backend)
                 recovered <- JointLedger.State.recover(
                   p,
                   ledger,
                   Some(BlockNumber(2)),
-                  config.initialEvacuationMap
+                  config.initialEvacuationMap,
+                  emm
                 )
                 anchored <- ledger.peekState.map(_.commandNumber)
             yield assert(
@@ -188,7 +194,7 @@ class RecoverSeamsTest extends AnyFunSuite:
     test("StackComposer.recover returns None for an empty store (no own hard-ack)") {
         withStore { p =>
             StackComposer.State
-                .recover(p, None, None, PeerId.Head(HeadPeerNumber(0)))
+                .recover(p, None, None, None)
                 .map(s => assert(s.isEmpty))
         }
     }
@@ -212,18 +218,23 @@ class RecoverSeamsTest extends AnyFunSuite:
                 _ <- p.put(StoreKey.UnsignedStack(StackNumber(stackN)))(us)
                 _ <- p.put(StoreKey.Treasury)(balancedTreasury)
                 _ <- p.put(StoreKey.EvacuationMap(BlockNumber(lastBlock)))(EvacuationMap.empty)
-                markers = Markers(
-                  softConfirmed = None,
-                  fastBlockMark = None,
-                  hardConfirmed = Some(StackNumber(stackN)), // stack 2 hard-confirmed → gate armed
-                  hardAcked = Some(HardAckNumber(hardAckNum)),
-                  nextRequestNumber = RequestNumber(0)
+                // DERIVED, not hand-built: `hardAckedStack` is unpacked from the hard-ack VALUE
+                // inside `Markers.derive`, and that unpacking is what this test exists to check —
+                // passing it in by hand would assert the fixture, not the code. Only
+                // `hardConfirmed` is overridden, because no HardConfirmation is seeded and this
+                // case wants the gate armed.
+                markers <- Markers
+                    .derive(p, PeerId.Head(own))
+                    .map(_.copy(hardConfirmed = Some(StackNumber(stackN))))
+                _ = assert(
+                  markers.hardAckedStack == Some(StackNumber(stackN)),
+                  s"ack $hardAckNum must unpack to stack $stackN, got ${markers.hardAckedStack}"
                 )
                 recovered <- StackComposer.State.recover(
                   p,
                   markers.hardAcked,
                   markers.hardConfirmed,
-                  PeerId.Head(own)
+                  markers.hardAckedStack
                 )
             yield assert(
               recovered.exists { s =>
@@ -267,18 +278,16 @@ class RecoverSeamsTest extends AnyFunSuite:
                 _ <- p.put(StoreKey.BlockResult(BlockNumber(5)))(br5.persisted)
                 _ <- p.put(JournalKey.Block(BlockNumber(4)))(JournalValue(stamp, br4.brief))
                 _ <- p.put(JournalKey.Block(BlockNumber(5)))(JournalValue(stamp, br5.brief))
-                markers = Markers(
-                  softConfirmed = None,
-                  fastBlockMark = None,
-                  hardConfirmed = Some(StackNumber(0)), // below stack 1 → gate disarmed
-                  hardAcked = Some(HardAckNumber(0)),
-                  nextRequestNumber = RequestNumber(0)
-                )
+                // Derived for the same reason as above; `hardConfirmed` overridden to keep the
+                // gate disarmed, which is what this case is about.
+                markers <- Markers
+                    .derive(p, PeerId.Head(own))
+                    .map(_.copy(hardConfirmed = Some(StackNumber(0))))
                 recovered <- StackComposer.State.recover(
                   p,
                   markers.hardAcked,
                   markers.hardConfirmed,
-                  PeerId.Head(own)
+                  markers.hardAckedStack
                 )
             yield assert(
               recovered.exists { s =>
@@ -329,11 +338,16 @@ class RecoverSeamsTest extends AnyFunSuite:
                       Timestamped(stamp, softConfirmedOf(br))
                     )
                 )
+                // Derived so the acked stack comes from the seeded ack VALUE (stack 1 here, not
+                // the ack number 0); `hardConfirmed` is pinned below it to keep the gate disarmed.
+                markers <- Markers
+                    .derive(p, PeerId.Head(own))
+                    .map(_.copy(hardConfirmed = Some(StackNumber(0))))
                 recovered <- StackComposer.State.recover(
                   p,
-                  Some(HardAckNumber(0)),
-                  Some(StackNumber(0)),
-                  PeerId.Head(own)
+                  markers.hardAcked,
+                  markers.hardConfirmed,
+                  markers.hardAckedStack
                 )
             yield assert(
               recovered.exists { s =>
@@ -351,7 +365,7 @@ class RecoverSeamsTest extends AnyFunSuite:
     test("StackComposer.recover (coil) returns None for an empty store (no own coil hard-ack)") {
         withStore { p =>
             StackComposer.State
-                .recover(p, None, None, PeerId.Coil(CoilPeerNumber(0)))
+                .recover(p, None, None, None)
                 .map(r => assert(r.isEmpty))
         }
     }
@@ -406,7 +420,7 @@ class RecoverSeamsTest extends AnyFunSuite:
                   p,
                   Some(HardAckNumber(hardAckNum)),
                   Some(StackNumber(stackN)), // stack 2 hard-confirmed → gate armed
-                  PeerId.Coil(coil)
+                  Some(StackNumber(stackN))
                 )
             yield assert(
               recovered.exists { s =>
@@ -444,7 +458,7 @@ class RecoverSeamsTest extends AnyFunSuite:
                 store <- InMemoryL2Store.create
                 ledger <- EutxoL2Ledger(config, store)
                 r <- JointLedger.State
-                    .recover(p, ledger, None, config.initialEvacuationMap)
+                    .recover(p, ledger, None, config.initialEvacuationMap, None)
                     .attempt
             yield assert(r == Right(None))
         }
@@ -459,7 +473,7 @@ class RecoverSeamsTest extends AnyFunSuite:
                 // or against a different configuration of this one. Dropping one entry is enough —
                 // the check is on the digest of the whole map.
                 divergent = EvacuationMap.from(config.initialEvacuationMap.drop(1))
-                r <- JointLedger.State.recover(p, ledger, None, divergent).attempt
+                r <- JointLedger.State.recover(p, ledger, None, divergent, None).attempt
             yield assert(
               r.swap.toOption.exists {
                   case RestoreError.EvacuationMapMismatch(expected, actual) =>
@@ -493,8 +507,12 @@ class RecoverSeamsTest extends AnyFunSuite:
                 // A stack closed at block 1, so its stored map — not the config's initial one — is
                 // the base, and only block 2's diffs are folded on top.
                 _ <- p.put(StoreKey.EvacuationMap(BlockNumber(1)))(config.initialEvacuationMap)
+                // Derived: these cases seed EvacuationMap(1) so the STORED map is the fold base.
+                // A hard-coded None would restore the config's initial map instead, and the
+                // divergence these tests assert on would quietly stop being exercised.
+                emm <- Markers.recoverEvacuationMapMark(p.backend)
                 r <- JointLedger.State
-                    .recover(p, ledger, Some(BlockNumber(2)), config.initialEvacuationMap)
+                    .recover(p, ledger, Some(BlockNumber(2)), config.initialEvacuationMap, emm)
                     .attempt
             yield assert(r.map(_.isDefined) == Right(true))
         }
@@ -520,8 +538,12 @@ class RecoverSeamsTest extends AnyFunSuite:
                 // The stack-close base disagrees with what the ledger holds, and the blocks folded
                 // on top carry no diffs to reconcile it — so the anchor maps differ.
                 _ <- p.put(StoreKey.EvacuationMap(BlockNumber(1)))(EvacuationMap.empty)
+                // Derived: these cases seed EvacuationMap(1) so the STORED map is the fold base.
+                // A hard-coded None would restore the config's initial map instead, and the
+                // divergence these tests assert on would quietly stop being exercised.
+                emm <- Markers.recoverEvacuationMapMark(p.backend)
                 r <- JointLedger.State
-                    .recover(p, ledger, Some(BlockNumber(2)), config.initialEvacuationMap)
+                    .recover(p, ledger, Some(BlockNumber(2)), config.initialEvacuationMap, emm)
                     .attempt
             yield assert(
               r.swap.toOption.exists(_.isInstanceOf[RestoreError.EvacuationMapMismatch])
@@ -537,8 +559,12 @@ class RecoverSeamsTest extends AnyFunSuite:
                 _ <- p.put(JournalKey.Block(BlockNumber(2)))(JournalValue(stamp, brief))
                 _ <- p.put(StoreKey.DepositMap)(DepositsMap.empty)
                 // L2CommandNumber intentionally not written
+                // Derived: these cases seed EvacuationMap(1) so the STORED map is the fold base.
+                // A hard-coded None would restore the config's initial map instead, and the
+                // divergence these tests assert on would quietly stop being exercised.
+                emm <- Markers.recoverEvacuationMapMark(p.backend)
                 r <- JointLedger.State
-                    .recover(p, ledger, Some(BlockNumber(2)), config.initialEvacuationMap)
+                    .recover(p, ledger, Some(BlockNumber(2)), config.initialEvacuationMap, emm)
                     .attempt
             yield assert(r.swap.toOption.exists(_.isInstanceOf[IllegalStateException]))
         }
@@ -554,15 +580,18 @@ class RecoverSeamsTest extends AnyFunSuite:
                 )
                 _ <- p.put(StoreKey.UnsignedStack(StackNumber(1)))(us)
                 // Treasury intentionally not written
-                markers = Markers(
-                  None,
-                  None,
-                  Some(StackNumber(1)),
-                  Some(HardAckNumber(0)),
-                  RequestNumber(0)
-                )
+                // Derived, so the ack-value unpacking stays under test; only `hardConfirmed` is
+                // pinned, since no HardConfirmation is seeded here.
+                markers <- Markers
+                    .derive(p, PeerId.Head(own))
+                    .map(_.copy(hardConfirmed = Some(StackNumber(1))))
                 r <- StackComposer.State
-                    .recover(p, markers.hardAcked, markers.hardConfirmed, PeerId.Head(own))
+                    .recover(
+                      p,
+                      markers.hardAcked,
+                      markers.hardConfirmed,
+                      markers.hardAckedStack
+                    )
                     .attempt
             yield assert(r.swap.toOption.exists(_.isInstanceOf[IllegalStateException]))
         }

--- a/src/test/scala/hydrozoa/multisig/persistence/recovery/ReplayCursorsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/persistence/recovery/ReplayCursorsTest.scala
@@ -68,7 +68,9 @@ class ReplayCursorsTest extends AnyFunSuite:
           hardConfirmed = Some(StackNumber(3)),
           hardAcked =
               Some(HardAckNumber(4)), // the counter — derive ignores it; acked stack is a param
-          nextRequestNumber = RequestNumber(0)
+          nextRequestNumber = RequestNumber(0),
+          evacuationMapMark = None,
+          hardAckedStack = None
         )
         val hw = Map(HeadPeerNumber(0) -> RequestNumber(7), HeadPeerNumber(1) -> RequestNumber(2))
         val cursors =
@@ -139,7 +141,9 @@ class ReplayCursorsTest extends AnyFunSuite:
           fastBlockMark = Some(BlockNumber(5)),
           hardConfirmed = None,
           hardAcked = Some(HardAckNumber(5)),
-          nextRequestNumber = RequestNumber(0)
+          nextRequestNumber = RequestNumber(0),
+          evacuationMapMark = None,
+          hardAckedStack = None
         )
         val cursors =
             ReplayCursors.derive(
@@ -164,7 +168,7 @@ class ReplayCursorsTest extends AnyFunSuite:
     }
 
     test("derive: empty store (all None, no acked stack) yields index-0 floors everywhere") {
-        val markers = Markers(None, None, None, None, RequestNumber(0))
+        val markers = Markers(None, None, None, None, RequestNumber(0), None, None)
         val cursors = ReplayCursors.derive(
           markers,
           peers,
@@ -188,7 +192,7 @@ class ReplayCursorsTest extends AnyFunSuite:
     test("scanFloors enumerates exactly 2 + 3N journals (no hubs; spines collapse to confirmed)") {
         val cursors =
             ReplayCursors.derive(
-              Markers(None, None, None, None, RequestNumber(0)),
+              Markers(None, None, None, None, RequestNumber(0), None, None),
               peers,
               Nil,
               Map.empty,
@@ -205,7 +209,7 @@ class ReplayCursorsTest extends AnyFunSuite:
         val hubs = List(HeadPeerNumber(0), HeadPeerNumber(1))
         val cursors =
             ReplayCursors.derive(
-              Markers(None, None, None, None, RequestNumber(0)),
+              Markers(None, None, None, None, RequestNumber(0), None, None),
               peers,
               hubs,
               Map.empty,
@@ -227,7 +231,7 @@ class ReplayCursorsTest extends AnyFunSuite:
         val own = PeerId.Coil(CoilPeerNumber(0))
         val cursors =
             ReplayCursors.derive(
-              Markers(None, None, None, None, RequestNumber(0)),
+              Markers(None, None, None, None, RequestNumber(0), None, None),
               peers,
               hubs,
               Map.empty,


### PR DESCRIPTION
> [!WARNING]
> **DO NOT MERGE UNTIL AFTER THE COMPETITION.** Stacked on #690, which moves
> `rateLimits` out of every peer's private config. Merge order is #690 first.

Slice 2 of the `headParamsHash` work. Implements the digest and tests it;
**nothing consumes it yet** — no datum field, no check, no behaviour change.

Stacked on `ilia/head-params-hash` (#690). Review only the second commit.

## What it computes

`HeadParamsHash` writes the preimage out byte by byte — domain tag
`gummiworm-head-params-v1`, fixed-width scalars big-endian, length framing on
everything variable-width — following `EvacuationMap.digest`'s idiom. It does not
go through a JSON or CBOR encoder on purpose: `QuantizedFiniteDuration`, `Coin`
and `PositiveInt` each have their own codec quirks, and a codec tweak that
silently moved this value once it is in a treasury datum would leave a live head
unable to parse its own initialization transaction.

Layout and rationale are in `design/head-params-hash.md`, added in #690.

## Where it lives

On `HeadConfig.Section`, as a `lazy val` on the case class that the trait
delegates to. The old stub sat on `HeadParameters.Section`, which is too narrow:
the digest also covers the per-peer equity split, block-zero timing, the coil hub
topology, and the script references.

`InitializationTx.Parse` will **not** compute it when the check lands — its
`Config` is a deliberately minimal five-section intersection, and widening it to
the whole config would work against the rule of least knowledge. The plan is to
pass the already-computed 32 bytes in alongside `blockCreationEndTime`.

## Testing

`HeadParamsHashTest` mutates each covered field one at a time and asserts the
digest moves — a field that silently falls out of the preimage is invisible in
production, because every peer just agrees on a hash that fails to constrain the
thing that differs. 16 properties, 100 cases each:

- determinism;
- one property per covered `HeadParameters` field (`txTiming` via a whole-section
  swap, since its constructor is private);
- `initialEquityContributions`;
- and the inverse for `webSocketAddress` — asserting the digest does **not** move,
  since folding an address in would make every peer relocation a head
  re-initialization.

`just fmt`, `just lint`, `core/testOnly *` (381 tests, 0 failures),
`integration/Test/compile` and `examples/Test/compile` green.

## Still to come

| slice | contents | blocked on |
|---|---|---|
| 3 | datum third field + init-tx and per-block checks | competition — changes `Data` arity, a running head cannot survive it |
| 4 | store identity stamp in `Cf.Meta` + `StoreVersion` bump to 3 | — |
| 5 | `L2Ledger.restoreTo` returns `(EvacuationMapHash, Hash32)` + the anchor check | paired sugar-rush PR |
