### PR TITLE
Report whole-process resource gauges on /head/stats and /metrics

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1242,6 +1242,7 @@ components:
       - sequencerHeadroom
       - equityLovelace
       - composer
+      - runtime
       properties:
         uptimeSeconds:
           type: integer
@@ -1272,6 +1273,8 @@ components:
           format: int64
         composer:
           $ref: '#/components/schemas/ComposerStats'
+        runtime:
+          $ref: '#/components/schemas/RuntimeStats'
     RateStats:
       title: RateStats
       type: object
@@ -1449,6 +1452,59 @@ components:
         type:
           type: string
           const: rollout
+    RuntimeStats:
+      title: RuntimeStats
+      type: object
+      required:
+      - fibersSuspended
+      - fibersQueuedLocal
+      - workerThreads
+      - workersActive
+      - workersSearching
+      - workersBlocked
+      - timersOutstanding
+      - timersExecuted
+      - liveThreads
+      - heapUsedBytes
+      - heapCommittedBytes
+      - openFileDescriptors
+      properties:
+        fibersSuspended:
+          type: integer
+          format: int64
+        fibersQueuedLocal:
+          type: integer
+          format: int64
+        workerThreads:
+          type: integer
+          format: int32
+        workersActive:
+          type: integer
+          format: int32
+        workersSearching:
+          type: integer
+          format: int32
+        workersBlocked:
+          type: integer
+          format: int32
+        timersOutstanding:
+          type: integer
+          format: int64
+        timersExecuted:
+          type: integer
+          format: int64
+        liveThreads:
+          type: integer
+          format: int32
+        heapUsedBytes:
+          type: integer
+          format: int64
+        heapCommittedBytes:
+          type: integer
+          format: int64
+        openFileDescriptors:
+          type: integer
+          format: int64
     Sec:
       title: Sec
       type: object

--- a/integration/src/test/scala/hydrozoa/integration/harness/MultiPeerHeadHarness.scala
+++ b/integration/src/test/scala/hydrozoa/integration/harness/MultiPeerHeadHarness.scala
@@ -1568,6 +1568,9 @@ object MultiPeerHeadHarness:
                   0L,
                   nodeConfig.headConfig.headPeerNums.toList.map(_.convert).toVector
                 )
+                // A real node runs the 1 Hz sampler for the whole life of the process
+                // (`Serve.scala`); without it the runtime gauges read their initial values.
+                _ <- metrics.sampler().background
                 mrm <- HeadMultisigRegimeManager.resource(
                   nodeConfig,
                   cardanoBackend,
@@ -1642,6 +1645,9 @@ object MultiPeerHeadHarness:
                   0L,
                   coilConfig.headConfig.headPeerNums.toList.map(_.convert).toVector
                 )
+                // A coil runs the 1 Hz sampler too, and for the same reason: without it the
+                // runtime gauges never leave their initial values.
+                _ <- metrics.sampler().background
                 mrm <- CoilMultisigRegimeManager.resource(
                   coilConfig,
                   cardanoBackend,

--- a/src/main/scala/hydrozoa/multisig/metrics/PeerMetrics.scala
+++ b/src/main/scala/hydrozoa/multisig/metrics/PeerMetrics.scala
@@ -1,6 +1,8 @@
 package hydrozoa.multisig.metrics
 
 import cats.effect.IO
+import cats.effect.unsafe.IORuntime
+import java.lang.management.ManagementFactory
 import java.util.concurrent.atomic.{AtomicLong, AtomicReference, LongAdder}
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.duration.*
@@ -232,6 +234,7 @@ final class PeerMetrics private (startedAtMillis: Long, remotePeerNums: Vector[I
           leaderMempoolDrain = leaderMempoolDrain.get(),
           sequencerHeadroom = seqHeadroom.get(),
           equityLovelace = equityLovelace.get(),
+          runtime = PeerMetrics.runtimeSnapshot(),
           composer = ComposerStats(
             phase = composerPhase.get(),
             secondsInPhase = math.max(0L, (nowMillis - composerPhaseSince.get()) / 1000),
@@ -297,6 +300,50 @@ final class PeerMetrics private (startedAtMillis: Long, remotePeerNums: Vector[I
 
 object PeerMetrics:
     private val Taus: Vector[Double] = Vector(60.0, 300.0, 900.0) // 1m / 5m / 15m
+
+    /** Read the whole-process resource gauges. Cheap enough for the 1 Hz sampler: counter reads,
+      * one `MemoryMXBean` poll, and one attribute read for the fd count.
+      *
+      * Deliberately tolerant. `workStealingThreadPool` is `None` on a non-WSTP compute pool (the
+      * test harnesses), the fd count is an `OperatingSystemMXBean` attribute that exists on Linux
+      * and not everywhere, and none of this is worth failing a stats request over — so anything
+      * unavailable reports as -1 rather than throwing.
+      */
+    def runtimeSnapshot(): RuntimeStats =
+        val heap = ManagementFactory.getMemoryMXBean.getHeapMemoryUsage
+        val wstp = IORuntime.global.metrics.workStealingThreadPool
+        RuntimeStats(
+          fibersSuspended = wstp.map(_.suspendedFiberCount()).getOrElse(-1L),
+          fibersQueuedLocal = wstp.map(_.localQueueFiberCount()).getOrElse(-1L),
+          workerThreads = wstp.map(_.workerThreadCount()).getOrElse(-1),
+          workersActive = wstp.map(_.activeThreadCount()).getOrElse(-1),
+          workersSearching = wstp.map(_.searchingThreadCount()).getOrElse(-1),
+          workersBlocked = wstp.map(_.blockedWorkerThreadCount()).getOrElse(-1),
+          timersOutstanding = wstp
+              .map(_.workerThreads.map(_.timerHeap.timersOutstandingCount().toLong).sum)
+              .getOrElse(-1L),
+          timersExecuted = wstp
+              .map(_.workerThreads.map(_.timerHeap.totalTimersExecutedCount()).sum)
+              .getOrElse(-1L),
+          liveThreads = ManagementFactory.getThreadMXBean.getThreadCount,
+          heapUsedBytes = heap.getUsed,
+          heapCommittedBytes = heap.getCommitted,
+          openFileDescriptors = openFdCount()
+        )
+
+    /** Open file descriptors, or -1 where the platform does not expose them. Socket exhaustion
+      * presents as a box that has stopped responding, with nothing in the process reporting why.
+      */
+    private def openFdCount(): Long =
+        try
+            ManagementFactory.getPlatformMBeanServer
+                .getAttribute(
+                  new javax.management.ObjectName("java.lang:type=OperatingSystem"),
+                  "OpenFileDescriptorCount"
+                )
+                .asInstanceOf[java.lang.Long]
+                .longValue()
+        catch case _: Throwable => -1L
 
     /** Upper bound on in-flight (unclosed) block clocks before we assume a leak and reset. */
     private val InFlightCap = 8192
@@ -435,7 +482,43 @@ final case class PeerStats(
     leaderMempoolDrain: Long,
     sequencerHeadroom: Long,
     equityLovelace: Long,
-    composer: ComposerStats
+    composer: ComposerStats,
+    runtime: RuntimeStats
+)
+
+/** Whole-process resource use, for answering one question about a run: is the resource curve
+  * proportional to work IN FLIGHT, or to HISTORY?
+  *
+  * The discriminator is a slope against the right denominator, so these have to be read against the
+  * cumulative counters already in [[PeerStats]] (`blocks`, `stacks`, `localAccepted`) and against a
+  * deliberate load step-down: an in-flight-sized resource plateaus at constant load and comes back
+  * DOWN when load drops; a history-sized one tracks the cumulative counter and does not.
+  *
+  * ⛔ Every axis here is a CONCURRENCY axis. A peer can hold all of them at their idle floor while
+  * carrying a large backlog of unabsorbed deposits, unconfirmed blocks and queued resubmissions, so
+  * these do not answer "has the node drained?" — only "is it running work right now?"
+  *
+  * `fibersSuspended` is a fiber census, not a fiber dump: `kill -USR1` costs seconds and megabytes,
+  * this is two counter reads. `workersSearching` and `timersExecuted` are the cats-effect
+  * scheduler-seizure signature — in that state `workersSearching` stays non-zero while
+  * `timersExecuted` stops advancing, and the runtime cannot self-report it, because its own
+  * starvation checker is an `IO.sleep` that fires once and then goes silent. All of these are read
+  * from a plain snapshot rather than from a fiber, so a scraper outside the process still gets them
+  * when the runtime is seized.
+  */
+final case class RuntimeStats(
+    fibersSuspended: Long,
+    fibersQueuedLocal: Long,
+    workerThreads: Int,
+    workersActive: Int,
+    workersSearching: Int,
+    workersBlocked: Int,
+    timersOutstanding: Long,
+    timersExecuted: Long,
+    liveThreads: Int,
+    heapUsedBytes: Long,
+    heapCommittedBytes: Long,
+    openFileDescriptors: Long
 )
 
 /** What the [[hydrozoa.multisig.consensus.StackComposer]] is doing, and for how long.

--- a/src/main/scala/hydrozoa/multisig/metrics/PrometheusFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/metrics/PrometheusFormat.scala
@@ -167,6 +167,55 @@ object PrometheusFormat:
                 }\n"
         }
 
+        // Whole-process resource gauges — concurrency axes, read against a cumulative counter
+        // above and across a load step-down (see `RuntimeStats`). The `_total` counters here are
+        // monotonic by construction.
+        gauge(
+          "hydrozoa_fibers_suspended",
+          "Fibers suspended on the cats-effect runtime. The axis that failed on 2026-08-26.",
+          s.runtime.fibersSuspended
+        )
+        gauge(
+          "hydrozoa_fibers_queued_local",
+          "Fibers sitting in worker-local run queues.",
+          s.runtime.fibersQueuedLocal
+        )
+        gauge("hydrozoa_worker_threads", "cats-effect compute workers.", s.runtime.workerThreads)
+        gauge(
+          "hydrozoa_workers_active",
+          "Compute workers running a fiber.",
+          s.runtime.workersActive
+        )
+        gauge(
+          "hydrozoa_workers_searching",
+          "Compute workers searching for work. Non-zero while hydrozoa_timers_executed_total is " +
+              "flat is the cats-effect scheduler-seizure signature.",
+          s.runtime.workersSearching
+        )
+        gauge(
+          "hydrozoa_workers_blocked",
+          "Compute workers inside a blocking region.",
+          s.runtime.workersBlocked
+        )
+        gauge(
+          "hydrozoa_timers_outstanding",
+          "Armed timers across all worker heaps.",
+          s.runtime.timersOutstanding
+        )
+        counter(
+          "hydrozoa_timers_executed_total",
+          "Timers fired since start. Flat while the process is loaded means timer delivery is dead.",
+          s.runtime.timersExecuted
+        )
+        gauge("hydrozoa_live_threads", "JVM live threads.", s.runtime.liveThreads)
+        gauge("hydrozoa_heap_used_bytes", "JVM heap in use.", s.runtime.heapUsedBytes)
+        gauge("hydrozoa_heap_committed_bytes", "JVM heap committed.", s.runtime.heapCommittedBytes)
+        gauge(
+          "hydrozoa_open_file_descriptors",
+          "Open file descriptors, or -1 where the platform does not report them.",
+          s.runtime.openFileDescriptors
+        )
+
         b.toString
 
     private def rate(name: String, help: String, r: RateView, b: StringBuilder): Unit =

--- a/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
+++ b/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
@@ -264,9 +264,31 @@ object ApiDto {
           * closed. One side of `treasury.value == evacuation map total + equity + beacon`.
           */
         equityLovelace: Long,
-        composer: ComposerStatsView
+        composer: ComposerStatsView,
+        runtime: RuntimeStatsView
     )
     given Codec[PeerStatsView] = deriveCodec
+
+    /** Whole-process resource gauges. Read these against the cumulative counters above (`blocks`,
+      * `stacks`, `localRequests.total`) and across a deliberate load step-down; they are
+      * concurrency axes, not backlog. Anything the platform does not expose reads as -1. See
+      * [[hydrozoa.multisig.metrics.RuntimeStats]] for how to read them and what they cannot say.
+      */
+    final case class RuntimeStatsView(
+        fibersSuspended: Long,
+        fibersQueuedLocal: Long,
+        workerThreads: Int,
+        workersActive: Int,
+        workersSearching: Int,
+        workersBlocked: Int,
+        timersOutstanding: Long,
+        timersExecuted: Long,
+        liveThreads: Int,
+        heapUsedBytes: Long,
+        heapCommittedBytes: Long,
+        openFileDescriptors: Long
+    )
+    given Codec[RuntimeStatsView] = deriveCodec
 
     /** Map a [[hydrozoa.multisig.metrics.PeerStats]] snapshot to its JSON body. */
     def mkPeerStatsView(s: PeerStats): PeerStatsView =
@@ -280,6 +302,20 @@ object ApiDto {
             )
         PeerStatsView(
           uptimeSeconds = s.uptimeSeconds,
+          runtime = RuntimeStatsView(
+            fibersSuspended = s.runtime.fibersSuspended,
+            fibersQueuedLocal = s.runtime.fibersQueuedLocal,
+            workerThreads = s.runtime.workerThreads,
+            workersActive = s.runtime.workersActive,
+            workersSearching = s.runtime.workersSearching,
+            workersBlocked = s.runtime.workersBlocked,
+            timersOutstanding = s.runtime.timersOutstanding,
+            timersExecuted = s.runtime.timersExecuted,
+            liveThreads = s.runtime.liveThreads,
+            heapUsedBytes = s.runtime.heapUsedBytes,
+            heapCommittedBytes = s.runtime.heapCommittedBytes,
+            openFileDescriptors = s.runtime.openFileDescriptors
+          ),
           localRequests = LocalRequestStatsView(
             total = s.localAccepted,
             rate = rate(s.localRate),

--- a/src/test/scala/hydrozoa/multisig/metrics/PrometheusFormatTest.scala
+++ b/src/test/scala/hydrozoa/multisig/metrics/PrometheusFormatTest.scala
@@ -51,6 +51,21 @@ class PrometheusFormatTest extends AnyFunSuite:
         secondsInPhase = 42,
         partitionsDone = 17,
         partitionsTotal = 300
+      ),
+      runtime = RuntimeStats(
+        fibersSuspended = 27428,
+        fibersQueuedLocal = 5654,
+        workerThreads = 4,
+        workersActive = 2,
+        workersSearching = 1,
+        workersBlocked = 0,
+        timersOutstanding = 12,
+        timersExecuted = 98765,
+        liveThreads = 36,
+        heapUsedBytes = 241172480,
+        heapCommittedBytes = 536870912,
+        // -1 is the "platform does not report this" sentinel, and it must survive rendering.
+        openFileDescriptors = -1
       )
     )
 
@@ -102,3 +117,11 @@ class PrometheusFormatTest extends AnyFunSuite:
               !out.contains("E-"), // no scientific notation
           out
         )
+
+    test("the runtime gauges render, including the -1 unavailable sentinel"):
+        val out = PrometheusFormat.render(sample)
+        val _ = assert(out.contains("hydrozoa_fibers_suspended 27428"))
+        val _ = assert(out.contains("hydrozoa_workers_searching 1"))
+        val _ = assert(out.contains("hydrozoa_timers_executed_total 98765"))
+        val _ = assert(out.contains("# TYPE hydrozoa_timers_executed_total counter"))
+        assert(out.contains("hydrozoa_open_file_descriptors -1"))


### PR DESCRIPTION
The run that wedged on 2026-08-26 reached 27,428 fibers against an idle floor of 174, and nothing in the process was reporting a fiber count. The stats surface tracked requests, blocks and stacks — *work* — but no resource axis, so the axis that actually failed was invisible while it failed.

## How to review this

Mechanical and additive. `PeerMetrics.scala` is where the reads happen; `ApiDto.scala` and `PrometheusFormat.scala` are the two renderings. `openapi.yaml` is generated — check it matches by running `OpenApiSchemaTest`, not by reading it.

## Change

A `runtime` block on `/head/stats`, and the matching gauges on `/head/metrics`: fibers (suspended and locally queued), compute-worker state, timers outstanding and executed, live threads, heap used and committed, and open file descriptors.

The integration harness also starts the 1 Hz sampler that every real node runs. It never did, so no integration test could exercise anything downstream of it — including these gauges.

## Rationale

**They exist to answer one question about a run: is resource use proportional to work in flight, or to history?** That is a slope against the right denominator, so each gauge is meant to be read against the cumulative counters already on this surface, over hours of steady load or across a deliberate load step-down. An in-flight-sized resource comes back down; a history-sized one does not.

**`workersSearching` and `timersExecuted` are also the cats-effect scheduler-seizure signature.** In that state searching stays non-zero while executed stops advancing. The runtime cannot self-report it, because its own starvation checker is an `IO.sleep`: on the wedged box it fired exactly once, at the moment of seizure, and then went silent for 63 minutes. Reading these from outside the process is the detection we actually have.

**Specifically not a fiber dump.** `kill -USR1` costs seconds and megabytes, and its frames cannot be trusted for identity anyway — cats-effect's cached tracing aliases every `>>` in the program to one call site. These are counter reads plus one `MemoryMXBean` poll, cheap enough for a 1 Hz sampler.

## Risk

A stats request must not fail because the platform withheld a number, so anything unavailable reports `-1` rather than throwing. That is a sentinel a consumer has to know about; the alternative — an absent field — would have made the Prometheus rendering ragged.

## Testing

**557 passed, 0 failed, 0 errors** on this commit; `integration/Test/compile` green; `OpenApiSchemaTest` green on this commit, which is the point of regenerating the schema here rather than later. The suite also reports **10 canceled and 3 ignored** on every commit of this stack: the canceled ones are the Blockfrost-backed tests, which need an API key this environment does not have. They are pre-existing and identical on the base.

`PrometheusFormatTest` covers the new gauge rendering. Not covered: the values themselves, which come from the runtime and are pinned by nothing but the runtime's own contract.

## Known gap — these gauges measure concurrency, not state

Every gauge here is a concurrency or JVM axis: fibers, worker state, timers, threads, heap, fds. **None of them is a measure of retained state**, and that turns out to matter for the exact question this block exists to answer.

Read at idle after a mixed L1/L2 run, the gauges said the head was below its pre-load baseline on every axis. It was in fact holding ~15,335 blocks awaiting hard confirmation — roughly 452,000 requests — because a coil peer was down, plus ~1,000 L2 accounts against the 20 it started with, evacuation maps sized for that N, an unknown number of unabsorbed deposits in `JointLedger`, and an unknown resubmit set in `CardanoLiaison`.

So the in-flight-vs-history question splits, and this block only answers half of it. The concurrency axes are genuinely in-flight-proportional — they step up under load and return below baseline when it stops, which this run demonstrated with a real step-down. The state axes cannot floor and should not: the ledger was legitimately larger.

Worth adding, all cheap counter reads: unabsorbed-deposit count, liaison resubmit-queue depth, L2 account count, evacuation-map size, and blocks-pending-hard-confirmation. The last is derivable today only as `blocks.minor − (stacks.lastStackNumber × stacks.avgBlocksAbsorbed)`, which uses a mean as though it were exact.

Left out of this PR deliberately rather than silently: they are a different subsystem's counters, and this change is already the largest additive surface on the stack. The scaladoc on `RuntimeStats` states the limitation, so a reader of the gauges meets it where they will actually be standing.

## Scope

Read-only instrumentation. It adds fields to two responses and changes no behaviour.

## Base

`fix/composer-gate-reconciliation`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)