### PR TITLE
Reconcile the stack composer's single-flight gate against persisted confirmation

### DIFF
--- a/src/main/scala/hydrozoa/multisig/consensus/StackComposer.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/StackComposer.scala
@@ -23,6 +23,7 @@ import hydrozoa.multisig.metrics.{PeerMetrics, StackComposerPhase}
 import hydrozoa.multisig.persistence.recovery.{BlockResultScan, SoftConfirmationScan}
 import hydrozoa.multisig.persistence.{JournalKey, JournalValue, Markers, Persistence, StoreKey, WriteBatch}
 import scala.annotation.tailrec
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scalus.cardano.ledger.{TransactionHash, Value}
 
 /** Stack composer.
@@ -51,7 +52,12 @@ final case class StackComposer(
     pendingConnections: HeadMultisigRegimeManager.PendingConnections | StackComposer.Connections,
     tracer: ContraTracer[IO, StackComposerEvent],
     persistence: Persistence[IO],
-    metrics: PeerMetrics
+    metrics: PeerMetrics,
+    /** How long to wait for a `Stack.HardConfirmed` before re-deriving the single-flight gate from
+      * persistence. Injectable so tests need not wait it out; see
+      * [[StackComposer.HardConfirmReconcileAfter]].
+      */
+    hardConfirmReconcileAfter: FiniteDuration = StackComposer.HardConfirmReconcileAfter
 ) extends Actor[IO, StackComposer.Request] {
     import StackComposer.*
 
@@ -65,6 +71,11 @@ final case class StackComposer(
     private val connections = Ref.unsafe[IO, Option[Connections]](None)
 
     val state: Ref[IO, State] = Ref.unsafe[IO, State](State.initial(config))
+
+    /** Wall-clock millis at which the composer started waiting for a hard confirmation, or `None`
+      * when it is not waiting. Read by [[reconcileHardConfirmedFromPersistence]].
+      */
+    private val hardConfirmWaitSinceMs = Ref.unsafe[IO, Option[Long]](None)
 
     override def preStart: IO[Unit] = for {
         _ <- context.self ! PreStart
@@ -227,10 +238,55 @@ final case class StackComposer(
     private def tryProgress: IO[Unit] = state.get.flatMap { s =>
         val nextStackNum = s.lastClosedStackNum.increment
         if !s.previousStackHardConfirmed then
-            reportPhase(StackComposerPhase.WaitingForPreviousHardConfirmation)
-        else if config.canLeadSlow(nextStackNum) then tryCloseAsLeader(s, nextStackNum)
-        else tryCloseAsFollower(s, nextStackNum)
+            reportPhase(StackComposerPhase.WaitingForPreviousHardConfirmation) >>
+                reconcileHardConfirmedFromPersistence(s)
+        else
+            hardConfirmWaitSinceMs.set(None) >>
+                (if config.canLeadSlow(nextStackNum) then tryCloseAsLeader(s, nextStackNum)
+                 else tryCloseAsFollower(s, nextStackNum))
     }
+
+    /** Open the single-flight gate from durable state when the `Stack.HardConfirmed` message that
+      * should have opened it never arrived.
+      *
+      * Without this the gate is opened by exactly one message, with no timeout and no retry, so a
+      * single lost delivery stalls the head until it is restarted — a restart recovers only because
+      * [[State.recover]] recomputes the flag from the persisted marker instead of waiting. This
+      * does the same thing without the restart.
+      *
+      * Two properties matter:
+      *
+      *   - It is driven by [[tryProgress]], which runs on every inbound message, so it needs no
+      *     timer. That is deliberate: the failures that can lose a message include ones that also
+      *     stop timers firing, and a timeout armed on the same runtime would die with them.
+      *   - Firing early is harmless. If the persisted marker has not advanced there is nothing to
+      *     do, and the check is a `lastKey` point read. So the threshold only has to sit above
+      *     normal hold times; it does not have to be tuned.
+      */
+    private def reconcileHardConfirmedFromPersistence(s: State): IO[Unit] =
+        IO.realTime.map(_.toMillis).flatMap { nowMs =>
+            hardConfirmWaitSinceMs.get.flatMap {
+                case None => hardConfirmWaitSinceMs.set(Some(nowMs))
+                case Some(since) if nowMs - since < hardConfirmReconcileAfter.toMillis =>
+                    IO.unit
+                case Some(_) =>
+                    // Re-arm first, so a persisted marker that has not advanced costs one point
+                    // read per interval rather than one per inbound message.
+                    hardConfirmWaitSinceMs.set(Some(nowMs)) >>
+                        Markers.recoverHardConfirmed(persistence.backend).flatMap {
+                            case Some(persisted)
+                                if Ordering[StackNumber].gteq(persisted, s.lastClosedStackNum) =>
+                                tracer.traceWith(
+                                  StackComposerEvent.HardConfirmationReconciled(
+                                    s.lastClosedStackNum,
+                                    persisted
+                                  )
+                                ) >> state.update(_.withPreviousStackHardConfirmed(persisted)) >>
+                                    hardConfirmWaitSinceMs.set(None) >> tryProgress
+                            case _ => IO.unit
+                        }
+            }
+        }
 
     /** Publish the composer's phase for `GET /head/stats`. Re-reporting the same phase leaves its
       * clock running, so `secondsInPhase` reads as time stuck rather than time since the last event
@@ -823,6 +879,13 @@ final case class StackComposer(
 
 object StackComposer {
     type Handle = ActorRef[IO, Request]
+
+    /** How long the composer waits for a `Stack.HardConfirmed` before it stops trusting the
+      * delivery path and re-derives the gate from persistence. Well above any legitimate hold
+      * (`hardStackMinPeriod` defaults to 30 s), and firing early is a no-op — see
+      * `reconcileHardConfirmedFromPersistence`.
+      */
+    val HardConfirmReconcileAfter: FiniteDuration = 2.minutes
 
     type Config = HeadConfig.Section & OwnPeerPrivate.Section
 

--- a/src/main/scala/hydrozoa/multisig/consensus/StackComposerEvent.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/StackComposerEvent.scala
@@ -44,6 +44,17 @@ object StackComposerEvent:
       */
     final case class SingleFlightGateClosed(stackNum: StackNumber) extends StackComposerEvent
 
+    /** The single-flight gate was opened from PERSISTENCE rather than from a delivered
+      * `Stack.HardConfirmed`: the composer had been waiting past `HardConfirmReconcileAfterMs` and
+      * the durable hard-confirmation marker had already advanced past the stack it was waiting on.
+      * One of these means a message was lost — the node kept going, but the lane that lost it is
+      * worth looking at.
+      */
+    final case class HardConfirmationReconciled(
+        awaited: StackNumber,
+        persisted: StackNumber
+    ) extends StackComposerEvent
+
     /** Follower detected a structural inconsistency between the leader's brief and the local
       * single-flight position — unrecoverable; node will panic.
       */

--- a/src/main/scala/hydrozoa/multisig/consensus/StackComposerEventFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/StackComposerEventFormat.scala
@@ -31,6 +31,13 @@ object StackComposerEventFormat:
                   s"single-flight gate CLOSED on stack $sn; awaiting its hard confirmation",
                   "stackNum" -> s"${sn: Int}"
                 )
+            case HardConfirmationReconciled(awaited, persisted) =>
+                warn(
+                  s"single-flight gate OPEN by reconciliation: awaited stack $awaited, " +
+                      s"persisted hard confirmation is $persisted — the HardConfirmed message " +
+                      s"for $awaited never arrived",
+                  "stackNum" -> s"${awaited: Int}"
+                )
             case StructuralDivergence(sn, lFirst, lLast, expected) =>
                 warn(
                   s"Follower stack $sn structural divergence: leader brief [$lFirst..$lLast] but expected to start at $expected",

--- a/src/test/scala/hydrozoa/multisig/consensus/StackComposerReconciliationTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/StackComposerReconciliationTest.scala
@@ -1,0 +1,130 @@
+package hydrozoa.multisig.consensus
+
+import cats.effect.unsafe.implicits.global
+import cats.effect.{IO, Ref}
+import cats.implicits.*
+import cats.syntax.contravariant.*
+import com.suprnation.actor.ActorSystem
+import hydrozoa.config.head.HeadConfig
+import hydrozoa.config.head.multisig.timing.TxTiming.StackTimes.StackCreationEndTime
+import hydrozoa.config.node.{MultiNodeConfig, NodeConfig}
+import hydrozoa.lib.cardano.scalus.QuantizedTime.QuantizedInstant.realTimeQuantizedInstant
+import hydrozoa.lib.logging.{ContraTracer, Slf4jTracer}
+import hydrozoa.multisig.consensus.peer.HeadPeerNumber
+import hydrozoa.multisig.ledger.block.BlockNumber
+import hydrozoa.multisig.ledger.joint.JointLedger
+import hydrozoa.multisig.ledger.stack.{StackBrief, StackNumber}
+import hydrozoa.multisig.metrics.PeerMetrics
+import hydrozoa.multisig.persistence.{Cf, InMemoryBackendStore, Persistence, PersistenceEventFormat}
+import org.scalacheck.Gen
+import org.scalatest.funsuite.AnyFunSuite
+import scala.concurrent.duration.DurationInt
+
+/** The single-flight gate is opened by exactly one `Stack.HardConfirmed` message — no timeout, no
+  * retry, no re-derivation — so one lost delivery stops the head permanently, while composition
+  * completes, both peers log the confirmation, and durable state stays consistent. Only a restart
+  * recovers it, and only because `State.recover` re-derives the gate from the persisted marker.
+  *
+  * `StackComposer.reconcileHardConfirmedFromPersistence` does that re-derivation without the
+  * restart. These tests drive the composer with the message never delivered and assert the gate
+  * opens anyway — and, as the control, that it stays shut when persistence genuinely has not
+  * advanced.
+  */
+class StackComposerReconciliationTest extends AnyFunSuite:
+
+    private val config: NodeConfig =
+        MultiNodeConfig.generateDefault
+            .map(_.nodeConfigs(HeadPeerNumber.zero))
+            .pureApply(Gen.Parameters.default, org.scalacheck.rng.Seed(0L))
+    private val headConfig: HeadConfig = config.headConfig
+    private given HeadConfig.Bootstrap.Section = config
+
+    test("the gate opens from persistence when the HardConfirmed message never arrives") {
+        val events = run(seedHardConfirmationFor = Some(StackNumber.zero))
+        assert(
+          events.exists(_.isInstanceOf[StackComposerEvent.HardConfirmationReconciled]),
+          s"expected the gate to be reconciled from persistence; saw: $events"
+        )
+    }
+
+    // Control. Without it this suite could not tell "reconciliation works" from "the event fires
+    // whenever the composer waits", which is the failure mode that matters -- reconciling off a
+    // marker that has NOT advanced would open the gate on a stack that is not confirmed.
+    test("the gate stays shut when the persisted marker has not advanced") {
+        val events = run(seedHardConfirmationFor = None)
+        assert(
+          !events.exists(_.isInstanceOf[StackComposerEvent.HardConfirmationReconciled]),
+          s"gate was reconciled with nothing persisted; saw: $events"
+        )
+    }
+
+    /** Boot a cold composer (which bootstraps stack 0 and closes the gate behind it), optionally
+      * seed the hard-confirmation marker, then drive `tryProgress` with inbound briefs. The
+      * `Stack.HardConfirmed` message is never sent.
+      */
+    private def run(seedHardConfirmationFor: Option[StackNumber]): List[StackComposerEvent] =
+        val persistenceTracer = Slf4jTracer.sink.contramap(PersistenceEventFormat.humanFormat)
+        InMemoryBackendStore
+            .open(persistenceTracer)
+            .use(backend =>
+                ActorSystem[IO]("sc-reconcile").use(system =>
+                    for {
+                        persistence <- Persistence.fromBackend(backend, persistenceTracer)
+                        seen <- Ref.of[IO, List[StackComposerEvent]](Nil)
+                        jlSink <- system.actorOf(NoopSink[JointLedger.Requests.Request]())
+                        fcaSink <- system.actorOf(NoopSink[FastConsensusActor.Request]())
+                        scaSink <- system.actorOf(NoopSink[SlowConsensusActor.Request]())
+                        composer <- system.actorOf(
+                          StackComposer(
+                            config,
+                            StackComposer.Connections(
+                              jointLedger = jlSink,
+                              fastConsensusActor = fcaSink,
+                              slowConsensusActor = scaSink,
+                              headPeerLiaisons = List()
+                            ),
+                            ContraTracer[IO, StackComposerEvent](e => seen.update(e :: _)),
+                            persistence,
+                            PeerMetrics.create(0L, Vector.empty),
+                            // The production threshold is 2 minutes; collapse it so the test does
+                            // not have to wait it out.
+                            hardConfirmReconcileAfter = 1.milli
+                          )
+                        )
+                        _ <- IO.sleep(
+                          500.millis
+                        ) // let PreStart bootstrap stack 0 and close the gate
+                        // `recoverHardConfirmed` reads only the LAST KEY of Cf.HardConfirmation, so
+                        // a raw key with an empty value is a faithful stand-in for a real
+                        // multisigned effects payload and keeps this test off the codec.
+                        _ <- seedHardConfirmationFor.traverse_(sn =>
+                            backend
+                                .put(Cf.HardConfirmation, stackKeyBytes(sn), Array.emptyByteArray)
+                        )
+                        // `tryProgress` runs on every inbound message and is the only clock the
+                        // reconciliation has. The first pass only arms the wait, so drive twice.
+                        _ <- driveOnce(composer, 1)
+                        _ <- IO.sleep(50.millis)
+                        _ <- driveOnce(composer, 2)
+                        _ <- IO.sleep(500.millis)
+                        events <- seen.get
+                    } yield events
+                )
+            )
+            .unsafeRunSync()
+
+    /** Spine-shaped key: a 4-byte big-endian stack number. Spelled out here because the production
+      * encoder is `private[persistence]`.
+      */
+    private def stackKeyBytes(sn: StackNumber): Array[Byte] =
+        java.nio.ByteBuffer.allocate(4).putInt(sn: Int).array()
+
+    private def driveOnce(composer: StackComposer.Handle, stack: Int): IO[Unit] =
+        realTimeQuantizedInstant(headConfig.slotConfig).flatMap { now =>
+            composer ! StackBrief(
+              stackNum = StackNumber(stack),
+              firstBlockNum = BlockNumber(0),
+              lastBlockNum = BlockNumber(0),
+              creationEndTime = StackCreationEndTime(now)
+            )
+        }


### PR DESCRIPTION
The `StackComposer`'s single-flight gate is opened by exactly one `Stack.HardConfirmed` message — no timeout, no retry, no re-derivation — so one lost delivery stops the head permanently.

That happened to the staging head on 2026-08-26. Composition had finished (`partitionsDone == partitionsTotal`), both peers logged the hard confirmation, durable state was fully consistent, and the composer still sat in `WaitingForPreviousHardConfirmation` for 63 minutes until it was restarted.

## How to review this

Smallest change on the branch and self-contained. `StackComposer.scala` is the whole of it; the two design points below are what the review should turn on.

## Change

After two minutes of waiting, the gate is re-derived from `Markers.recoverHardConfirmed` — the same persisted marker `State.recover` already reads. A restart recovers this state precisely because recovery does not wait for a message; this does the same thing without the restart.

Reconciling logs a WARN, because reaching it means a message was lost and the lane that lost it is worth looking at.

## Rationale

**It is driven by `tryProgress`, which runs on every inbound message, so it needs no timer.** That is deliberate rather than incidental: the failure that loses the message can be one that also stops timers firing — the same incident seized the cats-effect worker pool — and a timeout armed on that runtime dies with everything else it was meant to rescue.

**Firing early is harmless, so the threshold needs no tuning.** If the persisted marker has not advanced there is nothing to do, and the check is a `lastKey` point read. The threshold only has to sit above normal hold times. It is injectable so tests need not wait it out.

### Alternatives rejected

**A timeout in the `Limiter`.** It would pace on the delivery path, which is the path that failed. Durable state stayed consistent throughout the incident, so pacing on state is strictly better information — and a `Limiter` timeout dies inside a pool seizure exactly as any other timer does.

**Retrying the delivery.** That fixes one lane. Re-deriving from persistence fixes every way the message can fail to arrive, including ones not yet observed.

## Risk

The reconcile path opens a gate that a message would otherwise have opened, so a spurious open would let a second composition start while the first is live. It cannot: the marker it reads is only written when a stack is genuinely hard-confirmed, so the gate opens on the same fact, just from a different source.

## Testing

**556 passed, 0 failed, 0 errors** on this commit. The suite also reports **10 canceled and 3 ignored** on every commit of this stack: the canceled ones are the Blockfrost-backed tests, which need an API key this environment does not have. They are pre-existing and identical on the base.

`StackComposerReconciliationTest` covers the positive case and its control. **The positive case was verified by ablation** — with the reconcile call removed it fails — and the control ("gate stays shut when persistence has not advanced") still passes, so the suite cannot go green by measuring nothing.

Not covered: the message loss itself. The upstream cause is a cats-effect runtime defect ([typelevel/cats-effect#4674](https://github.com/typelevel/cats-effect/issues/4674)); this change makes the head survive it rather than preventing it.

## Scope

A liveness fix for one gate. It does not address why the message was lost.

## Base

`fix/fiber-lifecycle`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
