### PR TITLE
Drop the two unpaged listing endpoints — an unauthenticated caller can OOM a node

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -4,40 +4,6 @@ info:
   version: 0.1.0
 paths:
   /head/requests:
-    get:
-      tags:
-      - Requests
-      description: Requests the head has assigned an id — opaque request id, author
-        peer number, and type (transaction or deposit). Filter with ?type=transaction|deposit
-        and ?peer_number=<n>.
-      operationId: getHeadRequests
-      parameters:
-      - name: type
-        in: query
-        required: false
-        schema:
-          type: string
-      - name: peer_number
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/RequestSummary'
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
     post:
       tags:
       - Requests
@@ -161,28 +127,6 @@ paths:
                       settlementEffect: 4d5e6f7a8b9c…
                       type: HARD_CONFIRMED
                     type: deposit
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-  /head/blocks:
-    get:
-      tags:
-      - Blocks
-      description: Every block of the head in block order — number, fast-cycle leader,
-        and type. Block 0 is the head's initial block (config, no leader).
-      operationId: getHeadBlocks
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/BlockSummary'
         default:
           description: ''
           content:
@@ -889,26 +833,6 @@ components:
           $ref: '#/components/schemas/RateStats'
         requestRate:
           $ref: '#/components/schemas/RateStats'
-    BlockSummary:
-      title: BlockSummary
-      type: object
-      required:
-      - number
-      - blockType
-      properties:
-        number:
-          type: integer
-          format: int32
-        leader:
-          type: integer
-          format: int32
-        blockType:
-          type: string
-          enum:
-          - initial
-          - minor
-          - major
-          - final
     BlockTiming:
       title: BlockTiming
       type: object
@@ -1500,25 +1424,6 @@ components:
           PROPOSED: '#/components/schemas/RequestProposed'
           SOFT_CONFIRMED: '#/components/schemas/RequestSoftConfirmed'
           UNPROCESSED: '#/components/schemas/RequestUnprocessed'
-    RequestSummary:
-      title: RequestSummary
-      type: object
-      required:
-      - requestId
-      - peerNumber
-      - requestType
-      properties:
-        requestId:
-          type: integer
-          format: int64
-        peerNumber:
-          type: integer
-          format: int32
-        requestType:
-          type: string
-          enum:
-          - deposit
-          - transaction
     RequestUnprocessed:
       title: RequestUnprocessed
       type: object

--- a/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
+++ b/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
@@ -6,7 +6,6 @@ import hydrozoa.BuildInfo
 import hydrozoa.config.head.HeadConfig
 import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.NodeStatus
-import hydrozoa.multisig.consensus.peer.HeadPeerNumber
 import hydrozoa.multisig.consensus.{BlockWeaver, RequestSequencer, UserRequest, UserRequestWithId}
 import hydrozoa.multisig.ledger.block.{BlockBrief, BlockNumber}
 import hydrozoa.multisig.ledger.event.RequestId
@@ -172,28 +171,6 @@ class HydrozoaRoutes(
                     DecodeResult.Error(s, new IllegalArgumentException("malformed 32-byte l1TxId"))
         )(_.toHex)
 
-    private val blocksEndpoint: ServerEndpoint[Any, IO] =
-        endpoint.get
-            .in("head" / "blocks")
-            .name("getHeadBlocks")
-            .tag("Blocks")
-            .out(jsonBody[List[BlockSummaryView]])
-            .errorOut(errorOut)
-            .description(
-              "Every block of the head in block order — number, fast-cycle leader, and type. " +
-                  "Block 0 is the head's initial block (config, no leader)."
-            )
-            .serverLogic(_ =>
-                consensusReader.blockBriefs
-                    .map(briefs =>
-                        Right(
-                          ApiDto.mkInitialBlockSummaryView ::
-                              briefs.map(ApiDto.mkBlockSummaryView(_, headConfig.nHeadPeers))
-                        )
-                    )
-                    .handleError(err => Left(fail(StatusCode.InternalServerError, err.getMessage)))
-            )
-
     private val blockDetailsEndpoint: ServerEndpoint[Any, IO] =
         endpoint.get
             .in("head" / "blocks" / path[BlockNumber]("block-number"))
@@ -320,25 +297,6 @@ class HydrozoaRoutes(
           "fallback" -> EffectKind.Fallback,
           "finalization" -> EffectKind.Finalization
         ).map(blockTxEffectEndpoint) :+ blockSecEffectEndpoint
-
-    private val requestsEndpoint: ServerEndpoint[Any, IO] =
-        endpoint.get
-            .in("head" / "requests")
-            .in(query[Option[String]]("type"))
-            .in(query[Option[Int]]("peer_number"))
-            .name("getHeadRequests")
-            .tag("Requests")
-            .out(jsonBody[List[RequestSummaryView]])
-            .errorOut(errorOut)
-            .description(
-              "Requests the head has assigned an id — opaque request id, author peer number, and " +
-                  "type (transaction or deposit). Filter with ?type=transaction|deposit and " +
-                  "?peer_number=<n>."
-            )
-            .serverLogic((typeFilter, peerFilter) =>
-                listRequests(typeFilter, peerFilter)
-                    .handleError(err => Left(fail(StatusCode.InternalServerError, err.getMessage)))
-            )
 
     private val transactionDetailExample: RequestDetailsView =
         RequestDetailsView.TransactionView(
@@ -603,13 +561,19 @@ class HydrozoaRoutes(
     private val finalizeEndpoints: List[ServerEndpoint[Any, IO]] =
         requestSequencer.fold(List.empty)(_ => List(finalizeEndpoint))
 
-    /** The core API endpoints, in the order they appear in the docs. */
+    /** The core API endpoints, in the order they appear in the docs.
+      *
+      * ⛔ `GET /head/requests` and `GET /head/blocks` are deliberately ABSENT. Each listed an entire
+      * column family into a heap `List` with no limit or offset — `?type=` / `?peer_number=` filter
+      * the result but still scan everything — so one unauthenticated call could exhaust the heap,
+      * and both journals only grow. Re-mount them only behind real paging (a cursor plus a bounded
+      * page size), never a bare limit that still requires the full scan to apply it. Everything
+      * kept here is keyed by id or block number, or is a fixed-size summary.
+      */
     private val coreEndpoints: List[ServerEndpoint[Any, IO]] =
         submitEndpoints ++ List(
           headInfoEndpoint,
-          requestsEndpoint,
           requestDetailsEndpoint,
-          blocksEndpoint,
           blockDetailsEndpoint,
           blockBodyEndpoint,
           blockEffectsEndpoint,
@@ -870,24 +834,6 @@ class HydrozoaRoutes(
       * The lifecycle status resolves through the request → block index and the block's confirmation
       * records.
       */
-    /** The request listing, optionally narrowed to one author peer (`peer_number`) and one type
-      * (`transaction`/`deposit`). An unknown `type` value matches nothing (empty list); an
-      * out-of-range `peer_number` likewise yields an empty list, since no such author exists.
-      */
-    private def listRequests(
-        typeFilter: Option[String],
-        peerFilter: Option[Int]
-    ): IO[Either[(StatusCode, ErrorResponse), List[RequestSummaryView]]] =
-        val peers = peerFilter match
-            case None    => headConfig.headPeerNums.toList
-            case Some(p) => headConfig.headPeerNums.toList.filter(_.convert == p)
-        peers
-            .traverse(consensusReader.requestsOf)
-            .map { perPeer =>
-                val rows = perPeer.flatten.map(t => ApiDto.mkRequestSummaryView(t.payload))
-                Right(typeFilter.fold(rows)(t => rows.filter(_.requestType == t)))
-            }
-
     private def requestDetails(
         id: RequestId
     ): IO[Either[(StatusCode, ErrorResponse), RequestDetailsView]] =

--- a/src/test/scala/hydrozoa/multisig/server/HeadBlocksEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/HeadBlocksEndpointsTest.scala
@@ -191,23 +191,27 @@ class HeadBlocksEndpointsTest extends AnyFunSuite:
             body <- resp.as[Json]
         } yield (resp.status, body)
 
-    test("GET /head/blocks lists block 0 plus the spine briefs, leaders round-robin") {
+    test("GET /head/blocks is not mounted — it listed the whole spine with no paging") {
+        // Same defect as GET /head/requests: every block brief into one heap List, no limit and no
+        // offset at all. Keyed lookups are unaffected, which is what the second assertion pins.
         mkMinorBrief1
             .flatMap(brief =>
                 IO(withRoutes(stubReader(brief, soft = false, hard = false)) { app =>
-                    get(app, "/head/blocks").map { (status, body) =>
-                        val _ = assert(status == Status.Ok)
-                        val rows = body.asArray.get
-                        val _ = assert(rows.size == 2)
-                        val row0 = rows(0).hcursor
-                        val _ = assert(row0.get[Int]("number") == Right(0))
-                        val _ = assert(row0.get[String]("blockType") == Right("initial"))
-                        val _ = assert(row0.downField("leader").focus.forall(_.isNull))
-                        val row1 = rows(1).hcursor
-                        val _ = assert(row1.get[Int]("number") == Right(1))
-                        val _ = assert(row1.get[String]("blockType") == Right("minor"))
+                    for {
+                        listing <- app.run(
+                          Request[IO](Method.GET, Uri.unsafeFromString("/head/blocks"))
+                        )
+                        byNum <- app.run(
+                          Request[IO](Method.GET, Uri.unsafeFromString("/head/blocks/1"))
+                        )
+                    } yield {
                         val _ = assert(
-                          row1.get[Int]("leader") == Right(1 % headConfig.nHeadPeers.convert)
+                          listing.status == Status.NotFound,
+                          s"GET /head/blocks must not be mounted, got ${listing.status}"
+                        )
+                        val _ = assert(
+                          byNum.status == Status.Ok,
+                          s"GET /head/blocks/{n} must still serve, got ${byNum.status}"
                         )
                         ()
                     }

--- a/src/test/scala/hydrozoa/multisig/server/HeadRequestsEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/HeadRequestsEndpointsTest.scala
@@ -155,47 +155,33 @@ class HeadRequestsEndpointsTest extends AnyFunSuite:
             body <- resp.as[Json]
         } yield (resp.status, body)
 
-    test("GET /head/requests lists rows with the opaque i64 id, peer number, and type") {
-        val reader = stubReader(
-          Map(peer0 -> List(txRequest(peer0, 0), depositRequest(peer0, 1)))
-        )
-        withRoutes(reader) { app =>
-            get(app, "/head/requests").map { (status, body) =>
-                val _ = assert(status == Status.Ok)
-                val rows = body.asArray.get
-                val _ = assert(rows.size == 2)
-                val r0 = rows(0).hcursor
-                // peer 0, request 0 packs to i64 0.
-                val _ = assert(r0.get[Long]("requestId") == Right(0L))
-                val _ = assert(r0.get[Int]("peerNumber") == Right(0))
-                val _ = assert(r0.get[String]("requestType") == Right("transaction"))
-                val r1 = rows(1).hcursor
-                val _ = assert(r1.get[Long]("requestId") == Right(1L))
-                val _ = assert(r1.get[String]("requestType") == Right("deposit"))
-                ()
-            }
-        }
-    }
-
-    test("GET /head/requests?type= and ?peer_number= narrow the listing") {
-        val reader = stubReader(
-          Map(peer0 -> List(txRequest(peer0, 0), depositRequest(peer0, 1)))
-        )
-        withRoutes(reader) { app =>
+    test("GET /head/requests is not mounted — an unpaged full-CF scan is an OOM, not an API") {
+        // Keyed lookups stay mounted, so it is the second assertion that carries the test: a
+        // router that mounted nothing at all would pass the first one on its own.
+        withRoutes(stubReader(Map(peer0 -> List(txRequest(peer0, 0))))) { app =>
             for {
-                deposits <- get(app, "/head/requests?type=deposit")
-                thisPeer <- get(app, "/head/requests?peer_number=0")
-                otherPeer <- get(app, "/head/requests?peer_number=99")
-                unknownType <- get(app, "/head/requests?type=nonsense")
+                listing <- app.run(
+                  Request[IO](Method.GET, Uri.unsafeFromString("/head/requests"))
+                )
+                filtered <- app.run(
+                  Request[IO](Method.GET, Uri.unsafeFromString("/head/requests?type=deposit"))
+                )
+                byId <- app.run(Request[IO](Method.GET, Uri.unsafeFromString("/head/requests/0")))
             } yield {
-                val _ = assert(deposits._1 == Status.Ok)
-                val depRows = deposits._2.asArray.get
-                val _ = assert(depRows.size == 1)
-                val _ = assert(depRows(0).hcursor.get[String]("requestType") == Right("deposit"))
-                val _ = assert(thisPeer._2.asArray.get.size == 2)
-                // No such author peer -> empty, not an error.
-                val _ = assert(otherPeer._1 == Status.Ok && otherPeer._2.asArray.get.isEmpty)
-                val _ = assert(unknownType._2.asArray.get.isEmpty)
+                // 405 rather than 404 on a HEAD node: POST /head/requests is mounted, so the
+                // path exists and only the GET verb is gone.
+                val _ = assert(
+                  listing.status == Status.MethodNotAllowed,
+                  s"GET /head/requests must not be mounted, got ${listing.status}"
+                )
+                val _ = assert(
+                  filtered.status == Status.MethodNotAllowed,
+                  s"a filtered listing must not be mounted either, got ${filtered.status}"
+                )
+                val _ = assert(
+                  byId.status == Status.Ok,
+                  s"GET /head/requests/{id} must still serve, got ${byId.status}"
+                )
                 ()
             }
         }
@@ -386,11 +372,9 @@ class HeadRequestsEndpointsTest extends AnyFunSuite:
                 stats <- app.run(Request[IO](Method.GET, Uri.unsafeFromString("/head/stats")))
                 ready <- app.run(Request[IO](Method.GET, Uri.unsafeFromString("/ready")))
             } yield {
-                // 405, not 404: the coil still serves GET /head/requests (the listing), so the
-                // PATH exists and only the POST method is gone. That is the more accurate answer
-                // of the two, and asserting 404 here would be asserting the wrong behaviour.
+                // 404, not 405: a coil mounts neither verb, so the path does not exist there.
                 val _ = assert(
-                  submit.status == Status.MethodNotAllowed,
+                  submit.status == Status.NotFound,
                   s"POST /head/requests must not be mounted on a coil, got ${submit.status}"
                 )
                 // 404, not the 401 challenge a mounted admin route would give.


### PR DESCRIPTION
`GET /head/requests` and `GET /head/blocks` each listed an entire RocksDB column family into a heap `List` with no limit and no offset. The `?type=` and `?peer_number=` filters narrowed the *result* but still scanned everything, so they bounded nothing. A single unauthenticated call was therefore an out-of-memory kill, and that is not hypothetical: one operator `curl` to `/head/requests` killed the demo stand on 2026-08-26.

Closes [GUM-298](https://linear.app/gummiworm-labs/issue/GUM-298).

## How to review this

One commit. Read the removal in `HydrozoaRoutes.scala`, then the two new tests, which pin what is left.

## Change

Both endpoints are removed, along with the now-orphaned `listRequests` helper. The generated `openapi.yaml` drops the two operations accordingly.

Everything that remains is keyed by request id or block number, or is a fixed-size summary. `GET /head/requests/{id}` and `GET /head/blocks/{n}` are untouched.

## Rationale

**Removal rather than a `limit` parameter.** A bare limit still needs the full scan to apply it, so it would bound the response and not the work. Re-mounting these wants a cursor plus a bounded page size, which is a different change with a different review.

Note the two different "absent" answers, both correct. On a head node `GET /head/requests` is a **405**, because `POST /head/requests` is still mounted, so the path exists and only the method is gone. On a coil it is a **404**, because nothing is mounted at that path at all.

## Risk

Anything that was calling these breaks. Nothing in this repo does; `srtop` and the sugar-rush services read the store or the keyed endpoints. Operator scripts are the population worth checking before merge.

## Testing

**546 passed, 0 failed, 0 errors** on this commit — one fewer than the commit below it, because removing the endpoints removes their test. The suite also reports **10 canceled and 3 ignored** on every commit of this stack: the canceled ones are the Blockfrost-backed tests, which need an API key this environment does not have. They are pre-existing and identical on the base. Newly covered: that the keyed endpoints still serve, and that the listing paths answer 405/404 as described — the second half matters, because a test that only asserts "not 200" would pass against a broken router.

## Scope

A denial-of-service fix. It removes API surface and adds none.

## Stacking

Sits on top of `feat/coil-http-surface`, which restructured the same routes file. Landing it first on its own needs a manual rebase — the two conflict in `HydrozoaRoutes.scala` and `HeadRequestsEndpointsTest.scala`.

## Base

`feat/coil-http-surface`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
