### PR TITLE
Serve the read-only HTTP surface on coil peers

### DIFF
--- a/integration/src/test/scala/hydrozoa/integration/harness/MultiPeerHeadHarness.scala
+++ b/integration/src/test/scala/hydrozoa/integration/harness/MultiPeerHeadHarness.scala
@@ -1690,7 +1690,9 @@ object MultiPeerHeadHarness:
               nodeConfig.headConfig.headPeerNums.toList.map(_.convert).toVector
             )
             HydrozoaRoutes(
-              requestSequencer,
+              // Some: the harness builds a head node's routes, and only a head mounts the
+              // submission and admin-finalize endpoints.
+              Some(requestSequencer),
               conns.blockWeaver,
               // The harness runs no head lifecycle, so readiness is a constant Active.
               IO.pure(NodeStatus.Active),

--- a/src/main/scala/hydrozoa/app/Serve.scala
+++ b/src/main/scala/hydrozoa/app/Serve.scala
@@ -215,7 +215,14 @@ object Serve {
                       httpExtraTracer
                     )
                 case NodeRun.CoilNode(mrm) =>
-                    runCoilNode(system, mrm)
+                    runCoilNode(
+                      nodeConfig,
+                      system,
+                      mrm,
+                      consensusReader,
+                      metrics,
+                      httpExtraTracer
+                    )
             }
         }
     }
@@ -446,8 +453,9 @@ object Serve {
         } yield NodeRun.HeadNode(mrm, l2QueryReader)
     }
 
-    /** Build the coil-node uplink dialer (no inbound server) and allocate the
-      * [[CoilMultisigRegimeManager]]. A coil peer runs no user-facing HTTP server.
+    /** Build the coil-node uplink dialer (no inbound WebSocket server) and allocate the
+      * [[CoilMultisigRegimeManager]]. The coil's HTTP surface is bound separately, in
+      * `runCoilNode`.
       */
     private def buildCoilNode(
         nodeConfig: NodeConfig,
@@ -497,6 +505,33 @@ object Serve {
         } yield NodeRun.CoilNode(mrm)
     }
 
+    /** The HTTP bind address and admin credentials, from the node's own private config. Shared by
+      * both roles: a coil serves the same server minus the mutating routes, so it reads the same
+      * fields.
+      */
+    private def httpServerConfig(nodeConfig: NodeConfig): HydrozoaServer.Config = {
+        val httpHost = Host
+            .fromString(nodeConfig.httpHost)
+            .getOrElse(
+              throw new IllegalArgumentException(
+                s"Invalid httpHost in node config: ${nodeConfig.httpHost}"
+              )
+            )
+        val httpPort = Port
+            .fromString(nodeConfig.httpPort)
+            .getOrElse(
+              throw new IllegalArgumentException(
+                s"Invalid httpPort in node config: ${nodeConfig.httpPort}"
+              )
+            )
+        HydrozoaServer.Config(
+          host = httpHost,
+          port = httpPort,
+          adminUsername = nodeConfig.adminUsername,
+          adminPassword = nodeConfig.adminPassword
+        )
+    }
+
     private def runHeadNode(
         nodeConfig: NodeConfig,
         system: ActorSystem[IO],
@@ -512,33 +547,17 @@ object Serve {
 
             // Start HTTP server once RequestSequencer is available
             _ <- mrm.connectionsDeferred.get.flatMap { connections =>
-                val httpHost = Host
-                    .fromString(nodeConfig.httpHost)
-                    .getOrElse(
-                      throw new IllegalArgumentException(
-                        s"Invalid httpHost in node config: ${nodeConfig.httpHost}"
-                      )
-                    )
-                val httpPort = Port
-                    .fromString(nodeConfig.httpPort)
-                    .getOrElse(
-                      throw new IllegalArgumentException(
-                        s"Invalid httpPort in node config: ${nodeConfig.httpPort}"
-                      )
-                    )
-                val serverConfig = HydrozoaServer.Config(
-                  host = httpHost,
-                  port = httpPort,
-                  adminUsername = nodeConfig.adminUsername,
-                  adminPassword = nodeConfig.adminPassword
-                )
+                val serverConfig = httpServerConfig(nodeConfig)
                 val httpTracer = Slf4jTracer.sink
                     .contramap(HydrozoaHttpEventFormat.humanFormat) |+| httpExtraTracer
                 log.info("Starting HTTP server...") *>
                     HydrozoaServer
                         .create(
-                          connections.requestSequencer.getOrElse(
-                            sys.error("RequestSequencer required on head peers")
+                          // Always present on a head; the `Option` exists for the coil.
+                          Some(
+                            connections.requestSequencer.getOrElse(
+                              sys.error("RequestSequencer required on head peers")
+                            )
                           ),
                           connections.blockWeaver,
                           mrm.nodeStatus.get,
@@ -560,13 +579,50 @@ object Serve {
             exit <- abnormalTermination
         } yield exit
 
+    /** A coil peer runs the same HTTP server as a head, minus the mutating routes: it passes `None`
+      * for the request sequencer, which is what removes them (see
+      * [[hydrozoa.multisig.server.HydrozoaRoutes]]).
+      *
+      * Serving a coil at all is for observability. It runs its own `StackComposer`, and its
+      * hard-ack gates the head's next stack — so without `/head/stats` and `/metrics`, a coil
+      * wedged on its single-flight gate looks exactly like an idle one.
+      */
     private def runCoilNode(
+        nodeConfig: NodeConfig,
         system: ActorSystem[IO],
         mrm: CoilMultisigRegimeManager,
+        consensusReader: ConsensusStoreReader[IO],
+        metrics: PeerMetrics,
+        httpExtraTracer: ContraTracer[IO, HydrozoaHttpEvent],
     ): IO[ExitCode] =
         for {
             _ <- system.actorOf(mrm, "CoilMultisigRegimeManager")
             _ <- log.info("Hydrozoa coil node started successfully")
+
+            _ <- mrm.connectionsDeferred.get.flatMap { connections =>
+                val serverConfig = httpServerConfig(nodeConfig)
+                val httpTracer = Slf4jTracer.sink
+                    .contramap(HydrozoaHttpEventFormat.humanFormat) |+| httpExtraTracer
+                log.info("Starting HTTP server (coil: read-only surface)...") *>
+                    HydrozoaServer
+                        .create(
+                          // None on a coil — this is what removes the mutating routes.
+                          connections.requestSequencer,
+                          connections.blockWeaver,
+                          mrm.nodeStatus.get,
+                          consensusReader,
+                          // A coil always runs a remote ledger, so no L2-query endpoints.
+                          None,
+                          nodeConfig.headConfig,
+                          serverConfig,
+                          metrics,
+                          httpTracer,
+                        )
+                        .use(_ => IO.never)
+                        .start
+                        .void
+            }
+
             _ <- system.waitForTermination
             exit <- abnormalTermination
         } yield exit

--- a/src/main/scala/hydrozoa/multisig/consensus/StackComposer.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/StackComposer.scala
@@ -214,6 +214,7 @@ final case class StackComposer(
     ): IO[Unit] = {
         val stackNum = s.brief.stackNum
         for {
+            _ <- tracer.traceWith(StackComposerEvent.PreviousStackHardConfirmed(stackNum))
             _ <- state.update(_.withPreviousStackHardConfirmed(stackNum))
             _ <- tryProgress
         } yield ()
@@ -287,6 +288,9 @@ final case class StackComposer(
                     // withheld until local round-1 confirmation).
                     _ <- conn.slowConsensusActor ! handoff
                     _ <- state.update(_.afterClose(nextStackNum, prefix, newTreasury, newMap))
+                    _ <- tracer.traceWith(
+                      StackComposerEvent.SingleFlightGateClosed(nextStackNum)
+                    )
                     _ <- reportEquity(newTreasury)
                 } yield ()
         }
@@ -489,6 +493,9 @@ final case class StackComposer(
                                 _ <- conn.slowConsensusActor ! handoff
                                 _ <- state.update(
                                   _.afterClose(nextStackNum, slice, newTreasury, newMap)
+                                )
+                                _ <- tracer.traceWith(
+                                  StackComposerEvent.SingleFlightGateClosed(nextStackNum)
                                 )
                                 _ <- reportEquity(newTreasury)
                             } yield ()

--- a/src/main/scala/hydrozoa/multisig/consensus/StackComposerEvent.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/StackComposerEvent.scala
@@ -29,6 +29,21 @@ object StackComposerEvent:
         isLeader: Boolean
     ) extends StackComposerEvent
 
+    /** The single-flight gate OPENED: `Stack.HardConfirmed` for the previous stack reached the
+      * composer, so the next stack may close.
+      *
+      * Paired with [[SingleFlightGateClosed]], these make the gate's transitions observable. A
+      * composer parked in `WaitingForPreviousHardConfirmation` otherwise gives no way to tell a
+      * confirmation that never arrived from one that arrived and was then overwritten.
+      */
+    final case class PreviousStackHardConfirmed(stackNum: StackNumber) extends StackComposerEvent
+
+    /** The single-flight gate CLOSED: a stack was closed, so the composer will not close another
+      * until that one hard-confirms. Emitted from `afterClose`, i.e. after the brief and hard-acks
+      * have already left this node.
+      */
+    final case class SingleFlightGateClosed(stackNum: StackNumber) extends StackComposerEvent
+
     /** Follower detected a structural inconsistency between the leader's brief and the local
       * single-flight position — unrecoverable; node will panic.
       */

--- a/src/main/scala/hydrozoa/multisig/consensus/StackComposerEventFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/StackComposerEventFormat.scala
@@ -21,6 +21,16 @@ object StackComposerEventFormat:
                   s"$role closing stack $sn with blocks $first..$last",
                   "stackNum" -> s"${sn: Int}"
                 )
+            case PreviousStackHardConfirmed(sn) =>
+                info(
+                  s"single-flight gate OPEN: stack $sn hard-confirmed",
+                  "stackNum" -> s"${sn: Int}"
+                )
+            case SingleFlightGateClosed(sn) =>
+                info(
+                  s"single-flight gate CLOSED on stack $sn; awaiting its hard confirmation",
+                  "stackNum" -> s"${sn: Int}"
+                )
             case StructuralDivergence(sn, lFirst, lLast, expected) =>
                 warn(
                   s"Follower stack $sn structural divergence: leader brief [$lFirst..$lLast] but expected to start at $expected",

--- a/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
+++ b/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
@@ -41,7 +41,11 @@ import sttp.tapir.swagger.bundle.SwaggerInterpreter
   * result is a plain `HttpRoutes[IO]`, and it mounts on the same Ember server.
   */
 class HydrozoaRoutes(
-    requestSequencer: RequestSequencer.Handle,
+    /** `None` on a coil peer, which must not accept user submissions or trigger finalization. Same
+      * idiom as [[l2QueryReader]]: an absent capability removes its routes rather than mounting one
+      * that fails at request time.
+      */
+    requestSequencer: Option[RequestSequencer.Handle],
     blockWeaver: BlockWeaver.Handle,
     nodeStatus: IO[NodeStatus],
     consensusReader: ConsensusStoreReader[IO],
@@ -78,7 +82,9 @@ class HydrozoaRoutes(
 
     // ---- Endpoint definitions (the single source of truth for routes + schema) ----
 
-    private val submitRequestEndpoint: ServerEndpoint[Any, IO] =
+    private def submitRequestEndpoint(
+        sequencer: RequestSequencer.Handle
+    ): ServerEndpoint[Any, IO] =
         endpoint.post
             .in("head" / "requests")
             .name("postHeadRequest")
@@ -112,7 +118,7 @@ class HydrozoaRoutes(
                   "transaction (a native, self-authenticating Cardano tx). Payloads are lowercase " +
                   "hex. Returns the assigned request id."
             )
-            .serverLogic(body => acceptUserRequest("POST /head/requests", body))
+            .serverLogic(body => acceptUserRequest("POST /head/requests", body, sequencer))
 
     private val headInfoEndpoint: ServerEndpoint[Any, IO] =
         endpoint.get
@@ -585,10 +591,21 @@ class HydrozoaRoutes(
                     )
             )
 
-    /** The core API endpoints, in the order they appear in the docs — always served. */
+    /** The two mutating endpoints, mounted only on a node that accepts submissions.
+      *
+      * They stay at the head and tail of `coreEndpoints` below so that on a head node the endpoint
+      * ORDER is unchanged — the generated `openapi.yaml` is pinned by a golden test, and order is
+      * part of that document.
+      */
+    private val submitEndpoints: List[ServerEndpoint[Any, IO]] =
+        requestSequencer.fold(List.empty)(sequencer => List(submitRequestEndpoint(sequencer)))
+
+    private val finalizeEndpoints: List[ServerEndpoint[Any, IO]] =
+        requestSequencer.fold(List.empty)(_ => List(finalizeEndpoint))
+
+    /** The core API endpoints, in the order they appear in the docs. */
     private val coreEndpoints: List[ServerEndpoint[Any, IO]] =
-        List(
-          submitRequestEndpoint,
+        submitEndpoints ++ List(
           headInfoEndpoint,
           requestsEndpoint,
           requestDetailsEndpoint,
@@ -602,9 +619,8 @@ class HydrozoaRoutes(
           readyEndpoint,
           statsEndpoint,
           metricsEndpoint,
-          versionEndpoint,
-          finalizeEndpoint
-        ) ++ blockEffectKindEndpoints
+          versionEndpoint
+        ) ++ finalizeEndpoints ++ blockEffectKindEndpoints
 
     /** OpenAPI doc options:
       *   - drop the `View` suffix from every DTO's component-schema name (the Scala types keep it
@@ -653,7 +669,8 @@ class HydrozoaRoutes(
       */
     private def acceptUserRequest(
         path: String,
-        body: SubmitRequestView
+        body: SubmitRequestView,
+        sequencer: RequestSequencer.Handle
     ): IO[Either[(StatusCode, ErrorResponse), RequestAcceptedResponse]] =
         val handled: IO[Either[(StatusCode, ErrorResponse), RequestAcceptedResponse]] =
             for {
@@ -664,7 +681,7 @@ class HydrozoaRoutes(
                     case Right(request) => IO.pure(request)
                 }
                 _ <- tracer.traceWith(HydrozoaRoutes.decodedEvent(path, userRequest))
-                result <- (requestSequencer ?: userRequest).flatMap {
+                result <- (sequencer ?: userRequest).flatMap {
                     case Right(id) =>
                         IO.pure(Right(ApiDto.mkRequestAcceptedResponse(id)))
                     // Screening / backpressure rejection: an expected 400, not a fault — log the
@@ -964,7 +981,7 @@ object HydrozoaRoutes {
     val apiVersion: String = "0.1.0"
 
     def apply(
-        requestSequencer: RequestSequencer.Handle,
+        requestSequencer: Option[RequestSequencer.Handle],
         blockWeaver: BlockWeaver.Handle,
         nodeStatus: IO[NodeStatus],
         consensusReader: ConsensusStoreReader[IO],

--- a/src/main/scala/hydrozoa/multisig/server/HydrozoaServer.scala
+++ b/src/main/scala/hydrozoa/multisig/server/HydrozoaServer.scala
@@ -31,7 +31,8 @@ object HydrozoaServer {
     /** Create and start the HTTP server.
       *
       * @param requestSequencer
-      *   Handle to the RequestSequencer actor
+      *   Handle to the RequestSequencer actor, or `None` on a coil peer. See [[HydrozoaRoutes]] for
+      *   what its absence removes.
       * @param blockWeaver
       *   Handle to the BlockWeaver actor
       * @param nodeStatus
@@ -53,7 +54,7 @@ object HydrozoaServer {
       *   Resource that manages the server lifecycle
       */
     def create(
-        requestSequencer: RequestSequencer.Handle,
+        requestSequencer: Option[RequestSequencer.Handle],
         blockWeaver: BlockWeaver.Handle,
         nodeStatus: IO[NodeStatus],
         consensusReader: ConsensusStoreReader[IO],
@@ -91,7 +92,7 @@ object HydrozoaServer {
       * Note: In production, this would be integrated into HydrozoaNode
       */
     def run(
-        requestSequencer: RequestSequencer.Handle,
+        requestSequencer: Option[RequestSequencer.Handle],
         blockWeaver: BlockWeaver.Handle,
         nodeStatus: IO[NodeStatus],
         consensusReader: ConsensusStoreReader[IO],

--- a/src/test/scala/hydrozoa/multisig/server/HeadBlocksEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/HeadBlocksEndpointsTest.scala
@@ -170,7 +170,7 @@ class HeadBlocksEndpointsTest extends AnyFunSuite:
                       }
                     )
                     routes <- HydrozoaRoutes(
-                      requestSequencerStub,
+                      Some(requestSequencerStub),
                       blockWeaverStub,
                       IO.pure(NodeStatus.Active),
                       reader,

--- a/src/test/scala/hydrozoa/multisig/server/HeadEffectsEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/HeadEffectsEndpointsTest.scala
@@ -169,7 +169,7 @@ class HeadEffectsEndpointsTest extends AnyFunSuite:
                                 _ => IO.pure(())
                         })
                         routes <- HydrozoaRoutes(
-                          reqStub,
+                          Some(reqStub),
                           bwStub,
                           IO.pure(NodeStatus.Active),
                           stubReader(brief),

--- a/src/test/scala/hydrozoa/multisig/server/HeadRequestsEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/HeadRequestsEndpointsTest.scala
@@ -134,7 +134,7 @@ class HeadRequestsEndpointsTest extends AnyFunSuite:
                       }
                     )
                     routes <- HydrozoaRoutes(
-                      requestSequencerStub,
+                      Some(requestSequencerStub),
                       blockWeaverStub,
                       IO.pure(NodeStatus.Active),
                       reader,
@@ -336,6 +336,76 @@ class HeadRequestsEndpointsTest extends AnyFunSuite:
                 val _ = assert(missing._1 == Status.NotFound)
                 val _ = assert(malformed.status.code >= 400 && malformed.status.code < 500)
                 val _ = assert(outOfRange.status.code >= 400 && outOfRange.status.code < 500)
+                ()
+            }
+        }
+    }
+
+    /** Build the routes the way a **coil** peer gets them — `requestSequencer = None`, because a
+      * follower accepts no user requests — and run `check`.
+      */
+    private def withCoilRoutes(check: HttpApp[IO] => IO[Unit]): Unit =
+        ActorSystem[IO]("HeadRequestsEndpointsTest-coil")
+            .use { system =>
+                for {
+                    blockWeaverStub <- system.actorOf(
+                      new Actor[IO, BlockWeaver.Request] {
+                          override def receive: Receive[IO, BlockWeaver.Request] = _ => IO.pure(())
+                      }
+                    )
+                    routes <- HydrozoaRoutes(
+                      None,
+                      blockWeaverStub,
+                      IO.pure(NodeStatus.Active),
+                      stubReader(Map.empty),
+                      None,
+                      headConfig,
+                      HydrozoaServer.Config(adminUsername = "admin", adminPassword = "admin"),
+                      PeerMetrics.create(0L, Vector.empty),
+                      ContraTracer[IO, HydrozoaHttpEvent](_ => IO.unit)
+                    )
+                    _ <- check(routes.routes.orNotFound)
+                } yield ()
+            }
+            .unsafeRunSync()
+
+    test(
+      "on a coil peer (no request sequencer) the mutating routes are absent, reads still serve"
+    ) {
+        // The coil exists to be observable: its read surface must answer, or the whole point of
+        // giving it a server is lost. So this asserts both halves — the mutations are gone AND a
+        // read still works. Without the second assertion a totally unmounted router would pass.
+        withCoilRoutes { app =>
+            for {
+                submit <- app.run(
+                  Request[IO](Method.POST, Uri.unsafeFromString("/head/requests"))
+                )
+                finalize <- app.run(
+                  Request[IO](Method.POST, Uri.unsafeFromString("/api/admin/finalize"))
+                )
+                stats <- app.run(Request[IO](Method.GET, Uri.unsafeFromString("/head/stats")))
+                ready <- app.run(Request[IO](Method.GET, Uri.unsafeFromString("/ready")))
+            } yield {
+                // 405, not 404: the coil still serves GET /head/requests (the listing), so the
+                // PATH exists and only the POST method is gone. That is the more accurate answer
+                // of the two, and asserting 404 here would be asserting the wrong behaviour.
+                val _ = assert(
+                  submit.status == Status.MethodNotAllowed,
+                  s"POST /head/requests must not be mounted on a coil, got ${submit.status}"
+                )
+                // 404, not the 401 challenge a mounted admin route would give.
+                val _ = assert(
+                  finalize.status == Status.NotFound,
+                  s"POST /api/admin/finalize must not be mounted on a coil, got ${finalize.status}"
+                )
+                val _ = assert(
+                  stats.status == Status.Ok,
+                  s"GET /head/stats must serve on a coil, got ${stats.status}"
+                )
+                val _ = assert(
+                  ready.status == Status.Ok,
+                  s"GET /ready must serve on a coil, got ${ready.status}"
+                )
                 ()
             }
         }

--- a/src/test/scala/hydrozoa/multisig/server/L2QueryEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/L2QueryEndpointsTest.scala
@@ -89,7 +89,7 @@ class L2QueryEndpointsTest extends AnyFunSuite:
                       }
                     )
                     routes <- HydrozoaRoutes(
-                      requestSequencerStub,
+                      Some(requestSequencerStub),
                       blockWeaverStub,
                       IO.pure(NodeStatus.Active),
                       ConsensusStoreReader.empty,
@@ -123,7 +123,7 @@ class L2QueryEndpointsTest extends AnyFunSuite:
                       }
                     )
                     routes <- HydrozoaRoutes(
-                      requestSequencerStub,
+                      Some(requestSequencerStub),
                       blockWeaverStub,
                       IO.pure(NodeStatus.Active),
                       ConsensusStoreReader.empty,

--- a/src/test/scala/hydrozoa/multisig/server/OpenApiSchemaTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/OpenApiSchemaTest.scala
@@ -54,7 +54,7 @@ class OpenApiSchemaTest extends AnyFunSuite:
                       }
                     )
                     routes <- HydrozoaRoutes(
-                      requestSequencerStub,
+                      Some(requestSequencerStub),
                       blockWeaverStub,
                       IO.pure(NodeStatus.Active),
                       ConsensusStoreReader.empty,

--- a/src/test/scala/hydrozoa/multisig/server/ReadyEndpointTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/ReadyEndpointTest.scala
@@ -48,7 +48,7 @@ class ReadyEndpointTest extends AnyFunSuite:
                       }
                     )
                     routes <- HydrozoaRoutes(
-                      requestSequencerStub,
+                      Some(requestSequencerStub),
                       blockWeaverStub,
                       IO.pure(status),
                       ConsensusStoreReader.empty,


### PR DESCRIPTION
A coil runs its own `StackComposer`, and its hard-ack gates the head's next stack — but it served no HTTP at all, so its composer phase, `/head/stats` and `/metrics` were unreachable. During the staging stall on 2026-08-26 that cost real diagnostic time: with no way to query the coil, its idleness had to be inferred from CPU, and an idle composer looks exactly like a wedged one.

## How to review this

One commit. `HydrozoaRoutes.scala` is where the shape change lives; `Serve.scala` is the wiring. The test worth reading is the coil case in `HeadRequestsEndpointsTest`, because it asserts both halves.

## Change

`requestSequencer` becomes an `Option` on `HydrozoaRoutes` and `HydrozoaServer`. It is `None` on a coil — followers accept no user requests — and the submission and admin-finalization routes are simply not mounted when it is absent. That is the idiom `l2QueryReader` already uses, so the surface is read-only by construction rather than by configuration.

The composer's single-flight gate also gains two events. It had none for receiving `Stack.HardConfirmed`, so a composer parked in `WaitingForPreviousHardConfirmation` gave no way to tell a confirmation that never arrived from one that arrived and was then overwritten. `PreviousStackHardConfirmed` and `SingleFlightGateClosed` make both transitions observable.

## Rationale

**The two mutating endpoints stay at the head and tail of `coreEndpoints`.** A head node's endpoint order is therefore unchanged, and so is its golden `openapi.yaml` — the schema diff for this change is empty, which is the check that the head's public surface did not move.

**The integration harness is updated in this commit rather than a follow-up.** Widening the parameter breaks every caller that passed a handle unwrapped, and one of them is the harness, which lives in `integration` — a separate sbt project that `sbt test` does not compile. Splitting it would leave a commit on this branch that builds under `sbt test` and fails under `sbt integration/Test/compile`.

## Risk

The failure mode this introduces is a head node accidentally constructed with `None`, which would silently serve no submission endpoint. The coil test guards the shape from the other direction — it asserts the mutating routes are gone **and** that reads still serve, so a wholly unmounted router fails rather than passes.

`POST /head/requests` is a 405 on a coil, not a 404: `GET /head/requests` is still mounted there, so the path exists and only the method is gone.

## Testing

**547 passed, 0 failed, 0 errors** on this commit, and `integration/Test/compile` green on it too. The suite also reports **10 canceled and 3 ignored** on every commit of this stack: the canceled ones are the Blockfrost-backed tests, which need an API key this environment does not have. They are pre-existing and identical on the base.

Newly covered: a coil's route set, asserted positively and negatively.

Not covered: a coil serving under real load. That is exercised by the staging deployment rather than by a test.

## Scope

An observability change. Nothing about consensus, and nothing a head node serves, is different.

## Base

`base/pr-stack-2026-08-27` — a branch that merges the three open PRs this stack needs and adds nothing of its own:

| merged | branch                                  | why this stack needs it                                  |
| ------ | --------------------------------------- | -------------------------------------------------------- |
| #683   | `peter/bytestring-hex-hygiene`          | carries the whole #675 -> #683 chain                     |
| #673   | `ilia/stack-composer-phase-metrics`     | the composer tracing here builds on it                   |
| #682   | `peter/rulebased-tick-fiber-idempotent` | required by `fix/fiber-lifecycle` further up — see there |

Once those three are on `main`, retarget this PR at `main` and the merge commit disappears from the diff. #670 and #672 are in the staging RC but are **not** dependencies of anything here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
