### PR TITLE
Logging: scribe-vs-slf4j benchmarks + contra-tracer perf parity port

### DIFF
--- a/benchmark/src/main/scala/hydrozoa/benchmarks/LoggingBackendBench.scala
+++ b/benchmark/src/main/scala/hydrozoa/benchmarks/LoggingBackendBench.scala
@@ -1,0 +1,245 @@
+package hydrozoa.benchmarks
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import cats.syntax.all.*
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.classic.{Level as LbLevel, LoggerContext, PatternLayout}
+import ch.qos.logback.core.AppenderBase
+import hydrozoa.lib.logging.{ContraTracer, Level as HLevel, LogEvent, Slf4jTracer}
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
+import org.openjdk.jmh.annotations.*
+// Reaches logback's global context on purpose (raw-backend baseline + the ContraTracer sink path).
+import org.slf4j.{Logger as Slf4jLogger, LoggerFactory} // scalafix:ok DisableSyntax
+import scribe.cats.*
+import scribe.format.*
+import scribe.handler.AsynchronousLogHandle
+import scribe.output.LogOutput
+import scribe.output.format.OutputFormat
+import scribe.writer.Writer
+import scribe.{Level as SLevel, LogRecord, Logger as SLogger, Scribe}
+
+/** Backend microbenchmark: SLF4J/Logback vs scribe, plus the cost the `ContraTracer` sink adds over
+  * calling a backend directly. A real logging call from a cached logger through the framework's own
+  * level check and formatter to a **discarding, counting sink** — the same shape scribe uses in its
+  * own JMH suite (`PerformanceBenchmark`), so neither side pays disk I/O.
+  *
+  * Fairness / correctness (checked against scribe's repo):
+  *   - scribe loggers use scribe's **own recommended benchmark formatter**
+  *     `formatter"$$date $$levelPaddedRight [$$threadName] $$messages"` — not `Formatter.default`,
+  *     which adds source-position capture and unfairly inflates scribe. One variant keeps the
+  *     default so the formatter's cost is visible.
+  *   - Both writers materialize the formatted line (`output.plainText` / `layout.doLayout`) and sum
+  *     its length: scribe formats eagerly in the handler, logback formats in the appender, so
+  *     making both produce the final String is the apples-to-apples point. The counter defeats DCE.
+  *   - Loggers are cached once; level = INFO.
+  *
+  * Axes:
+  *   - `disabled*`: a TRACE call at an INFO threshold. Logback's arg is strict (naive builds the
+  *     string; `guarded` is the idiomatic `isTraceEnabled` fix). scribe's macro captures by-name,
+  *     so bare `trace` is already lazy; `guarded` uses `includes` to also skip the closure alloc.
+  *   - `enabled{Cheap,Expensive}`: constant vs interpolated message, both backends.
+  *   - `scribeAsync`: scribe's fire-and-forget `AsynchronousLogHandle` — its advertised "fastest"
+  *     path. NB: default maxBuffer=1000, drain loop flushes one record then `Thread.sleep(1)`
+  *     (~1000 rec/s ceiling) with `Overflow.DropOld`, so under JMH's call rate it SILENTLY DROPS;
+  *     this measures caller-side enqueue cost only, not delivery.
+  *   - `scribeCats`: the effectful `.f[IO]` path (what a scribe `ContraTracer` sink would use).
+  *   - `contra*`: `rawIO` (IO + unsafeRunSync, no tracer) → `contraEmit` (ContraTracer arrow + Eval
+  *     + LogEvent build, no backend) → `contraSink` (full `Slf4jTracer.sink` through
+  *     log4cats+logback). Deltas isolate what ContraTracer/Eval add and what the whole sink costs
+  *     over a bare slf4j call.
+  *
+  * Run: `sbt "benchmark/Jmh/run -prof gc -i 4 -wi 3 -f 1 -t 1 .*LoggingBackendBench.*"` Read
+  * `gc.alloc.rate.norm` (B/op) next to throughput (ops/s).
+  */
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 4, time = 1)
+@Fork(1)
+class LoggingBackendBench:
+
+    /** Discarding sink shared by every backend: format to a String, sum its length. */
+    private val sink = new AtomicLong(0)
+
+    // Per-invocation-varying payload so interpolated messages are not compile-time constants.
+    private var n: Long = 0L
+    private val payload = new Object:
+        override def toString: String = "payload#" + (n & 0xff)
+
+    private var slf4j: Slf4jLogger = scala.compiletime.uninitialized
+    private var scribeSync: SLogger = scala.compiletime.uninitialized
+    private var scribeMsgOnly: SLogger = scala.compiletime.uninitialized
+    private var scribeDefaultFmt: SLogger = scala.compiletime.uninitialized
+    private var scribeAsync: SLogger = scala.compiletime.uninitialized
+    private var scribeCats: Scribe[IO] = scala.compiletime.uninitialized
+
+    // scribe's own recommended benchmark formatter (no source-position capture).
+    private val leanFmt: Formatter = formatter"$date $levelPaddedRight [$threadName] $messages"
+
+    /** ContraTracer with no backend: forces the Eval render (as a real sink would) and counts. */
+    private val contraEmitSink: ContraTracer[IO, LogEvent] =
+        ContraTracer.emit((ev: LogEvent) =>
+            IO { val _ = sink.addAndGet(ev.render.value.msg.length.toLong) }
+        )
+
+    @Setup(Level.Trial)
+    def setup(): Unit =
+        configureLogback()
+        scribeSync = scribeLogger(leanFmt, None)
+        scribeMsgOnly = scribeLogger(formatter"$messages$newLine", None)
+        scribeDefaultFmt = scribeLogger(Formatter.default, None)
+        scribeAsync = scribeLogger(leanFmt, Some(AsynchronousLogHandle()))
+        scribeCats = scribeLogger(leanFmt, None).f[IO]
+
+    // --- Logback wiring -----------------------------------------------------
+
+    private class CountingLogbackAppender(layout: PatternLayout)
+        extends AppenderBase[ILoggingEvent]:
+        override def append(e: ILoggingEvent): Unit =
+            val _ = sink.addAndGet(layout.doLayout(e).length.toLong)
+
+    private def configureLogback(): Unit =
+        val ctx = LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext]
+        val layout = new PatternLayout()
+        layout.setContext(ctx)
+        layout.setPattern("%d{HH:mm:ss.SSS} %-5level %logger{20} - %msg%n")
+        layout.start()
+        val appender = new CountingLogbackAppender(layout)
+        appender.setContext(ctx)
+        appender.start()
+        val lg = ctx.getLogger("bench.slf4j")
+        lg.setAdditive(false)
+        lg.detachAndStopAllAppenders()
+        lg.addAppender(appender)
+        lg.setLevel(LbLevel.INFO)
+        slf4j = lg
+
+    // --- scribe wiring ------------------------------------------------------
+
+    private class CountingScribeWriter extends Writer:
+        def write(record: LogRecord, output: LogOutput, outputFormat: OutputFormat): Unit =
+            val _ = sink.addAndGet(output.plainText.length.toLong)
+
+    private def scribeLogger(fmt: Formatter, handle: Option[AsynchronousLogHandle]): SLogger =
+        val base = SLogger.empty.orphan()
+        handle.fold(
+          base.withHandler(
+            formatter = fmt,
+            writer = new CountingScribeWriter,
+            minimumLevel = Some(SLevel.Info)
+          )
+        )(h =>
+            base.withHandler(
+              formatter = fmt,
+              writer = new CountingScribeWriter,
+              minimumLevel = Some(SLevel.Info),
+              handle = h
+            )
+        )
+
+    // --- Disabled level (TRACE call, INFO threshold) ------------------------
+
+    @Benchmark def slf4j_disabled_naive(): Unit =
+        n += 1
+        slf4j.trace(s"disabled n=$n obj=$payload")
+
+    @Benchmark def slf4j_disabled_guarded(): Unit =
+        n += 1
+        if slf4j.isTraceEnabled then slf4j.trace(s"disabled n=$n obj=$payload")
+
+    @Benchmark def scribe_disabled_macro(): Unit =
+        n += 1
+        scribeSync.trace(s"disabled n=$n obj=$payload")
+
+    @Benchmark def scribe_disabled_guarded(): Unit =
+        n += 1
+        if scribeSync.includes(SLevel.Trace) then scribeSync.trace(s"disabled n=$n obj=$payload")
+
+    // --- Enabled, cheap constant --------------------------------------------
+
+    @Benchmark def slf4j_enabledCheap(): Unit = slf4j.info("constant message")
+
+    @Benchmark def scribe_enabledCheap(): Unit = scribeSync.info("constant message")
+
+    // --- Enabled, interpolated ----------------------------------------------
+
+    @Benchmark def slf4j_enabledExpensive(): Unit =
+        n += 1
+        slf4j.info(s"enabled n=$n obj=$payload")
+
+    @Benchmark def scribe_enabledExpensive(): Unit =
+        n += 1
+        scribeSync.info(s"enabled n=$n obj=$payload")
+
+    @Benchmark def scribe_enabledExpensive_msgOnly(): Unit =
+        n += 1
+        scribeMsgOnly.info(s"enabled n=$n obj=$payload")
+
+    @Benchmark def scribe_enabledExpensive_defaultFmt(): Unit =
+        n += 1
+        scribeDefaultFmt.info(s"enabled n=$n obj=$payload")
+
+    @Benchmark def scribe_enabledExpensive_async(): Unit =
+        n += 1
+        scribeAsync.info(s"enabled n=$n obj=$payload") // enqueue only; drops above ~1000/s
+
+    @Benchmark def scribeCats_enabledExpensive(): Unit =
+        n += 1
+        scribeCats.info(s"enabled n=$n obj=$payload").unsafeRunSync()
+
+    // --- ContraTracer overhead decomposition (enabled INFO) -----------------
+
+    @Benchmark def contra_rawIO_baseline(): Unit =
+        n += 1
+        val m = s"enabled n=$n obj=$payload"
+        IO { val _ = sink.addAndGet(m.length.toLong) }.unsafeRunSync()
+
+    @Benchmark def contra_emit_overhead(): Unit =
+        n += 1
+        contraEmitSink
+            .traceWith(LogEvent(HLevel.Info, s"enabled n=$n obj=$payload", routingKey = Some("x")))
+            .unsafeRunSync()
+
+    @Benchmark def contra_sink_full(): Unit =
+        n += 1
+        Slf4jTracer.sink
+            .traceWith(
+              LogEvent(HLevel.Info, s"enabled n=$n obj=$payload", routingKey = Some("bench.slf4j"))
+            )
+            .unsafeRunSync()
+
+    // Batched: one `unsafeRunSync` amortized over `Batch` fresh events, so throughput reflects the
+    // per-log cost of the sink (as it runs inside an actor's already-running IO), not the ~11µs
+    // runloop-entry tax. The `traverse_` plumbing is identical across the three, so their deltas are
+    // clean: (emit - rawIO) = ContraTracer arrow + Eval + LogEvent build; (sink - emit) = log4cats + logback.
+    private val Batch = 1000
+
+    @Benchmark @OperationsPerInvocation(1000) def contra_rawIO_batch(): Unit =
+        (0 until Batch).toList
+            .traverse_(i => IO { val _ = sink.addAndGet(i.toLong & 0xff) })
+            .unsafeRunSync()
+
+    @Benchmark @OperationsPerInvocation(1000) def contra_emit_batch(): Unit =
+        (0 until Batch).toList
+            .traverse_(i =>
+                contraEmitSink.traceWith(
+                  LogEvent(HLevel.Info, s"enabled $i obj=$payload", routingKey = Some("x"))
+                )
+            )
+            .unsafeRunSync()
+
+    @Benchmark @OperationsPerInvocation(1000) def contra_sink_batch(): Unit =
+        (0 until Batch).toList
+            .traverse_(i =>
+                Slf4jTracer.sink.traceWith(
+                  LogEvent(
+                    HLevel.Info,
+                    s"enabled $i obj=$payload",
+                    routingKey = Some("bench.slf4j")
+                  )
+                )
+            )
+            .unsafeRunSync()

--- a/benchmark/src/main/scala/hydrozoa/benchmarks/LoggingBackendBench.scala
+++ b/benchmark/src/main/scala/hydrozoa/benchmarks/LoggingBackendBench.scala
@@ -85,6 +85,22 @@ class LoggingBackendBench:
             IO { val _ = sink.addAndGet(ev.render.value.msg.length.toLong) }
         )
 
+    /** An eager event: the same fields a [[LogEvent]] carries, but the message is built and stored
+      * directly — no `Eval.later` deferral, no `Rendered` wrapper. Lets us isolate what that
+      * machinery costs from the bare ContraTracer arrow + event allocation.
+      */
+    private final case class EagerEvent(
+        level: HLevel,
+        routingKey: Option[String],
+        msg: String,
+        ctx: Map[String, String] = Map.empty,
+        cause: Option[Throwable] = None
+    )
+
+    /** ContraTracer over the eager event: reads `msg` directly (nothing to force) and counts. */
+    private val contraEmitEagerSink: ContraTracer[IO, EagerEvent] =
+        ContraTracer.emit((ev: EagerEvent) => IO { val _ = sink.addAndGet(ev.msg.length.toLong) })
+
     @Setup(Level.Trial)
     def setup(): Unit =
         configureLogback()
@@ -214,7 +230,8 @@ class LoggingBackendBench:
     // Batched: one `unsafeRunSync` amortized over `Batch` fresh events, so throughput reflects the
     // per-log cost of the sink (as it runs inside an actor's already-running IO), not the ~11µs
     // runloop-entry tax. The `traverse_` plumbing is identical across the three, so their deltas are
-    // clean: (emit - rawIO) = ContraTracer arrow + Eval + LogEvent build; (sink - emit) = log4cats + logback.
+    // clean: (emit - rawIO) = ContraTracer arrow + Eval + LogEvent build; (sink - emit) = log4cats +
+    // logback; (emit - emit_eager) = the Eval.later + Rendered deferral alone.
     private val Batch = 1000
 
     @Benchmark @OperationsPerInvocation(1000) def contra_rawIO_batch(): Unit =
@@ -227,6 +244,15 @@ class LoggingBackendBench:
             .traverse_(i =>
                 contraEmitSink.traceWith(
                   LogEvent(HLevel.Info, s"enabled $i obj=$payload", routingKey = Some("x"))
+                )
+            )
+            .unsafeRunSync()
+
+    @Benchmark @OperationsPerInvocation(1000) def contra_emit_eager_batch(): Unit =
+        (0 until Batch).toList
+            .traverse_(i =>
+                contraEmitEagerSink.traceWith(
+                  EagerEvent(HLevel.Info, Some("x"), s"enabled $i obj=$payload")
                 )
             )
             .unsafeRunSync()

--- a/benchmark/src/main/scala/hydrozoa/benchmarks/LoggingLoadTest.scala
+++ b/benchmark/src/main/scala/hydrozoa/benchmarks/LoggingLoadTest.scala
@@ -1,0 +1,177 @@
+package hydrozoa.benchmarks
+
+import ch.qos.logback.classic.encoder.PatternLayoutEncoder
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.classic.{AsyncAppender, Level as LbLevel, LoggerContext}
+import ch.qos.logback.core.FileAppender
+import java.nio.file.{Files, Path}
+// Harness drives logback directly to a temp file; it needs the SLF4J-bound global context.
+import org.slf4j.LoggerFactory // scalafix:ok DisableSyntax
+import scribe.file.*
+import scribe.format.*
+import scribe.handler.AsynchronousLogHandle
+import scribe.{Level as SLevel, Logger as SLogger}
+
+/** End-to-end file-writer load test: SLF4J/Logback vs scribe, synchronous vs asynchronous, under a
+  * burst that outruns the writers. Unlike the JMH microbench (`LoggingBackendBench`, which measures
+  * caller-side cost to a discarding sink), this measures **delivery**: fire `total` INFO lines from
+  * `threads` producers as fast as possible, let the async drains settle, then count how many lines
+  * actually reached the file. `dropped = total - delivered`.
+  *
+  * The point is the async trade-off. Both async paths use a **bounded 1000-slot buffer** and drop
+  * on overflow, matching their real defaults:
+  *   - scribe `AsynchronousLogHandle`: maxBuffer=1000, `Overflow.DropOld`, drain loop flushes ONE
+  *     record then `Thread.sleep(1)` (~1000 rec/s ceiling).
+  *   - logback `AsyncAppender`: queueSize=1000, `neverBlock=true` (hydrozoa's config),
+  *     discardingThreshold=0; its worker drains as fast as the `FileAppender` can write.
+  * The sync variants are the lossless baselines — they deliver 100% and their produce time is the
+  * real sustainable write throughput.
+  *
+  * Run: `sbt "benchmark/runMain hydrozoa.benchmarks.LoggingLoadTest [total] [threads]"` (defaults:
+  * 500000 lines, 8 threads).
+  */
+object LoggingLoadTest:
+
+    private val leanFmt: Formatter = formatter"$date $levelPaddedRight [$threadName] $messages"
+    private val Buffer = 1000
+    private val DrainWindowMs = 3000L // generous settle time for async drains before counting
+
+    final case class Result(
+        name: String,
+        produced: Long,
+        delivered: Long,
+        produceMs: Double,
+        drainMs: Double
+    ):
+        def dropped: Long = produced - delivered
+        def dropPct: Double = 100.0 * dropped / produced
+        def producerRate: Double = produced / (produceMs / 1000.0) // lines/s the producer sustained
+
+    def main(args: Array[String]): Unit =
+        val total = args.lift(0).map(_.toLong).getOrElse(500000L)
+        val threads = args.lift(1).map(_.toInt).getOrElse(8)
+        println(
+          s"File-writer load test: total=$total lines, producers=$threads, async buffer=$Buffer, drain window=${DrainWindowMs}ms\n"
+        )
+
+        // Warm the JIT (discarded) so the first real config isn't penalised.
+        val _ = runScribe("warm", async = false, 20000, threads)
+        val _ = runLogback("warm", async = false, 20000, threads)
+
+        val results = List(
+          runScribe("scribe   sync ", async = false, total, threads),
+          runScribe("scribe   async", async = true, total, threads),
+          runLogback("logback  sync ", async = false, total, threads),
+          runLogback("logback  async", async = true, total, threads)
+        )
+        printTable(results)
+
+    // --- producers ----------------------------------------------------------
+
+    private def timeProduce(threads: Int, total: Long)(emit: Long => Unit): Double =
+        val per = total / threads
+        val ths = (0 until threads).map { t =>
+            new Thread(() =>
+                var i = 0L
+                val base = t.toLong * per
+                while i < per do { emit(base + i); i += 1 }
+            )
+        }
+        val start = System.nanoTime()
+        ths.foreach(_.start())
+        ths.foreach(_.join())
+        (System.nanoTime() - start) / 1.0e6
+
+    private def line(i: Long): String = s"consensus block $i soft-confirmed by peer ${i & 7}"
+
+    private def countLines(path: Path): Long =
+        val s = Files.lines(path)
+        try s.count()
+        finally s.close()
+
+    private def measure(name: String, async: Boolean, total: Long, threads: Int, path: Path)(
+        emit: Long => Unit,
+        close: () => Unit
+    ): Result =
+        val produceMs = timeProduce(threads, total)(emit)
+        val drainStart = System.nanoTime()
+        if async then Thread.sleep(DrainWindowMs)
+        close()
+        val drainMs = (System.nanoTime() - drainStart) / 1.0e6
+        val delivered = countLines(path)
+        Files.deleteIfExists(path)
+        Result(name, total, delivered, produceMs, drainMs)
+
+    // --- scribe -------------------------------------------------------------
+
+    private def runScribe(name: String, async: Boolean, total: Long, threads: Int): Result =
+        val path = Files.createTempFile("loadtest-scribe-", ".log")
+        val fw = FileWriter(path2PathBuilder(path))
+        val base = SLogger.empty.orphan()
+        val logger =
+            if async then
+                base.withHandler(
+                  formatter = leanFmt,
+                  writer = fw,
+                  minimumLevel = Some(SLevel.Info),
+                  handle = AsynchronousLogHandle(maxBuffer = Buffer)
+                )
+            else
+                base.withHandler(formatter = leanFmt, writer = fw, minimumLevel = Some(SLevel.Info))
+        measure(name, async, total, threads, path)(
+          i => { logger.info(line(i)); () },
+          () => fw.dispose()
+        )
+
+    // --- logback ------------------------------------------------------------
+
+    private def runLogback(name: String, async: Boolean, total: Long, threads: Int): Result =
+        val ctx = LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext]
+        val path = Files.createTempFile("loadtest-logback-", ".log")
+        val enc = new PatternLayoutEncoder()
+        enc.setContext(ctx)
+        enc.setPattern("%d{HH:mm:ss.SSS} %-5level [%thread] %logger - %msg%n")
+        enc.start()
+        val fa = new FileAppender[ILoggingEvent]()
+        fa.setContext(ctx)
+        fa.setFile(path.toString)
+        fa.setEncoder(enc)
+        fa.setImmediateFlush(false) // buffered, comparable to scribe's async flush; stop() flushes
+        fa.setAppend(false)
+        fa.start()
+        val appender =
+            if async then
+                val a = new AsyncAppender()
+                a.setContext(ctx)
+                a.setQueueSize(Buffer)
+                a.setNeverBlock(true) // drop instead of block on a full queue (hydrozoa's config)
+                a.setDiscardingThreshold(
+                  0
+                ) // don't discard by level; only neverBlock full-queue drops
+                a.addAppender(fa)
+                a.start()
+                a
+            else fa
+        val lg = ctx.getLogger(s"loadtest.$name.${System.identityHashCode(path)}")
+        lg.setAdditive(false)
+        lg.detachAndStopAllAppenders()
+        lg.addAppender(appender)
+        lg.setLevel(LbLevel.INFO)
+        val close = () =>
+            appender
+                .stop() // AsyncAppender drains its queue to the FileAppender within maxFlushTime
+            if async then fa.stop() // then flush + close the file stream
+        measure(name, async, total, threads, path)(i => lg.info(line(i)), close)
+
+    // --- report -------------------------------------------------------------
+
+    private def printTable(rs: List[Result]): Unit =
+        println(
+          f"${"config"}%-15s ${"produced"}%10s ${"delivered"}%10s ${"dropped"}%10s ${"drop%"}%7s ${"producer lines/s"}%18s ${"drainMs"}%9s"
+        )
+        println("-" * 90)
+        rs.foreach { r =>
+            println(
+              f"${r.name}%-15s ${r.produced}%10d ${r.delivered}%10d ${r.dropped}%10d ${r.dropPct}%6.2f%% ${r.producerRate}%18.0f ${r.drainMs}%9.0f"
+            )
+        }

--- a/build.sbt
+++ b/build.sbt
@@ -497,7 +497,11 @@ lazy val benchmark: Project = (project in file("benchmark"))
       libraryDependencies ++= Seq(
         // "org.scalacheck" %% "scalacheck" % "1.19.0",
         "org.scalatestplus" %% "scalacheck-1-18" % "3.2.19.0" % Test,
-        "org.scalus" %% "scalus-testkit" % scalusVersion
+        "org.scalus" %% "scalus-testkit" % scalusVersion,
+        // scribe backend, for the scribe-vs-slf4j head-to-head bench only (not in `core`).
+        "com.outr" %% "scribe" % "3.19.0",
+        "com.outr" %% "scribe-cats" % "3.19.0",
+        "com.outr" %% "scribe-file" % "3.19.0"
       )
     )
 

--- a/design/logging-backend-bench.md
+++ b/design/logging-backend-bench.md
@@ -1,0 +1,140 @@
+# Logging backend benchmark: SLF4J/Logback vs scribe
+
+**Question.** scribe advertises itself as "the fastest logging framework on the JVM." Is there a
+performance case for swapping hydrozoa's SLF4J/Logback backend for scribe? And separately: how much
+does the `ContraTracer` typed-event-bus layer cost over calling a backend directly?
+
+**Answer.** No performance case for scribe. It is slower and allocates more per call, ~2.6× slower
+on the lossless file path, and its asynchronous path drops ~99.8% of records under burst. The
+`ContraTracer` + `Eval` layer is not free (~600 B/op over a bare `IO`), but it is backend-independent
+and small relative to the actual logging work.
+
+The two benchmarks live in the `benchmark` subproject:
+
+- `LoggingBackendBench.scala` — JMH microbenchmark: caller-side cost per log call, to a discarding
+  counting sink (the same shape scribe uses in its own `PerformanceBenchmark`).
+- `LoggingLoadTest.scala` — standalone burst-and-count harness: end-to-end **delivery** to a real
+  file under load (models scribe's own `LoggingStressTest`).
+
+scribe/scribe-cats/scribe-file are dependencies of the `benchmark` subproject only — not `core`.
+
+## Methodology / fairness
+
+- **Discarding sink, no disk I/O** for the microbench, so numbers isolate framework overhead, not
+  storage. Both writers materialize the formatted line and sum its length (scribe formats eagerly in
+  the handler, logback in the appender — making both produce the final `String` is the
+  apples-to-apples point); the counter defeats dead-code elimination.
+- **scribe uses its own recommended benchmark formatter** `formatter"$date $levelPaddedRight
+  [$threadName] $messages"` (from scribe's repo), not `Formatter.default` (which adds source-position
+  capture). One variant keeps the default so the formatter's cost is visible.
+- **Loggers cached once; level = INFO.** Disabled scenarios call at TRACE.
+- **Async buffers matched at 1000 slots** on both sides in the load test, with each framework's real
+  default overflow policy.
+- Single machine, single JVM per run, G1GC, `-Xmx16G` (the benchmark subproject's fork options).
+  Scala 3.3.7, scribe 3.19.0, logback-classic 1.5.18. Absolute numbers are storage/JVM-dependent;
+  the **ratios** are the takeaway.
+
+## Result 1 — per-call microbenchmark (JMH, `-prof gc`)
+
+`Mode.Throughput`, higher ops/s is better; `gc.alloc.rate.norm` is bytes allocated per call.
+
+| Scenario | Backend / config | Throughput (ops/s) | Alloc (B/op) |
+|---|---|---:|---:|
+| **enabled, interpolated** | **slf4j/logback** | **7,185,000** | **844** |
+| | scribe — default formatter | 5,940,000 | 1,234 |
+| | scribe — message-only formatter | 5,633,000 | 1,265 |
+| | scribe — its own "lean" formatter | 3,727,000 | 1,959 |
+| | scribe — **async** (fire-and-forget) | 15,343,000 | 528 |
+| | scribe-cats `.f[IO]` (per-op `unsafeRunSync`)† | 90,000 | 2,957 |
+| **enabled, cheap constant** | **slf4j/logback** | **8,982,000** | **488** |
+| | scribe | 4,426,000 | 1,584 |
+| **disabled** (TRACE @ INFO) | **slf4j — guarded `if(isTraceEnabled)`** | **1,108,000,000** | **~0** |
+| | slf4j — naive `trace(s"…")` | 31,453,000 | 309 |
+| | scribe — macro (no guard) | 17,013,000 | 464 |
+| | scribe — guarded `includes(…)` | 18,758,000 | 464 |
+
+† The `unsafeRunSync`-per-op figure is a benchmark artifact (~11 µs runloop entry). See Result 2 for
+the batched, honest effectful throughput.
+
+Notes:
+
+- **Enabled path: logback wins on every variant** — ~1.5–2× the throughput at roughly half the
+  allocation. Squeezing scribe didn't help: its *own* "lean" formatter is the **worst** (1,959 B/op)
+  because `$date`/`$threadName` cost more than `Formatter.default`'s cached blocks; message-only
+  can't get under ~1,265 B/op. logback sits at 844.
+- **Disabled path: guarded logback is untouchable** (~0 allocation). scribe's macro laziness is
+  ergonomic (no guard needed) but still allocates **~464 B/op even when it decides not to log**, and
+  a manual `includes` guard doesn't change that. For short messages, even naive logback beats
+  disabled scribe on both axes.
+- **scribe async's 15M ops/s is caller-side enqueue only** — see Result 3 for what actually gets
+  delivered.
+
+## Result 2 — ContraTracer overhead (batched)
+
+Running one `unsafeRunSync` per log call costs ~11 µs and swamps everything, which is *not* how the
+system runs (logging IO composes into the actor's already-running IO). Batching 1000 fresh events
+through one `unsafeRunSync` (`@OperationsPerInvocation(1000)`) gives the honest per-log cost. The
+`traverse_` plumbing is identical across the three, so their deltas are clean.
+
+| Layer (batched, per-op) | Throughput (ops/s) | Alloc (B/op) |
+|---|---:|---:|
+| bare `IO { counter }` (floor) | 20,515,000 | 137 |
+| + ContraTracer arrow + `Eval` + `LogEvent` build (no backend) | 6,249,000 | 736 |
+| + log4cats + logback (full `Slf4jTracer.sink`) | 3,077,000 | 1,288 |
+
+- The **typed-event-bus layer** (`ContraTracer` + `Eval.later` + `LogEvent`/`Rendered`) adds
+  **~600 B/op and a ~3× throughput hit over a bare `IO`** — backend-independent, the cost of the
+  abstraction itself.
+- Routing a line through the full sink (**3.1M ops/s, 1,288 B/op**) vs a direct logback call
+  (**7.2M ops/s, 844 B/op**) roughly **halves throughput and adds ~50% allocation**. At consensus log
+  rates this is almost certainly negligible against real work, but it is not zero.
+
+## Result 3 — file-writer delivery under load
+
+Fire 500,000 INFO lines from 8 producer threads as fast as possible, let the async drains settle
+(3 s), then count how many lines actually reached the file. `dropped = produced − delivered`.
+
+| config | produced | delivered | dropped | drop % | producer lines/s |
+|---|---:|---:|---:|---:|---:|
+| **scribe sync** | 500,000 | 499,997 | 3 | ~0% | 770,000 |
+| **scribe async** | 500,000 | **1,076** | 498,924 | **99.78%** | 5,100,000 |
+| **logback sync** | 500,000 | 500,000 | 0 | 0% | **2,036,000** |
+| **logback async** | 500,000 | 163,592 | 336,408 | 67.28% | 6,279,000 |
+
+- **scribe async drops 99.78%.** Only ~1,000 lines (≈ the buffer) survive. The drain loop is
+  `flushNext(); Thread.sleep(1)` → a **~1,000 rec/s** ceiling with `Overflow.DropOld`. **This is not a
+  buffer-size problem** — the per-record 1 ms sleep caps sustained delivery no matter how large
+  `maxBuffer` is. Its 5M-lines/s "producer rate" is a fiction; the records go into the void.
+- **logback async also sheds load under this burst (67%) but delivers ~150× more** (163,592) because
+  its worker drains at the `FileAppender`'s real speed (~2M/s), not an artificial 1/ms. At real
+  consensus rates (well under 2M lines/s) it delivers ~100%; `neverBlock=true` chooses "drop" over
+  stalling consensus fibers only when a burst genuinely outruns the disk.
+- **On the lossless path we actually use, logback is ~2.6× faster to file** (2.04M vs 0.77M lines/s),
+  both delivering ~100%. (scribe sync's 3-line tail loss is an `AsynchronousFlush`-on-dispose
+  artifact — effectively lossless.)
+
+Making scribe viable for lossless logging would require a hand-written drain handle (batch drain, no
+per-record sleep) — i.e. reimplementing what logback's `AsyncAppender` already does well.
+
+## Verdict
+
+| Axis | Winner | Margin |
+|---|---|---|
+| Per-call enabled (micro) | logback | ~1.5–2× faster, ~½ alloc |
+| Per-call disabled, guarded | logback | ~0 alloc vs scribe's ~464 B/op floor |
+| Lossless file throughput | logback | ~2.6× faster |
+| Async delivery under burst | logback | delivers ~150× more before dropping |
+| scribe async producer rate | scribe | but drops 99.78% — meaningless |
+
+No performance reason to migrate off SLF4J/Logback. Independently, scalus and bloxbean pull in SLF4J
+regardless, so scribe would be an *added* backend, not a replacement. Migration stays parked.
+
+## Reproduce
+
+```bash
+# Per-call microbenchmark + ContraTracer decomposition (GC profiler on):
+sbt "benchmark/Jmh/run -prof gc -i 4 -wi 3 -f 1 -t 1 .*LoggingBackendBench.*"
+
+# File-writer delivery under load (defaults: 500000 lines, 8 producers):
+sbt "benchmark/runMain hydrozoa.benchmarks.LoggingLoadTest [total] [threads]"
+```

--- a/design/logging-backend-bench.md
+++ b/design/logging-backend-bench.md
@@ -84,10 +84,42 @@ through one `unsafeRunSync` (`@OperationsPerInvocation(1000)`) gives the honest 
 
 - The **typed-event-bus layer** (`ContraTracer` + `Eval.later` + `LogEvent`/`Rendered`) adds
   **~600 B/op and a ~3× throughput hit over a bare `IO`** — backend-independent, the cost of the
-  abstraction itself.
+  abstraction itself. (Reduced to ~430 B/op by the Haskell-parity port below.)
 - Routing a line through the full sink (**3.1M ops/s, 1,288 B/op**) vs a direct logback call
   (**7.2M ops/s, 844 B/op**) roughly **halves throughput and adds ~50% allocation**. At consensus log
   rates this is almost certainly negligible against real work, but it is not zero.
+- An **eager-event control** (same fields, message stored directly — no `Eval.later`/`Rendered`)
+  measures the deferral itself at **~80 B/op** on the enabled path. That is the insurance premium
+  for never building a message (or forcing a domain `toString`) at a disabled level — cheap, and
+  kept.
+
+### ContraTracer: porting the Haskell library's own optimizations
+
+`ContraTracer` is a faithful port of avieth/contra-tracer, whose source carries four performance
+mechanisms that GHC applies automatically but the JVM cannot: `{-# INLINE traceWith #-}` (+
+let-floating hoists the compiled arrow out of the hot loop), `arr (const ())` as a CAF, a strict
+hand-written `(****)` for the `(***)`/`(&&&)` equations (upstream's comment measures the class
+default at ~1KB of thunks per level per dispatch), and explicit `(|||)` equations avoiding the class
+default's extra merge stage. The original Scala port inherited the *semantics* but recompiled the
+arrow on every `traceWith` and used the cats class defaults — paying per trace what GHC pays once.
+
+Porting all four by hand (memoised compiled runner per tracer; `.void` tail; strict `split`/`merge`;
+explicit `choice`) — semantics unchanged, verified against the composition-algebra and laziness
+tests:
+
+| Layer (batched, per-op) | before | after |
+|---|---:|---:|
+| bare `IO` floor | 21.7M ops/s, 137 B | 21.7M ops/s, 137 B |
+| ContraTracer emit, eager event | 7.9M, 656 B | **9.9M, 486 B** |
+| ContraTracer emit, `Eval` + `Rendered` | 6.9M, 736 B | **8.2M, 568 B** |
+| full `Slf4jTracer.sink` | 3.1M, 1,288 B | 3.2M, 1,142 B |
+
+The arrow tax over a bare `IO` drops ~28% (600 → 430 B/op), and a squelched (`nullTracer`) trace
+compiles to a cached `unit` — allocation-free. The full sink's throughput barely moves because
+log4cats + logback dominates that path. Most of the remaining ~430 B/op is the event object plus the
+interpolated message string — present in any logging design — so further gains would require
+flattening the arrow encoding itself (what GHC effectively compiles the Haskell down to), not
+tuning it.
 
 ## Result 3 — file-writer delivery under load
 

--- a/src/main/scala/hydrozoa/lib/logging/ContraTracer.scala
+++ b/src/main/scala/hydrozoa/lib/logging/ContraTracer.scala
@@ -56,13 +56,19 @@ import scala.annotation.unused
   * @tparam M
   * @tparam A
   */
-case class ContraTracer[M[_], A](runTracer: TracerA[M, A, Unit]) {
+case class ContraTracer[M[_], A](runTracer: TracerA[M, A, Unit])(using Monad[M]) {
     import TracerA.given
     import ContraTracer.given
 
+    /** [[runTracer]] compiled to a plain function, once per tracer. Tracers are wired at
+      * construction time and traced hot, and recompiling the arrow per trace allocates; the
+      * upstream Haskell gets the same effect from `INLINE traceWith` + GHC let-floating.
+      */
+    private lazy val compiled: A => M[Unit] = runTracer.compile
+
     /** Run a tracer with a given input.
       */
-    def traceWith(a: A)(using Monad[M]): M[Unit] = this.runTracer.runTracerA.run(a)
+    def traceWith(a: A): M[Unit] = compiled(a)
 
     /** -- | Inverse of 'arrow'. Useful when writing arrow tracers which use a -- contravariant
       * tracer (the newtype in this module).
@@ -77,7 +83,7 @@ case class ContraTracer[M[_], A](runTracer: TracerA[M, A, Unit]) {
       *   -> m ()@, in which the predicate _must_ be forced no matter what, because it's impossible
       *   to know a priori whether that function will not produce any tracing effects.
       */
-    def traceMaybe[B](f: B => Option[A])(using Monad[M]): ContraTracer[M, B] = {
+    def traceMaybe[B](f: B => Option[A]): ContraTracer[M, B] = {
         def classify: TracerA[M, B, Either[Unit, A]] =
             Arrow[[X, Y] =>> TracerA[M, X, Y]].lift((x: B) =>
                 f(x).map(Right(_)).getOrElse(Left(()))
@@ -87,7 +93,7 @@ case class ContraTracer[M[_], A](runTracer: TracerA[M, A, Unit]) {
 
     /** A monadic version of `traceMaybe`.
       */
-    def traceMaybeM[B](f: B => M[Option[A]])(using Monad[M]): ContraTracer[M, B] = {
+    def traceMaybeM[B](f: B => M[Option[A]]): ContraTracer[M, B] = {
         def classify: TracerA[M, B, Either[Unit, A]] =
             TracerA.effect((x: B) => f(x).map(_.map(Right(_)).getOrElse(Left(()))))
         ContraTracer(classify >>> (TracerA.squelch ||| this.use))
@@ -95,33 +101,35 @@ case class ContraTracer[M[_], A](runTracer: TracerA[M, A, Unit]) {
 
     /** Uses 'traceMaybe' to give a tracer which emits only if a predicate is true.
       */
-    def squelchUnless(p: (A => Boolean))(using Monad[M]): ContraTracer[M, A] =
+    def squelchUnless(p: (A => Boolean)): ContraTracer[M, A] =
         traceMaybe(a => Some(a).filter(p))
 
     /** A monadic version of `squelchUnless`. */
-    def squelchUnlessM(p: A => M[Boolean])(using Monad[M]): ContraTracer[M, A] =
+    def squelchUnlessM(p: A => M[Boolean]): ContraTracer[M, A] =
         traceMaybeM(a => p(a).map(prop => if prop then Some(a) else None))
 
-    def traceTraversable[T[_]: Foldable](using Monad[M]): ContraTracer[M, T[A]] = runTracer match {
+    def traceTraversable[T[_]: Foldable]: ContraTracer[M, T[A]] = runTracer match {
         case Squelching(_) => nullTracer
         case _ => ContraTracer(TracerA.emit((t: T[A]) => Foldable[T].traverse_(t)(this.traceWith)))
     }
 
-    def traceAll[T[_]: Foldable, B](f: (B => T[A]))(using Monad[M]): ContraTracer[M, B] =
+    def traceAll[T[_]: Foldable, B](f: (B => T[A])): ContraTracer[M, B] =
         Contravariant[[X] =>> ContraTracer[M, X]].contramap(this.traceTraversable)(f)
 
     /** A contravariant transformation of a tracer using a Kleisli arrow
       * @param f
       *   Kleisli arrow which is evaluated only if a downstream tracer emits
       */
-    def contramapM[B](f: B => M[A])(using Monad[M]): ContraTracer[M, B] = ContraTracer(
+    def contramapM[B](f: B => M[A]): ContraTracer[M, B] = ContraTracer(
       TracerA.effect(f) >>> this.use
     )
 
     /** Use a natural transformation to change the @m@ type. This is useful, for instance, to use
       * concrete IO tracers in monad transformer stacks that have IO as their base.
       */
-    def natTracer[N[_], S](h: M ~> N): ContraTracer[N, A] = ContraTracer(TracerA.nat(h)(this.use))
+    def natTracer[N[_]: Monad, S](h: M ~> N): ContraTracer[N, A] = ContraTracer(
+      TracerA.nat(h)(this.use)
+    )
 }
 
 object ContraTracer {
@@ -157,7 +165,7 @@ object ContraTracer {
     /** Make an emitting tracer from a callback. -- mkTracer :: Applicative m => (a -> m ()) ->
       * Tracer m a mkTracer = Tracer . Arrow.emit
       */
-    def apply[M[_]: Applicative, A](f: A => M[Unit]): ContraTracer[M, A] = ContraTracer(
+    def apply[M[_]: Monad, A](f: A => M[Unit]): ContraTracer[M, A] = ContraTracer(
       TracerA.emit(f)
     )
 
@@ -169,7 +177,7 @@ object ContraTracer {
     /** Create a simple contravariant tracer which runs a given side-effect. emit :: Applicative m =>
       * (a -> m ()) -> Tracer m a emit f = Tracer (Arrow.emit f)
       */
-    def emit[M[_]: Applicative, A](f: A => M[Unit]): ContraTracer[M, A] = ContraTracer(
+    def emit[M[_]: Monad, A](f: A => M[Unit]): ContraTracer[M, A] = ContraTracer(
       TracerA.emit(f)
     )
 }
@@ -178,8 +186,8 @@ object ContraTracer {
   */
 object ContraTracerSyntax {
 
-    def traceWith[M[_]: Monad, A](a: A)(using ct: ContraTracer[M, A]): M[Unit] =
-        ct.runTracer.runTracerA.run(a)
+    def traceWith[M[_], A](a: A)(using ct: ContraTracer[M, A]): M[Unit] =
+        ct.traceWith(a)
 
     def use[M[_], A](using ct: ContraTracer[M, A]): TracerA[M, A, Unit] = ct.runTracer
 
@@ -190,7 +198,7 @@ object ContraTracerSyntax {
 //
 //        /** A monadic version of `traceMaybe`.
 //         */
-//        def traceMaybeM[B](f: B => M[Option[A]])(using Monad[M]): ContraTracer[M, B] = {
+//        def traceMaybeM[B](f: B => M[Option[A]]): ContraTracer[M, B] = {
 //            def classify: TracerA[M, B, Either[Unit, A]] =
 //                TracerA.effect((x: B) => f(x).map(_.map(Right(_)).getOrElse(Left(()))))
 //
@@ -199,11 +207,11 @@ object ContraTracerSyntax {
 //
 //        /** Uses 'traceMaybe' to give a tracer which emits only if a predicate is true.
 //         */
-//        def squelchUnless(p: (A => Boolean))(using Monad[M]): ContraTracer[M, A] =
+//        def squelchUnless(p: (A => Boolean)): ContraTracer[M, A] =
 //            traceMaybe(a => Some(a).filter(p))
 //
 //        /** A monadic version of `squelchUnless`. */
-//        def squelchUnlessM(p: A => M[Boolean])(using Monad[M]): ContraTracer[M, A] =
+//        def squelchUnlessM(p: A => M[Boolean]): ContraTracer[M, A] =
 //            traceMaybeM(a => p(a).map(prop => if prop then Some(a) else None))
 //
 //        def traceTraversable[T[_] : Foldable](using Monad[M]): ContraTracer[M, T[A]] = runTracer match {
@@ -219,7 +227,7 @@ object ContraTracerSyntax {
 //         * @param f
 //         * Kleisli arrow which is evaluated only if a downstream tracer emits
 //         */
-//        def contramapM[B](f: B => M[A])(using Monad[M]): ContraTracer[M, B] = ContraTracer(
+//        def contramapM[B](f: B => M[A]): ContraTracer[M, B] = ContraTracer(
 //            TracerA.effect(f) >>> this.use
 //        )
 //

--- a/src/main/scala/hydrozoa/lib/logging/TracerA.scala
+++ b/src/main/scala/hydrozoa/lib/logging/TracerA.scala
@@ -38,6 +38,19 @@ extension [M[_], A](t: TracerA[M, A, Unit])
         }
     }
 
+    /** [[runTracerA]] compiled to a plain function, built once per tracer rather than per trace.
+      * The upstream Haskell gets this for free — `traceWith` is INLINE and `arr (const ())` is a
+      * CAF, so GHC floats the compiled arrow out of the hot path; on the JVM the equivalent must be
+      * done by hand ([[ContraTracer]] memoises the result). A squelching tracer compiles to a
+      * constant `unit`, making a squelched `traceWith` allocation-free.
+      */
+    def compile(using monadM: Monad[M]): A => M[Unit] = t match {
+        case TracerA.Emitting(emits, _) => a => monadM.void(emits.run(a))
+        case TracerA.Squelching(_) =>
+            val unit = monadM.unit
+            _ => unit
+    }
+
 object TracerA:
     case class Emitting[M[_], A, X, B](emitter: Kleisli[M, A, X], nonEmitter: Kleisli[M, X, B])
         extends TracerA[M, A, B]
@@ -99,6 +112,79 @@ object TracerA:
                 case Emitting(e, p) => Emitting(e.first, p.first)
             }
         }
+
+        // Strict Kleisli combinators backing the split/merge/choice overrides below — direct
+        // translations of the upstream Haskell's hand-written (****)/(|||) equations. The class
+        // defaults route through `first` plus lifted swap/dup/fold stages, each of which survives
+        // as a per-trace pure+flatMap in the fused arrow (upstream measured the default (***) at
+        // ~1KB of thunks per level per dispatch); these run the two legs directly.
+        def idK[M[_], A](using appM: Applicative[M]): Kleisli[M, A, A] =
+            Kleisli(a => appM.pure(a))
+
+        /** `f **** g`: run both legs on the halves of a pair. */
+        def parK[M[_], A, B, C, D](f: Kleisli[M, A, B], g: Kleisli[M, C, D])(using
+            monadM: Monad[M]
+        ): Kleisli[M, (A, C), (B, D)] =
+            Kleisli((ac: (A, C)) =>
+                monadM.flatMap(f.run(ac._1))(b => monadM.map(g.run(ac._2))(d => (b, d)))
+            )
+
+        /** `f &&& g` at the Kleisli level: run both legs on the same input, no dup/swap stages. */
+        def fanK[M[_], A, B, C](f: Kleisli[M, A, B], g: Kleisli[M, A, C])(using
+            monadM: Monad[M]
+        ): Kleisli[M, A, (B, C)] =
+            Kleisli((a: A) => monadM.flatMap(f.run(a))(b => monadM.map(g.run(a))(c => (b, c))))
+
+        /** `f ||| g` at the Kleisli level: dispatch on the Either, no merging `arr` stage. */
+        def eitherK[M[_], A, B, C](
+            f: Kleisli[M, A, C],
+            g: Kleisli[M, B, C]
+        ): Kleisli[M, Either[A, B], C] =
+            Kleisli(_.fold(f.run, g.run))
+
+        /** `f +++ g` at the Kleisli level. */
+        def plusK[M[_], A, B, C, D](f: Kleisli[M, A, B], g: Kleisli[M, C, D])(using
+            functorM: Functor[M]
+        ): Kleisli[M, Either[A, C], Either[B, D]] =
+            Kleisli(
+              _.fold(
+                a => functorM.map(f.run(a))(Left(_)),
+                c => functorM.map(g.run(c))(Right(_))
+              )
+            )
+
+        // The upstream equations: `Squelching l *** Emitting re rp = Emitting (id **** re) (l ****
+        // rp)` etc. Squelching legs fold into whichever side of the Emitting pair keeps them
+        // droppable.
+        def split[M[_]: Monad, A, B, C, D](
+            f: TracerA[M, A, B],
+            g: TracerA[M, C, D]
+        ): TracerA[M, (A, C), (B, D)] = (f, g) match {
+            case (Squelching(l), Squelching(r))       => Squelching(parK(l, r))
+            case (Squelching(l), Emitting(re, rp))    => Emitting(parK(idK, re), parK(l, rp))
+            case (Emitting(le, lp), Squelching(r))    => Emitting(parK(le, idK), parK(lp, r))
+            case (Emitting(le, lp), Emitting(re, rp)) => Emitting(parK(le, re), parK(lp, rp))
+        }
+
+        def merge[M[_]: Monad, A, B, C](
+            f: TracerA[M, A, B],
+            g: TracerA[M, A, C]
+        ): TracerA[M, A, (B, C)] = (f, g) match {
+            case (Squelching(l), Squelching(r))       => Squelching(fanK(l, r))
+            case (Squelching(l), Emitting(re, rp))    => Emitting(fanK(idK[M, A], re), parK(l, rp))
+            case (Emitting(le, lp), Squelching(r))    => Emitting(fanK(le, idK[M, A]), parK(lp, r))
+            case (Emitting(le, lp), Emitting(re, rp)) => Emitting(fanK(le, re), parK(lp, rp))
+        }
+
+        def choice[M[_]: Monad, A, B, C](
+            f: TracerA[M, A, C],
+            g: TracerA[M, B, C]
+        ): TracerA[M, Either[A, B], C] = (f, g) match {
+            case (Squelching(l), Squelching(r))    => Squelching(eitherK(l, r))
+            case (Squelching(l), Emitting(re, rp)) => Emitting(plusK(idK[M, A], re), eitherK(l, rp))
+            case (Emitting(le, lp), Squelching(r)) => Emitting(plusK(le, idK[M, B]), eitherK(lp, r))
+            case (Emitting(le, lp), Emitting(re, rp)) => Emitting(plusK(le, re), eitherK(lp, rp))
+        }
     }
 
     given [M[_]: Monad]: Category[[X, Y] =>> TracerA[M, X, Y]] with {
@@ -118,6 +204,16 @@ object TracerA:
         // The manual implementation would look like:
         //   (Kleisli((a, c) => s.run(a).map((_, c)))
         def first[A, B, C](fa: TracerA[M, A, B]): TracerA[M, (A, C), (B, C)] = TracerAOps.first(fa)
+
+        override def split[A, B, C, D](
+            f: TracerA[M, A, B],
+            g: TracerA[M, C, D]
+        ): TracerA[M, (A, C), (B, D)] = TracerAOps.split(f, g)
+
+        override def merge[A, B, C](
+            f: TracerA[M, A, B],
+            g: TracerA[M, A, C]
+        ): TracerA[M, A, (B, C)] = TracerAOps.merge(f, g)
     }
 
     given [M[_]: Monad]: ArrowChoice[[X, Y] =>> TracerA[M, X, Y]] with {
@@ -138,6 +234,25 @@ object TracerA:
             TracerAOps.compose(f, g)
 
         def first[A, B, C](fa: TracerA[M, A, B]): TracerA[M, (A, C), (B, C)] = TracerAOps.first(fa)
+
+        // Without an explicit `choice` the class default fires:
+        //   f ||| g = choose(f)(g) >>> lift(_.merge)
+        // which inserts an extra lifted merge stage on every dispatch (mirrors the upstream
+        // Haskell's hand-written (|||) equations).
+        override def choice[A, B, C](
+            f: TracerA[M, A, C],
+            g: TracerA[M, B, C]
+        ): TracerA[M, Either[A, B], C] = TracerAOps.choice(f, g)
+
+        override def split[A, B, C, D](
+            f: TracerA[M, A, B],
+            g: TracerA[M, C, D]
+        ): TracerA[M, (A, C), (B, D)] = TracerAOps.split(f, g)
+
+        override def merge[A, B, C](
+            f: TracerA[M, A, B],
+            g: TracerA[M, A, C]
+        ): TracerA[M, A, (B, C)] = TracerAOps.merge(f, g)
     }
 
     def nat[M[_], N[_], A, B](h: M ~> N)(t: TracerA[M, A, B]): TracerA[N, A, B] = t match {


### PR DESCRIPTION
Stacked on #686. Two related pieces of logging performance work:

## Benchmarks (`benchmark/` + `design/logging-backend-bench.md`)

A colleague-facing evaluation of scribe vs SLF4J/Logback, since scribe advertises itself as "the fastest logging framework on the JVM":

- **`LoggingBackendBench`** (JMH, `-prof gc`): per-call cost to a discarding counting sink — the same methodology as scribe's own `PerformanceBenchmark`, using scribe's own recommended formatter. Logback wins every enabled path (~1.5–2× throughput, ~½ the allocation) and the guarded disabled path (~0 B/op vs scribe's ~464 B/op floor).
- **`LoggingLoadTest`** (burst-and-count): end-to-end file **delivery** under a 500k-line burst. scribe's async handle drops **99.78%** (its drain loop flushes one record per ~1ms — a ~1,000 rec/s ceiling regardless of buffer size); logback's `AsyncAppender` delivers ~150× more under the same burst, and logback sync is ~2.6× faster lossless.
- Verdict in the doc: **no performance case for scribe**; migration stays parked. scribe deps are added to the `benchmark` subproject only, not `core`.

## ContraTracer perf: porting the Haskell library's own optimizations

The upstream avieth/contra-tracer carries four perf mechanisms GHC applies automatically (`INLINE traceWith` + let-floating, `arr (const ())` as a CAF, a strict hand-written `(****)` — its comment measures the class-default `(***)` at ~1KB of thunks per level — and explicit `(|||)` equations). The Scala port had inherited the semantics but recompiled the arrow on every `traceWith` and used the cats class defaults. This ports all four by hand, semantics unchanged:

- memoised compiled runner per tracer (`TracerA.compile` + `lazy val`); squelched tracers compile to a cached `unit` (allocation-free null tracing)
- `.void` tail instead of `>>> arr(const ())`
- strict `split`/`merge` overrides (no lifted dup/swap stages on `|+|` fan-out)
- explicit `choice` override (no extra merge stage on `traceMaybe`/`squelchUnlessM`)

Measured (batched JMH): emit path **6.9M → 8.2M ops/s, 736 → 568 B/op**; tracer overhead over a bare `IO` down ~28%. `ContraTracer` now stores its `Monad[M]` (needed to memoise), so `emit`/`apply` tighten `Applicative → Monad`; all call sites unchanged (everything is `IO`).

Validated with a clean `-Werror` compile (core + integration) and the full suite: 412 passed, 0 failed; the logging suite's composition-algebra and laziness proofs cover the new instance equations.