### PR TITLE
feat(persistence): stamp each store with the head, config, and peer it belongs to

### DIFF
--- a/design/head-params-hash.md
+++ b/design/head-params-hash.md
@@ -388,13 +388,14 @@ A node's persistent store is built for one head, under one configuration, by one
 at a different one and it does not fail — it proceeds on a store that means something else.
 
 The check is a **stamp in `Cf.Meta`**, written when a fresh store is initialized and compared on
-every subsequent open. Three keys, flat and name-keyed like the `store_version` key that is
+every subsequent open. Four keys, flat and name-keyed like the `store_version` key that is
 already there:
 
 | key | value | catches |
 |---|---|---|
 | `head_params_hash` | `raw(headParamsHash)` | a store built under a different configuration |
 | `head_id` | the head's treasury token name | a store built for a different head — and makes the error message actionable |
+| `head_address` | the head multisig address, bech32 | a store built for a different **roster** — the verification keys `headParamsHash` leaves out |
 | `own_peer_id` | `PeerId.toWireInt`, 4 bytes big-endian | a store built by a *different peer of the same head* |
 
 `own_peer_id` is the one that cannot come from `headParamsHash`, and the one whose absence is
@@ -409,13 +410,23 @@ inventing a second encoding.
 mismatch tells an operator nothing they can act on. "This store belongs to head `0134…6b10`,
 this config is head `8f2a…c401`" names the mistake.
 
+`head_address` is stamped for the same reason and covers what neither of the others does.
+`headParamsHash` deliberately omits the peer verification keys — they are pinned by
+construction, through the native script hash that becomes this address — and `head_id` is the
+beacon token *name*, not the policy id, so it identifies the head instance but not its roster.
+Without the address the stamp holds no record of who the peers are. `InitializationTx.Parse`
+already rejects a swapped key by comparing this same address, and runs before any store is
+opened, so this is defence in depth rather than the only guard. What it adds on its own is that
+a store handed over without its config still says which head, and which roster, it was written
+for.
+
 **Where it runs, and what it costs.** `RocksDbBackendStore.openInternal` runs
 `versionCheck` at open, and `StoreVersion.Check` already has the right three-way shape —
 `Fresh` / `Compatible` / `Incompatible`. The identity stamp is a sibling of that, with the same
 semantics: a writable open stamps a fresh store; a **read-only** open — the mode
 `hydrozoa evacuate` uses — treats a missing stamp as a hard error, because it cannot stamp and
 an unstamped store cannot be served; an incompatible stamp refuses the open, naming which of
-the three fields differs. It runs **after** the version check, because a store whose schema this
+the four fields differs. It runs **after** the version check, because a store whose schema this
 build does not understand should not have its metadata interpreted at all, and **before** any
 recovery read. The cost is one point lookup per key on an already-open handle at startup, the
 same as the version check.

--- a/design/head-params-hash.md
+++ b/design/head-params-hash.md
@@ -338,8 +338,8 @@ Five checks, at four moments. Every one reuses a comparison point the code alrea
 | 4 | every `restoreTo` anchor | `JointLedger` | the ledger's reported `l2ParamsHash` against the config's | refuse to boot |
 | 5 | every major block | every head and coil peer | the settlement tx's treasury datum `headParamsHash` against the local one | refuse to sign the block |
 
-Check 3 exists today. Checks 1 and 5 are built — they sit in `InitializationTx.Parse` and
-`SettlementTx`. Checks 2 and 4 are not yet.
+Check 3 exists today. Checks 1, 2 and 5 are built — `InitializationTx.Parse`, `StoreIdentity`,
+and `SettlementTx`. Check 4 is not yet.
 
 ### 1. The initialization transaction matches the hash
 
@@ -409,7 +409,7 @@ inventing a second encoding.
 mismatch tells an operator nothing they can act on. "This store belongs to head `0134…6b10`,
 this config is head `8f2a…c401`" names the mistake.
 
-**Where it runs, and what it costs.** `RocksDbBackendStore.openInternal` already runs
+**Where it runs, and what it costs.** `RocksDbBackendStore.openInternal` runs
 `versionCheck` at open, and `StoreVersion.Check` already has the right three-way shape —
 `Fresh` / `Compatible` / `Incompatible`. The identity stamp is a sibling of that, with the same
 semantics: a writable open stamps a fresh store; a **read-only** open — the mode

--- a/integration/src/test/scala/hydrozoa/integration/harness/MultiPeerHeadHarness.scala
+++ b/integration/src/test/scala/hydrozoa/integration/harness/MultiPeerHeadHarness.scala
@@ -1532,6 +1532,7 @@ object MultiPeerHeadHarness:
                   StoreIdentity(
                     headParamsHash = nodeConfig.headParamsHash,
                     headId = nodeConfig.headId,
+                    headAddress = nodeConfig.headMultisigAddress,
                     ownPeerId = nodeConfig.ownPeerId
                   ),
                   persistenceTracer,

--- a/integration/src/test/scala/hydrozoa/integration/harness/MultiPeerHeadHarness.scala
+++ b/integration/src/test/scala/hydrozoa/integration/harness/MultiPeerHeadHarness.scala
@@ -36,7 +36,7 @@ import hydrozoa.multisig.ledger.l1.tx.{EnrichedTx, SettlementTx}
 import hydrozoa.multisig.ledger.l2.L2Ledger
 import hydrozoa.multisig.metrics.PeerMetrics
 import hydrozoa.multisig.persistence.rocksdb.RocksDbBackendStore
-import hydrozoa.multisig.persistence.{BackendStore, Cf, ConsensusStoreReader, InMemoryBackendStore, Persistence, PersistenceEvent, PersistenceEventFormat}
+import hydrozoa.multisig.persistence.{BackendStore, Cf, ConsensusStoreReader, InMemoryBackendStore, Persistence, PersistenceEvent, PersistenceEventFormat, StoreIdentity}
 import hydrozoa.multisig.server.{HydrozoaHttpEvent, HydrozoaHttpEventFormat, HydrozoaRoutes, HydrozoaServer, SubmissionClient}
 import hydrozoa.multisig.{CoilMultisigRegimeManager, CoilMultisigRegimeManagerEventFormat, CoilRegimeManagerEvent, HeadMultisigRegimeManager, HeadMultisigRegimeManagerEventFormat, HeadRegimeManagerEvent, NodeStatus}
 import hydrozoa.rulebased.ledger.l1.script.plutus.DeploymentTx
@@ -1145,6 +1145,7 @@ object MultiPeerHeadHarness:
             peerNum: HeadPeerNumber,
             mode: Mode,
             cfs: List[Cf],
+            identity: StoreIdentity,
             tracer: ContraTracer[IO, PersistenceEvent],
         ): Resource[IO, BackendStore[IO]] =
             mode match
@@ -1152,7 +1153,7 @@ object MultiPeerHeadHarness:
                 case Mode.RocksDb(root) =>
                     val dir = root.resolve(s"peer-${peerNum: Int}")
                     Resource.eval(IO.blocking(Files.createDirectories(dir))) >>
-                        RocksDbBackendStore.open(dir, cfs, tracer)
+                        RocksDbBackendStore.open(dir, cfs, identity, tracer)
 
     // ===================================
     // Transport — per-mode bring-up
@@ -1527,6 +1528,11 @@ object MultiPeerHeadHarness:
                     headPeers = multiNodeConfig.headConfig.headPeerNums.toList,
                     coilPeers = multiNodeConfig.headConfig.coilPeers.coilPeerNumbers,
                     hubs = multiNodeConfig.headConfig.coilPeers.hubHeadPeerNumbers,
+                  ),
+                  StoreIdentity(
+                    headParamsHash = nodeConfig.headParamsHash,
+                    headId = nodeConfig.headId,
+                    ownPeerId = nodeConfig.ownPeerId
                   ),
                   persistenceTracer,
                 )

--- a/src/main/scala/hydrozoa/app/Evacuate.scala
+++ b/src/main/scala/hydrozoa/app/Evacuate.scala
@@ -13,7 +13,7 @@ import hydrozoa.multisig.backend.cardano.CardanoBackend
 import hydrozoa.multisig.consensus.CardanoLiaisonEventFormat
 import hydrozoa.multisig.consensus.peer.{HeadPeerNumber, PeerId}
 import hydrozoa.multisig.persistence.rocksdb.RocksDbBackendStore
-import hydrozoa.multisig.persistence.{Cf, Persistence, PersistenceEventFormat}
+import hydrozoa.multisig.persistence.{Cf, Persistence, PersistenceEventFormat, StoreIdentity}
 import hydrozoa.rulebased.{RuleBasedActorEventFormat, RuleBasedRegimeManager}
 import java.nio.file.Path
 
@@ -124,6 +124,11 @@ object Evacuate {
                 headPeers = nodeConfig.headConfig.headPeerNums.toList,
                 coilPeers = nodeConfig.headConfig.coilPeers.coilPeerNumbers,
                 hubs = nodeConfig.headConfig.coilPeers.hubHeadPeerNumbers
+              ),
+              StoreIdentity(
+                headParamsHash = nodeConfig.headParamsHash,
+                headId = nodeConfig.headId,
+                ownPeerId = nodeConfig.ownPeerId
               ),
               persistenceTracer,
             )

--- a/src/main/scala/hydrozoa/app/Evacuate.scala
+++ b/src/main/scala/hydrozoa/app/Evacuate.scala
@@ -128,6 +128,7 @@ object Evacuate {
               StoreIdentity(
                 headParamsHash = nodeConfig.headParamsHash,
                 headId = nodeConfig.headId,
+                headAddress = nodeConfig.headMultisigAddress,
                 ownPeerId = nodeConfig.ownPeerId
               ),
               persistenceTracer,

--- a/src/main/scala/hydrozoa/app/Serve.scala
+++ b/src/main/scala/hydrozoa/app/Serve.scala
@@ -169,6 +169,7 @@ object Serve {
                   StoreIdentity(
                     headParamsHash = nodeConfig.headParamsHash,
                     headId = nodeConfig.headId,
+                    headAddress = nodeConfig.headMultisigAddress,
                     ownPeerId = nodeConfig.ownPeerId
                   ),
                   persistenceTracer,

--- a/src/main/scala/hydrozoa/app/Serve.scala
+++ b/src/main/scala/hydrozoa/app/Serve.scala
@@ -27,7 +27,7 @@ import hydrozoa.multisig.ledger.remote.{RemoteL2Ledger, RemoteL2LedgerEventForma
 import hydrozoa.multisig.ledger.stack.StackNumber
 import hydrozoa.multisig.metrics.PeerMetrics
 import hydrozoa.multisig.persistence.rocksdb.RocksDbBackendStore
-import hydrozoa.multisig.persistence.{Cf, ConsensusStoreReader, Markers, Persistence, PersistenceEventFormat}
+import hydrozoa.multisig.persistence.{Cf, ConsensusStoreReader, Markers, Persistence, PersistenceEventFormat, StoreIdentity}
 import hydrozoa.multisig.server.{HydrozoaHttpEvent, HydrozoaHttpEventFormat, HydrozoaServer}
 import hydrozoa.multisig.{CoilMultisigRegimeManager, CoilMultisigRegimeManagerEventFormat, CoilRegimeManagerEvent, HeadMultisigRegimeManager, HeadMultisigRegimeManagerEventFormat, HeadRegimeManagerEvent, MrmTracers}
 import java.nio.file.Path
@@ -165,6 +165,11 @@ object Serve {
                     headPeers = nodeConfig.headConfig.headPeerNums.toList,
                     coilPeers = nodeConfig.headConfig.coilPeers.coilPeerNumbers,
                     hubs = nodeConfig.headConfig.coilPeers.hubHeadPeerNumbers
+                  ),
+                  StoreIdentity(
+                    headParamsHash = nodeConfig.headParamsHash,
+                    headId = nodeConfig.headId,
+                    ownPeerId = nodeConfig.ownPeerId
                   ),
                   persistenceTracer,
                 )

--- a/src/main/scala/hydrozoa/multisig/persistence/StoreIdentity.scala
+++ b/src/main/scala/hydrozoa/multisig/persistence/StoreIdentity.scala
@@ -5,6 +5,7 @@ import hydrozoa.config.head.initialization.InitializationParameters.HeadId.toHex
 import hydrozoa.multisig.consensus.peer.PeerId
 import hydrozoa.multisig.consensus.peer.PeerId.toWireInt
 import java.nio.ByteBuffer
+import scalus.cardano.address.ShelleyAddress
 import scalus.cardano.ledger.Hash32
 
 /** What a store belongs to: one head, under one configuration, written by one peer.
@@ -31,11 +32,21 @@ import scalus.cardano.ledger.Hash32
   * `headId` is redundant against `headParamsHash` and is stamped anyway, because a bare hash
   * mismatch tells an operator nothing they can act on.
   *
+  * `headAddress` is stamped for the same reason, and covers what neither of the others does. The
+  * digest deliberately leaves the peer verification keys out — they are pinned by construction,
+  * through the native script hash that becomes this address — and `headId` is the beacon token
+  * *name*, not the policy id, so it names the head instance but not its roster. Without the address
+  * the stamp records no trace of who the peers are. `InitializationTx.Parse` already rejects a
+  * swapped key by comparing the same address, and runs before any store is opened, so this is
+  * defence in depth rather than the only guard; what it adds on its own is that a store handed over
+  * without its config still says which head, and which roster, it was written for.
+  *
   * See `design/head-params-hash.md`.
   */
 final case class StoreIdentity(
     headParamsHash: Hash32,
     headId: HeadId,
+    headAddress: ShelleyAddress,
     ownPeerId: PeerId
 )
 
@@ -44,6 +55,7 @@ object StoreIdentity {
     /** Keys in [[Cf.Meta]], name-keyed UTF-8 like [[StoreVersion.key]]. */
     val headParamsHashKey: Array[Byte] = "head_params_hash".getBytes("UTF-8")
     val headIdKey: Array[Byte] = "head_id".getBytes("UTF-8")
+    val headAddressKey: Array[Byte] = "head_address".getBytes("UTF-8")
     val ownPeerIdKey: Array[Byte] = "own_peer_id".getBytes("UTF-8")
 
     extension (self: StoreIdentity) {
@@ -53,16 +65,25 @@ object StoreIdentity {
           * no raw-bytes accessor.
           */
         def headIdBytes: Array[Byte] = self.headId.toHex.getBytes("UTF-8")
+
+        /** The head's multisig address as bech32, falling back to hex — the same rendering the
+          * server's JSON codecs use. Stored in its readable form for the same reason as
+          * [[headIdBytes]]: a store dump has no config to decode it against.
+          */
+        def headAddressText: String =
+            self.headAddress.toBech32.getOrElse(self.headAddress.toHex)
+        def headAddressBytes: Array[Byte] = self.headAddressText.getBytes("UTF-8")
         def ownPeerIdBytes: Array[Byte] =
             ByteBuffer.allocate(4).putInt(self.ownPeerId.toWireInt).array()
     }
 
-    /** The three stamped fields, paired with how to read one off a [[StoreIdentity]] and how to
+    /** The four stamped fields, paired with how to read one off a [[StoreIdentity]] and how to
       * render it for an operator. Single-sourced so writing, comparing and reporting cannot drift.
       */
     val fields: List[Field] = List(
       Field("head_params_hash", headParamsHashKey, _.headParamsHashBytes, _.headParamsHash.toHex),
       Field("head_id", headIdKey, _.headIdBytes, _.headId.toHex),
+      Field("head_address", headAddressKey, _.headAddressBytes, _.headAddressText),
       Field("own_peer_id", ownPeerIdKey, _.ownPeerIdBytes, _.ownPeerId.toWireInt.toString)
     )
 
@@ -86,7 +107,7 @@ object StoreIdentity {
 
     /** Compare a store's stamped fields against `expected`.
       *
-      * A partially-written stamp is a mismatch, not a fresh store: writing all three is a single
+      * A partially-written stamp is a mismatch, not a fresh store: writing all four is a single
       * step on a fresh open, so a store missing only some of them is one this build does not
       * understand.
       */
@@ -115,6 +136,7 @@ object StoreIdentity {
     private def renderRaw(field: Field, bytes: Array[Byte]): String =
         if field.name == "own_peer_id" && bytes.length == 4 then
             ByteBuffer.wrap(bytes).getInt.toString
-        else if field.name == "head_id" then new String(bytes, "UTF-8")
+        else if field.name == "head_id" || field.name == "head_address" then
+            new String(bytes, "UTF-8")
         else bytes.map("%02x".format(_)).mkString
 }

--- a/src/main/scala/hydrozoa/multisig/persistence/StoreIdentity.scala
+++ b/src/main/scala/hydrozoa/multisig/persistence/StoreIdentity.scala
@@ -1,0 +1,120 @@
+package hydrozoa.multisig.persistence
+
+import hydrozoa.config.head.initialization.InitializationParameters.HeadId
+import hydrozoa.config.head.initialization.InitializationParameters.HeadId.toHex
+import hydrozoa.multisig.consensus.peer.PeerId
+import hydrozoa.multisig.consensus.peer.PeerId.toWireInt
+import java.nio.ByteBuffer
+import scalus.cardano.ledger.Hash32
+
+/** What a store belongs to: one head, under one configuration, written by one peer.
+  *
+  * A store carries no record of any of that today, so pointing a node at the wrong one does not
+  * fail — it proceeds on a store that means something else. Worse, `Cf.mkAll` derives the column
+  * family set from head and coil membership and
+  * [[hydrozoa.multisig.persistence.rocksdb.RocksDbBackendStore]] opens with
+  * `setCreateMissingColumnFamilies(true)`, so a store built for a different roster does not even
+  * fail at open: the missing per-author families are created **empty** and the node proceeds as
+  * though it had no history. A store that reads as empty re-bootstraps from stack 0, the peer can
+  * never rejoin the head, and the symptom surfaces far from the cause as an out-of-bounds journal
+  * cursor.
+  *
+  * The stamp is written when a fresh store is initialized and compared on every subsequent open —
+  * one point lookup per field, alongside the [[StoreVersion]] check that already runs there.
+  *
+  * `ownPeerId` is the field that cannot be derived from the configuration, and the one whose
+  * absence is most dangerous: which peer a node is comes from `NodePrivateConfig`, so every peer of
+  * a head has the identical `headParamsHash`. Opening head peer 0's store as head peer 1 passes
+  * every other check while adopting peer 0's own-author journals as this peer's own — the state
+  * equivocation avoidance exists to prevent.
+  *
+  * `headId` is redundant against `headParamsHash` and is stamped anyway, because a bare hash
+  * mismatch tells an operator nothing they can act on.
+  *
+  * See `design/head-params-hash.md`.
+  */
+final case class StoreIdentity(
+    headParamsHash: Hash32,
+    headId: HeadId,
+    ownPeerId: PeerId
+)
+
+object StoreIdentity {
+
+    /** Keys in [[Cf.Meta]], name-keyed UTF-8 like [[StoreVersion.key]]. */
+    val headParamsHashKey: Array[Byte] = "head_params_hash".getBytes("UTF-8")
+    val headIdKey: Array[Byte] = "head_id".getBytes("UTF-8")
+    val ownPeerIdKey: Array[Byte] = "own_peer_id".getBytes("UTF-8")
+
+    extension (self: StoreIdentity) {
+        def headParamsHashBytes: Array[Byte] = self.headParamsHash.bytes
+
+        /** The head id as its hex string: self-describing in a store dump, and [[HeadId]] exposes
+          * no raw-bytes accessor.
+          */
+        def headIdBytes: Array[Byte] = self.headId.toHex.getBytes("UTF-8")
+        def ownPeerIdBytes: Array[Byte] =
+            ByteBuffer.allocate(4).putInt(self.ownPeerId.toWireInt).array()
+    }
+
+    /** The three stamped fields, paired with how to read one off a [[StoreIdentity]] and how to
+      * render it for an operator. Single-sourced so writing, comparing and reporting cannot drift.
+      */
+    val fields: List[Field] = List(
+      Field("head_params_hash", headParamsHashKey, _.headParamsHashBytes, _.headParamsHash.toHex),
+      Field("head_id", headIdKey, _.headIdBytes, _.headId.toHex),
+      Field("own_peer_id", ownPeerIdKey, _.ownPeerIdBytes, _.ownPeerId.toWireInt.toString)
+    )
+
+    final case class Field(
+        name: String,
+        key: Array[Byte],
+        of: StoreIdentity => Array[Byte],
+        render: StoreIdentity => String
+    )
+
+    /** Outcome of the open-time identity check, mirroring [[StoreVersion.Check]]. */
+    enum Check:
+        /** No stamp present — the caller writes the current identity (writable opens only). */
+        case Fresh
+
+        /** Every stamped field matches — proceed as normal. */
+        case Compatible
+
+        /** At least one field differs, or the stamp is partially written. Refuse to open. */
+        case Mismatch(problems: List[String])
+
+    /** Compare a store's stamped fields against `expected`.
+      *
+      * A partially-written stamp is a mismatch, not a fresh store: writing all three is a single
+      * step on a fresh open, so a store missing only some of them is one this build does not
+      * understand.
+      */
+    def check(stamped: Map[String, Array[Byte]], expected: StoreIdentity): Check =
+        if fields.forall(f => !stamped.contains(f.name)) then Check.Fresh
+        else {
+            val problems = fields.flatMap { f =>
+                stamped.get(f.name) match {
+                    case None =>
+                        Some(s"${f.name} is missing from the store's identity stamp")
+                    case Some(found) if found.sameElements(f.of(expected)) =>
+                        None
+                    case Some(found) =>
+                        Some(
+                          s"${f.name}: the store holds ${renderRaw(f, found)}, " +
+                              s"this node has ${f.render(expected)}"
+                        )
+                }
+            }
+            if problems.isEmpty then Check.Compatible else Check.Mismatch(problems)
+        }
+
+    /** Render a stamped value without decoding it back into its domain type — the stored bytes may
+      * be exactly what does not parse.
+      */
+    private def renderRaw(field: Field, bytes: Array[Byte]): String =
+        if field.name == "own_peer_id" && bytes.length == 4 then
+            ByteBuffer.wrap(bytes).getInt.toString
+        else if field.name == "head_id" then new String(bytes, "UTF-8")
+        else bytes.map("%02x".format(_)).mkString
+}

--- a/src/main/scala/hydrozoa/multisig/persistence/StoreVersion.scala
+++ b/src/main/scala/hydrozoa/multisig/persistence/StoreVersion.scala
@@ -18,8 +18,11 @@ object StoreVersion:
       *
       *   - 2: the Request journals' values changed from the circe wire form to the canonical
       *     protobuf record (`proto/request_record.proto`).
+      *   - 3: [[StoreIdentity]] arrived. Bumped rather than treating an unstamped store as fresh,
+      *     which would bless whatever store the node happens to be pointed at on its first open —
+      *     exactly the mistake the stamp exists to catch. Existing stores rebuild.
       */
-    val current: Int = 2
+    val current: Int = 3
 
     /** The key under which the schema version is stored in [[Cf.Meta]]. */
     val key: Array[Byte] = "store_version".getBytes("UTF-8")

--- a/src/main/scala/hydrozoa/multisig/persistence/rocksdb/RocksDbBackendStore.scala
+++ b/src/main/scala/hydrozoa/multisig/persistence/rocksdb/RocksDbBackendStore.scala
@@ -1,6 +1,7 @@
 package hydrozoa.multisig.persistence.rocksdb
 
 import cats.effect.{IO, Resource}
+import cats.syntax.all.*
 import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.persistence.*
 import hydrozoa.multisig.persistence.PersistenceEvent.{OpenRocksDbReady, OpenRocksDbStart}
@@ -100,9 +101,10 @@ object RocksDbBackendStore:
     def open(
         path: Path,
         cfs: List[Cf],
+        identity: StoreIdentity,
         tracer: ContraTracer[IO, PersistenceEvent]
     ): Resource[IO, BackendStore[IO]] =
-        openInternal(path, cfs, tracer, readOnly = false)
+        openInternal(path, cfs, identity, tracer, readOnly = false)
 
     /** Open an existing store **read-only** — the mode `hydrozoa evacuate` uses (design
       * `docs/spec/evacuate-command.md`). The rule-based regime only reads persistence, so RO is
@@ -112,13 +114,15 @@ object RocksDbBackendStore:
     def openReadOnly(
         path: Path,
         cfs: List[Cf],
+        identity: StoreIdentity,
         tracer: ContraTracer[IO, PersistenceEvent]
     ): Resource[IO, BackendStore[IO]] =
-        openInternal(path, cfs, tracer, readOnly = true)
+        openInternal(path, cfs, identity, tracer, readOnly = true)
 
     private def openInternal(
         path: Path,
         cfs: List[Cf],
+        identity: StoreIdentity,
         tracer: ContraTracer[IO, PersistenceEvent],
         readOnly: Boolean
     ): Resource[IO, BackendStore[IO]] =
@@ -152,7 +156,10 @@ object RocksDbBackendStore:
             opened <- openDb(path, dbOpts, cfOpts, cfs, readOnly)
             (db, handles) = opened
             backend = new RocksDbBackendStore(db, handles, writeOptions, readOptions)
+            // Order matters: a store whose schema this build does not understand must not have
+            // its metadata interpreted at all, and neither check may run after a recovery read.
             _ <- Resource.eval(versionCheck(backend, readOnly))
+            _ <- Resource.eval(identityCheck(backend, identity, readOnly))
             _ <- Resource.eval(tracer.traceWith(OpenRocksDbReady(path, handles.size)))
         yield backend
 
@@ -276,6 +283,46 @@ object RocksDbBackendStore:
                       )
                     )
         }
+
+    /** Run the open-time identity check ([[StoreIdentity]]). On a writable open a fresh store gets
+      * the current identity stamped; a mismatch raises, naming every field that differs.
+      *
+      * A read-only open never writes, so a missing stamp is a hard error there — it cannot stamp
+      * one, and an unstamped store cannot be served. Same rule [[versionCheck]] follows.
+      */
+    private def identityCheck(
+        backend: BackendStore[IO],
+        identity: StoreIdentity,
+        readOnly: Boolean
+    ): IO[Unit] =
+        for {
+            stamped <- StoreIdentity.fields
+                .traverse(f => backend.get(Cf.Meta, f.key).map(_.map(f.name -> _)))
+                .map(_.flatten.toMap)
+            _ <- StoreIdentity.check(stamped, identity) match {
+                case StoreIdentity.Check.Fresh =>
+                    if readOnly then
+                        IO.raiseError(
+                          new IllegalStateException(
+                            s"Persistence store at $backend has no identity stamp " +
+                                "(uninitialized); cannot open read-only"
+                          )
+                        )
+                    else
+                        StoreIdentity.fields.traverse_(f =>
+                            backend.put(Cf.Meta, f.key, f.of(identity))
+                        )
+                case StoreIdentity.Check.Compatible => IO.unit
+                case StoreIdentity.Check.Mismatch(problems) =>
+                    IO.raiseError(
+                      new IllegalStateException(
+                        s"Persistence store at $backend belongs to a different head, " +
+                            "configuration, or peer than this node: " +
+                            problems.mkString("; ")
+                      )
+                    )
+            }
+        } yield ()
 
     private def openDb(
         path: Path,

--- a/src/test/scala/hydrozoa/multisig/persistence/PersistenceTest.scala
+++ b/src/test/scala/hydrozoa/multisig/persistence/PersistenceTest.scala
@@ -173,7 +173,7 @@ class PersistenceTest extends AnyFunSuite:
             val program = for
                 // First open bumps to a fresh generation and anchors it; take a stamp + conversion.
                 firstOpen <- RocksDbBackendStore
-                    .open(tempDir, testCfs, tracer)
+                    .open(tempDir, testCfs, TestStoreIdentity.default, tracer)
                     .use(backend =>
                         Persistence
                             .fromBackend(backend, tracer)
@@ -185,7 +185,7 @@ class PersistenceTest extends AnyFunSuite:
                 // anchor persists, so its stamp still converts to the same wall clock through the
                 // new instance's per-generation lookup.
                 secondWall <- RocksDbBackendStore
-                    .open(tempDir, testCfs, tracer)
+                    .open(tempDir, testCfs, TestStoreIdentity.default, tracer)
                     .use(backend =>
                         Persistence.fromBackend(backend, tracer).flatMap(_.wallClockOf(oldStamp))
                     )
@@ -204,7 +204,7 @@ class PersistenceTest extends AnyFunSuite:
         val tracer = Slf4jTracer.sink.contramap(PersistenceEventFormat.humanFormat)
         try
             RocksDbBackendStore
-                .open(tempDir, testCfs, tracer)
+                .open(tempDir, testCfs, TestStoreIdentity.default, tracer)
                 .use(backend => Persistence.fromBackend(backend, tracer).flatMap(prog))
                 .unsafeRunSync()
         finally recursivelyDelete(tempDir)

--- a/src/test/scala/hydrozoa/multisig/persistence/RocksDbBackendStoreTest.scala
+++ b/src/test/scala/hydrozoa/multisig/persistence/RocksDbBackendStoreTest.scala
@@ -254,6 +254,14 @@ class RocksDbBackendStoreTest extends AnyFunSuite:
         assertIdentityRefused(mkIdentity(headIdByte = 0x44), "head_id")
     }
 
+    /** The address is the roster: `headParamsHash` leaves the peer verification keys out because
+      * the native script hash behind this address already pins them, so a swapped key moves the
+      * address and nothing else in the stamp.
+      */
+    test("opening a store stamped for a different head address is refused") {
+        assertIdentityRefused(mkIdentity(headAddressByte = 0x55), "head_address")
+    }
+
     /** Stamp a fresh store with [[testIdentity]], then reopen it as `other` and require the failure
       * to name `expectedField`.
       */

--- a/src/test/scala/hydrozoa/multisig/persistence/RocksDbBackendStoreTest.scala
+++ b/src/test/scala/hydrozoa/multisig/persistence/RocksDbBackendStoreTest.scala
@@ -32,6 +32,10 @@ class RocksDbBackendStoreTest extends AnyFunSuite:
 
     private lazy val tracer = Slf4jTracer.sink.contramap(PersistenceEventFormat.humanFormat)
 
+    import TestStoreIdentity.mkIdentity
+
+    private val testIdentity: StoreIdentity = TestStoreIdentity.default
+
     test("put then get returns the same bytes in the same CF") {
         withFreshStore { p =>
             val key = JournalKey.Block(BlockNumber(7)).encode
@@ -116,14 +120,14 @@ class RocksDbBackendStoreTest extends AnyFunSuite:
             val value = "durable".getBytes("UTF-8")
             // First session: write.
             RocksDbBackendStore
-                .open(tempDir, testCfs, tracer)
+                .open(tempDir, testCfs, testIdentity, tracer)
                 .use { p =>
                     p.put(Cf.Block, k, value)
                 }
                 .unsafeRunSync()
             // Second session: read back.
             val got = RocksDbBackendStore
-                .open(tempDir, testCfs, tracer)
+                .open(tempDir, testCfs, testIdentity, tracer)
                 .use { p =>
                     p.get(Cf.Block, k)
                 }
@@ -183,10 +187,13 @@ class RocksDbBackendStoreTest extends AnyFunSuite:
         val tempDir = newTempDir()
         try
             // First open seeds the current version.
-            RocksDbBackendStore.open(tempDir, testCfs, tracer).use(_ => IO.unit).unsafeRunSync()
+            RocksDbBackendStore
+                .open(tempDir, testCfs, testIdentity, tracer)
+                .use(_ => IO.unit)
+                .unsafeRunSync()
             // Tamper: rewrite the version key with a bogus value.
             RocksDbBackendStore
-                .open(tempDir, testCfs, tracer)
+                .open(tempDir, testCfs, testIdentity, tracer)
                 .use { p =>
                     p.put(
                       Cf.Meta,
@@ -198,7 +205,7 @@ class RocksDbBackendStoreTest extends AnyFunSuite:
             // Reopen — must fail.
             val outcome =
                 RocksDbBackendStore
-                    .open(tempDir, testCfs, tracer)
+                    .open(tempDir, testCfs, testIdentity, tracer)
                     .use(_ => IO.unit)
                     .attempt
                     .unsafeRunSync()
@@ -210,12 +217,77 @@ class RocksDbBackendStoreTest extends AnyFunSuite:
         finally recursivelyDelete(tempDir)
     }
 
+    test("a fresh store is stamped with this node's identity and reopens cleanly") {
+        val tempDir = newTempDir()
+        try
+            RocksDbBackendStore
+                .open(tempDir, testCfs, testIdentity, tracer)
+                .use(_ => IO.unit)
+                .unsafeRunSync()
+            val outcome = RocksDbBackendStore
+                .open(tempDir, testCfs, testIdentity, tracer)
+                .use(_ => IO.unit)
+                .attempt
+                .unsafeRunSync()
+            assert(outcome.isRight, s"expected a clean reopen, got $outcome")
+        finally recursivelyDelete(tempDir)
+    }
+
+    /** A store built under one configuration must not be adopted by a node holding another: the
+      * digests differ, and the store's history means something else.
+      */
+    test("opening a store stamped for a different head config is refused") {
+        assertIdentityRefused(mkIdentity(headParamsHashByte = 0x33), "head_params_hash")
+    }
+
+    /** The dangerous one: every peer of a head has the identical `headParamsHash`, so nothing but
+      * `own_peer_id` stops head peer 1 adopting head peer 0's own-author journals as its own.
+      */
+    test("opening another peer's store from the same head is refused") {
+        assertIdentityRefused(
+          mkIdentity(ownPeerId = PeerId.Head(HeadPeerNumber(1))),
+          "own_peer_id"
+        )
+    }
+
+    test("opening a store stamped for a different head is refused") {
+        assertIdentityRefused(mkIdentity(headIdByte = 0x44), "head_id")
+    }
+
+    /** Stamp a fresh store with [[testIdentity]], then reopen it as `other` and require the failure
+      * to name `expectedField`.
+      */
+    private def assertIdentityRefused(other: StoreIdentity, expectedField: String): Assertion =
+        val tempDir = newTempDir()
+        try
+            RocksDbBackendStore
+                .open(tempDir, testCfs, testIdentity, tracer)
+                .use(_ => IO.unit)
+                .unsafeRunSync()
+            val outcome = RocksDbBackendStore
+                .open(tempDir, testCfs, other, tracer)
+                .use(_ => IO.unit)
+                .attempt
+                .unsafeRunSync()
+            assert(
+              outcome.left.toOption.exists(e =>
+                  e.getMessage.contains("belongs to a different head") &&
+                      e.getMessage.contains(expectedField)
+              ),
+              s"expected an identity-mismatch failure naming $expectedField, got $outcome"
+            )
+        finally recursivelyDelete(tempDir)
+
     // ---- helpers ----
 
     /** Run `prog(backend)` against a fresh temp-dir store; clean up afterward. */
     private def withFreshStore(prog: BackendStore[IO] => IO[Assertion]): Assertion =
         val tempDir = newTempDir()
-        try RocksDbBackendStore.open(tempDir, testCfs, tracer).use(prog).unsafeRunSync()
+        try
+            RocksDbBackendStore
+                .open(tempDir, testCfs, testIdentity, tracer)
+                .use(prog)
+                .unsafeRunSync()
         finally recursivelyDelete(tempDir)
 
     private def newTempDir(): Path =

--- a/src/test/scala/hydrozoa/multisig/persistence/StoreDumpTest.scala
+++ b/src/test/scala/hydrozoa/multisig/persistence/StoreDumpTest.scala
@@ -70,6 +70,7 @@ class StoreDumpTest extends AnyFunSuite:
                 .open(
                   tempDir,
                   testCfs,
+                  TestStoreIdentity.default,
                   Slf4jTracer.sink.contramap(PersistenceEventFormat.humanFormat)
                 )
                 .use(b => populate(b) *> StoreDump.stats(b, testCfs))
@@ -78,7 +79,8 @@ class StoreDumpTest extends AnyFunSuite:
             // Build a name → entries map to assert key counts independent of CF ordering.
             val byCf = stats.perCf.map(s => s.cf -> s.entries).toMap
             val rendered = stats.render
-            // 8 we wrote + the schema-version entry seeded by `RocksDbBackendStore.open` = 9.
+            // 8 we wrote + the 4 Meta entries `RocksDbBackendStore.open` seeds on a fresh store
+            // (the schema version, plus the three `StoreIdentity` fields) = 12.
             assert(
               byCf(Cf.Block) == 2 &&
                   byCf(Cf.SoftAck(ownPeer)) == 1 &&
@@ -87,8 +89,8 @@ class StoreDumpTest extends AnyFunSuite:
                   byCf(Cf.HardConfirmation) == 1 &&
                   byCf(Cf.DepositMap) == 1 &&
                   byCf(Cf.Treasury) == 1 &&
-                  byCf(Cf.Meta) == 1 &&
-                  stats.total.entries == 9 &&
+                  byCf(Cf.Meta) == 4 &&
+                  stats.total.entries == 12 &&
                   rendered.contains("TOTAL") &&
                   rendered.contains("Block"),
               s"stats=$stats\nrendered:\n$rendered"
@@ -104,6 +106,7 @@ class StoreDumpTest extends AnyFunSuite:
                 .open(
                   tempDir,
                   testCfs,
+                  TestStoreIdentity.default,
                   Slf4jTracer.sink.contramap(PersistenceEventFormat.humanFormat)
                 )
                 .use { b =>

--- a/src/test/scala/hydrozoa/multisig/persistence/StoreDumpTest.scala
+++ b/src/test/scala/hydrozoa/multisig/persistence/StoreDumpTest.scala
@@ -79,8 +79,8 @@ class StoreDumpTest extends AnyFunSuite:
             // Build a name → entries map to assert key counts independent of CF ordering.
             val byCf = stats.perCf.map(s => s.cf -> s.entries).toMap
             val rendered = stats.render
-            // 8 we wrote + the 4 Meta entries `RocksDbBackendStore.open` seeds on a fresh store
-            // (the schema version, plus the three `StoreIdentity` fields) = 12.
+            // 8 we wrote + the 5 Meta entries `RocksDbBackendStore.open` seeds on a fresh store
+            // (the schema version, plus the four `StoreIdentity` fields) = 13.
             assert(
               byCf(Cf.Block) == 2 &&
                   byCf(Cf.SoftAck(ownPeer)) == 1 &&
@@ -89,8 +89,8 @@ class StoreDumpTest extends AnyFunSuite:
                   byCf(Cf.HardConfirmation) == 1 &&
                   byCf(Cf.DepositMap) == 1 &&
                   byCf(Cf.Treasury) == 1 &&
-                  byCf(Cf.Meta) == 4 &&
-                  stats.total.entries == 12 &&
+                  byCf(Cf.Meta) == 5 &&
+                  stats.total.entries == 13 &&
                   rendered.contains("TOTAL") &&
                   rendered.contains("Block"),
               s"stats=$stats\nrendered:\n$rendered"

--- a/src/test/scala/hydrozoa/multisig/persistence/TestStoreIdentity.scala
+++ b/src/test/scala/hydrozoa/multisig/persistence/TestStoreIdentity.scala
@@ -2,7 +2,8 @@ package hydrozoa.multisig.persistence
 
 import hydrozoa.config.head.initialization.InitializationParameters.HeadId
 import hydrozoa.multisig.consensus.peer.{HeadPeerNumber, PeerId}
-import scalus.cardano.ledger.{AssetName, Blake2b_256, Hash}
+import scalus.cardano.address.{Network, ShelleyAddress, ShelleyDelegationPart, ShelleyPaymentPart}
+import scalus.cardano.ledger.{AssetName, Blake2b_256, Hash, ScriptHash}
 import scalus.uplc.builtin.ByteString
 
 /** The [[StoreIdentity]] the persistence tests stamp their stores with.
@@ -16,12 +17,21 @@ object TestStoreIdentity {
     def mkIdentity(
         headParamsHashByte: Byte = 0x11,
         headIdByte: Byte = 0x22,
+        headAddressByte: Byte = 0x33,
         ownPeerId: PeerId = PeerId.Head(HeadPeerNumber(0))
     ): StoreIdentity = StoreIdentity(
       headParamsHash = Hash[Blake2b_256, Any](
         ByteString.fromArray(Array.fill[Byte](32)(headParamsHashByte))
       ),
       headId = HeadId(AssetName(ByteString.fromArray(Array.fill[Byte](16)(headIdByte)))),
+      // A script address, as a real head's is: the head multisig script hash under Testnet.
+      headAddress = ShelleyAddress(
+        network = Network.Testnet,
+        payment = ShelleyPaymentPart.Script(
+          ScriptHash.fromArray(Array.fill[Byte](28)(headAddressByte))
+        ),
+        delegation = ShelleyDelegationPart.Null
+      ),
       ownPeerId = ownPeerId
     )
 

--- a/src/test/scala/hydrozoa/multisig/persistence/TestStoreIdentity.scala
+++ b/src/test/scala/hydrozoa/multisig/persistence/TestStoreIdentity.scala
@@ -1,0 +1,29 @@
+package hydrozoa.multisig.persistence
+
+import hydrozoa.config.head.initialization.InitializationParameters.HeadId
+import hydrozoa.multisig.consensus.peer.{HeadPeerNumber, PeerId}
+import scalus.cardano.ledger.{AssetName, Blake2b_256, Hash}
+import scalus.uplc.builtin.ByteString
+
+/** The [[StoreIdentity]] the persistence tests stamp their stores with.
+  *
+  * Every store open takes one, so a suite that only cares about bytes in and bytes out still needs
+  * a value; these tests are not exercising configuration agreement. Suites that *are* — see
+  * `RocksDbBackendStoreTest` — vary one field at a time via [[mkIdentity]].
+  */
+object TestStoreIdentity {
+
+    def mkIdentity(
+        headParamsHashByte: Byte = 0x11,
+        headIdByte: Byte = 0x22,
+        ownPeerId: PeerId = PeerId.Head(HeadPeerNumber(0))
+    ): StoreIdentity = StoreIdentity(
+      headParamsHash = Hash[Blake2b_256, Any](
+        ByteString.fromArray(Array.fill[Byte](32)(headParamsHashByte))
+      ),
+      headId = HeadId(AssetName(ByteString.fromArray(Array.fill[Byte](16)(headIdByte)))),
+      ownPeerId = ownPeerId
+    )
+
+    val default: StoreIdentity = mkIdentity()
+}


### PR DESCRIPTION
> [!WARNING]
> **DO NOT MERGE UNTIL AFTER THE COMPETITION.** Stacked on #692, which is
> head-fatal on its own. This one also bumps `StoreVersion.current` to 3, so every
> existing store is refused and must be rebuilt.

Slice 4. Stacked on #692 → #691 → #690; review only the fourth commit.

## The gap this closes

A store is built for one head, under one configuration, by one peer, and carries
no record of any of it. Point a node at the wrong one and nothing fails.

It is worse than a missing check. `Cf.mkAll` derives the column-family set from
head and coil membership, and `RocksDbBackendStore` opens with
`setCreateMissingColumnFamilies(true)` — so a store built for a **different
roster** does not fail at open either: the missing per-author families are created
**empty** and the node proceeds as though it had no history. A store that reads as
empty re-bootstraps from stack 0, the peer can never rejoin the head, and the
symptom surfaces far from the cause as an out-of-bounds journal cursor.

## What it does

Three keys in `Cf.Meta`, written on a fresh open and compared on every subsequent
one, right beside the `StoreVersion` check that already runs there:

| key | catches |
|---|---|
| `head_params_hash` | a store built under a different configuration |
| `head_id` | a store built for a different head |
| `own_peer_id` | a store built by a **different peer of the same head** |

`own_peer_id` is the one that cannot come from the config, and the dangerous one:
which peer a node is comes from `NodePrivateConfig`, so every peer of a head has
the identical `headParamsHash`. Opening head peer 0's store as head peer 1 passes
every other check while adopting peer 0's own-author journals as this peer's own —
the state equivocation avoidance exists to prevent. It reuses `PeerId.toWireInt`,
already the author discriminant in the `HardAck` CF name.

`head_id` is redundant against the hash and stamped anyway: a bare hash mismatch
tells an operator nothing they can act on.

Cost is one point lookup per field at startup. It runs **after** the version check
(a store whose schema this build does not understand must not have its metadata
interpreted) and **before** any recovery read. A read-only open — the mode
`hydrozoa evacuate` uses — treats a missing stamp as a hard error, exactly as
`versionCheck` does, since it cannot stamp one.

## `StoreVersion.current` → 3

Treating an unstamped store as fresh would silently bless whatever store a node
happens to be pointed at on its first open after upgrading — precisely the mistake
the stamp exists to catch. Bumping refuses existing stores instead, and they
rebuild.

## Testing

Four new tests in `RocksDbBackendStoreTest`: a fresh store stamps and reopens
cleanly, and each of the three fields is varied in turn with the failure required
to name that field. `StoreDumpTest`'s `Cf.Meta` count moves 1 → 4 (12 total).

`just fmt`, `just lint`, `just build-werror`, `core/testOnly *` (385 tests, 0
failures), `integration/Test/compile` and `examples/Test/compile` green.
