### PR TITLE
Cap block production at the configured rate, and slow it when the composer falls behind

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -743,6 +743,31 @@ components:
         type:
           type: string
           const: minor
+    BlockGateStats:
+      title: BlockGateStats
+      type: object
+      required:
+      - multiplier
+      - backlog
+      - residual
+      - holds
+      - drains
+      properties:
+        multiplier:
+          type: number
+          format: double
+        backlog:
+          type: integer
+          format: int64
+        residual:
+          type: number
+          format: double
+        holds:
+          type: integer
+          format: int64
+        drains:
+          type: integer
+          format: int64
     BlockHardConfirmed:
       title: BlockHardConfirmed
       type: object
@@ -1243,6 +1268,7 @@ components:
       - equityLovelace
       - composer
       - runtime
+      - blockGate
       properties:
         uptimeSeconds:
           type: integer
@@ -1275,6 +1301,8 @@ components:
           $ref: '#/components/schemas/ComposerStats'
         runtime:
           $ref: '#/components/schemas/RuntimeStats'
+        blockGate:
+          $ref: '#/components/schemas/BlockGateStats'
     RateStats:
       title: RateStats
       type: object

--- a/src/main/scala/hydrozoa/config/node/operation/multisig/RateLimits.scala
+++ b/src/main/scala/hydrozoa/config/node/operation/multisig/RateLimits.scala
@@ -1,6 +1,7 @@
 package hydrozoa.config.node.operation.multisig
 
 import hydrozoa.lib.cardano.scalus.QuantizedTime.given
+import hydrozoa.multisig.consensus.limiter.LimiterGate
 import io.circe.*
 import io.circe.generic.semiauto.*
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
@@ -8,17 +9,26 @@ import scala.concurrent.duration.{DurationInt, FiniteDuration}
 /** Per-message-type minimum wall-clock periods enforced by the
   * [[hydrozoa.multisig.consensus.limiter.Limiter]] actor sitting between two actors.
   *
-  * Each throttled message `m` carries its own timestamp (see
-  * [[hydrozoa.multisig.consensus.limiter.LimiterTimestamp]]) and is held until
-  * `m.limiterTimestamp + minPeriod(m) <= now` — the gate is computed from the message itself, not
-  * from limiter-side memory of previous messages. Non-throttled messages on the same lane block
-  * behind any currently-held message (strict FIFO).
+  * Each lane is a **spacing gate** measured from the limiter's own last release, not from the
+  * message's timestamp — see [[hydrozoa.multisig.consensus.limiter.Limiter]] for why that
+  * distinction is what makes it a rate limit rather than a delay line.
   *
-  * The defaults below are non-zero: these lanes are limited unless a config overrides them.
+  * ⚠️ **Node-local.** These change only the cadence at which a peer offers work to its own
+  * downstream, never what it sends, so peers may run different values without diverging. The cost
+  * is a leader-dependent cadence under rotation; operators should align informally.
+  *
+  * Defaults are non-zero: these lanes are limited unless a config overrides them.
   */
 final case class RateLimits(
     override val softBlockMinPeriod: FiniteDuration,
-    override val hardStackMinPeriod: FiniteDuration
+    override val hardStackMinPeriod: FiniteDuration,
+    // Scala-level defaults, matching the decoder's fallbacks below, so that adding a
+    // gate knob stays source-compatible with construction sites outside this project.
+    override val blockBacklogSoftLimit: Int = RateLimits.defaultBlockBacklogSoftLimit,
+    override val blockBacklogHardLimit: Int = RateLimits.defaultBlockBacklogHardLimit,
+    override val blockGateFloor: Double = RateLimits.defaultBlockGateFloor,
+    override val blockGateSmoothing: Double = RateLimits.defaultBlockGateSmoothing,
+    override val blockGateSlice: FiniteDuration = RateLimits.defaultBlockGateSlice
 ) extends RateLimits.Section {
     override transparent inline def rateLimits: RateLimits = this
 }
@@ -31,6 +41,11 @@ object RateLimits {
           * [[hydrozoa.multisig.ledger.block.Block.SoftConfirmed]] forwards from
           * [[hydrozoa.multisig.consensus.FastConsensusActor]] to
           * [[hydrozoa.multisig.consensus.BlockWeaver]].
+          *
+          * Binds only when the natural block cycle is faster than the period, so it is
+          * self-disabling at low load and needs no feature flag. Throughput ceiling is
+          * `1/period * maxRequestsPerBlock`; the cost is up to one period of extra latency for a
+          * request arriving just after a block closes.
           */
         def softBlockMinPeriod: FiniteDuration = rateLimits.softBlockMinPeriod
 
@@ -40,14 +55,89 @@ object RateLimits {
           * [[hydrozoa.multisig.consensus.StackComposer]].
           */
         def hardStackMinPeriod: FiniteDuration = rateLimits.hardStackMinPeriod
+
+        /** Soft-confirmed blocks outstanding per stack cycle below which the block gate stays fully
+          * open. Above it the block lane is progressively slowed so block production cannot outrun
+          * what stack production absorbs.
+          *
+          * Sized above the accumulation the shaper itself produces in one downstream cycle
+          * (`1/softBlockMinPeriod * hardStackMinPeriod`), so a healthy head sits inside the flat
+          * region and the gate does nothing unless the composer is falling behind.
+          */
+        def blockBacklogSoftLimit: Int = rateLimits.blockBacklogSoftLimit
+
+        /** Backlog at which the block lane is slowed all the way to [[blockGateFloor]].
+          *
+          * Sized well under the point where draining the composer's mailbox turns superlinear
+          * (cats-actors scans its queue per message), and far above healthy per-cycle accumulation.
+          */
+        def blockBacklogHardLimit: Int = rateLimits.blockBacklogHardLimit
+
+        /** The slowest the block lane is ever shaped to, as a fraction of [[softBlockMinPeriod]]'s
+          * rate. ⛔ Never 0. Block production is self-clocked by the soft confirmations this lane
+          * releases, so a full stop would stop the clock that later reopens the gate.
+          */
+        def blockGateFloor: Double = rateLimits.blockGateFloor
+
+        /** EWMA weight on the newest downstream cycle. Instantaneous depth is dominated by where in
+          * the cycle it is sampled; a controller driven by that sawtooths at the cycle cadence.
+          */
+        def blockGateSmoothing: Double = rateLimits.blockGateSmoothing
+
+        /** Longest single sleep the block limiter commits to before re-reading its mailbox, which
+          * bounds how stale its multiplier can be while a hold is outstanding.
+          */
+        def blockGateSlice: FiniteDuration = rateLimits.blockGateSlice
+
+        /** The block lane's gate, assembled from the knobs above. */
+        def blockLimiterGate: LimiterGate = LimiterGate(
+          backlogSoftLimit = blockBacklogSoftLimit,
+          backlogHardLimit = blockBacklogHardLimit,
+          floor = blockGateFloor,
+          smoothing = blockGateSmoothing,
+          slice = blockGateSlice
+        )
     }
+
+    val defaultBlockBacklogSoftLimit: Int = 600
+    val defaultBlockBacklogHardLimit: Int = 3000
+    val defaultBlockGateFloor: Double = 0.02
+    val defaultBlockGateSmoothing: Double = 0.3
+    val defaultBlockGateSlice: FiniteDuration = 150.milliseconds
 
     lazy val default: RateLimits = RateLimits(
       softBlockMinPeriod = 100.milliseconds,
-      hardStackMinPeriod = 30.seconds
+      hardStackMinPeriod = 30.seconds,
+      blockBacklogSoftLimit = defaultBlockBacklogSoftLimit,
+      blockBacklogHardLimit = defaultBlockBacklogHardLimit,
+      blockGateFloor = defaultBlockGateFloor,
+      blockGateSmoothing = defaultBlockGateSmoothing,
+      blockGateSlice = defaultBlockGateSlice
     )
 
     given Encoder[RateLimits] = deriveEncoder[RateLimits]
 
-    given Decoder[RateLimits] = deriveDecoder[RateLimits]
+    /** Hand-written rather than derived so every gate field may be **absent**: a node whose config
+      * fails to decode does not start at all, and every `private.json` already deployed predates
+      * these fields. The defaults are chosen so that adopting the gate needs no config edit.
+      */
+    given Decoder[RateLimits] = Decoder.instance(c =>
+        for {
+            softBlock <- c.downField("softBlockMinPeriod").as[FiniteDuration]
+            hardStack <- c.downField("hardStackMinPeriod").as[FiniteDuration]
+            softLimit <- c.downField("blockBacklogSoftLimit").as[Option[Int]]
+            hardLimit <- c.downField("blockBacklogHardLimit").as[Option[Int]]
+            floor <- c.downField("blockGateFloor").as[Option[Double]]
+            smoothing <- c.downField("blockGateSmoothing").as[Option[Double]]
+            slice <- c.downField("blockGateSlice").as[Option[FiniteDuration]]
+        } yield RateLimits(
+          softBlockMinPeriod = softBlock,
+          hardStackMinPeriod = hardStack,
+          blockBacklogSoftLimit = softLimit.getOrElse(defaultBlockBacklogSoftLimit),
+          blockBacklogHardLimit = hardLimit.getOrElse(defaultBlockBacklogHardLimit),
+          blockGateFloor = floor.getOrElse(defaultBlockGateFloor),
+          blockGateSmoothing = smoothing.getOrElse(defaultBlockGateSmoothing),
+          blockGateSlice = slice.getOrElse(defaultBlockGateSlice)
+        )
+    )
 }

--- a/src/main/scala/hydrozoa/multisig/CoilMultisigRegimeManager.scala
+++ b/src/main/scala/hydrozoa/multisig/CoilMultisigRegimeManager.scala
@@ -100,6 +100,8 @@ trait CoilMultisigRegimeManager(
               jointLedger = core.jointLedger,
               stackComposer = core.stackComposer,
               stackComposerLimiter = core.stackComposer,
+              // No limiter actor exists to gate, and a coil never leads block production.
+              blockRateGate = None,
               slowConsensusActor = core.slowConsensusActor,
               coilUplink = Some(hubLiaison),
               remoteHubLiaison = Some(remoteHubProxy),

--- a/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManager.scala
+++ b/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManager.scala
@@ -4,14 +4,14 @@ import cats.*
 import cats.effect.{Deferred, IO, Ref, Resource}
 import cats.implicits.*
 import com.suprnation.actor.ActorContext
-import com.suprnation.actor.ActorRef.NoSendActorRef
+import com.suprnation.actor.ActorRef.{ActorRef, NoSendActorRef}
 import hydrozoa.config.node.NodeConfig
 import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.HeadMultisigRegimeManager.*
 import hydrozoa.multisig.LifecycleEvent.{StartingActors, WatchingActors}
 import hydrozoa.multisig.backend.cardano.CardanoBackend
 import hydrozoa.multisig.consensus.*
-import hydrozoa.multisig.consensus.limiter.Limiter
+import hydrozoa.multisig.consensus.limiter.{Limiter, LimiterControl}
 import hydrozoa.multisig.consensus.peer.{CoilPeerNumber, HeadPeerNumber, PeerId}
 import hydrozoa.multisig.consensus.transport.{HubTransport, PeerTransport, RemoteCoilProxy, RemotePeerProxy}
 import hydrozoa.multisig.ledger.joint.JointLedger
@@ -62,8 +62,17 @@ trait HeadMultisigRegimeManager(
             // hydrozoa.multisig.consensus.limiter.Limiter). Only the consensus actor's reference
             // to BlockWeaver is routed through this limiter; other senders (JointLedger,
             // PeerLiaisonHeadToHead, …) keep direct refs.
+            // The block lane carries the gate as well as the shaper: `gate` makes the period
+            // dynamic, tightening as the composer falls behind. The stack lane below deliberately
+            // takes no gate — it is a pure spacing gate at `hardStackMinPeriod`.
             blockWeaverLimiter <- context.actorOf(
-              Limiter[BlockWeaver.Request](core.blockWeaver, config, tracers.blockWeaverLimiter)
+              Limiter[BlockWeaver.Request](
+                core.blockWeaver,
+                config,
+                tracers.blockWeaverLimiter,
+                gate = Some(config.blockLimiterGate),
+                metrics = Some(metrics)
+              )
             )
 
             requestSequencer <- context.actorOf(
@@ -199,6 +208,7 @@ trait HeadMultisigRegimeManager(
             connections = HeadMultisigRegimeManager.Connections(
               blockWeaver = core.blockWeaver,
               blockWeaverLimiter = blockWeaverLimiter,
+              blockRateGate = Some(blockWeaverLimiter),
               cardanoLiaison = core.cardanoLiaison,
               consensusActor = core.consensusActor,
               requestSequencer = Some(requestSequencer),
@@ -315,6 +325,11 @@ object HeadMultisigRegimeManager {
         stackComposer: StackComposer.Handle,
         /** Throttled-write handle for the SlowConsensusActor → StackComposer lane. */
         stackComposerLimiter: StackComposer.Handle,
+        /** Control handle on the block lane's limiter, used to tell it a stack hard-confirmed.
+          * `None` on a coil peer, which runs no limiters. Contravariance in the message type is
+          * what lets the same actor be addressed both as `blockWeaverLimiter` and as this.
+          */
+        blockRateGate: Option[ActorRef[IO, LimiterControl]] = None,
         slowConsensusActor: SlowConsensusActor.Handle,
         // ---- Producer broadcast targets (§5.2) [doc-ref] ----
         /** Head-peer-mesh liaisons (one per other head peer); empty on a coil peer. Producers

--- a/src/main/scala/hydrozoa/multisig/consensus/SlowConsensusActor.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/SlowConsensusActor.scala
@@ -11,6 +11,7 @@ import hydrozoa.config.node.owninfo.OwnPeerPublic
 import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.HeadMultisigRegimeManager
 import hydrozoa.multisig.consensus.ack.HardAck
+import hydrozoa.multisig.consensus.limiter.LimiterControl
 import hydrozoa.multisig.consensus.peer.PeerId
 import hydrozoa.multisig.ledger.block.BlockNumber
 import hydrozoa.multisig.ledger.stack.{EffectIds, PartitionEffects, Stack, StackBrief, StackEffects, StackNumber}
@@ -391,6 +392,9 @@ final case class SlowConsensusActor(
         _ <- persistHardConfirmation(stackNum, restricted.unsigned.brief, signed)
         _ <- conn.cardanoLiaison ! hardConfirmed
         _ <- conn.stackComposer ! hardConfirmed
+        // Headroom signal for the block lane: the stack this peer just hard-confirmed is the
+        // backlog the block limiter released, now absorbed.
+        _ <- conn.blockRateGate.traverse_(_ ! LimiterControl.DownstreamDrained)
         _ <- stateRef.update(_.dropCell(stackNum))
         _ <- tracer.traceWith(SlowConsensusActorEvent.StackHardConfirmed(hardConfirmed))
         // Peer stats (docs/spec/peer-stats-endpoint.md): count the stack and the blocks it absorbed.
@@ -518,7 +522,8 @@ final case class SlowConsensusActor(
                       cardanoLiaison = c.cardanoLiaison,
                       headPeerLiaisons = c.headPeerLiaisons,
                       coilUplink = c.coilUplink,
-                      coilRelay = c.coilRelay
+                      coilRelay = c.coilRelay,
+                      blockRateGate = c.blockRateGate
                     )
                   )
                 )
@@ -547,7 +552,13 @@ object SlowConsensusActor {
         /** A hub's coil relay (§5.4) [doc-ref]: this actor's **own** hard-ack is sent here so the
           * hub's coil peers receive it. `None` off a hub.
           */
-        coilRelay: Option[CoilRelay.Handle] = None
+        coilRelay: Option[CoilRelay.Handle] = None,
+        /** The block lane's rate limiter, told each time a stack hard-confirms so it can reopen its
+          * downstream-backlog gate. `None` on a coil peer, which never leads and therefore runs no
+          * limiter at all. Hard confirmation is the signal rather than this peer's own hard ack;
+          * [[hydrozoa.multisig.consensus.limiter.LimiterControl.DownstreamDrained]] says why.
+          */
+        blockRateGate: Option[ActorRef[IO, LimiterControl]] = None
     )
 
     type Request = PreStart.type | StackHandoff | HardAck

--- a/src/main/scala/hydrozoa/multisig/consensus/limiter/Limiter.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/limiter/Limiter.scala
@@ -1,64 +1,258 @@
 package hydrozoa.multisig.consensus.limiter
 
-import cats.effect.IO
+import cats.effect.{IO, Ref}
 import com.suprnation.actor.Actor.{Actor, Receive}
 import com.suprnation.actor.ActorRef.ActorRef
 import hydrozoa.config.node.operation.multisig.RateLimits
 import hydrozoa.lib.logging.ContraTracer
+import hydrozoa.multisig.metrics.PeerMetrics
 import scala.concurrent.duration.DurationLong
 
-/** Stateless FIFO rate-limiter actor sitting between two actors on one lane.
+/** FIFO rate-limiter actor sitting between two actors on one lane.
   *
-  * For each incoming message mixing in [[LimiterTimestamp]], the limiter checks whether
-  * `msg.limiterTimestamp + msg.minPeriod` is still in the future; if so it holds the message for
-  * exactly that difference, then forwards. Otherwise it forwards immediately. Messages without the
-  * trait pass through with no delay.
+  * Enforces a **spacing gate**: consecutive throttled messages are released at least `period`
+  * apart, where `period` is the message's own `minPeriod` divided by the gate multiplier (1.0 on a
+  * lane with no [[LimiterGate]]). The limiter times from its own last release, not from the
+  * message's timestamp.
   *
-  * The limiter keeps no state about prior messages: every throttled message gates itself based on
-  * the timestamp it carries. Strict FIFO is provided by the single mailbox — `IO.sleep` inside
-  * `receive` blocks subsequent (including non-throttled) messages until the hold elapses.
+  * ⛔ That distinction is the whole contract. Gating on `msg.limiterTimestamp + minPeriod` is an AGE
+  * filter: it delays each message by a fixed amount and lets the arrival rate through unchanged, so
+  * it bounds latency rather than rate. It coincides with a rate limit only on a lane that is
+  * already single-flight, where releasing one message is what creates the next. Do not "simplify"
+  * back to it.
   *
-  * Using an actor (rather than a fiber wrapping `(msg) => sleep >> send`) guarantees no concurrent
-  * delivery to `downstream` from this lane — out-of-order delivery would otherwise be possible.
+  * Spacing is measured on [[cats.effect.IO.monotonic]], so a wall-clock step cannot open or freeze
+  * the gate, and the resolution of `limiterTimestamp` is irrelevant.
+  *
+  * Messages are released in arrival order. One that is not throttled (or is exempt) is forwarded
+  * immediately when nothing is held, and queued behind whatever is held otherwise.
+  *
+  * ⚠️ On a single-flight lane the queue never exceeds one throttled entry. That is an upstream
+  * property this class does not enforce, so a second one is traced rather than assumed impossible.
+  *
+  * ==Failure==
+  * This actor is not restarted — `MultisigRegimeManagerBase` escalates every supervisor directive —
+  * so a failure takes the node down and anything held is lost. That is the safe outcome for a
+  * self-clocked lane: upstream waiting forever on a release that was silently dropped is a stall
+  * with nothing in the log, whereas a crash restarts and recovers its position from persistence. ⛔
+  * Do not catch exceptions here to "be safe"; swallowing one converts the crash into the stall.
   *
   * @param downstream
-  *   the actor the throttled lane terminates at (e.g. `BlockWeaver`, `StackComposer`). The
-  *   limiter's own [[ActorRef]] is what upstream actors are wired to in place of `downstream`.
-  * @param config
-  *   reads `minPeriod` from per-message-type knobs.
+  *   the actor the throttled lane terminates at. The limiter's own [[ActorRef]] is what upstream
+  *   actors are wired to in place of `downstream`. `ActorRef` is contravariant in its message type,
+  *   so the limiter's wider handle is usable wherever the downstream's narrower one is expected.
+  * @param gate
+  *   opt-in downstream-backlog gating. `None` means a pure spacing gate at the configured period:
+  *   no counting, no ticks, multiplier fixed at 1.0. ⛔ Must stay opt-in — a lane that counted
+  *   releases but was never sent [[LimiterControl.DownstreamDrained]] would stretch its period
+  *   without bound, silently.
+  * @param metrics
+  *   write-only publication of gate state for the stats endpoints. Nothing in the control path
+  *   reads it back; the multiplier acted on is the one in this actor's state.
   */
 final case class Limiter[Msg](
     downstream: ActorRef[IO, Msg],
     config: RateLimits.Section,
     tracer: ContraTracer[IO, LimiterEvent],
-) extends Actor[IO, Msg] {
+    gate: Option[LimiterGate] = None,
+    metrics: Option[PeerMetrics] = None
+) extends Actor[IO, Msg | LimiterControl] {
 
     given RateLimits.Section = config
+
+    /** Actor-private state, read and written only from inside `receive`. cats-actors drains a
+      * mailbox serially, so read-modify-write across a `flatMap` needs no further synchronisation.
+      */
+    private val stateRef: Ref[IO, Limiter.State[Msg]] =
+        Ref.unsafe[IO, Limiter.State[Msg]](Limiter.State.initial[Msg])
 
     override def preStart: IO[Unit] =
         tracer.traceWith(LimiterEvent.Started)
 
-    override def receive: Receive[IO, Msg] = PartialFunction.fromFunction { msg =>
-        msg match {
-            case throttled: LimiterTimestamp =>
-                for {
-                    now <- IO.realTimeInstant
-                    gate = throttled.limiterTimestamp.plusMillis(throttled.minPeriod.toMillis)
-                    waitMs = gate.toEpochMilli - now.toEpochMilli
-                    _ <-
-                        if waitMs > 0 then
-                            tracer.traceWith(
-                              LimiterEvent.HoldingMsg(msg.getClass.getSimpleName, waitMs)
-                            ) >> IO.sleep(waitMs.millis)
-                        else IO.unit
-                    _ <- downstream ! msg
-                } yield ()
-            case other =>
-                downstream ! other
+    override def receive: Receive[IO, Msg | LimiterControl] = PartialFunction.fromFunction {
+        case LimiterControl.Tick =>
+            stateRef.update(_.copy(tickArmed = false)) >> pumpAndArm
+
+        case LimiterControl.DownstreamDrained =>
+            onDrained
+
+        case msg =>
+            // Safe by disjointness: `LimiterControl` is matched above and is not part of any lane's
+            // message type. `Msg` is erased, so this is a no-op cast.
+            enqueue(msg.asInstanceOf[Msg]) >> pumpAndArm
+    }
+
+    // ---- queueing -----------------------------------------------------------------------------
+
+    /** Commit the arrival to `stateRef` before anything else looks at it, so the queue is the one
+      * source of truth every step below re-reads.
+      */
+    private def enqueue(msg: Msg): IO[Unit] =
+        stateRef.updateAndGet(st => st.copy(queue = st.queue :+ msg)).flatMap { st =>
+            val throttledPending = st.queue.count {
+                case t: LimiterTimestamp => !t.limiterExempt
+                case _                   => false
+            }
+            // The single-flight invariant says this is 1. Trace, do not drop and do not fail: if
+            // the invariant is ever relaxed upstream, FIFO queueing is still correct behaviour.
+            if throttledPending > 1 then
+                tracer.traceWith(LimiterEvent.QueueDepthUnexpected(throttledPending))
+            else IO.unit
         }
+
+    /** Release everything currently due, then arm a tick if something is still waiting. */
+    private def pumpAndArm: IO[Unit] =
+        pump.flatMap(st => if st.queue.isEmpty || st.tickArmed then IO.unit else armTick(st))
+
+    private def pump: IO[Limiter.State[Msg]] =
+        stateRef.get.flatMap { st =>
+            st.queue.headOption match {
+                case None => IO.pure(st)
+                case Some(head) =>
+                    head match {
+                        case t: LimiterTimestamp if !t.limiterExempt =>
+                            IO.monotonic.map(_.toMillis).flatMap { now =>
+                                st.lastReleaseMs match {
+                                    case Some(last) if now < last + periodMs(t, st) =>
+                                        holdBegun(st, t, last + periodMs(t, st) - now)
+                                    case _ => releaseHead(st, head, advanceTo = Some(now))
+                                }
+                            }
+                        // Deliberately does NOT restart the spacing clock: an exempt message is
+                        // not paced, so letting it reset the clock would let a stream of them
+                        // shift the whole schedule.
+                        case other => releaseHead(st, other, advanceTo = None)
+                    }
+            }
+        }
+
+    /** Send first, then advance. A send that fails therefore leaves the message queued and the
+      * spacing clock unmoved: the state never records a release that did not happen.
+      */
+    private def releaseHead(
+        st: Limiter.State[Msg],
+        head: Msg,
+        advanceTo: Option[Long]
+    ): IO[Limiter.State[Msg]] =
+        val released = st.gateState.released + advanceTo.fold(0L)(_ => 1L)
+        val advanced = advanceTo match {
+            case Some(now) =>
+                st.copy(
+                  queue = st.queue.tail,
+                  lastReleaseMs = Some(now),
+                  holdStartedMs = None,
+                  gateState = st.gateState.copy(released = released)
+                )
+            case None => st.copy(queue = st.queue.tail)
+        }
+        release(head) >> stateRef.set(advanced) >>
+            advanceTo.fold(IO.unit)(_ => publishBacklog(released)) >> pump
+
+    /** Trace once when a hold starts, not once per slice — a 5 s hold at a 150 ms slice is 33
+      * ticks, and a log line per tick would bury the signal.
+      */
+    private def holdBegun(
+        st: Limiter.State[Msg],
+        t: LimiterTimestamp,
+        waitMs: Long
+    ): IO[Limiter.State[Msg]] =
+        if st.holdStartedMs.isDefined then IO.pure(st)
+        else
+            val name = t.getClass.getSimpleName
+            for {
+                _ <- tracer.traceWith(LimiterEvent.HoldingMsg(name, waitMs))
+                _ <- if gate.isEmpty then IO.unit else IO(metrics.foreach(_.onBlockGateHold()))
+                now <- IO.monotonic.map(_.toMillis)
+                updated <- stateRef.updateAndGet(_.copy(holdStartedMs = Some(now)))
+            } yield updated
+
+    private def armTick(st: Limiter.State[Msg]): IO[Unit] =
+        val sliceMs = gate.fold(Limiter.DefaultSliceMs)(_.slice.toMillis)
+        for {
+            now <- IO.monotonic.map(_.toMillis)
+            due = st.queue.headOption match {
+                case Some(t: LimiterTimestamp) =>
+                    st.lastReleaseMs.fold(now)(_ + periodMs(t, st))
+                case _ => now
+            }
+            waitMs = math.max(0L, math.min(due - now, sliceMs))
+            _ <- stateRef.update(_.copy(tickArmed = true))
+            // Blocks this mailbox for at most one slice, deliberately. The self-send goes out
+            // AFTER the sleep, so anything that arrived meanwhile is processed first.
+            _ <- IO.sleep(waitMs.millis)
+            _ <- context.self ! LimiterControl.Tick
+        } yield ()
+
+    private def release(msg: Msg): IO[Unit] = (downstream ! msg).void
+
+    /** Only a gated lane may write these; otherwise the gauges would carry another lane's numbers.
+      */
+    private def publishBacklog(released: Long): IO[Unit] =
+        if gate.isEmpty then IO.unit else IO(metrics.foreach(_.onBlockGateRelease(released)))
+
+    // ---- the gate -----------------------------------------------------------------------------
+
+    private def periodMs(t: LimiterTimestamp, st: Limiter.State[Msg]): Long =
+        val base = t.minPeriod.toMillis
+        val m = if gate.isEmpty then 1.0 else st.gateState.multiplier
+        if m >= 1.0 then base else math.ceil(base / m).toLong
+
+    private def onDrained: IO[Unit] = gate match {
+        // A lane with no gate has no notion of downstream backlog. Nothing sends it drain signals
+        // today; ignoring them keeps that from mattering if something ever does.
+        case None => IO.unit
+        case Some(g) =>
+            stateRef.get.flatMap { st =>
+                val before = st.gateState.released
+                val next = g.observeDrain(st.gateState)
+                stateRef.set(st.copy(gateState = next)) >>
+                    tracer.traceWith(
+                      LimiterEvent.GateUpdated(before, next.residual, next.multiplier)
+                    ) >>
+                    IO(
+                      metrics.foreach(_.onBlockGateUpdate(before, next.residual, next.multiplier))
+                    ) >>
+                    pumpAndArm
+            }
     }
 }
 
 object Limiter {
     type Handle[Msg] = ActorRef[IO, Msg]
+
+    /** Slice for a lane with no gate. Its period is static, so slicing only bounds how long the
+      * mailbox is blocked.
+      */
+    private val DefaultSliceMs: Long = 1000L
+
+    /** ⛔ `Option`, not a `-1` sentinel: these hold [[cats.effect.IO.monotonic]] readings, i.e.
+      * `System.nanoTime`, whose origin is arbitrary and which the JDK permits to be negative. A
+      * `>= 0` test for "have we released yet" would read false forever on such a platform and the
+      * gate would never engage.
+      *
+      * @param lastReleaseMs
+      *   monotonic millis of the last throttled release; `None` before the first, which is what
+      *   makes the first message due immediately — a freshly started limiter must not invent a
+      *   delay.
+      * @param holdStartedMs
+      *   monotonic millis at which the current hold began; `None` when nothing is held. Exists only
+      *   so a hold is traced once rather than once per slice.
+      */
+    final case class State[Msg](
+        lastReleaseMs: Option[Long],
+        queue: Vector[Msg],
+        tickArmed: Boolean,
+        holdStartedMs: Option[Long],
+        gateState: LimiterGate.State
+    )
+
+    object State {
+        def initial[Msg]: State[Msg] = State[Msg](
+          lastReleaseMs = None,
+          queue = Vector.empty,
+          tickArmed = false,
+          holdStartedMs = None,
+          gateState = LimiterGate.Open
+        )
+    }
 }

--- a/src/main/scala/hydrozoa/multisig/consensus/limiter/LimiterControl.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/limiter/LimiterControl.scala
@@ -1,0 +1,31 @@
+package hydrozoa.multisig.consensus.limiter
+
+/** Control messages a [[Limiter]] consumes for its own account. Never forwarded downstream, so the
+  * lane's downstream actor needs no case for them.
+  *
+  * Messages rather than a shared [[cats.effect.Ref]]: a `Ref` read inside a sleep loop is invisible
+  * to deterministic replay.
+  */
+sealed trait LimiterControl
+
+object LimiterControl:
+
+    /** Downstream has absorbed the backlog this limiter released — on the block lane, one stack
+      * hard-confirmed. Reopens the gate.
+      *
+      * Hard confirmation rather than the peer's own hard ack: it is one event per downstream cycle
+      * and strictly later, so it subsumes the ack, and where a coil lags the extra conservatism is
+      * what we want. It also cannot deadlock against the gate — hard confirmation needs hard acks
+      * and the stack clock, never new blocks — so throttling the block lane all the way to its
+      * floor can never suppress the event that lifts the throttle.
+      */
+    case object DownstreamDrained extends LimiterControl
+
+    /** Self-tick: re-evaluate an outstanding hold.
+      *
+      * A hold is a chain of short sleeps each followed by one of these, not a single `IO.sleep` for
+      * the whole wait, so the mailbox drains between slices and [[DownstreamDrained]] is acted on
+      * at most one slice late. The handler recomputes from current state, so a stale or duplicated
+      * tick is harmless.
+      */
+    case object Tick extends LimiterControl

--- a/src/main/scala/hydrozoa/multisig/consensus/limiter/LimiterEvent.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/limiter/LimiterEvent.scala
@@ -8,4 +8,14 @@ sealed trait LimiterEvent
 object LimiterEvent:
     case object Started extends LimiterEvent
 
+    /** Emitted once when a hold begins, not once per slice. */
     final case class HoldingMsg(msgType: String, holdMs: Long) extends LimiterEvent
+
+    /** The backlog gate re-derived its multiplier from a completed downstream cycle. */
+    final case class GateUpdated(backlog: Long, residual: Double, multiplier: Double)
+        extends LimiterEvent
+
+    /** More than one throttled message was queued at once. Upstream is supposed to be single-flight
+      * on this lane, so this says an invariant the gate's sizing assumes no longer holds.
+      */
+    final case class QueueDepthUnexpected(throttledPending: Int) extends LimiterEvent

--- a/src/main/scala/hydrozoa/multisig/consensus/limiter/LimiterEventFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/limiter/LimiterEventFormat.scala
@@ -13,5 +13,11 @@ object LimiterEventFormat:
         e match {
             case Started           => debug(s"Limiter[$label] started.")
             case HoldingMsg(t, ms) => debug(s"Limiter[$label] holding $t for ${ms}ms")
+            case GateUpdated(backlog, residual, m) =>
+                debug(
+                  f"Limiter[$label] gate: backlog=$backlog residual=$residual%.1f multiplier=$m%.3f"
+                )
+            case QueueDepthUnexpected(n) =>
+                warn(s"Limiter[$label] has $n throttled messages queued; expected at most 1.")
         }
     }

--- a/src/main/scala/hydrozoa/multisig/consensus/limiter/LimiterGate.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/limiter/LimiterGate.scala
@@ -1,0 +1,86 @@
+package hydrozoa.multisig.consensus.limiter
+
+import scala.concurrent.duration.FiniteDuration
+
+/** The downstream-backlog gate: turns "how much work downstream has yet to absorb" into a
+  * multiplier on the lane's release rate.
+  *
+  * ⛔ **Opt-in.** Without a gate there is no counting, no ticking and no multiplier, so a lane that
+  * is never sent [[LimiterControl.DownstreamDrained]] cannot ratchet its period toward infinity.
+  *
+  * The spacing gate alone bounds the floor on cycle time; this bounds the ceiling on outstanding
+  * work. Neither subsumes the other.
+  */
+final case class LimiterGate(
+    /** Backlog (in released messages per downstream cycle) below which the gate is fully open. Set
+      * above healthy steady-state accumulation and the controller does nothing; the sizing rule is
+      * on the config knob that supplies it.
+      */
+    backlogSoftLimit: Int,
+
+    /** Backlog at which the multiplier reaches [[floor]]. */
+    backlogHardLimit: Int,
+
+    /** The slowest the lane is ever shaped to, as a fraction of the configured rate. ⛔ Never 0:
+      * upstream is self-clocked by what this lane releases, so releasing nothing stops the clock
+      * that would later reopen the gate. Same reason TCP always sends a full segment eventually.
+      */
+    floor: Double,
+
+    /** EWMA weight on the newest cycle's residual. Below 1.0 the controller acts on a filtered
+      * count rather than the raw one.
+      */
+    smoothing: Double,
+
+    /** Longest single sleep the limiter will commit to before re-reading its mailbox. Bounds how
+      * stale the multiplier can be while a hold is outstanding.
+      */
+    slice: FiniteDuration
+):
+    require(backlogHardLimit > backlogSoftLimit, "backlogHardLimit must exceed backlogSoftLimit")
+    require(floor > 0.0 && floor <= 1.0, "gate floor must be in (0, 1]")
+    require(smoothing > 0.0 && smoothing <= 1.0, "gate smoothing must be in (0, 1]")
+
+    /** Headroom, 1.0 fully open through 0.0 fully loaded. */
+    def headroom(backlog: Double): Double =
+        val span = (backlogHardLimit - backlogSoftLimit).toDouble
+        ((backlogHardLimit - backlog) / span).max(0.0).min(1.0)
+
+    /** The rate multiplier for a filtered backlog.
+      *
+      * `1 - (1 - h)^2` is flat near full headroom and steepens as it runs out. ⛔ Not `h^2`, whose
+      * highest gain sits where the system is healthy: the loop's dead time is a full downstream
+      * cycle, and high gain across long dead time produces a limit cycle.
+      */
+    def multiplier(backlog: Double): Double =
+        val h = headroom(backlog)
+        val open = 1.0 - (1.0 - h) * (1.0 - h)
+        floor + (1.0 - floor) * open
+
+object LimiterGate:
+
+    /** The gate's running state. Owned by the limiter actor and read by nothing else — the copy
+      * published to `PeerMetrics` is for the stats endpoints and is never read back.
+      *
+      * @param released
+      *   throttled messages released since the last drain signal. This is the live count.
+      * @param residual
+      *   the filtered per-cycle residual the multiplier is derived from. Updated only on a drain
+      *   signal, from the count accumulated over the cycle just ended, so between signals the
+      *   multiplier is constant.
+      */
+    final case class State(released: Long, residual: Double, multiplier: Double, drains: Long)
+
+    val Open: State = State(released = 0L, residual = 0.0, multiplier = 1.0, drains = 0L)
+
+    extension (gate: LimiterGate)
+        /** Fold one completed downstream cycle into the filter and re-derive the multiplier. */
+        def observeDrain(s: State): State =
+            val residual =
+                gate.smoothing * s.released.toDouble + (1.0 - gate.smoothing) * s.residual
+            State(
+              released = 0L,
+              residual = residual,
+              multiplier = gate.multiplier(residual),
+              drains = s.drains + 1
+            )

--- a/src/main/scala/hydrozoa/multisig/consensus/limiter/LimiterTimestamp.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/limiter/LimiterTimestamp.scala
@@ -28,4 +28,12 @@ trait LimiterTimestamp {
     /** Minimum wall-clock gap between this message and the next throttled message on the same lane.
       */
     def minPeriod(using RateLimits.Section): FiniteDuration
+
+    /** Released without pacing, in arrival order, and does not restart the spacing clock.
+      *
+      * For messages that end the lane: they add no ongoing backlog, so pacing them only costs
+      * latency. In arrival order, not ahead of the queue — overtaking a held message would reorder
+      * the lane.
+      */
+    def limiterExempt: Boolean = false
 }

--- a/src/main/scala/hydrozoa/multisig/ledger/block/Block.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/block/Block.scala
@@ -88,6 +88,11 @@ object Block {
             override transparent inline def header: BlockHeader.Final = blockBrief.header
             override transparent inline def body: BlockBody.Final = blockBrief.body
             override transparent inline def finalizationRequested: Boolean = false
+
+            /** The last block this head will ever produce: there is no next block to pace against,
+              * and holding it only delays finalization.
+              */
+            override def limiterExempt: Boolean = true
         }
 
         type Next = Block.SoftConfirmed & BlockType.Next

--- a/src/main/scala/hydrozoa/multisig/metrics/PeerMetrics.scala
+++ b/src/main/scala/hydrozoa/multisig/metrics/PeerMetrics.scala
@@ -73,6 +73,16 @@ final class PeerMetrics private (startedAtMillis: Long, remotePeerNums: Vector[I
     private val seqHeadroom = new AtomicLong(0)
     private val equityLovelace = new AtomicLong(0)
 
+    // ---- block-rate gate (written by the block lane's Limiter) ----
+    // Observability only. The limiter acts on the multiplier in its own actor state; these are a
+    // write-only copy so the stats endpoints can show what the gate is doing. Nothing in the
+    // control path reads them back.
+    private val gateMultiplierMilli = new AtomicLong(1000)
+    private val gateBacklog = new AtomicLong(0)
+    private val gateResidualMilli = new AtomicLong(0)
+    private val gateHolds = new AtomicLong(0)
+    private val gateDrains = new AtomicLong(0)
+
     // ---- stack-composer phase (see StackComposerPhase) ----
     private val composerPhase = new AtomicReference[StackComposerPhase](StackComposerPhase.Deriving)
     private val composerPhaseSince = new AtomicLong(startedAtMillis)
@@ -166,6 +176,19 @@ final class PeerMetrics private (startedAtMillis: Long, remotePeerNums: Vector[I
       * clock, so `secondsInPhase` measures how long the composer has been stuck in it — the whole
       * point of the gauge, and `tryProgress` re-evaluates on every inbound event.
       */
+    /** One throttled message released; `backlog` is the running count since the last drain. */
+    def onBlockGateRelease(backlog: Long): Unit = gateBacklog.set(backlog)
+
+    /** A hold began (once per hold, not once per slice). */
+    def onBlockGateHold(): Unit = { val _ = gateHolds.incrementAndGet() }
+
+    /** The gate re-derived its multiplier at the end of a downstream cycle. */
+    def onBlockGateUpdate(backlogAtDrain: Long, residual: Double, multiplier: Double): Unit =
+        gateBacklog.set(backlogAtDrain)
+        gateResidualMilli.set(math.round(residual * 1000.0))
+        gateMultiplierMilli.set(math.round(multiplier * 1000.0))
+        val _ = gateDrains.incrementAndGet()
+
     def onComposerPhase(phase: StackComposerPhase, nowMillis: Long): Unit =
         if composerPhase.getAndSet(phase) != phase then composerPhaseSince.set(nowMillis)
 
@@ -235,6 +258,13 @@ final class PeerMetrics private (startedAtMillis: Long, remotePeerNums: Vector[I
           sequencerHeadroom = seqHeadroom.get(),
           equityLovelace = equityLovelace.get(),
           runtime = PeerMetrics.runtimeSnapshot(),
+          blockGate = BlockGateStats(
+            multiplier = gateMultiplierMilli.get() / 1000.0,
+            backlog = gateBacklog.get(),
+            residual = gateResidualMilli.get() / 1000.0,
+            holds = gateHolds.get(),
+            drains = gateDrains.get()
+          ),
           composer = ComposerStats(
             phase = composerPhase.get(),
             secondsInPhase = math.max(0L, (nowMillis - composerPhaseSince.get()) / 1000),
@@ -483,7 +513,23 @@ final case class PeerStats(
     sequencerHeadroom: Long,
     equityLovelace: Long,
     composer: ComposerStats,
-    runtime: RuntimeStats
+    runtime: RuntimeStats,
+    blockGate: BlockGateStats
+)
+
+/** What the block lane's rate limiter is doing, so a deploy can be checked with one request rather
+  * than by log-diving at a level the node does not run at.
+  *
+  * `multiplier` 1.0 means the backlog gate is fully open and the lane is paced only by the
+  * configured period — the expected steady state. Below 1.0 the composer is behind and the lane is
+  * being slowed; the effective period is `softBlockMinPeriod / multiplier`.
+  */
+final case class BlockGateStats(
+    multiplier: Double,
+    backlog: Long,
+    residual: Double,
+    holds: Long,
+    drains: Long
 )
 
 /** Whole-process resource use, for answering one question about a run: is the resource curve

--- a/src/main/scala/hydrozoa/multisig/metrics/PrometheusFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/metrics/PrometheusFormat.scala
@@ -216,6 +216,37 @@ object PrometheusFormat:
           s.runtime.openFileDescriptors
         )
 
+        // ---- block-rate limiter ----
+        gaugeD(
+          "hydrozoa_block_gate_multiplier",
+          "Block-lane rate multiplier. 1 means the downstream-backlog gate is fully open and " +
+              "block production is paced only by softBlockMinPeriod; below 1 the stack composer " +
+              "is behind and the effective period is softBlockMinPeriod divided by this.",
+          s.blockGate.multiplier
+        )
+        gauge(
+          "hydrozoa_block_gate_backlog",
+          "Soft-confirmed blocks released since the last hard confirmation.",
+          s.blockGate.backlog
+        )
+        gaugeD(
+          "hydrozoa_block_gate_residual",
+          "Per-stack-cycle backlog, filtered over several cycles. The multiplier is derived from " +
+              "this rather than from instantaneous depth, which is dominated by cycle phase.",
+          s.blockGate.residual
+        )
+        counter(
+          "hydrozoa_block_gate_holds_total",
+          "Holds begun by the block limiter. Rising means the shaper is binding.",
+          s.blockGate.holds
+        )
+        counter(
+          "hydrozoa_block_gate_drains_total",
+          "Headroom signals received (one per hard confirmation). Flat while blocks are being " +
+              "produced means the gate has stopped being reopened.",
+          s.blockGate.drains
+        )
+
         b.toString
 
     private def rate(name: String, help: String, r: RateView, b: StringBuilder): Unit =

--- a/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
+++ b/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
@@ -265,9 +265,24 @@ object ApiDto {
           */
         equityLovelace: Long,
         composer: ComposerStatsView,
-        runtime: RuntimeStatsView
+        runtime: RuntimeStatsView,
+        blockGate: BlockGateStatsView
     )
     given Codec[PeerStatsView] = deriveCodec
+
+    /** What the block lane's rate limiter is doing right now. `multiplier` 1.0 is the expected
+      * steady state; below 1.0 the stack composer is behind and the lane is being slowed. `backlog`
+      * is blocks released since the last hard confirmation, and `residual` is that count filtered
+      * over several stack cycles — see [[hydrozoa.multisig.metrics.BlockGateStats]].
+      */
+    final case class BlockGateStatsView(
+        multiplier: Double,
+        backlog: Long,
+        residual: Double,
+        holds: Long,
+        drains: Long
+    )
+    given Codec[BlockGateStatsView] = deriveCodec
 
     /** Whole-process resource gauges. Read these against the cumulative counters above (`blocks`,
       * `stacks`, `localRequests.total`) and across a deliberate load step-down; they are
@@ -302,6 +317,13 @@ object ApiDto {
             )
         PeerStatsView(
           uptimeSeconds = s.uptimeSeconds,
+          blockGate = BlockGateStatsView(
+            multiplier = s.blockGate.multiplier,
+            backlog = s.blockGate.backlog,
+            residual = s.blockGate.residual,
+            holds = s.blockGate.holds,
+            drains = s.blockGate.drains
+          ),
           runtime = RuntimeStatsView(
             fibersSuspended = s.runtime.fibersSuspended,
             fibersQueuedLocal = s.runtime.fibersQueuedLocal,

--- a/src/test/scala/hydrozoa/multisig/consensus/limiter/LimiterSpacingTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/limiter/LimiterSpacingTest.scala
@@ -1,0 +1,337 @@
+package hydrozoa.multisig.consensus.limiter
+
+import cats.effect.unsafe.implicits.global
+import cats.effect.{IO, Ref}
+import cats.implicits.*
+import com.suprnation.actor.Actor.{Actor, Receive}
+import com.suprnation.actor.ActorRef.ActorRef
+import com.suprnation.actor.ActorSystem
+import hydrozoa.config.node.operation.multisig.RateLimits
+import hydrozoa.lib.logging.ContraTracer
+import io.circe.parser.decode
+import java.time.Instant
+import org.scalatest.funsuite.AnyFunSuite
+import scala.concurrent.duration.{DurationInt, DurationLong, FiniteDuration}
+
+/** Every message on the test lane carries the SAME, ancient timestamp.
+  *
+  * That is the production defect in its strongest form. The block lane's `limiterTimestamp` is a
+  * block's end time, quantized to a one-second Cardano slot, so every block produced inside one
+  * second really did share a single gate — and the old limiter, which computed its gate as
+  * `limiterTimestamp + minPeriod`, let all but the first through with no hold at all. Fixing that
+  * timestamp to `EPOCH` here means the gate can only come from the limiter's memory of its own last
+  * release. A limiter that consults the message cannot pass these tests.
+  */
+private sealed trait LaneMsg extends LimiterTimestamp:
+    def id: Int
+    override def limiterTimestamp: Instant = Instant.EPOCH
+    override def minPeriod(using cfg: RateLimits.Section): FiniteDuration = cfg.softBlockMinPeriod
+
+private final case class Paced(id: Int) extends LaneMsg
+
+private final case class Exempt(id: Int) extends LaneMsg:
+    override def limiterExempt: Boolean = true
+
+/** Records what reached the downstream, and when, on the same monotonic clock the limiter uses. */
+private final case class Recorder(seen: Ref[IO, Vector[(Int, Long)]]) extends Actor[IO, LaneMsg]:
+    override def receive: Receive[IO, LaneMsg] = PartialFunction.fromFunction { m =>
+        IO.monotonic.map(_.toMillis).flatMap(t => seen.update(_ :+ (m.id -> t)))
+    }
+
+/** The block lane's 100 ms period was inert in production: the head produced 30 blocks/s against a
+  * 10 Hz config, and at low load exactly 1.00 requests per block — one block per request, which is
+  * the degenerate case the shaper exists to prevent.
+  *
+  * Two defects caused it, and gating on the limiter's own last release fixes both at once. These
+  * tests pin the fixed behaviour, and each rate assertion is paired with a control that must NOT
+  * space, so a suite that silently stopped measuring anything would fail rather than pass.
+  */
+class LimiterSpacingTest extends AnyFunSuite:
+
+    private val PeriodMs = 200L
+
+    private def limits(
+        softBlockMinPeriod: FiniteDuration = PeriodMs.millis,
+        hardStackMinPeriod: FiniteDuration = 30.seconds
+    ): RateLimits =
+        RateLimits.default.copy(
+          softBlockMinPeriod = softBlockMinPeriod,
+          hardStackMinPeriod = hardStackMinPeriod
+        )
+
+    // ---- the spacing gate ---------------------------------------------------------------------
+
+    test("messages sharing one timestamp are still released a full period apart") {
+        val seen = runLane(limits(), gate = None, settle = 1500.millis) { lim =>
+            (0 until 5).toList.traverse_(i => (lim ! Paced(i)) >> IO.sleep(10.millis))
+        }
+        val _ = assert(seen.size == 5, s"expected all 5 messages through, got ${seen.size}: $seen")
+        assertSpacing(seen, atLeastMs = (PeriodMs * 0.8).toLong)
+        assertOrdered(seen)
+    }
+
+    // Control for the test above. Same injection, same assertions machinery, but a period short
+    // enough that spacing cannot show up -- so if the limiter ever stopped holding anything, the
+    // test above would fail while this one still passes. Without this pair, "gaps are >= 160ms"
+    // could be satisfied by a limiter that simply delivered slowly for some unrelated reason.
+    test("control: with a negligible period the same injection is NOT spaced") {
+        val seen = runLane(limits(softBlockMinPeriod = 1.milli), gate = None, settle = 500.millis) {
+            lim => (0 until 5).toList.traverse_(i => (lim ! Paced(i)) >> IO.sleep(10.millis))
+        }
+        val _ = assert(seen.size == 5, s"expected all 5 through, got $seen")
+        val span = seen.last._2 - seen.head._2
+        assert(span < 150L, s"expected no spacing with a 1ms period, but the span was ${span}ms")
+    }
+
+    // ⛔ The regression that matters most for the shared implementation. The stack lane uses the
+    // same Limiter class with NO gate, and nothing ever sends it a drain signal. If the gate's
+    // counting were unconditional rather than opt-in, its residual would climb forever and stretch
+    // hardStackMinPeriod without bound -- silently, and only in integration. Here the period must
+    // stay put across many releases with no drain signal ever sent.
+    test("a lane with no gate holds its exact period and never stretches") {
+        val seen = runLane(limits(), gate = None, settle = 2500.millis) { lim =>
+            (0 until 8).toList.traverse_(i => lim ! Paced(i))
+        }
+        val _ = assert(seen.size == 8, s"expected 8 through, got ${seen.size}")
+        assertSpacing(seen, atLeastMs = (PeriodMs * 0.8).toLong)
+        assertNoStretch(seen, atMostMs = (PeriodMs * 1.6).toLong)
+    }
+
+    test("a gated lane does not stretch either until a drain signal arrives") {
+        val gate = Some(tightGate)
+        val seen = runLane(limits(), gate = gate, settle = 2500.millis) { lim =>
+            (0 until 8).toList.traverse_(i => lim ! Paced(i))
+        }
+        val _ = assert(seen.size == 8, s"expected 8 through, got ${seen.size}")
+        // The multiplier is re-derived only on a drain signal, so with none sent it stays 1.0 even
+        // though the backlog is well past this gate's hard limit. That constancy between signals is
+        // what stops the controller sawtoothing at the downstream cadence.
+        assertNoStretch(seen, atMostMs = (PeriodMs * 1.6).toLong)
+    }
+
+    // ---- the backlog gate ---------------------------------------------------------------------
+
+    test("a drain signal carrying a large backlog stretches the period") {
+        val seen = runLane(limits(), gate = Some(tightGate), settle = 3000.millis) { lim =>
+            for {
+                // Three releases with this gate's hard limit at 3 puts the filtered residual at the
+                // bottom of the ramp, so the multiplier lands on the floor.
+                _ <- (0 until 3).toList.traverse_(i =>
+                    (lim ! Paced(i)) >> IO.sleep(PeriodMs.millis)
+                )
+                _ <- lim ! LimiterControl.DownstreamDrained
+                _ <- lim ! Paced(100)
+                _ <- lim ! Paced(101)
+            } yield ()
+        }
+        val tail = seen.filter(_._1 >= 100)
+        val _ = assert(tail.size == 2, s"expected both post-drain messages, got $seen")
+        val gap = tail(1)._2 - tail(0)._2
+        // floor 0.25 => the period is stretched 4x.
+        val expected = (PeriodMs * 4 * 0.8).toLong
+        assert(
+          gap >= expected,
+          s"expected the gate to stretch the period to >=${expected}ms, got ${gap}ms"
+        )
+    }
+
+    // ---- exemption ----------------------------------------------------------------------------
+
+    test("an exempt message passes straight through and does not restart the spacing clock") {
+        val seen =
+            runLane(limits(softBlockMinPeriod = 500.millis), gate = None, settle = 2.seconds) {
+                lim => (lim ! Paced(0)) >> (lim ! Exempt(1)) >> (lim ! Paced(2))
+            }
+        val at = seen.toMap
+        val _ = assert(at.keySet == Set(0, 1, 2), s"expected all three through, got $seen")
+        val _ = assert(
+          at(1) - at(0) < 100L,
+          s"the exempt message was held for ${at(1) - at(0)}ms; it must not be paced"
+        )
+        // If the exempt release had reset `lastReleaseMs`, this gap would be measured from the
+        // exempt message instead and the schedule would drift by one message every time.
+        assert(
+          at(2) - at(0) >= 400L,
+          s"expected the paced message to stay 500ms behind its predecessor, got ${at(2) - at(0)}ms"
+        )
+    }
+
+    // ---- failing loudly ------------------------------------------------------------------------
+
+    // ⛔ Do not make the limiter "fail open" by overriding `preRestart` to forward whatever it is
+    // holding. `MultisigRegimeManagerBase` maps every supervisor directive to `Escalate` ("normally
+    // `Restart` but our actors can't do that yet"), so this actor never restarts and such an
+    // override is unreachable — it would claim a safety property the system does not have.
+    //
+    // What protects the lane is the property below: a failure must NOT be absorbed. The lane is
+    // self-clocked, so a limiter that swallowed an exception and carried on with a message stuck in
+    // its queue would leave upstream waiting forever for a release that is never coming — a wedge
+    // with nothing in the log. Escalating turns that into a loud crash that systemd restarts and
+    // that recovers from persistence. If someone ever wraps this actor's body in `.attempt`, this
+    // test is what should fail.
+    test("a failure inside the limiter is escalated, not swallowed and carried on from") {
+        val period = 500.millis
+        val seen = ActorSystem[IO]("limiter-failure")
+            .use(system =>
+                for {
+                    got <- Ref.of[IO, Vector[(Int, Long)]](Vector.empty)
+                    sink <- system.actorOf(Recorder(got))
+                    lim <- system.actorOf(
+                      Limiter[LaneMsg](sink, limits(softBlockMinPeriod = period), throwOnHold)
+                    )
+                    _ <- lim ! Paced(0) // released immediately; nothing is held yet
+                    _ <- lim ! Paced(1) // held -> the injected failure fires
+                    _ <- IO.sleep(300.millis)
+                    _ <- (lim ! Paced(2)).attempt // must not be served by a limiter that carried on
+                    _ <- IO.sleep(1500.millis)
+                    r <- got.get
+                } yield r
+            )
+            .attempt
+            .unsafeRunSync()
+            .getOrElse(Vector.empty)
+        val delivered = seen.map(_._1).toSet
+        val _ = assert(
+          delivered.contains(0),
+          s"the pre-failure message should have been delivered: $seen"
+        )
+        assert(
+          !delivered.contains(2),
+          s"the limiter kept serving the lane after failing; the failure was swallowed: $seen"
+        )
+    }
+
+    // ---- the gate's arithmetic (no actor system) ----------------------------------------------
+
+    private val curve = LimiterGate(
+      backlogSoftLimit = 0,
+      backlogHardLimit = 1000,
+      floor = 0.01,
+      smoothing = 0.5,
+      slice = 150.millis
+    )
+
+    test(
+      "the multiplier is 1 at or below the soft limit and the floor at or above the hard limit"
+    ) {
+        val _ = assert(curve.multiplier(0.0) === 1.0)
+        val _ = assert(curve.multiplier(-5.0) === 1.0)
+        val _ = assert(curve.multiplier(1000.0) === curve.floor)
+        assert(curve.multiplier(5000.0) === curve.floor)
+    }
+
+    test("the multiplier decreases monotonically across the ramp") {
+        val ms = (0 to 1000 by 50).map(b => curve.multiplier(b.toDouble))
+        assert(
+          ms.sliding(2).forall(w => w(0) >= w(1)),
+          s"multiplier is not monotonically decreasing: $ms"
+        )
+    }
+
+    // The design decision this pins: gain belongs where the backlog is dangerous, not where the
+    // system is fine. The loop's dead time is a whole stack cycle plus confirmation latency, and
+    // high gain across a long dead time is how a controller ends up in a limit cycle. The obvious
+    // alternative curve, h^2, has exactly the opposite curvature and would fail this test.
+    test("the ramp is flat where healthy and steepens as headroom runs out") {
+        val early = curve.multiplier(250.0) - curve.multiplier(500.0)
+        val late = curve.multiplier(500.0) - curve.multiplier(750.0)
+        assert(late > early, s"expected the ramp to steepen; early drop $early, late drop $late")
+    }
+
+    test("a drain signal folds the cycle's count into the filter and resets the live count") {
+        import LimiterGate.observeDrain
+        val one = curve.observeDrain(LimiterGate.Open.copy(released = 100L))
+        val _ = assert(
+          one.residual === 50.0,
+          s"expected a half-weighted first sample, got ${one.residual}"
+        )
+        val _ = assert(one.released == 0L, "the live count must reset on a drain signal")
+        val _ = assert(one.drains == 1L)
+        val two = curve.observeDrain(one.copy(released = 100L))
+        assert(two.residual === 75.0, s"expected the filter to converge, got ${two.residual}")
+    }
+
+    // ---- config ------------------------------------------------------------------------------
+
+    // A node whose config fails to decode does not start at all, and every private.json already
+    // deployed predates the gate fields. This is what makes the deploy a binary swap with no
+    // config edit.
+    test("a rateLimits block written before the gate existed still decodes, with gate defaults") {
+        val legacy = """{"softBlockMinPeriod":100,"hardStackMinPeriod":30000}"""
+        decode[RateLimits](legacy) match {
+            case Left(e) => fail(s"a pre-gate rateLimits block must still decode: $e")
+            case Right(r) =>
+                val _ = assert(r.softBlockMinPeriod == 100.millis)
+                val _ = assert(r.hardStackMinPeriod == 30.seconds)
+                val _ = assert(r.blockBacklogSoftLimit == RateLimits.defaultBlockBacklogSoftLimit)
+                val _ = assert(r.blockBacklogHardLimit == RateLimits.defaultBlockBacklogHardLimit)
+                assert(r.blockGateFloor == RateLimits.defaultBlockGateFloor)
+        }
+    }
+
+    // ---- harness -----------------------------------------------------------------------------
+
+    /** Fails the limiter from inside a hold, and only from there, so the crash lands at the one
+      * moment it is holding a message. `preRestart`'s own trace is deliberately `attempt`ed in the
+      * limiter, so a tracer this hostile still cannot stop the flush.
+      */
+    private def throwOnHold: ContraTracer[IO, LimiterEvent] =
+        ContraTracer[IO, LimiterEvent] {
+            case _: LimiterEvent.HoldingMsg =>
+                IO.raiseError(new RuntimeException("injected failure inside the hold"))
+            case _ => IO.unit
+        }
+
+    /** A gate small enough to reach its floor after a handful of releases, so the dynamics are
+      * testable in seconds rather than in a 30-second stack cycle. `smoothing = 1.0` takes the
+      * newest cycle unfiltered, which makes the arithmetic exact.
+      */
+    private def tightGate: LimiterGate = LimiterGate(
+      backlogSoftLimit = 1,
+      backlogHardLimit = 3,
+      floor = 0.25,
+      smoothing = 1.0,
+      slice = 50.millis
+    )
+
+    private def runLane(
+        rateLimits: RateLimits,
+        gate: Option[LimiterGate],
+        settle: FiniteDuration
+    )(send: ActorRef[IO, LaneMsg | LimiterControl] => IO[Unit]): Vector[(Int, Long)] =
+        ActorSystem[IO]("limiter-test")
+            .use(system =>
+                for {
+                    seen <- Ref.of[IO, Vector[(Int, Long)]](Vector.empty)
+                    sink <- system.actorOf(Recorder(seen))
+                    lim <- system.actorOf(
+                      Limiter[LaneMsg](
+                        sink,
+                        rateLimits,
+                        ContraTracer.nullTracer[IO, LimiterEvent],
+                        gate
+                      )
+                    )
+                    _ <- send(lim)
+                    _ <- IO.sleep(settle)
+                    r <- seen.get
+                } yield r
+            )
+            .unsafeRunSync()
+
+    private def assertSpacing(seen: Vector[(Int, Long)], atLeastMs: Long): Unit =
+        val gaps = seen.map(_._2).sliding(2).map(w => w(1) - w(0)).toList
+        val _ = assert(
+          gaps.forall(_ >= atLeastMs),
+          s"expected every gap >= ${atLeastMs}ms, got $gaps"
+        )
+
+    private def assertNoStretch(seen: Vector[(Int, Long)], atMostMs: Long): Unit =
+        val gaps = seen.map(_._2).sliding(2).map(w => w(1) - w(0)).toList
+        val _ = assert(
+          gaps.forall(_ <= atMostMs),
+          s"a gap exceeded ${atMostMs}ms, so the period is stretching: $gaps"
+        )
+
+    private def assertOrdered(seen: Vector[(Int, Long)]): Unit =
+        val _ = assert(seen.map(_._1) == seen.map(_._1).sorted, s"messages were reordered: $seen")

--- a/src/test/scala/hydrozoa/multisig/metrics/PrometheusFormatTest.scala
+++ b/src/test/scala/hydrozoa/multisig/metrics/PrometheusFormatTest.scala
@@ -66,6 +66,13 @@ class PrometheusFormatTest extends AnyFunSuite:
         heapCommittedBytes = 536870912,
         // -1 is the "platform does not report this" sentinel, and it must survive rendering.
         openFileDescriptors = -1
+      ),
+      blockGate = BlockGateStats(
+        multiplier = 0.25,
+        backlog = 917,
+        residual = 903.5,
+        holds = 288347,
+        drains = 313
       )
     )
 
@@ -125,3 +132,17 @@ class PrometheusFormatTest extends AnyFunSuite:
         val _ = assert(out.contains("hydrozoa_timers_executed_total 98765"))
         val _ = assert(out.contains("# TYPE hydrozoa_timers_executed_total counter"))
         assert(out.contains("hydrozoa_open_file_descriptors -1"))
+
+    // The gate is what tells an operator whether the shaper is live and whether it is binding, and
+    // the node runs at WARN so the limiter's own traces are invisible. If these stop being rendered
+    // the deploy becomes unverifiable from outside the process.
+    test("the block-rate gate is rendered, with the multiplier as a plain decimal"):
+        val out = PrometheusFormat.render(sample)
+        assert(
+          out.contains("# TYPE hydrozoa_block_gate_multiplier gauge") &&
+              out.contains("hydrozoa_block_gate_multiplier 0.25") &&
+              out.contains("hydrozoa_block_gate_backlog 917") &&
+              out.contains("# TYPE hydrozoa_block_gate_drains_total counter") &&
+              out.contains("hydrozoa_block_gate_drains_total 313"),
+          out
+        )


### PR DESCRIPTION
`softBlockMinPeriod` was inert. The head produced **30 blocks/s against a 10 Hz config**, and at low load exactly **1.00 requests per block** — one block per request, the degenerate case the limit exists to prevent. Measured on staging after this change: **31.4 → 10.01 blocks/s, and 1.08 → 3.40 requests/block**, with the gate correctly non-binding at low load.

Measurements and the negative controls: https://claude.ai/code/artifact/3d04d567-f23c-4eea-a8ab-a6ea94fb8b08

Closes [GUM-292](https://linear.app/gummiworm-labs/issue/GUM-292/rate-limiter-doesnt-work-on-sub-seconds-rates), which names the quantization half of this — and proposes a different fix. See **Alternatives rejected**.

## How to review this

The file is `Limiter.scala`, and the paragraph that matters is why the backlog gate is opt-in.

`RateLimits.scala` carries the knobs and their sizing rationale. `LimiterSpacingTest` is long but each rate assertion is paired with a control, so read them in pairs.

## Change

Two defects, both from gating on the message instead of on the limiter:

- **It was an age filter, not a rate limit.** Messages arriving 49 ms apart were each held until their own stamp plus 100 ms, so they left 49 ms apart. The rate passed straight through a fixed delay line.
- **`limiterTimestamp` on this lane is a block's end time, quantized to a one-second Cardano slot** — ten times coarser than the period — so every block produced within one second shared a single gate and all but the first passed with no hold at all.

Gating on the limiter's own last release fixes both at once, and it explains why `hardStackMinPeriod` measured dead-on 30 s while this one did nothing: an age gate coincides with a rate limit only on a lane that is already single-flight, where releasing one message is what creates the next. The stack lane is such a lane; the block lane is not. Spacing is now measured on the monotonic clock, so an NTP step cannot open it.

On top of that, an opt-in downstream-backlog gate makes the period dynamic. The limiter counts what it releases, a hard confirmation folds that count into a filter over several stack cycles, and the multiplier is re-derived from the filtered value. Multiplier 1 is the shaper alone; below 1 the lane is slowed because the stack composer is behind.

## Rationale

**Each half is silent exactly where the other is needed.** A backlog gate never engages on a head whose composer keeps up; a fixed period does not help when the composer drains slower than it.

**The backlog gate is opt-in, and that is load-bearing rather than stylistic.** The stack lane uses this same `Limiter` class and is never sent a drain signal, so unconditional counting would stretch its period without bound — silently, and only in integration. `LimiterSpacingTest` covers exactly that case.

**The five new `RateLimits` fields have Scala defaults as well as decoder defaults**, and the two agree. Without the Scala defaults every existing construction site breaks on a purely additive config change — and both of them are in `integration`, a separate sbt project that `sbt test` does not compile, so the breakage would reach CI rather than a local run.

### Alternatives rejected

**Removing the one-second rounding from block start and end times**, which is what GUM-292 proposes. It would fix the quantization, but not the age-filter defect underneath it — messages would still leave at the interval they arrived at, just with finer stamps. And the rounding is there because those times reach L1, where the slot is the unit. Gating on the limiter's own last release makes the message timestamp irrelevant to the rate, so the rounding can stay where it belongs.

**A majors denominator for the backlog gate.** Trading load produces almost none (2 majors in ~240k blocks) and its threshold needs a deposit-flood run to calibrate; an invented constant would be untestable either way. The seam is left as `min` over named signals.

**A `preRestart` flush in the limiter, to fail open if it died mid-hold.** Writing the test showed it never runs: `MultisigRegimeManagerBase` maps every supervisor directive to `Escalate`, so the actor is not restarted and the override was dead code asserting a safety property we do not have. Escalation is the safe behaviour for a self-clocked lane — a loud crash that systemd restarts and that recovers from persistence, rather than a stall with nothing in the log.

**Moving `rateLimits` into head parameters.** Deliberately not done here: it would invalidate the deployed mainnet head configuration. The new knobs live inside `RateLimits`, so they move with it when that change lands — at which point these defaults become head-agreed rather than per-node, and are worth a second look.

## Risk

The block-lane behaviour change is bounded by the configured period and self-disabling below it, so a head whose natural cycle is already slower than 100 ms is unaffected. Its throughput ceiling is `1/period × maxRequestsPerBlock`, which at the defaults is 10,000 requests/s.

The backlog gate's thresholds are reasoned from the shaper's own steady-state accumulation rather than measured under a backlog. It did not engage during the staging run, which is the correct outcome at that load — and also means its dynamics are unexercised in production.

## Testing

**570 passed, 0 failed, 0 errors** on this commit; `integration/Test/compile` green. The suite also reports **10 canceled and 3 ignored** on every commit of this stack: the canceled ones are the Blockfrost-backed tests, which need an API key this environment does not have. They are pre-existing and identical on the base.

Newly covered:

- **The rate limit.** Every message in `LimiterSpacingTest` carries the same `Instant.EPOCH` timestamp — the quantization defect in its strongest form, which the previous implementation cannot pass.
- **The stack lane not regressing**, with the gate machinery compiled in but not enabled.
- **Config decoding** of a `rateLimits` block written before the gate fields existed.

Each rate assertion is paired with a control that must **not** space, so a suite that silently stopped measuring would fail rather than pass.

Not covered: the backlog gate's dynamics in integration.

## Scope

This caps block production. It is **not** a throughput improvement — the head's ceiling is per-request work, unchanged by this branch and measured separately in the report above. What it changes is that the work arrives in batches rather than one request per block.

Deploys as a binary swap: every new config field is optional with a default, following the `peerLiaisonOutboxCap` precedent, because a node whose config fails to decode does not start.

Related upstream reports, both filed against the libraries this lane runs on: [typelevel/cats-effect#4674](https://github.com/typelevel/cats-effect/issues/4674) and [cloudmark/cats-actors#46](https://github.com/cloudmark/cats-actors/issues/46).

## Base

`feat/runtime-resource-gauges`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
