### PR TITLE
perf(logging): port contra-tracer's own optimizations to the JVM

### DIFF
--- a/src/main/scala/hydrozoa/lib/logging/ContraTracer.scala
+++ b/src/main/scala/hydrozoa/lib/logging/ContraTracer.scala
@@ -191,7 +191,7 @@ object ContraTracerSyntax {
 
     def use[M[_], A](using ct: ContraTracer[M, A]): TracerA[M, A, Unit] = ct.runTracer
 
-    def traceMaybe[M[_]: Monad, A, B](f: B => Option[A])(using
+    def traceMaybe[M[_], A, B](f: B => Option[A])(using
         ct: ContraTracer[M, A]
     ): ContraTracer[M, B] =
         ct.traceMaybe(f)

--- a/src/main/scala/hydrozoa/lib/logging/ContraTracer.scala
+++ b/src/main/scala/hydrozoa/lib/logging/ContraTracer.scala
@@ -56,13 +56,19 @@ import scala.annotation.unused
   * @tparam M
   * @tparam A
   */
-case class ContraTracer[M[_], A](runTracer: TracerA[M, A, Unit]) {
+case class ContraTracer[M[_], A](runTracer: TracerA[M, A, Unit])(using Monad[M]) {
     import TracerA.given
     import ContraTracer.given
 
+    /** [[runTracer]] compiled to a plain function, once per tracer. Tracers are wired at
+      * construction time and traced hot, and recompiling the arrow per trace allocates; the
+      * upstream Haskell gets the same effect from `INLINE traceWith` + GHC let-floating.
+      */
+    private lazy val compiled: A => M[Unit] = runTracer.compile
+
     /** Run a tracer with a given input.
       */
-    def traceWith(a: A)(using Monad[M]): M[Unit] = this.runTracer.runTracerA.run(a)
+    def traceWith(a: A): M[Unit] = compiled(a)
 
     /** -- | Inverse of 'arrow'. Useful when writing arrow tracers which use a -- contravariant
       * tracer (the newtype in this module).
@@ -77,7 +83,7 @@ case class ContraTracer[M[_], A](runTracer: TracerA[M, A, Unit]) {
       *   -> m ()@, in which the predicate _must_ be forced no matter what, because it's impossible
       *   to know a priori whether that function will not produce any tracing effects.
       */
-    def traceMaybe[B](f: B => Option[A])(using Monad[M]): ContraTracer[M, B] = {
+    def traceMaybe[B](f: B => Option[A]): ContraTracer[M, B] = {
         def classify: TracerA[M, B, Either[Unit, A]] =
             Arrow[[X, Y] =>> TracerA[M, X, Y]].lift((x: B) =>
                 f(x).map(Right(_)).getOrElse(Left(()))
@@ -87,7 +93,7 @@ case class ContraTracer[M[_], A](runTracer: TracerA[M, A, Unit]) {
 
     /** A monadic version of `traceMaybe`.
       */
-    def traceMaybeM[B](f: B => M[Option[A]])(using Monad[M]): ContraTracer[M, B] = {
+    def traceMaybeM[B](f: B => M[Option[A]]): ContraTracer[M, B] = {
         def classify: TracerA[M, B, Either[Unit, A]] =
             TracerA.effect((x: B) => f(x).map(_.map(Right(_)).getOrElse(Left(()))))
         ContraTracer(classify >>> (TracerA.squelch ||| this.use))
@@ -95,33 +101,35 @@ case class ContraTracer[M[_], A](runTracer: TracerA[M, A, Unit]) {
 
     /** Uses 'traceMaybe' to give a tracer which emits only if a predicate is true.
       */
-    def squelchUnless(p: (A => Boolean))(using Monad[M]): ContraTracer[M, A] =
+    def squelchUnless(p: (A => Boolean)): ContraTracer[M, A] =
         traceMaybe(a => Some(a).filter(p))
 
     /** A monadic version of `squelchUnless`. */
-    def squelchUnlessM(p: A => M[Boolean])(using Monad[M]): ContraTracer[M, A] =
+    def squelchUnlessM(p: A => M[Boolean]): ContraTracer[M, A] =
         traceMaybeM(a => p(a).map(prop => if prop then Some(a) else None))
 
-    def traceTraversable[T[_]: Foldable](using Monad[M]): ContraTracer[M, T[A]] = runTracer match {
+    def traceTraversable[T[_]: Foldable]: ContraTracer[M, T[A]] = runTracer match {
         case Squelching(_) => nullTracer
         case _ => ContraTracer(TracerA.emit((t: T[A]) => Foldable[T].traverse_(t)(this.traceWith)))
     }
 
-    def traceAll[T[_]: Foldable, B](f: (B => T[A]))(using Monad[M]): ContraTracer[M, B] =
+    def traceAll[T[_]: Foldable, B](f: (B => T[A])): ContraTracer[M, B] =
         Contravariant[[X] =>> ContraTracer[M, X]].contramap(this.traceTraversable)(f)
 
     /** A contravariant transformation of a tracer using a Kleisli arrow
       * @param f
       *   Kleisli arrow which is evaluated only if a downstream tracer emits
       */
-    def contramapM[B](f: B => M[A])(using Monad[M]): ContraTracer[M, B] = ContraTracer(
+    def contramapM[B](f: B => M[A]): ContraTracer[M, B] = ContraTracer(
       TracerA.effect(f) >>> this.use
     )
 
     /** Use a natural transformation to change the @m@ type. This is useful, for instance, to use
       * concrete IO tracers in monad transformer stacks that have IO as their base.
       */
-    def natTracer[N[_], S](h: M ~> N): ContraTracer[N, A] = ContraTracer(TracerA.nat(h)(this.use))
+    def natTracer[N[_]: Monad, S](h: M ~> N): ContraTracer[N, A] = ContraTracer(
+      TracerA.nat(h)(this.use)
+    )
 }
 
 object ContraTracer {
@@ -157,7 +165,7 @@ object ContraTracer {
     /** Make an emitting tracer from a callback. -- mkTracer :: Applicative m => (a -> m ()) ->
       * Tracer m a mkTracer = Tracer . Arrow.emit
       */
-    def apply[M[_]: Applicative, A](f: A => M[Unit]): ContraTracer[M, A] = ContraTracer(
+    def apply[M[_]: Monad, A](f: A => M[Unit]): ContraTracer[M, A] = ContraTracer(
       TracerA.emit(f)
     )
 
@@ -169,7 +177,7 @@ object ContraTracer {
     /** Create a simple contravariant tracer which runs a given side-effect. emit :: Applicative m =>
       * (a -> m ()) -> Tracer m a emit f = Tracer (Arrow.emit f)
       */
-    def emit[M[_]: Applicative, A](f: A => M[Unit]): ContraTracer[M, A] = ContraTracer(
+    def emit[M[_]: Monad, A](f: A => M[Unit]): ContraTracer[M, A] = ContraTracer(
       TracerA.emit(f)
     )
 }
@@ -178,8 +186,8 @@ object ContraTracer {
   */
 object ContraTracerSyntax {
 
-    def traceWith[M[_]: Monad, A](a: A)(using ct: ContraTracer[M, A]): M[Unit] =
-        ct.runTracer.runTracerA.run(a)
+    def traceWith[M[_], A](a: A)(using ct: ContraTracer[M, A]): M[Unit] =
+        ct.traceWith(a)
 
     def use[M[_], A](using ct: ContraTracer[M, A]): TracerA[M, A, Unit] = ct.runTracer
 
@@ -190,7 +198,7 @@ object ContraTracerSyntax {
 //
 //        /** A monadic version of `traceMaybe`.
 //         */
-//        def traceMaybeM[B](f: B => M[Option[A]])(using Monad[M]): ContraTracer[M, B] = {
+//        def traceMaybeM[B](f: B => M[Option[A]]): ContraTracer[M, B] = {
 //            def classify: TracerA[M, B, Either[Unit, A]] =
 //                TracerA.effect((x: B) => f(x).map(_.map(Right(_)).getOrElse(Left(()))))
 //
@@ -199,11 +207,11 @@ object ContraTracerSyntax {
 //
 //        /** Uses 'traceMaybe' to give a tracer which emits only if a predicate is true.
 //         */
-//        def squelchUnless(p: (A => Boolean))(using Monad[M]): ContraTracer[M, A] =
+//        def squelchUnless(p: (A => Boolean)): ContraTracer[M, A] =
 //            traceMaybe(a => Some(a).filter(p))
 //
 //        /** A monadic version of `squelchUnless`. */
-//        def squelchUnlessM(p: A => M[Boolean])(using Monad[M]): ContraTracer[M, A] =
+//        def squelchUnlessM(p: A => M[Boolean]): ContraTracer[M, A] =
 //            traceMaybeM(a => p(a).map(prop => if prop then Some(a) else None))
 //
 //        def traceTraversable[T[_] : Foldable](using Monad[M]): ContraTracer[M, T[A]] = runTracer match {
@@ -219,7 +227,7 @@ object ContraTracerSyntax {
 //         * @param f
 //         * Kleisli arrow which is evaluated only if a downstream tracer emits
 //         */
-//        def contramapM[B](f: B => M[A])(using Monad[M]): ContraTracer[M, B] = ContraTracer(
+//        def contramapM[B](f: B => M[A]): ContraTracer[M, B] = ContraTracer(
 //            TracerA.effect(f) >>> this.use
 //        )
 //

--- a/src/main/scala/hydrozoa/lib/logging/Slf4jMsg.scala
+++ b/src/main/scala/hydrozoa/lib/logging/Slf4jMsg.scala
@@ -1,7 +1,5 @@
 package hydrozoa.lib.logging
 
-import cats.Monad
-
 /** A small generic message ADT for call sites that don't merit a typed event of their own —
   * typically app entry points (`hydrozoa.app.*`) and test scaffolding. Production actors and shared
   * infrastructure define their own `XYZEvent` ADT and pass `ContraTracer[IO, XYZEvent]`.
@@ -44,7 +42,7 @@ object Slf4jMsgFormat:
   *
   * }}}
   */
-extension [F[_]: Monad](t: ContraTracer[F, Slf4jMsg])
+extension [F[_]](t: ContraTracer[F, Slf4jMsg])
     def trace(msg: => String): F[Unit] = t.traceWith(Slf4jMsg.Trace(msg))
     def debug(msg: => String): F[Unit] = t.traceWith(Slf4jMsg.Debug(msg))
     def info(msg: => String): F[Unit] = t.traceWith(Slf4jMsg.Info(msg))

--- a/src/main/scala/hydrozoa/lib/logging/TracerA.scala
+++ b/src/main/scala/hydrozoa/lib/logging/TracerA.scala
@@ -38,6 +38,19 @@ extension [M[_], A](t: TracerA[M, A, Unit])
         }
     }
 
+    /** [[runTracerA]] compiled to a plain function, built once per tracer rather than per trace.
+      * The upstream Haskell gets this for free — `traceWith` is INLINE and `arr (const ())` is a
+      * CAF, so GHC floats the compiled arrow out of the hot path; on the JVM the equivalent must be
+      * done by hand ([[ContraTracer]] memoises the result). A squelching tracer compiles to a
+      * constant `unit`, making a squelched `traceWith` allocation-free.
+      */
+    def compile(using monadM: Monad[M]): A => M[Unit] = t match {
+        case TracerA.Emitting(emits, _) => a => monadM.void(emits.run(a))
+        case TracerA.Squelching(_) =>
+            val unit = monadM.unit
+            _ => unit
+    }
+
 object TracerA:
     case class Emitting[M[_], A, X, B](emitter: Kleisli[M, A, X], nonEmitter: Kleisli[M, X, B])
         extends TracerA[M, A, B]
@@ -99,6 +112,79 @@ object TracerA:
                 case Emitting(e, p) => Emitting(e.first, p.first)
             }
         }
+
+        // Strict Kleisli combinators backing the split/merge/choice overrides below — direct
+        // translations of the upstream Haskell's hand-written (****)/(|||) equations. The class
+        // defaults route through `first` plus lifted swap/dup/fold stages, each of which survives
+        // as a per-trace pure+flatMap in the fused arrow (upstream measured the default (***) at
+        // ~1KB of thunks per level per dispatch); these run the two legs directly.
+        def idK[M[_], A](using appM: Applicative[M]): Kleisli[M, A, A] =
+            Kleisli(a => appM.pure(a))
+
+        /** `f **** g`: run both legs on the halves of a pair. */
+        def parK[M[_], A, B, C, D](f: Kleisli[M, A, B], g: Kleisli[M, C, D])(using
+            monadM: Monad[M]
+        ): Kleisli[M, (A, C), (B, D)] =
+            Kleisli((ac: (A, C)) =>
+                monadM.flatMap(f.run(ac._1))(b => monadM.map(g.run(ac._2))(d => (b, d)))
+            )
+
+        /** `f &&& g` at the Kleisli level: run both legs on the same input, no dup/swap stages. */
+        def fanK[M[_], A, B, C](f: Kleisli[M, A, B], g: Kleisli[M, A, C])(using
+            monadM: Monad[M]
+        ): Kleisli[M, A, (B, C)] =
+            Kleisli((a: A) => monadM.flatMap(f.run(a))(b => monadM.map(g.run(a))(c => (b, c))))
+
+        /** `f ||| g` at the Kleisli level: dispatch on the Either, no merging `arr` stage. */
+        def eitherK[M[_], A, B, C](
+            f: Kleisli[M, A, C],
+            g: Kleisli[M, B, C]
+        ): Kleisli[M, Either[A, B], C] =
+            Kleisli(_.fold(f.run, g.run))
+
+        /** `f +++ g` at the Kleisli level. */
+        def plusK[M[_], A, B, C, D](f: Kleisli[M, A, B], g: Kleisli[M, C, D])(using
+            functorM: Functor[M]
+        ): Kleisli[M, Either[A, C], Either[B, D]] =
+            Kleisli(
+              _.fold(
+                a => functorM.map(f.run(a))(Left(_)),
+                c => functorM.map(g.run(c))(Right(_))
+              )
+            )
+
+        // The upstream equations: `Squelching l *** Emitting re rp = Emitting (id **** re) (l ****
+        // rp)` etc. Squelching legs fold into whichever side of the Emitting pair keeps them
+        // droppable.
+        def split[M[_]: Monad, A, B, C, D](
+            f: TracerA[M, A, B],
+            g: TracerA[M, C, D]
+        ): TracerA[M, (A, C), (B, D)] = (f, g) match {
+            case (Squelching(l), Squelching(r))       => Squelching(parK(l, r))
+            case (Squelching(l), Emitting(re, rp))    => Emitting(parK(idK, re), parK(l, rp))
+            case (Emitting(le, lp), Squelching(r))    => Emitting(parK(le, idK), parK(lp, r))
+            case (Emitting(le, lp), Emitting(re, rp)) => Emitting(parK(le, re), parK(lp, rp))
+        }
+
+        def merge[M[_]: Monad, A, B, C](
+            f: TracerA[M, A, B],
+            g: TracerA[M, A, C]
+        ): TracerA[M, A, (B, C)] = (f, g) match {
+            case (Squelching(l), Squelching(r))       => Squelching(fanK(l, r))
+            case (Squelching(l), Emitting(re, rp))    => Emitting(fanK(idK[M, A], re), parK(l, rp))
+            case (Emitting(le, lp), Squelching(r))    => Emitting(fanK(le, idK[M, A]), parK(lp, r))
+            case (Emitting(le, lp), Emitting(re, rp)) => Emitting(fanK(le, re), parK(lp, rp))
+        }
+
+        def choice[M[_]: Monad, A, B, C](
+            f: TracerA[M, A, C],
+            g: TracerA[M, B, C]
+        ): TracerA[M, Either[A, B], C] = (f, g) match {
+            case (Squelching(l), Squelching(r))    => Squelching(eitherK(l, r))
+            case (Squelching(l), Emitting(re, rp)) => Emitting(plusK(idK[M, A], re), eitherK(l, rp))
+            case (Emitting(le, lp), Squelching(r)) => Emitting(plusK(le, idK[M, B]), eitherK(lp, r))
+            case (Emitting(le, lp), Emitting(re, rp)) => Emitting(plusK(le, re), eitherK(lp, rp))
+        }
     }
 
     given [M[_]: Monad]: Category[[X, Y] =>> TracerA[M, X, Y]] with {
@@ -118,6 +204,16 @@ object TracerA:
         // The manual implementation would look like:
         //   (Kleisli((a, c) => s.run(a).map((_, c)))
         def first[A, B, C](fa: TracerA[M, A, B]): TracerA[M, (A, C), (B, C)] = TracerAOps.first(fa)
+
+        override def split[A, B, C, D](
+            f: TracerA[M, A, B],
+            g: TracerA[M, C, D]
+        ): TracerA[M, (A, C), (B, D)] = TracerAOps.split(f, g)
+
+        override def merge[A, B, C](
+            f: TracerA[M, A, B],
+            g: TracerA[M, A, C]
+        ): TracerA[M, A, (B, C)] = TracerAOps.merge(f, g)
     }
 
     given [M[_]: Monad]: ArrowChoice[[X, Y] =>> TracerA[M, X, Y]] with {
@@ -138,6 +234,25 @@ object TracerA:
             TracerAOps.compose(f, g)
 
         def first[A, B, C](fa: TracerA[M, A, B]): TracerA[M, (A, C), (B, C)] = TracerAOps.first(fa)
+
+        // Without an explicit `choice` the class default fires:
+        //   f ||| g = choose(f)(g) >>> lift(_.merge)
+        // which inserts an extra lifted merge stage on every dispatch (mirrors the upstream
+        // Haskell's hand-written (|||) equations).
+        override def choice[A, B, C](
+            f: TracerA[M, A, C],
+            g: TracerA[M, B, C]
+        ): TracerA[M, Either[A, B], C] = TracerAOps.choice(f, g)
+
+        override def split[A, B, C, D](
+            f: TracerA[M, A, B],
+            g: TracerA[M, C, D]
+        ): TracerA[M, (A, C), (B, D)] = TracerAOps.split(f, g)
+
+        override def merge[A, B, C](
+            f: TracerA[M, A, B],
+            g: TracerA[M, A, C]
+        ): TracerA[M, A, (B, C)] = TracerAOps.merge(f, g)
     }
 
     def nat[M[_], N[_], A, B](h: M ~> N)(t: TracerA[M, A, B]): TracerA[N, A, B] = t match {


### PR DESCRIPTION
Supersedes #695 (which bundled this with scribe benchmark scaffolding and targeted the logging stack — please close it; this is the same tracer change, alone, against `main`). The two files touched are identical on `main` and the stack, so this is independent of #684–#686 and they will rebase over it cleanly.

## What

The upstream Haskell library ([avieth/contra-tracer](https://github.com/avieth/contra-tracer)) carries four performance mechanisms that GHC applies automatically but the JVM cannot:

- `{-# INLINE traceWith #-}` + let-floating — hoists the compiled arrow out of the hot loop
- `arr (const ())` as a CAF — the run-tail is allocated once, globally
- a strict hand-written `(****)` backing its `(***)` equations — its comment measures the class default at ~1KB of thunks per level per dispatch
- explicit `(|||)` equations — the class default inserts an extra merge stage per dispatch

The Scala port inherited the semantics but recompiled the arrow on every `traceWith` and used the cats class defaults — paying per trace what GHC pays once. This ports all four by hand, semantics unchanged:

- **`TracerA.compile`** + a memoised `lazy val` runner per `ContraTracer`: the arrow compiles to a plain `A => M[Unit]` once per tracer, not per trace. A squelched tracer compiles to a cached `unit` — null tracing is allocation-free.
- `compile` uses `.void` on the emitter (one map) instead of the `>>> arr(const ())` flatMap+pure tail.
- **`split`/`merge` overrides** in the `Arrow` given (strict `parK`/`fanK`), dropping the default's lifted dup/swap stages on every `|+|` fan-out.
- **`choice` override** in the `ArrowChoice` given (`eitherK`/`plusK`), dropping the default's extra merge stage on the `traceMaybe`/`squelchUnlessM` path.

Mechanical consequence: `ContraTracer` now stores its `Monad[M]` (needed to memoise), so `emit`/`apply` tighten `Applicative → Monad` and the redundant method-level `using Monad[M]` params drop. No call site changes (everything is `IO`).

## Measured

Batched JMH (1000 events per `unsafeRunSync`, `-prof gc`), enabled path:

| Layer (per-op) | before | after |
|---|---:|---:|
| bare `IO` floor | 21.7M ops/s, 137 B | 21.7M ops/s, 137 B |
| ContraTracer emit | 6.9M, 736 B | **8.2M, 568 B** |
| full SLF4J sink | 3.1M, 1,288 B | 3.2M, 1,142 B |

Tracer overhead over a bare `IO` drops ~28% (600 → 430 B/op). The full sink barely moves because log4cats+logback dominates that path. (Benchmark harness not included here; it lives on `peter/logging-backend-bench` with a writeup.)

## Validation

Clean `-Werror` compile (core + integration) from `clean` on this base; full suite: 330 passed, 0 failed. On the logging stack the same change also passes the tracer-specific suites (composition-algebra table and the squelch-laziness proof, which exercises the cached-unit path).