### PR TITLE
Land the coil-HTTP / fiber-lifecycle / metrics / block-shaper stack on main

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1242,6 +1242,7 @@ components:
       - sequencerHeadroom
       - equityLovelace
       - composer
+      - runtime
       properties:
         uptimeSeconds:
           type: integer
@@ -1272,6 +1273,8 @@ components:
           format: int64
         composer:
           $ref: '#/components/schemas/ComposerStats'
+        runtime:
+          $ref: '#/components/schemas/RuntimeStats'
     RateStats:
       title: RateStats
       type: object
@@ -1449,6 +1452,59 @@ components:
         type:
           type: string
           const: rollout
+    RuntimeStats:
+      title: RuntimeStats
+      type: object
+      required:
+      - fibersSuspended
+      - fibersQueuedLocal
+      - workerThreads
+      - workersActive
+      - workersSearching
+      - workersBlocked
+      - timersOutstanding
+      - timersExecuted
+      - liveThreads
+      - heapUsedBytes
+      - heapCommittedBytes
+      - openFileDescriptors
+      properties:
+        fibersSuspended:
+          type: integer
+          format: int64
+        fibersQueuedLocal:
+          type: integer
+          format: int64
+        workerThreads:
+          type: integer
+          format: int32
+        workersActive:
+          type: integer
+          format: int32
+        workersSearching:
+          type: integer
+          format: int32
+        workersBlocked:
+          type: integer
+          format: int32
+        timersOutstanding:
+          type: integer
+          format: int64
+        timersExecuted:
+          type: integer
+          format: int64
+        liveThreads:
+          type: integer
+          format: int32
+        heapUsedBytes:
+          type: integer
+          format: int64
+        heapCommittedBytes:
+          type: integer
+          format: int64
+        openFileDescriptors:
+          type: integer
+          format: int64
     Sec:
       title: Sec
       type: object

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -743,6 +743,31 @@ components:
         type:
           type: string
           const: minor
+    BlockGateStats:
+      title: BlockGateStats
+      type: object
+      required:
+      - multiplier
+      - backlog
+      - residual
+      - holds
+      - drains
+      properties:
+        multiplier:
+          type: number
+          format: double
+        backlog:
+          type: integer
+          format: int64
+        residual:
+          type: number
+          format: double
+        holds:
+          type: integer
+          format: int64
+        drains:
+          type: integer
+          format: int64
     BlockHardConfirmed:
       title: BlockHardConfirmed
       type: object
@@ -1243,6 +1268,7 @@ components:
       - equityLovelace
       - composer
       - runtime
+      - blockGate
       properties:
         uptimeSeconds:
           type: integer
@@ -1275,6 +1301,8 @@ components:
           $ref: '#/components/schemas/ComposerStats'
         runtime:
           $ref: '#/components/schemas/RuntimeStats'
+        blockGate:
+          $ref: '#/components/schemas/BlockGateStats'
     RateStats:
       title: RateStats
       type: object

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -4,40 +4,6 @@ info:
   version: 0.1.0
 paths:
   /head/requests:
-    get:
-      tags:
-      - Requests
-      description: Requests the head has assigned an id — opaque request id, author
-        peer number, and type (transaction or deposit). Filter with ?type=transaction|deposit
-        and ?peer_number=<n>.
-      operationId: getHeadRequests
-      parameters:
-      - name: type
-        in: query
-        required: false
-        schema:
-          type: string
-      - name: peer_number
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/RequestSummary'
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
     post:
       tags:
       - Requests
@@ -161,28 +127,6 @@ paths:
                       settlementEffect: 4d5e6f7a8b9c…
                       type: HARD_CONFIRMED
                     type: deposit
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-  /head/blocks:
-    get:
-      tags:
-      - Blocks
-      description: Every block of the head in block order — number, fast-cycle leader,
-        and type. Block 0 is the head's initial block (config, no leader).
-      operationId: getHeadBlocks
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/BlockSummary'
         default:
           description: ''
           content:
@@ -889,26 +833,6 @@ components:
           $ref: '#/components/schemas/RateStats'
         requestRate:
           $ref: '#/components/schemas/RateStats'
-    BlockSummary:
-      title: BlockSummary
-      type: object
-      required:
-      - number
-      - blockType
-      properties:
-        number:
-          type: integer
-          format: int32
-        leader:
-          type: integer
-          format: int32
-        blockType:
-          type: string
-          enum:
-          - initial
-          - minor
-          - major
-          - final
     BlockTiming:
       title: BlockTiming
       type: object
@@ -1500,25 +1424,6 @@ components:
           PROPOSED: '#/components/schemas/RequestProposed'
           SOFT_CONFIRMED: '#/components/schemas/RequestSoftConfirmed'
           UNPROCESSED: '#/components/schemas/RequestUnprocessed'
-    RequestSummary:
-      title: RequestSummary
-      type: object
-      required:
-      - requestId
-      - peerNumber
-      - requestType
-      properties:
-        requestId:
-          type: integer
-          format: int64
-        peerNumber:
-          type: integer
-          format: int32
-        requestType:
-          type: string
-          enum:
-          - deposit
-          - transaction
     RequestUnprocessed:
       title: RequestUnprocessed
       type: object

--- a/integration/src/test/scala/hydrozoa/integration/harness/MultiPeerHeadHarness.scala
+++ b/integration/src/test/scala/hydrozoa/integration/harness/MultiPeerHeadHarness.scala
@@ -1568,6 +1568,9 @@ object MultiPeerHeadHarness:
                   0L,
                   nodeConfig.headConfig.headPeerNums.toList.map(_.convert).toVector
                 )
+                // A real node runs the 1 Hz sampler for the whole life of the process
+                // (`Serve.scala`); without it the runtime gauges read their initial values.
+                _ <- metrics.sampler().background
                 mrm <- HeadMultisigRegimeManager.resource(
                   nodeConfig,
                   cardanoBackend,
@@ -1642,6 +1645,9 @@ object MultiPeerHeadHarness:
                   0L,
                   coilConfig.headConfig.headPeerNums.toList.map(_.convert).toVector
                 )
+                // A coil runs the 1 Hz sampler too, and for the same reason: without it the
+                // runtime gauges never leave their initial values.
+                _ <- metrics.sampler().background
                 mrm <- CoilMultisigRegimeManager.resource(
                   coilConfig,
                   cardanoBackend,

--- a/integration/src/test/scala/hydrozoa/integration/harness/MultiPeerHeadHarness.scala
+++ b/integration/src/test/scala/hydrozoa/integration/harness/MultiPeerHeadHarness.scala
@@ -1690,7 +1690,9 @@ object MultiPeerHeadHarness:
               nodeConfig.headConfig.headPeerNums.toList.map(_.convert).toVector
             )
             HydrozoaRoutes(
-              requestSequencer,
+              // Some: the harness builds a head node's routes, and only a head mounts the
+              // submission and admin-finalize endpoints.
+              Some(requestSequencer),
               conns.blockWeaver,
               // The harness runs no head lifecycle, so readiness is a constant Active.
               IO.pure(NodeStatus.Active),

--- a/src/main/scala/hydrozoa/app/Serve.scala
+++ b/src/main/scala/hydrozoa/app/Serve.scala
@@ -545,37 +545,36 @@ object Serve {
             _ <- system.actorOf(mrm, "HeadMultisigRegimeManager")
             _ <- log.info("Hydrozoa node started successfully")
 
-            // Start HTTP server once RequestSequencer is available
-            _ <- mrm.connectionsDeferred.get.flatMap { connections =>
-                val serverConfig = httpServerConfig(nodeConfig)
-                val httpTracer = Slf4jTracer.sink
-                    .contramap(HydrozoaHttpEventFormat.humanFormat) |+| httpExtraTracer
-                log.info("Starting HTTP server...") *>
-                    HydrozoaServer
-                        .create(
-                          // Always present on a head; the `Option` exists for the coil.
-                          Some(
-                            connections.requestSequencer.getOrElse(
-                              sys.error("RequestSequencer required on head peers")
-                            )
-                          ),
-                          connections.blockWeaver,
-                          mrm.nodeStatus.get,
-                          consensusReader,
-                          // Some(reader) for a cardano-eutxo node (mounts GET /l2/cardano-eutxo/...); None for
-                          // a remote-ledger node, which serves no L2-query endpoints.
-                          l2QueryReader,
-                          nodeConfig.headConfig,
-                          serverConfig,
-                          metrics,
-                          httpTracer,
-                        )
-                        .use(_ => IO.never)
-                        .start
-                        .void
-            }
+            // The HTTP server needs the RequestSequencer, which only exists once connections
+            // resolve, so wait for them before binding.
+            connections <- mrm.connectionsDeferred.get
+            _ <- log.info("Starting HTTP server...")
 
-            _ <- system.waitForTermination
+            // `surround`, not `start.void`: the server is bound for exactly as long as the node
+            // waits, and its finalizer runs when the actor system terminates. `runCoilNode` has
+            // the same shape and spells out what the old one leaked.
+            _ <- HydrozoaServer
+                .create(
+                  // Always present on a head; the `Option` exists for the coil.
+                  Some(
+                    connections.requestSequencer.getOrElse(
+                      sys.error("RequestSequencer required on head peers")
+                    )
+                  ),
+                  connections.blockWeaver,
+                  mrm.nodeStatus.get,
+                  consensusReader,
+                  // Some(reader) for a cardano-eutxo node (mounts GET /l2/cardano-eutxo/...); None for
+                  // a remote-ledger node, which serves no L2-query endpoints.
+                  l2QueryReader,
+                  nodeConfig.headConfig,
+                  httpServerConfig(nodeConfig),
+                  metrics,
+                  Slf4jTracer.sink
+                      .contramap(HydrozoaHttpEventFormat.humanFormat) |+| httpExtraTracer,
+                )
+                .surround(system.waitForTermination)
+
             exit <- abnormalTermination
         } yield exit
 
@@ -599,31 +598,31 @@ object Serve {
             _ <- system.actorOf(mrm, "CoilMultisigRegimeManager")
             _ <- log.info("Hydrozoa coil node started successfully")
 
-            _ <- mrm.connectionsDeferred.get.flatMap { connections =>
-                val serverConfig = httpServerConfig(nodeConfig)
-                val httpTracer = Slf4jTracer.sink
-                    .contramap(HydrozoaHttpEventFormat.humanFormat) |+| httpExtraTracer
-                log.info("Starting HTTP server (coil: read-only surface)...") *>
-                    HydrozoaServer
-                        .create(
-                          // None on a coil — this is what removes the mutating routes.
-                          connections.requestSequencer,
-                          connections.blockWeaver,
-                          mrm.nodeStatus.get,
-                          consensusReader,
-                          // A coil always runs a remote ledger, so no L2-query endpoints.
-                          None,
-                          nodeConfig.headConfig,
-                          serverConfig,
-                          metrics,
-                          httpTracer,
-                        )
-                        .use(_ => IO.never)
-                        .start
-                        .void
-            }
+            connections <- mrm.connectionsDeferred.get
+            _ <- log.info("Starting HTTP server (coil: read-only surface)...")
 
-            _ <- system.waitForTermination
+            // `surround` binds the server for the node's lifetime and releases it when the actor
+            // system terminates. `use(_ => IO.never).start.void` -- what this was, on both roles --
+            // dropped the fiber handle, so nothing could cancel it and the finalizer never ran: the
+            // port stayed bound and answering after the node was dead, and a bind failure could not
+            // fail the node because no one joined the fiber's outcome.
+            _ <- HydrozoaServer
+                .create(
+                  // None on a coil — this is what removes the mutating routes.
+                  connections.requestSequencer,
+                  connections.blockWeaver,
+                  mrm.nodeStatus.get,
+                  consensusReader,
+                  // A coil always runs a remote ledger, so no L2-query endpoints.
+                  None,
+                  nodeConfig.headConfig,
+                  httpServerConfig(nodeConfig),
+                  metrics,
+                  Slf4jTracer.sink
+                      .contramap(HydrozoaHttpEventFormat.humanFormat) |+| httpExtraTracer,
+                )
+                .surround(system.waitForTermination)
+
             exit <- abnormalTermination
         } yield exit
 

--- a/src/main/scala/hydrozoa/app/Serve.scala
+++ b/src/main/scala/hydrozoa/app/Serve.scala
@@ -215,7 +215,14 @@ object Serve {
                       httpExtraTracer
                     )
                 case NodeRun.CoilNode(mrm) =>
-                    runCoilNode(system, mrm)
+                    runCoilNode(
+                      nodeConfig,
+                      system,
+                      mrm,
+                      consensusReader,
+                      metrics,
+                      httpExtraTracer
+                    )
             }
         }
     }
@@ -446,8 +453,9 @@ object Serve {
         } yield NodeRun.HeadNode(mrm, l2QueryReader)
     }
 
-    /** Build the coil-node uplink dialer (no inbound server) and allocate the
-      * [[CoilMultisigRegimeManager]]. A coil peer runs no user-facing HTTP server.
+    /** Build the coil-node uplink dialer (no inbound WebSocket server) and allocate the
+      * [[CoilMultisigRegimeManager]]. The coil's HTTP surface is bound separately, in
+      * `runCoilNode`.
       */
     private def buildCoilNode(
         nodeConfig: NodeConfig,
@@ -497,6 +505,33 @@ object Serve {
         } yield NodeRun.CoilNode(mrm)
     }
 
+    /** The HTTP bind address and admin credentials, from the node's own private config. Shared by
+      * both roles: a coil serves the same server minus the mutating routes, so it reads the same
+      * fields.
+      */
+    private def httpServerConfig(nodeConfig: NodeConfig): HydrozoaServer.Config = {
+        val httpHost = Host
+            .fromString(nodeConfig.httpHost)
+            .getOrElse(
+              throw new IllegalArgumentException(
+                s"Invalid httpHost in node config: ${nodeConfig.httpHost}"
+              )
+            )
+        val httpPort = Port
+            .fromString(nodeConfig.httpPort)
+            .getOrElse(
+              throw new IllegalArgumentException(
+                s"Invalid httpPort in node config: ${nodeConfig.httpPort}"
+              )
+            )
+        HydrozoaServer.Config(
+          host = httpHost,
+          port = httpPort,
+          adminUsername = nodeConfig.adminUsername,
+          adminPassword = nodeConfig.adminPassword
+        )
+    }
+
     private def runHeadNode(
         nodeConfig: NodeConfig,
         system: ActorSystem[IO],
@@ -512,33 +547,17 @@ object Serve {
 
             // Start HTTP server once RequestSequencer is available
             _ <- mrm.connectionsDeferred.get.flatMap { connections =>
-                val httpHost = Host
-                    .fromString(nodeConfig.httpHost)
-                    .getOrElse(
-                      throw new IllegalArgumentException(
-                        s"Invalid httpHost in node config: ${nodeConfig.httpHost}"
-                      )
-                    )
-                val httpPort = Port
-                    .fromString(nodeConfig.httpPort)
-                    .getOrElse(
-                      throw new IllegalArgumentException(
-                        s"Invalid httpPort in node config: ${nodeConfig.httpPort}"
-                      )
-                    )
-                val serverConfig = HydrozoaServer.Config(
-                  host = httpHost,
-                  port = httpPort,
-                  adminUsername = nodeConfig.adminUsername,
-                  adminPassword = nodeConfig.adminPassword
-                )
+                val serverConfig = httpServerConfig(nodeConfig)
                 val httpTracer = Slf4jTracer.sink
                     .contramap(HydrozoaHttpEventFormat.humanFormat) |+| httpExtraTracer
                 log.info("Starting HTTP server...") *>
                     HydrozoaServer
                         .create(
-                          connections.requestSequencer.getOrElse(
-                            sys.error("RequestSequencer required on head peers")
+                          // Always present on a head; the `Option` exists for the coil.
+                          Some(
+                            connections.requestSequencer.getOrElse(
+                              sys.error("RequestSequencer required on head peers")
+                            )
                           ),
                           connections.blockWeaver,
                           mrm.nodeStatus.get,
@@ -560,13 +579,50 @@ object Serve {
             exit <- abnormalTermination
         } yield exit
 
+    /** A coil peer runs the same HTTP server as a head, minus the mutating routes: it passes `None`
+      * for the request sequencer, which is what removes them (see
+      * [[hydrozoa.multisig.server.HydrozoaRoutes]]).
+      *
+      * Serving a coil at all is for observability. It runs its own `StackComposer`, and its
+      * hard-ack gates the head's next stack — so without `/head/stats` and `/metrics`, a coil
+      * wedged on its single-flight gate looks exactly like an idle one.
+      */
     private def runCoilNode(
+        nodeConfig: NodeConfig,
         system: ActorSystem[IO],
         mrm: CoilMultisigRegimeManager,
+        consensusReader: ConsensusStoreReader[IO],
+        metrics: PeerMetrics,
+        httpExtraTracer: ContraTracer[IO, HydrozoaHttpEvent],
     ): IO[ExitCode] =
         for {
             _ <- system.actorOf(mrm, "CoilMultisigRegimeManager")
             _ <- log.info("Hydrozoa coil node started successfully")
+
+            _ <- mrm.connectionsDeferred.get.flatMap { connections =>
+                val serverConfig = httpServerConfig(nodeConfig)
+                val httpTracer = Slf4jTracer.sink
+                    .contramap(HydrozoaHttpEventFormat.humanFormat) |+| httpExtraTracer
+                log.info("Starting HTTP server (coil: read-only surface)...") *>
+                    HydrozoaServer
+                        .create(
+                          // None on a coil — this is what removes the mutating routes.
+                          connections.requestSequencer,
+                          connections.blockWeaver,
+                          mrm.nodeStatus.get,
+                          consensusReader,
+                          // A coil always runs a remote ledger, so no L2-query endpoints.
+                          None,
+                          nodeConfig.headConfig,
+                          serverConfig,
+                          metrics,
+                          httpTracer,
+                        )
+                        .use(_ => IO.never)
+                        .start
+                        .void
+            }
+
             _ <- system.waitForTermination
             exit <- abnormalTermination
         } yield exit

--- a/src/main/scala/hydrozoa/config/node/operation/multisig/RateLimits.scala
+++ b/src/main/scala/hydrozoa/config/node/operation/multisig/RateLimits.scala
@@ -1,6 +1,7 @@
 package hydrozoa.config.node.operation.multisig
 
 import hydrozoa.lib.cardano.scalus.QuantizedTime.given
+import hydrozoa.multisig.consensus.limiter.LimiterGate
 import io.circe.*
 import io.circe.generic.semiauto.*
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
@@ -8,17 +9,26 @@ import scala.concurrent.duration.{DurationInt, FiniteDuration}
 /** Per-message-type minimum wall-clock periods enforced by the
   * [[hydrozoa.multisig.consensus.limiter.Limiter]] actor sitting between two actors.
   *
-  * Each throttled message `m` carries its own timestamp (see
-  * [[hydrozoa.multisig.consensus.limiter.LimiterTimestamp]]) and is held until
-  * `m.limiterTimestamp + minPeriod(m) <= now` — the gate is computed from the message itself, not
-  * from limiter-side memory of previous messages. Non-throttled messages on the same lane block
-  * behind any currently-held message (strict FIFO).
+  * Each lane is a **spacing gate** measured from the limiter's own last release, not from the
+  * message's timestamp — see [[hydrozoa.multisig.consensus.limiter.Limiter]] for why that
+  * distinction is what makes it a rate limit rather than a delay line.
   *
-  * The defaults below are non-zero: these lanes are limited unless a config overrides them.
+  * ⚠️ **Node-local.** These change only the cadence at which a peer offers work to its own
+  * downstream, never what it sends, so peers may run different values without diverging. The cost
+  * is a leader-dependent cadence under rotation; operators should align informally.
+  *
+  * Defaults are non-zero: these lanes are limited unless a config overrides them.
   */
 final case class RateLimits(
     override val softBlockMinPeriod: FiniteDuration,
-    override val hardStackMinPeriod: FiniteDuration
+    override val hardStackMinPeriod: FiniteDuration,
+    // Scala-level defaults, matching the decoder's fallbacks below, so that adding a
+    // gate knob stays source-compatible with construction sites outside this project.
+    override val blockBacklogSoftLimit: Int = RateLimits.defaultBlockBacklogSoftLimit,
+    override val blockBacklogHardLimit: Int = RateLimits.defaultBlockBacklogHardLimit,
+    override val blockGateFloor: Double = RateLimits.defaultBlockGateFloor,
+    override val blockGateSmoothing: Double = RateLimits.defaultBlockGateSmoothing,
+    override val blockGateSlice: FiniteDuration = RateLimits.defaultBlockGateSlice
 ) extends RateLimits.Section {
     override transparent inline def rateLimits: RateLimits = this
 }
@@ -31,6 +41,11 @@ object RateLimits {
           * [[hydrozoa.multisig.ledger.block.Block.SoftConfirmed]] forwards from
           * [[hydrozoa.multisig.consensus.FastConsensusActor]] to
           * [[hydrozoa.multisig.consensus.BlockWeaver]].
+          *
+          * Binds only when the natural block cycle is faster than the period, so it is
+          * self-disabling at low load and needs no feature flag. Throughput ceiling is
+          * `1/period * maxRequestsPerBlock`; the cost is up to one period of extra latency for a
+          * request arriving just after a block closes.
           */
         def softBlockMinPeriod: FiniteDuration = rateLimits.softBlockMinPeriod
 
@@ -40,14 +55,89 @@ object RateLimits {
           * [[hydrozoa.multisig.consensus.StackComposer]].
           */
         def hardStackMinPeriod: FiniteDuration = rateLimits.hardStackMinPeriod
+
+        /** Soft-confirmed blocks outstanding per stack cycle below which the block gate stays fully
+          * open. Above it the block lane is progressively slowed so block production cannot outrun
+          * what stack production absorbs.
+          *
+          * Sized above the accumulation the shaper itself produces in one downstream cycle
+          * (`1/softBlockMinPeriod * hardStackMinPeriod`), so a healthy head sits inside the flat
+          * region and the gate does nothing unless the composer is falling behind.
+          */
+        def blockBacklogSoftLimit: Int = rateLimits.blockBacklogSoftLimit
+
+        /** Backlog at which the block lane is slowed all the way to [[blockGateFloor]].
+          *
+          * Sized well under the point where draining the composer's mailbox turns superlinear
+          * (cats-actors scans its queue per message), and far above healthy per-cycle accumulation.
+          */
+        def blockBacklogHardLimit: Int = rateLimits.blockBacklogHardLimit
+
+        /** The slowest the block lane is ever shaped to, as a fraction of [[softBlockMinPeriod]]'s
+          * rate. ⛔ Never 0. Block production is self-clocked by the soft confirmations this lane
+          * releases, so a full stop would stop the clock that later reopens the gate.
+          */
+        def blockGateFloor: Double = rateLimits.blockGateFloor
+
+        /** EWMA weight on the newest downstream cycle. Instantaneous depth is dominated by where in
+          * the cycle it is sampled; a controller driven by that sawtooths at the cycle cadence.
+          */
+        def blockGateSmoothing: Double = rateLimits.blockGateSmoothing
+
+        /** Longest single sleep the block limiter commits to before re-reading its mailbox, which
+          * bounds how stale its multiplier can be while a hold is outstanding.
+          */
+        def blockGateSlice: FiniteDuration = rateLimits.blockGateSlice
+
+        /** The block lane's gate, assembled from the knobs above. */
+        def blockLimiterGate: LimiterGate = LimiterGate(
+          backlogSoftLimit = blockBacklogSoftLimit,
+          backlogHardLimit = blockBacklogHardLimit,
+          floor = blockGateFloor,
+          smoothing = blockGateSmoothing,
+          slice = blockGateSlice
+        )
     }
+
+    val defaultBlockBacklogSoftLimit: Int = 600
+    val defaultBlockBacklogHardLimit: Int = 3000
+    val defaultBlockGateFloor: Double = 0.02
+    val defaultBlockGateSmoothing: Double = 0.3
+    val defaultBlockGateSlice: FiniteDuration = 150.milliseconds
 
     lazy val default: RateLimits = RateLimits(
       softBlockMinPeriod = 100.milliseconds,
-      hardStackMinPeriod = 30.seconds
+      hardStackMinPeriod = 30.seconds,
+      blockBacklogSoftLimit = defaultBlockBacklogSoftLimit,
+      blockBacklogHardLimit = defaultBlockBacklogHardLimit,
+      blockGateFloor = defaultBlockGateFloor,
+      blockGateSmoothing = defaultBlockGateSmoothing,
+      blockGateSlice = defaultBlockGateSlice
     )
 
     given Encoder[RateLimits] = deriveEncoder[RateLimits]
 
-    given Decoder[RateLimits] = deriveDecoder[RateLimits]
+    /** Hand-written rather than derived so every gate field may be **absent**: a node whose config
+      * fails to decode does not start at all, and every `private.json` already deployed predates
+      * these fields. The defaults are chosen so that adopting the gate needs no config edit.
+      */
+    given Decoder[RateLimits] = Decoder.instance(c =>
+        for {
+            softBlock <- c.downField("softBlockMinPeriod").as[FiniteDuration]
+            hardStack <- c.downField("hardStackMinPeriod").as[FiniteDuration]
+            softLimit <- c.downField("blockBacklogSoftLimit").as[Option[Int]]
+            hardLimit <- c.downField("blockBacklogHardLimit").as[Option[Int]]
+            floor <- c.downField("blockGateFloor").as[Option[Double]]
+            smoothing <- c.downField("blockGateSmoothing").as[Option[Double]]
+            slice <- c.downField("blockGateSlice").as[Option[FiniteDuration]]
+        } yield RateLimits(
+          softBlockMinPeriod = softBlock,
+          hardStackMinPeriod = hardStack,
+          blockBacklogSoftLimit = softLimit.getOrElse(defaultBlockBacklogSoftLimit),
+          blockBacklogHardLimit = hardLimit.getOrElse(defaultBlockBacklogHardLimit),
+          blockGateFloor = floor.getOrElse(defaultBlockGateFloor),
+          blockGateSmoothing = smoothing.getOrElse(defaultBlockGateSmoothing),
+          blockGateSlice = slice.getOrElse(defaultBlockGateSlice)
+        )
+    )
 }

--- a/src/main/scala/hydrozoa/lib/logging/Logging.scala
+++ b/src/main/scala/hydrozoa/lib/logging/Logging.scala
@@ -18,13 +18,4 @@ object Logging {
     /** log4cats SLF4J adapter used by [[Slf4jTracer.sink]]. */
     def loggerIO(name: String): Logger[IO] =
         Slf4jLogger.getLoggerFromName[IO](name)
-
-    /** A synchronous logger, for the few places that have no effect context to log in.
-      *
-      * A supervision decider is one: it is a pure `Throwable => Directive` the actor library calls
-      * on the failure path, so there is no `IO` to sequence a log into. Everything else should use
-      * [[loggerIO]] or a tracer.
-      */
-    def loggerSync(name: String): org.slf4j.Logger =
-        org.slf4j.LoggerFactory.getLogger(name)
 }

--- a/src/main/scala/hydrozoa/multisig/CoilMultisigRegimeManager.scala
+++ b/src/main/scala/hydrozoa/multisig/CoilMultisigRegimeManager.scala
@@ -100,6 +100,8 @@ trait CoilMultisigRegimeManager(
               jointLedger = core.jointLedger,
               stackComposer = core.stackComposer,
               stackComposerLimiter = core.stackComposer,
+              // No limiter actor exists to gate, and a coil never leads block production.
+              blockRateGate = None,
               slowConsensusActor = core.slowConsensusActor,
               coilUplink = Some(hubLiaison),
               remoteHubLiaison = Some(remoteHubProxy),

--- a/src/main/scala/hydrozoa/multisig/CoilMultisigRegimeManagerEventFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/CoilMultisigRegimeManagerEventFormat.scala
@@ -1,6 +1,6 @@
 package hydrozoa.multisig
 
-import hydrozoa.lib.logging.LogEvent
+import hydrozoa.lib.logging.{Level, LogEvent}
 import hydrozoa.multisig.consensus.liaison.PeerLiaisonEventFormat
 import hydrozoa.multisig.consensus.limiter.LimiterEventFormat
 import hydrozoa.multisig.consensus.peer.{CoilPeerNumber, HeadPeerNumber, PeerId}
@@ -30,6 +30,13 @@ object CoilMultisigRegimeManagerEventFormat:
             case LifecycleEvent.WatchingActors            => info("Watching multisig actors...")
             case LifecycleEvent.TerminatedActor(actor)    => warn(s"Terminated $actor actor")
             case LifecycleEvent.TerminatedDependency(dep) => warn(s"Terminated dependency $dep")
+            case LifecycleEvent.SupervisedFailureEscalated(cause) =>
+                LogEvent(
+                  Level.Error,
+                  "A supervised actor failed; escalating to the guardian, which will stop the system.",
+                  cause = Some(cause),
+                  routingKey = Some("Supervision")
+                )
             case CommonChildEvent.BlockWeaver(bw) =>
                 BlockWeaverEventFormat.humanFormat(syntheticLabel)(bw)
             case CommonChildEvent.JointLedger(jl) =>

--- a/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManager.scala
+++ b/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManager.scala
@@ -4,14 +4,14 @@ import cats.*
 import cats.effect.{Deferred, IO, Ref, Resource}
 import cats.implicits.*
 import com.suprnation.actor.ActorContext
-import com.suprnation.actor.ActorRef.NoSendActorRef
+import com.suprnation.actor.ActorRef.{ActorRef, NoSendActorRef}
 import hydrozoa.config.node.NodeConfig
 import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.HeadMultisigRegimeManager.*
 import hydrozoa.multisig.LifecycleEvent.{StartingActors, WatchingActors}
 import hydrozoa.multisig.backend.cardano.CardanoBackend
 import hydrozoa.multisig.consensus.*
-import hydrozoa.multisig.consensus.limiter.Limiter
+import hydrozoa.multisig.consensus.limiter.{Limiter, LimiterControl}
 import hydrozoa.multisig.consensus.peer.{CoilPeerNumber, HeadPeerNumber, PeerId}
 import hydrozoa.multisig.consensus.transport.{HubTransport, PeerTransport, RemoteCoilProxy, RemotePeerProxy}
 import hydrozoa.multisig.ledger.joint.JointLedger
@@ -62,8 +62,17 @@ trait HeadMultisigRegimeManager(
             // hydrozoa.multisig.consensus.limiter.Limiter). Only the consensus actor's reference
             // to BlockWeaver is routed through this limiter; other senders (JointLedger,
             // PeerLiaisonHeadToHead, …) keep direct refs.
+            // The block lane carries the gate as well as the shaper: `gate` makes the period
+            // dynamic, tightening as the composer falls behind. The stack lane below deliberately
+            // takes no gate — it is a pure spacing gate at `hardStackMinPeriod`.
             blockWeaverLimiter <- context.actorOf(
-              Limiter[BlockWeaver.Request](core.blockWeaver, config, tracers.blockWeaverLimiter)
+              Limiter[BlockWeaver.Request](
+                core.blockWeaver,
+                config,
+                tracers.blockWeaverLimiter,
+                gate = Some(config.blockLimiterGate),
+                metrics = Some(metrics)
+              )
             )
 
             requestSequencer <- context.actorOf(
@@ -199,6 +208,7 @@ trait HeadMultisigRegimeManager(
             connections = HeadMultisigRegimeManager.Connections(
               blockWeaver = core.blockWeaver,
               blockWeaverLimiter = blockWeaverLimiter,
+              blockRateGate = Some(blockWeaverLimiter),
               cardanoLiaison = core.cardanoLiaison,
               consensusActor = core.consensusActor,
               requestSequencer = Some(requestSequencer),
@@ -315,6 +325,11 @@ object HeadMultisigRegimeManager {
         stackComposer: StackComposer.Handle,
         /** Throttled-write handle for the SlowConsensusActor → StackComposer lane. */
         stackComposerLimiter: StackComposer.Handle,
+        /** Control handle on the block lane's limiter, used to tell it a stack hard-confirmed.
+          * `None` on a coil peer, which runs no limiters. Contravariance in the message type is
+          * what lets the same actor be addressed both as `blockWeaverLimiter` and as this.
+          */
+        blockRateGate: Option[ActorRef[IO, LimiterControl]] = None,
         slowConsensusActor: SlowConsensusActor.Handle,
         // ---- Producer broadcast targets (§5.2) [doc-ref] ----
         /** Head-peer-mesh liaisons (one per other head peer); empty on a coil peer. Producers

--- a/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManagerEventFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManagerEventFormat.scala
@@ -1,6 +1,6 @@
 package hydrozoa.multisig
 
-import hydrozoa.lib.logging.LogEvent
+import hydrozoa.lib.logging.{Level, LogEvent}
 import hydrozoa.multisig.consensus.liaison.PeerLiaisonEventFormat
 import hydrozoa.multisig.consensus.limiter.LimiterEventFormat
 import hydrozoa.multisig.consensus.peer.{HeadPeerNumber, PeerId}
@@ -22,6 +22,13 @@ object HeadMultisigRegimeManagerEventFormat:
             case LifecycleEvent.WatchingActors            => info("Watching multisig actors...")
             case LifecycleEvent.TerminatedActor(actor)    => warn(s"Terminated $actor actor")
             case LifecycleEvent.TerminatedDependency(dep) => warn(s"Terminated dependency $dep")
+            case LifecycleEvent.SupervisedFailureEscalated(cause) =>
+                LogEvent(
+                  Level.Error,
+                  "A supervised actor failed; escalating to the guardian, which will stop the system.",
+                  cause = Some(cause),
+                  routingKey = Some("Supervision")
+                )
             case CommonChildEvent.BlockWeaver(bw) =>
                 BlockWeaverEventFormat.humanFormat(peerNum)(bw)
             case CommonChildEvent.JointLedger(jl) =>

--- a/src/main/scala/hydrozoa/multisig/MultisigRegimeManagerBase.scala
+++ b/src/main/scala/hydrozoa/multisig/MultisigRegimeManagerBase.scala
@@ -5,10 +5,10 @@ import cats.effect.{Deferred, IO, Ref}
 import cats.implicits.*
 import com.suprnation.actor.Actor.{Actor, Receive}
 import com.suprnation.actor.ActorRef.NoSendActorRef
-import com.suprnation.actor.SupervisorStrategy.Escalate
-import com.suprnation.actor.{OneForOneStrategy, SupervisionStrategy}
+import com.suprnation.actor.SupervisorStrategy.{Directive, Escalate}
+import com.suprnation.actor.{ActorContext, OneForOneStrategy, SupervisionStrategy}
 import hydrozoa.config.node.NodeConfig
-import hydrozoa.lib.logging.{ContraTracer, Logging}
+import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.HeadMultisigRegimeManager.*
 import hydrozoa.multisig.MultisigRegimeManagerBase.CoreActors
 import hydrozoa.multisig.backend.cardano.CardanoBackend
@@ -74,39 +74,31 @@ trait MultisigRegimeManagerBase[E >: LifecycleEvent <: RegimeManagerEvent]
       * conspicuous.
       */
     override def supervisorStrategy: SupervisionStrategy[IO] =
-        OneForOneStrategy[IO](maxNrOfRetries = 3, withinTimeRange = 1.minute)(
-          PartialFunction.fromFunction { failure =>
-              recordFailure(failure)
-              failure match {
-                  case _: IllegalArgumentException =>
-                      Escalate // Normally `Stop` but we can't handle stopped actors yet
-                  case _: RuntimeException =>
-                      Escalate // Normally `Restart` but our actors can't do that yet
-                  case _: Exception => Escalate
-                  // `Error`, and anything extending `Throwable` directly. Keeping this arm last
-                  // leaves the intent of the arms above legible for when they can take their real
-                  // directives.
-                  case _ => Escalate
-              }
+        new OneForOneStrategy[IO](maxNrOfRetries = 3, withinTimeRange = 1.minute)(
+          PartialFunction.fromFunction {
+              case _: IllegalArgumentException =>
+                  Escalate // Normally `Stop` but we can't handle stopped actors yet
+              case _: RuntimeException =>
+                  Escalate // Normally `Restart` but our actors can't do that yet
+              case _: Exception => Escalate
+              // `Error`, and anything extending `Throwable` directly. Keeping this arm last leaves
+              // the intent of the arms above legible for when they can take their real directives.
+              case _ => Escalate
           }
-        )
-
-    /** Write down a child's failure while it is still intact.
-      *
-      * This is the last place that holds it. Escalation is the only directive available, and the
-      * escalation path itself raises before the cause is re-reported, so what survives in the log
-      * names that secondary failure and not this one — a node stops with no record of why.
-      * Everything downstream (`/ready`, the exit code, an operator reading journald) can say that
-      * the node died but not what killed it, unless it is written here.
-      *
-      * Synchronous, because a decider is a pure function with no effect context. It runs once per
-      * failure, which is once per node lifetime given every directive escalates.
-      */
-    private def recordFailure(cause: Throwable): Unit =
-        MultisigRegimeManagerBase.supervisionLog.error(
-          "A supervised actor failed; escalating to the guardian, which will stop the system.",
-          cause
-        )
+        ) {
+            override def logFailure(
+                context: ActorContext[IO, ?, ?],
+                child: NoSendActorRef[IO],
+                cause: Option[Throwable],
+                decision: Directive
+            ): IO[Unit] =
+                decision match
+                    case Escalate =>
+                        cause.traverse_(c =>
+                            tracer.traceWith(LifecycleEvent.SupervisedFailureEscalated(c))
+                        )
+                    case _ => super.logFailure(context, child, cause, decision)
+        }
 
     override def preStart: IO[Unit] = context.self ! PreStart
 
@@ -215,11 +207,6 @@ trait MultisigRegimeManagerBase[E >: LifecycleEvent <: RegimeManagerEvent]
 }
 
 object MultisigRegimeManagerBase {
-
-    /** Where a supervised failure's cause is written. Its own route so the line survives a log
-      * config that quiets `hydrozoa` generally — it is the only record of why a node stopped.
-      */
-    private val supervisionLog = Logging.loggerSync("Supervision")
 
     /** The actors spawned by [[MultisigRegimeManagerBase.spawnCoreActors]] — present on every
       * multisig peer regardless of role.

--- a/src/main/scala/hydrozoa/multisig/RegimeManagerEvent.scala
+++ b/src/main/scala/hydrozoa/multisig/RegimeManagerEvent.scala
@@ -35,6 +35,12 @@ object LifecycleEvent:
     final case class TerminatedActor(actor: Actors) extends LifecycleEvent
     final case class TerminatedDependency(dep: Dependencies) extends LifecycleEvent
 
+    /** A supervised child failed and the decider escalated to the guardian, which stops the system.
+      * Carries the original `cause`: escalation re-raises a secondary failure before the cause is
+      * reported, so this is the only record of why the node stopped.
+      */
+    final case class SupervisedFailureEscalated(cause: Throwable) extends LifecycleEvent
+
 /** Child actors every regime+role spawns — the "core" set in
   * [[MultisigRegimeManagerBase.spawnCoreActors]] plus the peer liaison (which both head-mesh and
   * coil-uplink reuse, tagged by `remotePeerId`).

--- a/src/main/scala/hydrozoa/multisig/consensus/BlockWeaver.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/BlockWeaver.scala
@@ -1,5 +1,5 @@
 package hydrozoa.multisig.consensus
-import cats.effect.IO
+import cats.effect.{FiberIO, IO, Ref}
 import cats.implicits.*
 import com.suprnation.actor.Actor.{Actor, Receive}
 import com.suprnation.actor.ActorRef.ActorRef
@@ -80,7 +80,8 @@ final case class BlockWeaver(
             } yield BlockWeaver.Connections(
               blockWeaver = context.self,
               jointLedger = c.jointLedger,
-              metrics = metrics
+              metrics = metrics,
+              wakeupFiber = Ref.unsafe[IO, Option[FiberIO[Unit]]](None)
             )
         case c: BlockWeaver.ConnectionsPartial => IO.pure(c(context.self))
     }
@@ -103,14 +104,24 @@ object BlockWeaver {
     final case class Connections private[BlockWeaver] (
         blockWeaver: BlockWeaver.Handle,
         jointLedger: JointLedger.Handle,
-        metrics: PeerMetrics
+        metrics: PeerMetrics,
+        /** Handle to the in-flight wakeup fiber (see `sleepSendWakeup`). Lives here because every
+          * state already carries `Connections`, and it is created once per weaver.
+          *
+          * At most one wakeup is ever wanted. ⚠️ The fiber's sleep is
+          * `min(depositDecisionWakeup, forcedMajorBlockWakeup) - now`, and the forced-major horizon
+          * derives from `minSettlementDuration` — routinely hours. An uncancelled fiber therefore
+          * outlives its block by that much, and at a high block rate they accumulate.
+          */
+        wakeupFiber: Ref[IO, Option[FiberIO[Unit]]]
     )
 
     final case class ConnectionsPartial(jointLedger: JointLedger.Handle, metrics: PeerMetrics) {
         def apply(blockWeaver: BlockWeaver.Handle): Connections = Connections(
           blockWeaver = blockWeaver,
           jointLedger = jointLedger,
-          metrics = metrics
+          metrics = metrics,
+          wakeupFiber = Ref.unsafe[IO, Option[FiberIO[Unit]]](None)
         )
     }
 
@@ -142,7 +153,14 @@ object BlockWeaver {
         def finalizationLocallyTriggered: LocalFinalizationTrigger
 
         final def stop(): IO[None.type] =
-            tracer.traceWith(BlockWeaverEvent.Stopped) >> IO.pure(None)
+            // A retiring weaver must not leave a wakeup sleeping past it.
+            clearWakeupFiber >> tracer.traceWith(BlockWeaverEvent.Stopped) >> IO.pure(None)
+
+        /** Cancel and forget whatever wakeup is currently armed. See `scheduleWakeupFiber` for why
+          * cancelling here is safe.
+          */
+        final def clearWakeupFiber: IO[Unit] =
+            connections.wakeupFiber.getAndSet(None).flatMap(_.fold(IO.unit)(_.cancel))
 
         final def logStateTransition: IO[Unit] =
             tracer.traceWith(BlockWeaverEvent.BecameState(stateName))
@@ -1022,13 +1040,26 @@ object BlockWeaver {
                                 //
                                 // See:
                                 //   https://linear.app/gummiworm-labs/issue/GUM-111/should-negative-weavers-wakeups-be-permitted
+                                // Clear as well as fire: this branch arms no new fiber, so nothing
+                                // else would collect the previous one.
                                 tracer.traceWith(
                                   BlockWeaverEvent.NonPositiveWakeupDelay(this.leadingBlockNumber)
-                                ) >> (connections.blockWeaver ! Wakeup(this.leadingBlockNumber))
+                                ) >> clearWakeupFiber >>
+                                    (connections.blockWeaver ! Wakeup(this.leadingBlockNumber))
                             } else
                                 tracer.traceWith(
                                   BlockWeaverEvent.WakeupFiberStarted(this.leadingBlockNumber)
-                                ) >> sleepSendWakeup(sleepDuration).start.void
+                                ) >> sleepSendWakeup(sleepDuration).start
+                                    .flatMap(fib =>
+                                        // ⛔ Cancelling here is safe only because the block-number
+                                        // guard in `Leader.AwaitingRequest` refuses a superseded
+                                        // `Wakeup`: a cancel that loses its race still delivers
+                                        // one. Remove that guard and this becomes a correctness
+                                        // hazard rather than a resource optimisation.
+                                        connections.wakeupFiber
+                                            .getAndSet(Some(fib))
+                                            .flatMap(_.fold(IO.unit)(_.cancel))
+                                    )
                     } yield ()
 
                 private def sleepSendWakeup(sleepDuration: QuantizedFiniteDuration): IO[Unit] =
@@ -1081,7 +1112,14 @@ object BlockWeaver {
                 private val currentBlockNumber = previousBlockConfirmed.blockNum.increment
 
                 override def react(config: Config)(req: Request): IO[Option[NextReactiveState]] = {
-                    def completeBlockRegular = sendCompleteRegularBlockAsLeader(config) >>
+                    // Completing this block is the moment its wakeup stops being wanted.
+                    // Cancel-on-replace alone does not cover it: leadership rotates, so the peer
+                    // usually becomes a FOLLOWER next and arms no replacement for several blocks,
+                    // leaving this fiber to sleep out a term that can be hours. The fiber being
+                    // cancelled is armed for the block being completed right now, so it cannot be
+                    // one anyone still needs.
+                    def completeBlockRegular = clearWakeupFiber >>
+                        sendCompleteRegularBlockAsLeader(config) >>
                         DecidingRole(
                           this,
                           mempool = Mempool.empty,

--- a/src/main/scala/hydrozoa/multisig/consensus/SlowConsensusActor.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/SlowConsensusActor.scala
@@ -11,6 +11,7 @@ import hydrozoa.config.node.owninfo.OwnPeerPublic
 import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.HeadMultisigRegimeManager
 import hydrozoa.multisig.consensus.ack.HardAck
+import hydrozoa.multisig.consensus.limiter.LimiterControl
 import hydrozoa.multisig.consensus.peer.PeerId
 import hydrozoa.multisig.ledger.block.BlockNumber
 import hydrozoa.multisig.ledger.stack.{EffectIds, PartitionEffects, Stack, StackBrief, StackEffects, StackNumber}
@@ -391,6 +392,9 @@ final case class SlowConsensusActor(
         _ <- persistHardConfirmation(stackNum, restricted.unsigned.brief, signed)
         _ <- conn.cardanoLiaison ! hardConfirmed
         _ <- conn.stackComposer ! hardConfirmed
+        // Headroom signal for the block lane: the stack this peer just hard-confirmed is the
+        // backlog the block limiter released, now absorbed.
+        _ <- conn.blockRateGate.traverse_(_ ! LimiterControl.DownstreamDrained)
         _ <- stateRef.update(_.dropCell(stackNum))
         _ <- tracer.traceWith(SlowConsensusActorEvent.StackHardConfirmed(hardConfirmed))
         // Peer stats (docs/spec/peer-stats-endpoint.md): count the stack and the blocks it absorbed.
@@ -518,7 +522,8 @@ final case class SlowConsensusActor(
                       cardanoLiaison = c.cardanoLiaison,
                       headPeerLiaisons = c.headPeerLiaisons,
                       coilUplink = c.coilUplink,
-                      coilRelay = c.coilRelay
+                      coilRelay = c.coilRelay,
+                      blockRateGate = c.blockRateGate
                     )
                   )
                 )
@@ -547,7 +552,13 @@ object SlowConsensusActor {
         /** A hub's coil relay (§5.4) [doc-ref]: this actor's **own** hard-ack is sent here so the
           * hub's coil peers receive it. `None` off a hub.
           */
-        coilRelay: Option[CoilRelay.Handle] = None
+        coilRelay: Option[CoilRelay.Handle] = None,
+        /** The block lane's rate limiter, told each time a stack hard-confirms so it can reopen its
+          * downstream-backlog gate. `None` on a coil peer, which never leads and therefore runs no
+          * limiter at all. Hard confirmation is the signal rather than this peer's own hard ack;
+          * [[hydrozoa.multisig.consensus.limiter.LimiterControl.DownstreamDrained]] says why.
+          */
+        blockRateGate: Option[ActorRef[IO, LimiterControl]] = None
     )
 
     type Request = PreStart.type | StackHandoff | HardAck

--- a/src/main/scala/hydrozoa/multisig/consensus/StackComposer.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/StackComposer.scala
@@ -214,6 +214,7 @@ final case class StackComposer(
     ): IO[Unit] = {
         val stackNum = s.brief.stackNum
         for {
+            _ <- tracer.traceWith(StackComposerEvent.PreviousStackHardConfirmed(stackNum))
             _ <- state.update(_.withPreviousStackHardConfirmed(stackNum))
             _ <- tryProgress
         } yield ()
@@ -287,6 +288,9 @@ final case class StackComposer(
                     // withheld until local round-1 confirmation).
                     _ <- conn.slowConsensusActor ! handoff
                     _ <- state.update(_.afterClose(nextStackNum, prefix, newTreasury, newMap))
+                    _ <- tracer.traceWith(
+                      StackComposerEvent.SingleFlightGateClosed(nextStackNum)
+                    )
                     _ <- reportEquity(newTreasury)
                 } yield ()
         }
@@ -489,6 +493,9 @@ final case class StackComposer(
                                 _ <- conn.slowConsensusActor ! handoff
                                 _ <- state.update(
                                   _.afterClose(nextStackNum, slice, newTreasury, newMap)
+                                )
+                                _ <- tracer.traceWith(
+                                  StackComposerEvent.SingleFlightGateClosed(nextStackNum)
                                 )
                                 _ <- reportEquity(newTreasury)
                             } yield ()

--- a/src/main/scala/hydrozoa/multisig/consensus/StackComposerEvent.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/StackComposerEvent.scala
@@ -29,6 +29,21 @@ object StackComposerEvent:
         isLeader: Boolean
     ) extends StackComposerEvent
 
+    /** The single-flight gate OPENED: `Stack.HardConfirmed` for the previous stack reached the
+      * composer, so the next stack may close.
+      *
+      * Paired with [[SingleFlightGateClosed]], these make the gate's transitions observable. A
+      * composer parked in `WaitingForPreviousHardConfirmation` otherwise gives no way to tell a
+      * confirmation that never arrived from one that arrived and was then overwritten.
+      */
+    final case class PreviousStackHardConfirmed(stackNum: StackNumber) extends StackComposerEvent
+
+    /** The single-flight gate CLOSED: a stack was closed, so the composer will not close another
+      * until that one hard-confirms. Emitted from `afterClose`, i.e. after the brief and hard-acks
+      * have already left this node.
+      */
+    final case class SingleFlightGateClosed(stackNum: StackNumber) extends StackComposerEvent
+
     /** Follower detected a structural inconsistency between the leader's brief and the local
       * single-flight position — unrecoverable; node will panic.
       */

--- a/src/main/scala/hydrozoa/multisig/consensus/StackComposerEventFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/StackComposerEventFormat.scala
@@ -21,6 +21,16 @@ object StackComposerEventFormat:
                   s"$role closing stack $sn with blocks $first..$last",
                   "stackNum" -> s"${sn: Int}"
                 )
+            case PreviousStackHardConfirmed(sn) =>
+                info(
+                  s"single-flight gate OPEN: stack $sn hard-confirmed",
+                  "stackNum" -> s"${sn: Int}"
+                )
+            case SingleFlightGateClosed(sn) =>
+                info(
+                  s"single-flight gate CLOSED on stack $sn; awaiting its hard confirmation",
+                  "stackNum" -> s"${sn: Int}"
+                )
             case StructuralDivergence(sn, lFirst, lLast, expected) =>
                 warn(
                   s"Follower stack $sn structural divergence: leader brief [$lFirst..$lLast] but expected to start at $expected",

--- a/src/main/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonCoilToHub.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonCoilToHub.scala
@@ -357,7 +357,14 @@ abstract class PeerLiaisonCoilToHub(
         (IO.sleep(
           config.peerLiaisonResendInterval
         ) >> (context.self ! ResendCurrent)).foreverM.start
-            .flatMap(fib => resendFiber.set(Some(fib)))
+            .flatMap(fib =>
+                // `getAndSet` + cancel, not `set`: `set` drops a fiber already stored without
+                // cancelling it, and the orphan is a `foreverM` that keeps delivering
+                // `ResendCurrent` for the life of the process. Keeping the single-fiber invariant
+                // local to this method is deliberate — see `FiberLifecycleTest` for why it cannot
+                // rest on the actor's own teardown running first.
+                resendFiber.getAndSet(Some(fib)).flatMap(_.fold(IO.unit)(_.cancel))
+            )
 
     /** Cancel the resend-timer fiber so it stops pinging `self` once the actor has stopped — e.g.
       * when fallback tears down the multisig regime and this liaison — instead of leaking a fiber

--- a/src/main/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonHeadToHead.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonHeadToHead.scala
@@ -489,7 +489,14 @@ abstract class PeerLiaisonHeadToHead(
         (IO.sleep(
           config.peerLiaisonResendInterval
         ) >> (context.self ! ResendCurrent)).foreverM.start
-            .flatMap(fib => resendFiber.set(Some(fib)))
+            .flatMap(fib =>
+                // `getAndSet` + cancel, not `set`: `set` drops a fiber already stored without
+                // cancelling it, and the orphan is a `foreverM` that keeps delivering
+                // `ResendCurrent` for the life of the process. Keeping the single-fiber invariant
+                // local to this method is deliberate — see `FiberLifecycleTest` for why it cannot
+                // rest on the actor's own teardown running first.
+                resendFiber.getAndSet(Some(fib)).flatMap(_.fold(IO.unit)(_.cancel))
+            )
 
     /** Cancel the resend-timer fiber so it stops pinging `self` once the actor has stopped — e.g.
       * when fallback tears down the multisig regime and this liaison — instead of leaking a fiber

--- a/src/main/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonHubToCoil.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonHubToCoil.scala
@@ -394,7 +394,14 @@ abstract class PeerLiaisonHubToCoil(
         (IO.sleep(
           config.peerLiaisonResendInterval
         ) >> (context.self ! ResendCurrent)).foreverM.start
-            .flatMap(fib => resendFiber.set(Some(fib)))
+            .flatMap(fib =>
+                // `getAndSet` + cancel, not `set`: `set` drops a fiber already stored without
+                // cancelling it, and the orphan is a `foreverM` that keeps delivering
+                // `ResendCurrent` for the life of the process. Keeping the single-fiber invariant
+                // local to this method is deliberate — see `FiberLifecycleTest` for why it cannot
+                // rest on the actor's own teardown running first.
+                resendFiber.getAndSet(Some(fib)).flatMap(_.fold(IO.unit)(_.cancel))
+            )
 
     /** Cancel the resend-timer fiber so it stops pinging `self` once the actor has stopped — e.g.
       * when fallback tears down the multisig regime and this liaison — instead of leaking a fiber

--- a/src/main/scala/hydrozoa/multisig/consensus/limiter/Limiter.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/limiter/Limiter.scala
@@ -1,64 +1,258 @@
 package hydrozoa.multisig.consensus.limiter
 
-import cats.effect.IO
+import cats.effect.{IO, Ref}
 import com.suprnation.actor.Actor.{Actor, Receive}
 import com.suprnation.actor.ActorRef.ActorRef
 import hydrozoa.config.node.operation.multisig.RateLimits
 import hydrozoa.lib.logging.ContraTracer
+import hydrozoa.multisig.metrics.PeerMetrics
 import scala.concurrent.duration.DurationLong
 
-/** Stateless FIFO rate-limiter actor sitting between two actors on one lane.
+/** FIFO rate-limiter actor sitting between two actors on one lane.
   *
-  * For each incoming message mixing in [[LimiterTimestamp]], the limiter checks whether
-  * `msg.limiterTimestamp + msg.minPeriod` is still in the future; if so it holds the message for
-  * exactly that difference, then forwards. Otherwise it forwards immediately. Messages without the
-  * trait pass through with no delay.
+  * Enforces a **spacing gate**: consecutive throttled messages are released at least `period`
+  * apart, where `period` is the message's own `minPeriod` divided by the gate multiplier (1.0 on a
+  * lane with no [[LimiterGate]]). The limiter times from its own last release, not from the
+  * message's timestamp.
   *
-  * The limiter keeps no state about prior messages: every throttled message gates itself based on
-  * the timestamp it carries. Strict FIFO is provided by the single mailbox — `IO.sleep` inside
-  * `receive` blocks subsequent (including non-throttled) messages until the hold elapses.
+  * ⛔ That distinction is the whole contract. Gating on `msg.limiterTimestamp + minPeriod` is an AGE
+  * filter: it delays each message by a fixed amount and lets the arrival rate through unchanged, so
+  * it bounds latency rather than rate. It coincides with a rate limit only on a lane that is
+  * already single-flight, where releasing one message is what creates the next. Do not "simplify"
+  * back to it.
   *
-  * Using an actor (rather than a fiber wrapping `(msg) => sleep >> send`) guarantees no concurrent
-  * delivery to `downstream` from this lane — out-of-order delivery would otherwise be possible.
+  * Spacing is measured on [[cats.effect.IO.monotonic]], so a wall-clock step cannot open or freeze
+  * the gate, and the resolution of `limiterTimestamp` is irrelevant.
+  *
+  * Messages are released in arrival order. One that is not throttled (or is exempt) is forwarded
+  * immediately when nothing is held, and queued behind whatever is held otherwise.
+  *
+  * ⚠️ On a single-flight lane the queue never exceeds one throttled entry. That is an upstream
+  * property this class does not enforce, so a second one is traced rather than assumed impossible.
+  *
+  * ==Failure==
+  * This actor is not restarted — `MultisigRegimeManagerBase` escalates every supervisor directive —
+  * so a failure takes the node down and anything held is lost. That is the safe outcome for a
+  * self-clocked lane: upstream waiting forever on a release that was silently dropped is a stall
+  * with nothing in the log, whereas a crash restarts and recovers its position from persistence. ⛔
+  * Do not catch exceptions here to "be safe"; swallowing one converts the crash into the stall.
   *
   * @param downstream
-  *   the actor the throttled lane terminates at (e.g. `BlockWeaver`, `StackComposer`). The
-  *   limiter's own [[ActorRef]] is what upstream actors are wired to in place of `downstream`.
-  * @param config
-  *   reads `minPeriod` from per-message-type knobs.
+  *   the actor the throttled lane terminates at. The limiter's own [[ActorRef]] is what upstream
+  *   actors are wired to in place of `downstream`. `ActorRef` is contravariant in its message type,
+  *   so the limiter's wider handle is usable wherever the downstream's narrower one is expected.
+  * @param gate
+  *   opt-in downstream-backlog gating. `None` means a pure spacing gate at the configured period:
+  *   no counting, no ticks, multiplier fixed at 1.0. ⛔ Must stay opt-in — a lane that counted
+  *   releases but was never sent [[LimiterControl.DownstreamDrained]] would stretch its period
+  *   without bound, silently.
+  * @param metrics
+  *   write-only publication of gate state for the stats endpoints. Nothing in the control path
+  *   reads it back; the multiplier acted on is the one in this actor's state.
   */
 final case class Limiter[Msg](
     downstream: ActorRef[IO, Msg],
     config: RateLimits.Section,
     tracer: ContraTracer[IO, LimiterEvent],
-) extends Actor[IO, Msg] {
+    gate: Option[LimiterGate] = None,
+    metrics: Option[PeerMetrics] = None
+) extends Actor[IO, Msg | LimiterControl] {
 
     given RateLimits.Section = config
+
+    /** Actor-private state, read and written only from inside `receive`. cats-actors drains a
+      * mailbox serially, so read-modify-write across a `flatMap` needs no further synchronisation.
+      */
+    private val stateRef: Ref[IO, Limiter.State[Msg]] =
+        Ref.unsafe[IO, Limiter.State[Msg]](Limiter.State.initial[Msg])
 
     override def preStart: IO[Unit] =
         tracer.traceWith(LimiterEvent.Started)
 
-    override def receive: Receive[IO, Msg] = PartialFunction.fromFunction { msg =>
-        msg match {
-            case throttled: LimiterTimestamp =>
-                for {
-                    now <- IO.realTimeInstant
-                    gate = throttled.limiterTimestamp.plusMillis(throttled.minPeriod.toMillis)
-                    waitMs = gate.toEpochMilli - now.toEpochMilli
-                    _ <-
-                        if waitMs > 0 then
-                            tracer.traceWith(
-                              LimiterEvent.HoldingMsg(msg.getClass.getSimpleName, waitMs)
-                            ) >> IO.sleep(waitMs.millis)
-                        else IO.unit
-                    _ <- downstream ! msg
-                } yield ()
-            case other =>
-                downstream ! other
+    override def receive: Receive[IO, Msg | LimiterControl] = PartialFunction.fromFunction {
+        case LimiterControl.Tick =>
+            stateRef.update(_.copy(tickArmed = false)) >> pumpAndArm
+
+        case LimiterControl.DownstreamDrained =>
+            onDrained
+
+        case msg =>
+            // Safe by disjointness: `LimiterControl` is matched above and is not part of any lane's
+            // message type. `Msg` is erased, so this is a no-op cast.
+            enqueue(msg.asInstanceOf[Msg]) >> pumpAndArm
+    }
+
+    // ---- queueing -----------------------------------------------------------------------------
+
+    /** Commit the arrival to `stateRef` before anything else looks at it, so the queue is the one
+      * source of truth every step below re-reads.
+      */
+    private def enqueue(msg: Msg): IO[Unit] =
+        stateRef.updateAndGet(st => st.copy(queue = st.queue :+ msg)).flatMap { st =>
+            val throttledPending = st.queue.count {
+                case t: LimiterTimestamp => !t.limiterExempt
+                case _                   => false
+            }
+            // The single-flight invariant says this is 1. Trace, do not drop and do not fail: if
+            // the invariant is ever relaxed upstream, FIFO queueing is still correct behaviour.
+            if throttledPending > 1 then
+                tracer.traceWith(LimiterEvent.QueueDepthUnexpected(throttledPending))
+            else IO.unit
         }
+
+    /** Release everything currently due, then arm a tick if something is still waiting. */
+    private def pumpAndArm: IO[Unit] =
+        pump.flatMap(st => if st.queue.isEmpty || st.tickArmed then IO.unit else armTick(st))
+
+    private def pump: IO[Limiter.State[Msg]] =
+        stateRef.get.flatMap { st =>
+            st.queue.headOption match {
+                case None => IO.pure(st)
+                case Some(head) =>
+                    head match {
+                        case t: LimiterTimestamp if !t.limiterExempt =>
+                            IO.monotonic.map(_.toMillis).flatMap { now =>
+                                st.lastReleaseMs match {
+                                    case Some(last) if now < last + periodMs(t, st) =>
+                                        holdBegun(st, t, last + periodMs(t, st) - now)
+                                    case _ => releaseHead(st, head, advanceTo = Some(now))
+                                }
+                            }
+                        // Deliberately does NOT restart the spacing clock: an exempt message is
+                        // not paced, so letting it reset the clock would let a stream of them
+                        // shift the whole schedule.
+                        case other => releaseHead(st, other, advanceTo = None)
+                    }
+            }
+        }
+
+    /** Send first, then advance. A send that fails therefore leaves the message queued and the
+      * spacing clock unmoved: the state never records a release that did not happen.
+      */
+    private def releaseHead(
+        st: Limiter.State[Msg],
+        head: Msg,
+        advanceTo: Option[Long]
+    ): IO[Limiter.State[Msg]] =
+        val released = st.gateState.released + advanceTo.fold(0L)(_ => 1L)
+        val advanced = advanceTo match {
+            case Some(now) =>
+                st.copy(
+                  queue = st.queue.tail,
+                  lastReleaseMs = Some(now),
+                  holdStartedMs = None,
+                  gateState = st.gateState.copy(released = released)
+                )
+            case None => st.copy(queue = st.queue.tail)
+        }
+        release(head) >> stateRef.set(advanced) >>
+            advanceTo.fold(IO.unit)(_ => publishBacklog(released)) >> pump
+
+    /** Trace once when a hold starts, not once per slice — a 5 s hold at a 150 ms slice is 33
+      * ticks, and a log line per tick would bury the signal.
+      */
+    private def holdBegun(
+        st: Limiter.State[Msg],
+        t: LimiterTimestamp,
+        waitMs: Long
+    ): IO[Limiter.State[Msg]] =
+        if st.holdStartedMs.isDefined then IO.pure(st)
+        else
+            val name = t.getClass.getSimpleName
+            for {
+                _ <- tracer.traceWith(LimiterEvent.HoldingMsg(name, waitMs))
+                _ <- if gate.isEmpty then IO.unit else IO(metrics.foreach(_.onBlockGateHold()))
+                now <- IO.monotonic.map(_.toMillis)
+                updated <- stateRef.updateAndGet(_.copy(holdStartedMs = Some(now)))
+            } yield updated
+
+    private def armTick(st: Limiter.State[Msg]): IO[Unit] =
+        val sliceMs = gate.fold(Limiter.DefaultSliceMs)(_.slice.toMillis)
+        for {
+            now <- IO.monotonic.map(_.toMillis)
+            due = st.queue.headOption match {
+                case Some(t: LimiterTimestamp) =>
+                    st.lastReleaseMs.fold(now)(_ + periodMs(t, st))
+                case _ => now
+            }
+            waitMs = math.max(0L, math.min(due - now, sliceMs))
+            _ <- stateRef.update(_.copy(tickArmed = true))
+            // Blocks this mailbox for at most one slice, deliberately. The self-send goes out
+            // AFTER the sleep, so anything that arrived meanwhile is processed first.
+            _ <- IO.sleep(waitMs.millis)
+            _ <- context.self ! LimiterControl.Tick
+        } yield ()
+
+    private def release(msg: Msg): IO[Unit] = (downstream ! msg).void
+
+    /** Only a gated lane may write these; otherwise the gauges would carry another lane's numbers.
+      */
+    private def publishBacklog(released: Long): IO[Unit] =
+        if gate.isEmpty then IO.unit else IO(metrics.foreach(_.onBlockGateRelease(released)))
+
+    // ---- the gate -----------------------------------------------------------------------------
+
+    private def periodMs(t: LimiterTimestamp, st: Limiter.State[Msg]): Long =
+        val base = t.minPeriod.toMillis
+        val m = if gate.isEmpty then 1.0 else st.gateState.multiplier
+        if m >= 1.0 then base else math.ceil(base / m).toLong
+
+    private def onDrained: IO[Unit] = gate match {
+        // A lane with no gate has no notion of downstream backlog. Nothing sends it drain signals
+        // today; ignoring them keeps that from mattering if something ever does.
+        case None => IO.unit
+        case Some(g) =>
+            stateRef.get.flatMap { st =>
+                val before = st.gateState.released
+                val next = g.observeDrain(st.gateState)
+                stateRef.set(st.copy(gateState = next)) >>
+                    tracer.traceWith(
+                      LimiterEvent.GateUpdated(before, next.residual, next.multiplier)
+                    ) >>
+                    IO(
+                      metrics.foreach(_.onBlockGateUpdate(before, next.residual, next.multiplier))
+                    ) >>
+                    pumpAndArm
+            }
     }
 }
 
 object Limiter {
     type Handle[Msg] = ActorRef[IO, Msg]
+
+    /** Slice for a lane with no gate. Its period is static, so slicing only bounds how long the
+      * mailbox is blocked.
+      */
+    private val DefaultSliceMs: Long = 1000L
+
+    /** ⛔ `Option`, not a `-1` sentinel: these hold [[cats.effect.IO.monotonic]] readings, i.e.
+      * `System.nanoTime`, whose origin is arbitrary and which the JDK permits to be negative. A
+      * `>= 0` test for "have we released yet" would read false forever on such a platform and the
+      * gate would never engage.
+      *
+      * @param lastReleaseMs
+      *   monotonic millis of the last throttled release; `None` before the first, which is what
+      *   makes the first message due immediately — a freshly started limiter must not invent a
+      *   delay.
+      * @param holdStartedMs
+      *   monotonic millis at which the current hold began; `None` when nothing is held. Exists only
+      *   so a hold is traced once rather than once per slice.
+      */
+    final case class State[Msg](
+        lastReleaseMs: Option[Long],
+        queue: Vector[Msg],
+        tickArmed: Boolean,
+        holdStartedMs: Option[Long],
+        gateState: LimiterGate.State
+    )
+
+    object State {
+        def initial[Msg]: State[Msg] = State[Msg](
+          lastReleaseMs = None,
+          queue = Vector.empty,
+          tickArmed = false,
+          holdStartedMs = None,
+          gateState = LimiterGate.Open
+        )
+    }
 }

--- a/src/main/scala/hydrozoa/multisig/consensus/limiter/LimiterControl.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/limiter/LimiterControl.scala
@@ -1,0 +1,31 @@
+package hydrozoa.multisig.consensus.limiter
+
+/** Control messages a [[Limiter]] consumes for its own account. Never forwarded downstream, so the
+  * lane's downstream actor needs no case for them.
+  *
+  * Messages rather than a shared [[cats.effect.Ref]]: a `Ref` read inside a sleep loop is invisible
+  * to deterministic replay.
+  */
+sealed trait LimiterControl
+
+object LimiterControl:
+
+    /** Downstream has absorbed the backlog this limiter released — on the block lane, one stack
+      * hard-confirmed. Reopens the gate.
+      *
+      * Hard confirmation rather than the peer's own hard ack: it is one event per downstream cycle
+      * and strictly later, so it subsumes the ack, and where a coil lags the extra conservatism is
+      * what we want. It also cannot deadlock against the gate — hard confirmation needs hard acks
+      * and the stack clock, never new blocks — so throttling the block lane all the way to its
+      * floor can never suppress the event that lifts the throttle.
+      */
+    case object DownstreamDrained extends LimiterControl
+
+    /** Self-tick: re-evaluate an outstanding hold.
+      *
+      * A hold is a chain of short sleeps each followed by one of these, not a single `IO.sleep` for
+      * the whole wait, so the mailbox drains between slices and [[DownstreamDrained]] is acted on
+      * at most one slice late. The handler recomputes from current state, so a stale or duplicated
+      * tick is harmless.
+      */
+    case object Tick extends LimiterControl

--- a/src/main/scala/hydrozoa/multisig/consensus/limiter/LimiterEvent.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/limiter/LimiterEvent.scala
@@ -8,4 +8,14 @@ sealed trait LimiterEvent
 object LimiterEvent:
     case object Started extends LimiterEvent
 
+    /** Emitted once when a hold begins, not once per slice. */
     final case class HoldingMsg(msgType: String, holdMs: Long) extends LimiterEvent
+
+    /** The backlog gate re-derived its multiplier from a completed downstream cycle. */
+    final case class GateUpdated(backlog: Long, residual: Double, multiplier: Double)
+        extends LimiterEvent
+
+    /** More than one throttled message was queued at once. Upstream is supposed to be single-flight
+      * on this lane, so this says an invariant the gate's sizing assumes no longer holds.
+      */
+    final case class QueueDepthUnexpected(throttledPending: Int) extends LimiterEvent

--- a/src/main/scala/hydrozoa/multisig/consensus/limiter/LimiterEventFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/limiter/LimiterEventFormat.scala
@@ -13,5 +13,11 @@ object LimiterEventFormat:
         e match {
             case Started           => debug(s"Limiter[$label] started.")
             case HoldingMsg(t, ms) => debug(s"Limiter[$label] holding $t for ${ms}ms")
+            case GateUpdated(backlog, residual, m) =>
+                debug(
+                  f"Limiter[$label] gate: backlog=$backlog residual=$residual%.1f multiplier=$m%.3f"
+                )
+            case QueueDepthUnexpected(n) =>
+                warn(s"Limiter[$label] has $n throttled messages queued; expected at most 1.")
         }
     }

--- a/src/main/scala/hydrozoa/multisig/consensus/limiter/LimiterGate.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/limiter/LimiterGate.scala
@@ -1,0 +1,86 @@
+package hydrozoa.multisig.consensus.limiter
+
+import scala.concurrent.duration.FiniteDuration
+
+/** The downstream-backlog gate: turns "how much work downstream has yet to absorb" into a
+  * multiplier on the lane's release rate.
+  *
+  * ⛔ **Opt-in.** Without a gate there is no counting, no ticking and no multiplier, so a lane that
+  * is never sent [[LimiterControl.DownstreamDrained]] cannot ratchet its period toward infinity.
+  *
+  * The spacing gate alone bounds the floor on cycle time; this bounds the ceiling on outstanding
+  * work. Neither subsumes the other.
+  */
+final case class LimiterGate(
+    /** Backlog (in released messages per downstream cycle) below which the gate is fully open. Set
+      * above healthy steady-state accumulation and the controller does nothing; the sizing rule is
+      * on the config knob that supplies it.
+      */
+    backlogSoftLimit: Int,
+
+    /** Backlog at which the multiplier reaches [[floor]]. */
+    backlogHardLimit: Int,
+
+    /** The slowest the lane is ever shaped to, as a fraction of the configured rate. ⛔ Never 0:
+      * upstream is self-clocked by what this lane releases, so releasing nothing stops the clock
+      * that would later reopen the gate. Same reason TCP always sends a full segment eventually.
+      */
+    floor: Double,
+
+    /** EWMA weight on the newest cycle's residual. Below 1.0 the controller acts on a filtered
+      * count rather than the raw one.
+      */
+    smoothing: Double,
+
+    /** Longest single sleep the limiter will commit to before re-reading its mailbox. Bounds how
+      * stale the multiplier can be while a hold is outstanding.
+      */
+    slice: FiniteDuration
+):
+    require(backlogHardLimit > backlogSoftLimit, "backlogHardLimit must exceed backlogSoftLimit")
+    require(floor > 0.0 && floor <= 1.0, "gate floor must be in (0, 1]")
+    require(smoothing > 0.0 && smoothing <= 1.0, "gate smoothing must be in (0, 1]")
+
+    /** Headroom, 1.0 fully open through 0.0 fully loaded. */
+    def headroom(backlog: Double): Double =
+        val span = (backlogHardLimit - backlogSoftLimit).toDouble
+        ((backlogHardLimit - backlog) / span).max(0.0).min(1.0)
+
+    /** The rate multiplier for a filtered backlog.
+      *
+      * `1 - (1 - h)^2` is flat near full headroom and steepens as it runs out. ⛔ Not `h^2`, whose
+      * highest gain sits where the system is healthy: the loop's dead time is a full downstream
+      * cycle, and high gain across long dead time produces a limit cycle.
+      */
+    def multiplier(backlog: Double): Double =
+        val h = headroom(backlog)
+        val open = 1.0 - (1.0 - h) * (1.0 - h)
+        floor + (1.0 - floor) * open
+
+object LimiterGate:
+
+    /** The gate's running state. Owned by the limiter actor and read by nothing else — the copy
+      * published to `PeerMetrics` is for the stats endpoints and is never read back.
+      *
+      * @param released
+      *   throttled messages released since the last drain signal. This is the live count.
+      * @param residual
+      *   the filtered per-cycle residual the multiplier is derived from. Updated only on a drain
+      *   signal, from the count accumulated over the cycle just ended, so between signals the
+      *   multiplier is constant.
+      */
+    final case class State(released: Long, residual: Double, multiplier: Double, drains: Long)
+
+    val Open: State = State(released = 0L, residual = 0.0, multiplier = 1.0, drains = 0L)
+
+    extension (gate: LimiterGate)
+        /** Fold one completed downstream cycle into the filter and re-derive the multiplier. */
+        def observeDrain(s: State): State =
+            val residual =
+                gate.smoothing * s.released.toDouble + (1.0 - gate.smoothing) * s.residual
+            State(
+              released = 0L,
+              residual = residual,
+              multiplier = gate.multiplier(residual),
+              drains = s.drains + 1
+            )

--- a/src/main/scala/hydrozoa/multisig/consensus/limiter/LimiterTimestamp.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/limiter/LimiterTimestamp.scala
@@ -28,4 +28,12 @@ trait LimiterTimestamp {
     /** Minimum wall-clock gap between this message and the next throttled message on the same lane.
       */
     def minPeriod(using RateLimits.Section): FiniteDuration
+
+    /** Released without pacing, in arrival order, and does not restart the spacing clock.
+      *
+      * For messages that end the lane: they add no ongoing backlog, so pacing them only costs
+      * latency. In arrival order, not ahead of the queue — overtaking a held message would reorder
+      * the lane.
+      */
+    def limiterExempt: Boolean = false
 }

--- a/src/main/scala/hydrozoa/multisig/ledger/block/Block.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/block/Block.scala
@@ -88,6 +88,11 @@ object Block {
             override transparent inline def header: BlockHeader.Final = blockBrief.header
             override transparent inline def body: BlockBody.Final = blockBrief.body
             override transparent inline def finalizationRequested: Boolean = false
+
+            /** The last block this head will ever produce: there is no next block to pace against,
+              * and holding it only delays finalization.
+              */
+            override def limiterExempt: Boolean = true
         }
 
         type Next = Block.SoftConfirmed & BlockType.Next

--- a/src/main/scala/hydrozoa/multisig/ledger/joint/EvacuationMap.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/joint/EvacuationMap.scala
@@ -24,6 +24,7 @@ import scalus.uplc.builtin.Builtins.{blake2b_224, serialiseData}
 import scalus.uplc.builtin.Data.toData
 import scalus.uplc.builtin.{ByteString, Data, ToData, platform}
 import scalus.|>
+import scodec.bits.ByteVector
 import supranational.blst.Scalar
 
 given toDataTransactionInput: ToData[TransactionInput] with {
@@ -56,7 +57,8 @@ object EvacuationMapInstances:
     }
 
     given evacuationKeyKeyEncoder: KeyEncoder[EvacuationKey] = {
-        KeyEncoder.encodeKeyString.contramap(_.byteString.toHex)
+        // Hex via ByteVector, not `byteString.toHex`: the latter caches its hex on the retained key.
+        KeyEncoder.encodeKeyString.contramap(ek => ByteVector(ek.byteString.bytes).toHex)
     }
 
     // FIXME: This is partial, but KeyDecoder lacks the "emap" method that Decoder has?
@@ -82,7 +84,9 @@ object EvacuationMapInstances:
   * golden, so a change to [[EvacuationMap.digest]] is a wire break.
   */
 final case class EvacuationMapHash(byteString: ByteString) {
-    def toHex: String = byteString.toHex
+    // ByteVector, not `byteString.toHex`: the latter caches its hex on this retained digest, and
+    // `toString`/the circe encoder both route through here. `bytes` is already in hand.
+    def toHex: String = ByteVector(byteString.bytes).toHex
 
     override def toString: String = toHex
 }

--- a/src/main/scala/hydrozoa/multisig/ledger/remote/RemoteL2LedgerCodecs.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/remote/RemoteL2LedgerCodecs.scala
@@ -11,6 +11,7 @@ import io.circe.generic.semiauto.*
 import io.circe.syntax.*
 import io.circe.{Codec, Decoder, Encoder}
 import scalus.cardano.ledger.{AssetName, Coin, KeepRaw, MultiAsset, PolicyId, ScriptHash, TransactionOutput, Value}
+import scodec.bits.ByteVector
 
 /** JSON codecs for RemoteL2Ledger WebSocket protocol */
 object RemoteL2LedgerCodecs {
@@ -42,8 +43,10 @@ object RemoteL2LedgerCodecs {
                 io.circe.Json.obj(
                   "asset" -> io.circe.Json.obj(
                     "tag" -> io.circe.Json.fromString("NativeToken"),
-                    "policyId" -> io.circe.Json.fromString(policyId.toHex),
-                    "assetName" -> io.circe.Json.fromString(assetName.bytes.toHex)
+                    // Hex via ByteVector, not `.toHex`: PolicyId/AssetName are ByteStrings that cache
+                    // hex on the instance, and these live in retained L2 ledger Values.
+                    "policyId" -> io.circe.Json.fromString(ByteVector(policyId.bytes).toHex),
+                    "assetName" -> io.circe.Json.fromString(ByteVector(assetName.bytes.bytes).toHex)
                   ),
                   "value" -> io.circe.Json.fromLong(quantity)
                 )

--- a/src/main/scala/hydrozoa/multisig/metrics/PeerMetrics.scala
+++ b/src/main/scala/hydrozoa/multisig/metrics/PeerMetrics.scala
@@ -1,6 +1,8 @@
 package hydrozoa.multisig.metrics
 
 import cats.effect.IO
+import cats.effect.unsafe.IORuntime
+import java.lang.management.ManagementFactory
 import java.util.concurrent.atomic.{AtomicLong, AtomicReference, LongAdder}
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.duration.*
@@ -232,6 +234,7 @@ final class PeerMetrics private (startedAtMillis: Long, remotePeerNums: Vector[I
           leaderMempoolDrain = leaderMempoolDrain.get(),
           sequencerHeadroom = seqHeadroom.get(),
           equityLovelace = equityLovelace.get(),
+          runtime = PeerMetrics.runtimeSnapshot(),
           composer = ComposerStats(
             phase = composerPhase.get(),
             secondsInPhase = math.max(0L, (nowMillis - composerPhaseSince.get()) / 1000),
@@ -297,6 +300,50 @@ final class PeerMetrics private (startedAtMillis: Long, remotePeerNums: Vector[I
 
 object PeerMetrics:
     private val Taus: Vector[Double] = Vector(60.0, 300.0, 900.0) // 1m / 5m / 15m
+
+    /** Read the whole-process resource gauges. Cheap enough for the 1 Hz sampler: counter reads,
+      * one `MemoryMXBean` poll, and one attribute read for the fd count.
+      *
+      * Deliberately tolerant. `workStealingThreadPool` is `None` on a non-WSTP compute pool (the
+      * test harnesses), the fd count is an `OperatingSystemMXBean` attribute that exists on Linux
+      * and not everywhere, and none of this is worth failing a stats request over — so anything
+      * unavailable reports as -1 rather than throwing.
+      */
+    def runtimeSnapshot(): RuntimeStats =
+        val heap = ManagementFactory.getMemoryMXBean.getHeapMemoryUsage
+        val wstp = IORuntime.global.metrics.workStealingThreadPool
+        RuntimeStats(
+          fibersSuspended = wstp.map(_.suspendedFiberCount()).getOrElse(-1L),
+          fibersQueuedLocal = wstp.map(_.localQueueFiberCount()).getOrElse(-1L),
+          workerThreads = wstp.map(_.workerThreadCount()).getOrElse(-1),
+          workersActive = wstp.map(_.activeThreadCount()).getOrElse(-1),
+          workersSearching = wstp.map(_.searchingThreadCount()).getOrElse(-1),
+          workersBlocked = wstp.map(_.blockedWorkerThreadCount()).getOrElse(-1),
+          timersOutstanding = wstp
+              .map(_.workerThreads.map(_.timerHeap.timersOutstandingCount().toLong).sum)
+              .getOrElse(-1L),
+          timersExecuted = wstp
+              .map(_.workerThreads.map(_.timerHeap.totalTimersExecutedCount()).sum)
+              .getOrElse(-1L),
+          liveThreads = ManagementFactory.getThreadMXBean.getThreadCount,
+          heapUsedBytes = heap.getUsed,
+          heapCommittedBytes = heap.getCommitted,
+          openFileDescriptors = openFdCount()
+        )
+
+    /** Open file descriptors, or -1 where the platform does not expose them. Socket exhaustion
+      * presents as a box that has stopped responding, with nothing in the process reporting why.
+      */
+    private def openFdCount(): Long =
+        try
+            ManagementFactory.getPlatformMBeanServer
+                .getAttribute(
+                  new javax.management.ObjectName("java.lang:type=OperatingSystem"),
+                  "OpenFileDescriptorCount"
+                )
+                .asInstanceOf[java.lang.Long]
+                .longValue()
+        catch case _: Throwable => -1L
 
     /** Upper bound on in-flight (unclosed) block clocks before we assume a leak and reset. */
     private val InFlightCap = 8192
@@ -435,7 +482,43 @@ final case class PeerStats(
     leaderMempoolDrain: Long,
     sequencerHeadroom: Long,
     equityLovelace: Long,
-    composer: ComposerStats
+    composer: ComposerStats,
+    runtime: RuntimeStats
+)
+
+/** Whole-process resource use, for answering one question about a run: is the resource curve
+  * proportional to work IN FLIGHT, or to HISTORY?
+  *
+  * The discriminator is a slope against the right denominator, so these have to be read against the
+  * cumulative counters already in [[PeerStats]] (`blocks`, `stacks`, `localAccepted`) and against a
+  * deliberate load step-down: an in-flight-sized resource plateaus at constant load and comes back
+  * DOWN when load drops; a history-sized one tracks the cumulative counter and does not.
+  *
+  * ⛔ Every axis here is a CONCURRENCY axis. A peer can hold all of them at their idle floor while
+  * carrying a large backlog of unabsorbed deposits, unconfirmed blocks and queued resubmissions, so
+  * these do not answer "has the node drained?" — only "is it running work right now?"
+  *
+  * `fibersSuspended` is a fiber census, not a fiber dump: `kill -USR1` costs seconds and megabytes,
+  * this is two counter reads. `workersSearching` and `timersExecuted` are the cats-effect
+  * scheduler-seizure signature — in that state `workersSearching` stays non-zero while
+  * `timersExecuted` stops advancing, and the runtime cannot self-report it, because its own
+  * starvation checker is an `IO.sleep` that fires once and then goes silent. All of these are read
+  * from a plain snapshot rather than from a fiber, so a scraper outside the process still gets them
+  * when the runtime is seized.
+  */
+final case class RuntimeStats(
+    fibersSuspended: Long,
+    fibersQueuedLocal: Long,
+    workerThreads: Int,
+    workersActive: Int,
+    workersSearching: Int,
+    workersBlocked: Int,
+    timersOutstanding: Long,
+    timersExecuted: Long,
+    liveThreads: Int,
+    heapUsedBytes: Long,
+    heapCommittedBytes: Long,
+    openFileDescriptors: Long
 )
 
 /** What the [[hydrozoa.multisig.consensus.StackComposer]] is doing, and for how long.

--- a/src/main/scala/hydrozoa/multisig/metrics/PeerMetrics.scala
+++ b/src/main/scala/hydrozoa/multisig/metrics/PeerMetrics.scala
@@ -73,6 +73,16 @@ final class PeerMetrics private (startedAtMillis: Long, remotePeerNums: Vector[I
     private val seqHeadroom = new AtomicLong(0)
     private val equityLovelace = new AtomicLong(0)
 
+    // ---- block-rate gate (written by the block lane's Limiter) ----
+    // Observability only. The limiter acts on the multiplier in its own actor state; these are a
+    // write-only copy so the stats endpoints can show what the gate is doing. Nothing in the
+    // control path reads them back.
+    private val gateMultiplierMilli = new AtomicLong(1000)
+    private val gateBacklog = new AtomicLong(0)
+    private val gateResidualMilli = new AtomicLong(0)
+    private val gateHolds = new AtomicLong(0)
+    private val gateDrains = new AtomicLong(0)
+
     // ---- stack-composer phase (see StackComposerPhase) ----
     private val composerPhase = new AtomicReference[StackComposerPhase](StackComposerPhase.Deriving)
     private val composerPhaseSince = new AtomicLong(startedAtMillis)
@@ -166,6 +176,19 @@ final class PeerMetrics private (startedAtMillis: Long, remotePeerNums: Vector[I
       * clock, so `secondsInPhase` measures how long the composer has been stuck in it — the whole
       * point of the gauge, and `tryProgress` re-evaluates on every inbound event.
       */
+    /** One throttled message released; `backlog` is the running count since the last drain. */
+    def onBlockGateRelease(backlog: Long): Unit = gateBacklog.set(backlog)
+
+    /** A hold began (once per hold, not once per slice). */
+    def onBlockGateHold(): Unit = { val _ = gateHolds.incrementAndGet() }
+
+    /** The gate re-derived its multiplier at the end of a downstream cycle. */
+    def onBlockGateUpdate(backlogAtDrain: Long, residual: Double, multiplier: Double): Unit =
+        gateBacklog.set(backlogAtDrain)
+        gateResidualMilli.set(math.round(residual * 1000.0))
+        gateMultiplierMilli.set(math.round(multiplier * 1000.0))
+        val _ = gateDrains.incrementAndGet()
+
     def onComposerPhase(phase: StackComposerPhase, nowMillis: Long): Unit =
         if composerPhase.getAndSet(phase) != phase then composerPhaseSince.set(nowMillis)
 
@@ -235,6 +258,13 @@ final class PeerMetrics private (startedAtMillis: Long, remotePeerNums: Vector[I
           sequencerHeadroom = seqHeadroom.get(),
           equityLovelace = equityLovelace.get(),
           runtime = PeerMetrics.runtimeSnapshot(),
+          blockGate = BlockGateStats(
+            multiplier = gateMultiplierMilli.get() / 1000.0,
+            backlog = gateBacklog.get(),
+            residual = gateResidualMilli.get() / 1000.0,
+            holds = gateHolds.get(),
+            drains = gateDrains.get()
+          ),
           composer = ComposerStats(
             phase = composerPhase.get(),
             secondsInPhase = math.max(0L, (nowMillis - composerPhaseSince.get()) / 1000),
@@ -483,7 +513,23 @@ final case class PeerStats(
     sequencerHeadroom: Long,
     equityLovelace: Long,
     composer: ComposerStats,
-    runtime: RuntimeStats
+    runtime: RuntimeStats,
+    blockGate: BlockGateStats
+)
+
+/** What the block lane's rate limiter is doing, so a deploy can be checked with one request rather
+  * than by log-diving at a level the node does not run at.
+  *
+  * `multiplier` 1.0 means the backlog gate is fully open and the lane is paced only by the
+  * configured period — the expected steady state. Below 1.0 the composer is behind and the lane is
+  * being slowed; the effective period is `softBlockMinPeriod / multiplier`.
+  */
+final case class BlockGateStats(
+    multiplier: Double,
+    backlog: Long,
+    residual: Double,
+    holds: Long,
+    drains: Long
 )
 
 /** Whole-process resource use, for answering one question about a run: is the resource curve

--- a/src/main/scala/hydrozoa/multisig/metrics/PrometheusFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/metrics/PrometheusFormat.scala
@@ -216,6 +216,37 @@ object PrometheusFormat:
           s.runtime.openFileDescriptors
         )
 
+        // ---- block-rate limiter ----
+        gaugeD(
+          "hydrozoa_block_gate_multiplier",
+          "Block-lane rate multiplier. 1 means the downstream-backlog gate is fully open and " +
+              "block production is paced only by softBlockMinPeriod; below 1 the stack composer " +
+              "is behind and the effective period is softBlockMinPeriod divided by this.",
+          s.blockGate.multiplier
+        )
+        gauge(
+          "hydrozoa_block_gate_backlog",
+          "Soft-confirmed blocks released since the last hard confirmation.",
+          s.blockGate.backlog
+        )
+        gaugeD(
+          "hydrozoa_block_gate_residual",
+          "Per-stack-cycle backlog, filtered over several cycles. The multiplier is derived from " +
+              "this rather than from instantaneous depth, which is dominated by cycle phase.",
+          s.blockGate.residual
+        )
+        counter(
+          "hydrozoa_block_gate_holds_total",
+          "Holds begun by the block limiter. Rising means the shaper is binding.",
+          s.blockGate.holds
+        )
+        counter(
+          "hydrozoa_block_gate_drains_total",
+          "Headroom signals received (one per hard confirmation). Flat while blocks are being " +
+              "produced means the gate has stopped being reopened.",
+          s.blockGate.drains
+        )
+
         b.toString
 
     private def rate(name: String, help: String, r: RateView, b: StringBuilder): Unit =

--- a/src/main/scala/hydrozoa/multisig/metrics/PrometheusFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/metrics/PrometheusFormat.scala
@@ -167,6 +167,55 @@ object PrometheusFormat:
                 }\n"
         }
 
+        // Whole-process resource gauges — concurrency axes, read against a cumulative counter
+        // above and across a load step-down (see `RuntimeStats`). The `_total` counters here are
+        // monotonic by construction.
+        gauge(
+          "hydrozoa_fibers_suspended",
+          "Fibers suspended on the cats-effect runtime. The axis that failed on 2026-08-26.",
+          s.runtime.fibersSuspended
+        )
+        gauge(
+          "hydrozoa_fibers_queued_local",
+          "Fibers sitting in worker-local run queues.",
+          s.runtime.fibersQueuedLocal
+        )
+        gauge("hydrozoa_worker_threads", "cats-effect compute workers.", s.runtime.workerThreads)
+        gauge(
+          "hydrozoa_workers_active",
+          "Compute workers running a fiber.",
+          s.runtime.workersActive
+        )
+        gauge(
+          "hydrozoa_workers_searching",
+          "Compute workers searching for work. Non-zero while hydrozoa_timers_executed_total is " +
+              "flat is the cats-effect scheduler-seizure signature.",
+          s.runtime.workersSearching
+        )
+        gauge(
+          "hydrozoa_workers_blocked",
+          "Compute workers inside a blocking region.",
+          s.runtime.workersBlocked
+        )
+        gauge(
+          "hydrozoa_timers_outstanding",
+          "Armed timers across all worker heaps.",
+          s.runtime.timersOutstanding
+        )
+        counter(
+          "hydrozoa_timers_executed_total",
+          "Timers fired since start. Flat while the process is loaded means timer delivery is dead.",
+          s.runtime.timersExecuted
+        )
+        gauge("hydrozoa_live_threads", "JVM live threads.", s.runtime.liveThreads)
+        gauge("hydrozoa_heap_used_bytes", "JVM heap in use.", s.runtime.heapUsedBytes)
+        gauge("hydrozoa_heap_committed_bytes", "JVM heap committed.", s.runtime.heapCommittedBytes)
+        gauge(
+          "hydrozoa_open_file_descriptors",
+          "Open file descriptors, or -1 where the platform does not report them.",
+          s.runtime.openFileDescriptors
+        )
+
         b.toString
 
     private def rate(name: String, help: String, r: RateView, b: StringBuilder): Unit =

--- a/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
+++ b/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
@@ -265,9 +265,24 @@ object ApiDto {
           */
         equityLovelace: Long,
         composer: ComposerStatsView,
-        runtime: RuntimeStatsView
+        runtime: RuntimeStatsView,
+        blockGate: BlockGateStatsView
     )
     given Codec[PeerStatsView] = deriveCodec
+
+    /** What the block lane's rate limiter is doing right now. `multiplier` 1.0 is the expected
+      * steady state; below 1.0 the stack composer is behind and the lane is being slowed. `backlog`
+      * is blocks released since the last hard confirmation, and `residual` is that count filtered
+      * over several stack cycles — see [[hydrozoa.multisig.metrics.BlockGateStats]].
+      */
+    final case class BlockGateStatsView(
+        multiplier: Double,
+        backlog: Long,
+        residual: Double,
+        holds: Long,
+        drains: Long
+    )
+    given Codec[BlockGateStatsView] = deriveCodec
 
     /** Whole-process resource gauges. Read these against the cumulative counters above (`blocks`,
       * `stacks`, `localRequests.total`) and across a deliberate load step-down; they are
@@ -302,6 +317,13 @@ object ApiDto {
             )
         PeerStatsView(
           uptimeSeconds = s.uptimeSeconds,
+          blockGate = BlockGateStatsView(
+            multiplier = s.blockGate.multiplier,
+            backlog = s.blockGate.backlog,
+            residual = s.blockGate.residual,
+            holds = s.blockGate.holds,
+            drains = s.blockGate.drains
+          ),
           runtime = RuntimeStatsView(
             fibersSuspended = s.runtime.fibersSuspended,
             fibersQueuedLocal = s.runtime.fibersQueuedLocal,

--- a/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
+++ b/src/main/scala/hydrozoa/multisig/server/ApiDto.scala
@@ -264,9 +264,31 @@ object ApiDto {
           * closed. One side of `treasury.value == evacuation map total + equity + beacon`.
           */
         equityLovelace: Long,
-        composer: ComposerStatsView
+        composer: ComposerStatsView,
+        runtime: RuntimeStatsView
     )
     given Codec[PeerStatsView] = deriveCodec
+
+    /** Whole-process resource gauges. Read these against the cumulative counters above (`blocks`,
+      * `stacks`, `localRequests.total`) and across a deliberate load step-down; they are
+      * concurrency axes, not backlog. Anything the platform does not expose reads as -1. See
+      * [[hydrozoa.multisig.metrics.RuntimeStats]] for how to read them and what they cannot say.
+      */
+    final case class RuntimeStatsView(
+        fibersSuspended: Long,
+        fibersQueuedLocal: Long,
+        workerThreads: Int,
+        workersActive: Int,
+        workersSearching: Int,
+        workersBlocked: Int,
+        timersOutstanding: Long,
+        timersExecuted: Long,
+        liveThreads: Int,
+        heapUsedBytes: Long,
+        heapCommittedBytes: Long,
+        openFileDescriptors: Long
+    )
+    given Codec[RuntimeStatsView] = deriveCodec
 
     /** Map a [[hydrozoa.multisig.metrics.PeerStats]] snapshot to its JSON body. */
     def mkPeerStatsView(s: PeerStats): PeerStatsView =
@@ -280,6 +302,20 @@ object ApiDto {
             )
         PeerStatsView(
           uptimeSeconds = s.uptimeSeconds,
+          runtime = RuntimeStatsView(
+            fibersSuspended = s.runtime.fibersSuspended,
+            fibersQueuedLocal = s.runtime.fibersQueuedLocal,
+            workerThreads = s.runtime.workerThreads,
+            workersActive = s.runtime.workersActive,
+            workersSearching = s.runtime.workersSearching,
+            workersBlocked = s.runtime.workersBlocked,
+            timersOutstanding = s.runtime.timersOutstanding,
+            timersExecuted = s.runtime.timersExecuted,
+            liveThreads = s.runtime.liveThreads,
+            heapUsedBytes = s.runtime.heapUsedBytes,
+            heapCommittedBytes = s.runtime.heapCommittedBytes,
+            openFileDescriptors = s.runtime.openFileDescriptors
+          ),
           localRequests = LocalRequestStatsView(
             total = s.localAccepted,
             rate = rate(s.localRate),

--- a/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
+++ b/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
@@ -6,7 +6,6 @@ import hydrozoa.BuildInfo
 import hydrozoa.config.head.HeadConfig
 import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.NodeStatus
-import hydrozoa.multisig.consensus.peer.HeadPeerNumber
 import hydrozoa.multisig.consensus.{BlockWeaver, RequestSequencer, UserRequest, UserRequestWithId}
 import hydrozoa.multisig.ledger.block.{BlockBrief, BlockNumber}
 import hydrozoa.multisig.ledger.event.RequestId
@@ -172,28 +171,6 @@ class HydrozoaRoutes(
                     DecodeResult.Error(s, new IllegalArgumentException("malformed 32-byte l1TxId"))
         )(_.toHex)
 
-    private val blocksEndpoint: ServerEndpoint[Any, IO] =
-        endpoint.get
-            .in("head" / "blocks")
-            .name("getHeadBlocks")
-            .tag("Blocks")
-            .out(jsonBody[List[BlockSummaryView]])
-            .errorOut(errorOut)
-            .description(
-              "Every block of the head in block order — number, fast-cycle leader, and type. " +
-                  "Block 0 is the head's initial block (config, no leader)."
-            )
-            .serverLogic(_ =>
-                consensusReader.blockBriefs
-                    .map(briefs =>
-                        Right(
-                          ApiDto.mkInitialBlockSummaryView ::
-                              briefs.map(ApiDto.mkBlockSummaryView(_, headConfig.nHeadPeers))
-                        )
-                    )
-                    .handleError(err => Left(fail(StatusCode.InternalServerError, err.getMessage)))
-            )
-
     private val blockDetailsEndpoint: ServerEndpoint[Any, IO] =
         endpoint.get
             .in("head" / "blocks" / path[BlockNumber]("block-number"))
@@ -320,25 +297,6 @@ class HydrozoaRoutes(
           "fallback" -> EffectKind.Fallback,
           "finalization" -> EffectKind.Finalization
         ).map(blockTxEffectEndpoint) :+ blockSecEffectEndpoint
-
-    private val requestsEndpoint: ServerEndpoint[Any, IO] =
-        endpoint.get
-            .in("head" / "requests")
-            .in(query[Option[String]]("type"))
-            .in(query[Option[Int]]("peer_number"))
-            .name("getHeadRequests")
-            .tag("Requests")
-            .out(jsonBody[List[RequestSummaryView]])
-            .errorOut(errorOut)
-            .description(
-              "Requests the head has assigned an id — opaque request id, author peer number, and " +
-                  "type (transaction or deposit). Filter with ?type=transaction|deposit and " +
-                  "?peer_number=<n>."
-            )
-            .serverLogic((typeFilter, peerFilter) =>
-                listRequests(typeFilter, peerFilter)
-                    .handleError(err => Left(fail(StatusCode.InternalServerError, err.getMessage)))
-            )
 
     private val transactionDetailExample: RequestDetailsView =
         RequestDetailsView.TransactionView(
@@ -603,13 +561,19 @@ class HydrozoaRoutes(
     private val finalizeEndpoints: List[ServerEndpoint[Any, IO]] =
         requestSequencer.fold(List.empty)(_ => List(finalizeEndpoint))
 
-    /** The core API endpoints, in the order they appear in the docs. */
+    /** The core API endpoints, in the order they appear in the docs.
+      *
+      * ⛔ `GET /head/requests` and `GET /head/blocks` are deliberately ABSENT. Each listed an entire
+      * column family into a heap `List` with no limit or offset — `?type=` / `?peer_number=` filter
+      * the result but still scan everything — so one unauthenticated call could exhaust the heap,
+      * and both journals only grow. Re-mount them only behind real paging (a cursor plus a bounded
+      * page size), never a bare limit that still requires the full scan to apply it. Everything
+      * kept here is keyed by id or block number, or is a fixed-size summary.
+      */
     private val coreEndpoints: List[ServerEndpoint[Any, IO]] =
         submitEndpoints ++ List(
           headInfoEndpoint,
-          requestsEndpoint,
           requestDetailsEndpoint,
-          blocksEndpoint,
           blockDetailsEndpoint,
           blockBodyEndpoint,
           blockEffectsEndpoint,
@@ -870,24 +834,6 @@ class HydrozoaRoutes(
       * The lifecycle status resolves through the request → block index and the block's confirmation
       * records.
       */
-    /** The request listing, optionally narrowed to one author peer (`peer_number`) and one type
-      * (`transaction`/`deposit`). An unknown `type` value matches nothing (empty list); an
-      * out-of-range `peer_number` likewise yields an empty list, since no such author exists.
-      */
-    private def listRequests(
-        typeFilter: Option[String],
-        peerFilter: Option[Int]
-    ): IO[Either[(StatusCode, ErrorResponse), List[RequestSummaryView]]] =
-        val peers = peerFilter match
-            case None    => headConfig.headPeerNums.toList
-            case Some(p) => headConfig.headPeerNums.toList.filter(_.convert == p)
-        peers
-            .traverse(consensusReader.requestsOf)
-            .map { perPeer =>
-                val rows = perPeer.flatten.map(t => ApiDto.mkRequestSummaryView(t.payload))
-                Right(typeFilter.fold(rows)(t => rows.filter(_.requestType == t)))
-            }
-
     private def requestDetails(
         id: RequestId
     ): IO[Either[(StatusCode, ErrorResponse), RequestDetailsView]] =

--- a/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
+++ b/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
@@ -41,7 +41,11 @@ import sttp.tapir.swagger.bundle.SwaggerInterpreter
   * result is a plain `HttpRoutes[IO]`, and it mounts on the same Ember server.
   */
 class HydrozoaRoutes(
-    requestSequencer: RequestSequencer.Handle,
+    /** `None` on a coil peer, which must not accept user submissions or trigger finalization. Same
+      * idiom as [[l2QueryReader]]: an absent capability removes its routes rather than mounting one
+      * that fails at request time.
+      */
+    requestSequencer: Option[RequestSequencer.Handle],
     blockWeaver: BlockWeaver.Handle,
     nodeStatus: IO[NodeStatus],
     consensusReader: ConsensusStoreReader[IO],
@@ -78,7 +82,9 @@ class HydrozoaRoutes(
 
     // ---- Endpoint definitions (the single source of truth for routes + schema) ----
 
-    private val submitRequestEndpoint: ServerEndpoint[Any, IO] =
+    private def submitRequestEndpoint(
+        sequencer: RequestSequencer.Handle
+    ): ServerEndpoint[Any, IO] =
         endpoint.post
             .in("head" / "requests")
             .name("postHeadRequest")
@@ -112,7 +118,7 @@ class HydrozoaRoutes(
                   "transaction (a native, self-authenticating Cardano tx). Payloads are lowercase " +
                   "hex. Returns the assigned request id."
             )
-            .serverLogic(body => acceptUserRequest("POST /head/requests", body))
+            .serverLogic(body => acceptUserRequest("POST /head/requests", body, sequencer))
 
     private val headInfoEndpoint: ServerEndpoint[Any, IO] =
         endpoint.get
@@ -585,10 +591,21 @@ class HydrozoaRoutes(
                     )
             )
 
-    /** The core API endpoints, in the order they appear in the docs — always served. */
+    /** The two mutating endpoints, mounted only on a node that accepts submissions.
+      *
+      * They stay at the head and tail of `coreEndpoints` below so that on a head node the endpoint
+      * ORDER is unchanged — the generated `openapi.yaml` is pinned by a golden test, and order is
+      * part of that document.
+      */
+    private val submitEndpoints: List[ServerEndpoint[Any, IO]] =
+        requestSequencer.fold(List.empty)(sequencer => List(submitRequestEndpoint(sequencer)))
+
+    private val finalizeEndpoints: List[ServerEndpoint[Any, IO]] =
+        requestSequencer.fold(List.empty)(_ => List(finalizeEndpoint))
+
+    /** The core API endpoints, in the order they appear in the docs. */
     private val coreEndpoints: List[ServerEndpoint[Any, IO]] =
-        List(
-          submitRequestEndpoint,
+        submitEndpoints ++ List(
           headInfoEndpoint,
           requestsEndpoint,
           requestDetailsEndpoint,
@@ -602,9 +619,8 @@ class HydrozoaRoutes(
           readyEndpoint,
           statsEndpoint,
           metricsEndpoint,
-          versionEndpoint,
-          finalizeEndpoint
-        ) ++ blockEffectKindEndpoints
+          versionEndpoint
+        ) ++ finalizeEndpoints ++ blockEffectKindEndpoints
 
     /** OpenAPI doc options:
       *   - drop the `View` suffix from every DTO's component-schema name (the Scala types keep it
@@ -653,7 +669,8 @@ class HydrozoaRoutes(
       */
     private def acceptUserRequest(
         path: String,
-        body: SubmitRequestView
+        body: SubmitRequestView,
+        sequencer: RequestSequencer.Handle
     ): IO[Either[(StatusCode, ErrorResponse), RequestAcceptedResponse]] =
         val handled: IO[Either[(StatusCode, ErrorResponse), RequestAcceptedResponse]] =
             for {
@@ -664,7 +681,7 @@ class HydrozoaRoutes(
                     case Right(request) => IO.pure(request)
                 }
                 _ <- tracer.traceWith(HydrozoaRoutes.decodedEvent(path, userRequest))
-                result <- (requestSequencer ?: userRequest).flatMap {
+                result <- (sequencer ?: userRequest).flatMap {
                     case Right(id) =>
                         IO.pure(Right(ApiDto.mkRequestAcceptedResponse(id)))
                     // Screening / backpressure rejection: an expected 400, not a fault — log the
@@ -964,7 +981,7 @@ object HydrozoaRoutes {
     val apiVersion: String = "0.1.0"
 
     def apply(
-        requestSequencer: RequestSequencer.Handle,
+        requestSequencer: Option[RequestSequencer.Handle],
         blockWeaver: BlockWeaver.Handle,
         nodeStatus: IO[NodeStatus],
         consensusReader: ConsensusStoreReader[IO],

--- a/src/main/scala/hydrozoa/multisig/server/HydrozoaServer.scala
+++ b/src/main/scala/hydrozoa/multisig/server/HydrozoaServer.scala
@@ -31,7 +31,8 @@ object HydrozoaServer {
     /** Create and start the HTTP server.
       *
       * @param requestSequencer
-      *   Handle to the RequestSequencer actor
+      *   Handle to the RequestSequencer actor, or `None` on a coil peer. See [[HydrozoaRoutes]] for
+      *   what its absence removes.
       * @param blockWeaver
       *   Handle to the BlockWeaver actor
       * @param nodeStatus
@@ -53,7 +54,7 @@ object HydrozoaServer {
       *   Resource that manages the server lifecycle
       */
     def create(
-        requestSequencer: RequestSequencer.Handle,
+        requestSequencer: Option[RequestSequencer.Handle],
         blockWeaver: BlockWeaver.Handle,
         nodeStatus: IO[NodeStatus],
         consensusReader: ConsensusStoreReader[IO],
@@ -91,7 +92,7 @@ object HydrozoaServer {
       * Note: In production, this would be integrated into HydrozoaNode
       */
     def run(
-        requestSequencer: RequestSequencer.Handle,
+        requestSequencer: Option[RequestSequencer.Handle],
         blockWeaver: BlockWeaver.Handle,
         nodeStatus: IO[NodeStatus],
         consensusReader: ConsensusStoreReader[IO],

--- a/src/main/scala/hydrozoa/rulebased/RuleBasedActor.scala
+++ b/src/main/scala/hydrozoa/rulebased/RuleBasedActor.scala
@@ -1128,15 +1128,14 @@ final case class RuleBasedActor(
     // evacuation regime then spawns but never polls, so funds never come back (custody-critical). A
     // fixed-cadence self-tick fires every `evacuationBotPollingPeriod` regardless of mailbox
     // activity, which is correct here because `handleTick` is a poll-then-retry safe to re-run.
-    // Idempotent: cancel whatever is already in `tickFiber` before storing the new fiber, so a second
-    // call can never orphan a poll loop. Not load-bearing under cats-actors' own restart path — the
-    // default `preRestart` runs `postStop` (which cancels) before a restart, and each restart rebuilds
-    // the actor from `props` with a fresh `tickFiber` Ref — but the cancel-on-swap keeps the single-
-    // fiber invariant local to this method instead of resting on that framework ordering.
     private def startTickTimer: IO[Unit] =
-        (IO.sleep(config.evacuationBotPollingPeriod) >> (context.self ! Tick)).foreverM.start
-            .flatMap(fib => tickFiber.getAndSet(Some(fib)))
-            .flatMap(_.fold(IO.unit)(_.cancel))
+        val pollLoop =
+            (IO.sleep(config.evacuationBotPollingPeriod) >> (context.self ! Tick)).foreverM
+        for
+            fib <- pollLoop.start
+            previous <- tickFiber.getAndSet(Some(fib))
+            _ <- previous.fold(IO.unit)(_.cancel)
+        yield ()
 
     /** Cancel the self-tick fiber so it stops pinging `self` once the actor has stopped, instead of
       * leaking a fiber that keeps delivering `Tick` to a dead actor (dead letters).

--- a/src/main/scala/hydrozoa/rulebased/RuleBasedActor.scala
+++ b/src/main/scala/hydrozoa/rulebased/RuleBasedActor.scala
@@ -1128,13 +1128,15 @@ final case class RuleBasedActor(
     // evacuation regime then spawns but never polls, so funds never come back (custody-critical). A
     // fixed-cadence self-tick fires every `evacuationBotPollingPeriod` regardless of mailbox
     // activity, which is correct here because `handleTick` is a poll-then-retry safe to re-run.
-    // TODO(#622-review): this overwrites `tickFiber` without cancelling any fiber already there. If
-    // cats-actors ever re-runs `preStart` on a restart without `postStop` in between, the old tick
-    // fiber orphans (two poll loops, one uncancellable). Cancel the existing fiber before replacing
-    // it — or confirm cats-actors' restart path always runs `postStop` first, and note that here.
+    // Idempotent: cancel whatever is already in `tickFiber` before storing the new fiber, so a second
+    // call can never orphan a poll loop. Not load-bearing under cats-actors' own restart path — the
+    // default `preRestart` runs `postStop` (which cancels) before a restart, and each restart rebuilds
+    // the actor from `props` with a fresh `tickFiber` Ref — but the cancel-on-swap keeps the single-
+    // fiber invariant local to this method instead of resting on that framework ordering.
     private def startTickTimer: IO[Unit] =
         (IO.sleep(config.evacuationBotPollingPeriod) >> (context.self ! Tick)).foreverM.start
-            .flatMap(fib => tickFiber.set(Some(fib)))
+            .flatMap(fib => tickFiber.getAndSet(Some(fib)))
+            .flatMap(_.fold(IO.unit)(_.cancel))
 
     /** Cancel the self-tick fiber so it stops pinging `self` once the actor has stopped, instead of
       * leaking a fiber that keeps delivering `Tick` to a dead actor (dead letters).

--- a/src/test/scala/hydrozoa/multisig/consensus/BlockWeaverTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/BlockWeaverTest.scala
@@ -9,12 +9,13 @@ import com.suprnation.actor.event.Error as ActorError
 import com.suprnation.actor.test.TestKit
 import com.suprnation.typelevel.actors.syntax.*
 import hydrozoa.config.head.multisig.block.BlockConfig
-import hydrozoa.config.head.multisig.timing.TxTiming.BlockTimes.{BlockCreationEndTime, BlockCreationStartTime}
+import hydrozoa.config.head.multisig.timing.TxTiming.BlockTimes.{BlockCreationEndTime, BlockCreationStartTime, DepositDecisionWakeupTime}
 import hydrozoa.config.head.parameters.generateHeadParameters
 import hydrozoa.config.head.{HeadConfig, generateHeadConfig, generateHeadConfigBootstrap}
 import hydrozoa.config.node.MultiNodeConfig
+import hydrozoa.lib.cardano.scalus.QuantizedTime.QuantizedFiniteDuration
 import hydrozoa.lib.cardano.scalus.QuantizedTime.QuantizedInstant.realTimeQuantizedInstant
-import hydrozoa.lib.logging.Slf4jTracer
+import hydrozoa.lib.logging.{ContraTracer, Slf4jTracer}
 import hydrozoa.lib.number.PositiveInt
 import hydrozoa.multisig.consensus.UserRequest.TransactionRequest
 import hydrozoa.multisig.consensus.UserRequestBody.TransactionRequestBody
@@ -29,7 +30,7 @@ import hydrozoa.multisig.persistence.{InMemoryBackendStore, Persistence, Persist
 import java.time.Instant
 import java.util.concurrent.atomic.AtomicReference
 import org.scalacheck.{Gen, Properties, PropertyM, Test}
-import scala.concurrent.duration.DurationInt
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scalus.uplc.builtin.ByteString
 import test.Generators.Hydrozoa.genRequestId
 import test.TestPeerName.{Bob, Carol}
@@ -103,6 +104,75 @@ object BlockWeaverTestHelpers {
           userRequest = userRequest,
           requestId = requestId
         )
+
+    /** Like [[mkBlockWeaverActor]] but also returns the weaver's event stream.
+      *
+      * The wakeup paths are only observable through events: a forced completion and a dropped
+      * wakeup both leave the joint ledger looking similar, and "no completion happened" cannot
+      * distinguish "the guard ignored it" from "nothing ever fired".
+      */
+    def mkBlockWeaverActorWithEvents(
+        peerNumber: HeadPeerNumber
+    ): BWTest[(BlockWeaver.Handle, AtomicReference[Vector[BlockWeaverEvent]])] =
+        for {
+            env <- ask
+            config = env.multiNodeConfig.nodeConfigs(peerNumber)
+            metrics = PeerMetrics.create(0L, Vector(peerNumber: Int))
+            connections = BlockWeaver.ConnectionsPartial(env.jointLedgerMockActor, metrics)
+            seen = AtomicReference(Vector.empty[BlockWeaverEvent])
+            logging = Slf4jTracer.sink.contramap(BlockWeaverEventFormat.humanFormat(peerNumber))
+            tracer = ContraTracer[IO, BlockWeaverEvent](e =>
+                IO(seen.updateAndGet(_ :+ e)) >> logging.traceWith(e)
+            )
+            persistenceTracer = Slf4jTracer.sink.contramap(PersistenceEventFormat.humanFormat)
+            backend <- lift(InMemoryBackendStore.open(persistenceTracer).allocated.map(_._1))
+            persistence <- lift(Persistence.fromBackend(backend, persistenceTracer)(using config))
+            actor <- lift(
+              env.system.actorOf(BlockWeaver(config, connections, tracer, metrics, persistence))
+            )
+        } yield (actor, seen)
+
+    /** A soft-confirmed minor block whose two wakeup targets are placed relative to now.
+      *
+      * `forcedMajorBlockWakeupTime` cannot be set directly — it is derived, and works out to
+      * `endTime + inactivityMarginDuration` once `minSettlementDuration` and `silenceDuration`
+      * cancel between `newFallbackStartTime` and `forcedMajorBlockWakeupTime`. So the only way to
+      * place it is to place `endTime`, which is what the subtraction below does.
+      * `mDepositDecisionWakeupTime` IS directly constructible, and is the deposit-driven target
+      * that competes with it — `scheduleWakeupFiber` sleeps until whichever is EARLIER.
+      */
+    def mkConfirmedWithWakeups(
+        blockNum: BlockNumber,
+        config: HeadConfig,
+        forcedMajorIn: FiniteDuration,
+        depositWakeupIn: Option[FiniteDuration]
+    ): BWTest[Block.SoftConfirmed.Minor] =
+        lift(for {
+            now <- realTimeQuantizedInstant(config.slotConfig)
+        } yield {
+            val endTime = BlockCreationEndTime(
+              (now + forcedMajorIn) - (config.txTiming.inactivityMarginDuration: QuantizedFiniteDuration)
+            )
+            val fallbackTxStartTime = config.txTiming.newFallbackStartTime(endTime)
+            BlockBrief.Minor(
+              BlockHeader.Minor(
+                blockNum = blockNum,
+                blockVersion = BlockVersion.Full(0, 0),
+                startTime = BlockCreationStartTime(now),
+                endTime = endTime,
+                fallbackTxStartTime = fallbackTxStartTime,
+                forcedMajorBlockWakeupTime =
+                    config.txTiming.forcedMajorBlockWakeupTime(fallbackTxStartTime),
+                mDepositDecisionWakeupTime =
+                    depositWakeupIn.map(d => DepositDecisionWakeupTime(now + d))
+              ),
+              BlockBody.Minor(requests = List.empty, depositsRejected = List.empty)
+            )
+        })
+            .map(brief =>
+                Block.SoftConfirmed
+                    .Minor(brief, headerMultiSigned = List.empty, finalizationRequested = false)
+            )
 
     def mkBlockWeaverActor(peerNumber: HeadPeerNumber): BWTest[BlockWeaver.Handle] =
         for {

--- a/src/test/scala/hydrozoa/multisig/consensus/BlockWeaverWakeupTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/BlockWeaverWakeupTest.scala
@@ -1,0 +1,314 @@
+package hydrozoa.multisig.consensus
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import com.suprnation.actor.test.TestKit
+import com.suprnation.typelevel.actors.syntax.*
+import hydrozoa.multisig.ledger.block.BlockNumber
+import java.util.concurrent.atomic.AtomicReference
+import org.scalacheck.{Properties, Test}
+import scala.concurrent.duration.DurationInt
+import test.TestPeerName.Carol
+
+/** The forced-wakeup path — the weaver's deadman, and until now completely untested.
+  *
+  * A leader that has confirmed the previous block but received no request sits in
+  * `Leader.AwaitingRequest` with one wakeup armed, sleeping until whichever of
+  * `mDepositDecisionWakeupTime` and `forcedMajorBlockWakeupTime` is EARLIER. When it fires the
+  * block is completed with no request at all — that is how a deposit gets absorbed on a quiet head,
+  * and how a fallback tx gets replaced before it can be posted. Nothing exercised it: both header
+  * builders in `BlockWeaverTest` hard-code `mDepositDecisionWakeupTime = None` and no property ever
+  * sends a `Wakeup`. The one comment that mentions it says "(or the forced wakeup)" and moves on.
+  *
+  * ==Why this suite exists now==
+  * `18a62249` reintroduced cancel-on-replace for the wakeup fiber, to stop the weaver orphaning one
+  * fiber per block. Fiber cancellation on this path had been deliberately REMOVED once before, in
+  * "Fix: prevent race condition when wakeup" (`e6ca939e`, PR #412), because back then cancellation
+  * was what kept a stale wakeup from forcing a block for the wrong block number, and the cancel
+  * raced the send. That commit made `Wakeup` carry a block number and filter at the handler
+  * instead.
+  *
+  * So correctness now lives in the guard, and cancellation is only a resource fix. This suite pins
+  * both halves of that claim: the wakeups still fire when they should (`L*`), the guard still
+  * refuses the ones it should (`S*`), and cancellation actually collects superseded fibers rather
+  * than merely letting the guard hide them (`R*`).
+  *
+  * ⚠️ These are wall-clock tests against a 1-second slot quantization, so targets are placed whole
+  * seconds out and each property runs a couple of times rather than the suite default of 100.
+  */
+object BlockWeaverWakeupTest extends Properties("Block weaver wakeup"), TestKit {
+
+    import BlockWeaverTestHelpers.*
+    import bwTest.*
+
+    override def overrideParameters(p: Test.Parameters): Test.Parameters =
+        p.withMinSuccessfulTests(2).withWorkers(1)
+
+    /** Long enough that nothing fires during a test that is asserting something else. */
+    private val NeverInThisTest = 300.seconds
+
+    /** Poll until the condition holds, then give up silently and let the caller assert with a
+      * readable message. `waitForIdle` can return while a message is still in flight to the ledger
+      * mock, so a one-shot read straight after it is stale. (Same helper as `BlockWeaverTest`,
+      * which keeps it private to its own object.)
+      */
+    private def settle(condition: => Boolean): BWTest[Unit] =
+        lift(awaitCond(IO(condition), 8.seconds, 50.millis).attempt.void)
+
+    private def events(seen: AtomicReference[Vector[BlockWeaverEvent]]): Vector[BlockWeaverEvent] =
+        seen.get
+
+    // ===================================
+    // L1 -- the deadman fires with no request at all (George's case 1)
+    // ===================================
+    val _ = property("a forced-major wakeup completes the block with no request") = run(
+      resource = defaultResource,
+      testM = for {
+          env <- ask
+          made <- mkBlockWeaverActorWithEvents(Carol.headPeerNumber)
+          weaver = made._1
+          seen = made._2
+          config = env.multiNodeConfig.nodeConfigs(Carol.headPeerNumber)
+          brief1 <- mkDummyBlockBrief1(config.headConfig)
+          _ <- lift((weaver ! brief1) >> env.system.waitForIdle())
+          _ <- settle(env.jointLedgerMock.startBlockNums.get == Vector(BlockNumber(1)))
+          confirmed <- mkConfirmedWithWakeups(
+            BlockNumber(1),
+            config.headConfig,
+            forcedMajorIn = 2.seconds,
+            depositWakeupIn = None
+          )
+          _ <- lift((weaver ! confirmed) >> env.system.waitForIdle())
+          _ <- settle(env.jointLedgerMock.startBlockNums.get.contains(BlockNumber(2)))
+          starts <- lift(IO(env.jointLedgerMock.startBlockNums.get))
+          fed <- lift(IO(env.jointLedgerMock.events.get))
+          evs <- lift(IO(events(seen)))
+          _ <- assertWith(
+            starts == Vector(BlockNumber(1), BlockNumber(2)),
+            s"the armed wakeup must start and complete block 2 unaided, but StartBlocks were $starts"
+          )
+          _ <- assertWith(
+            fed.isEmpty,
+            s"no request was ever sent, so none may reach the ledger, but got $fed"
+          )
+          _ <- assertWith(
+            evs.contains(BlockWeaverEvent.ForcedBlockCompletion(BlockNumber(2))),
+            s"expected a ForcedBlockCompletion for block 2; events were $evs"
+          )
+      } yield true
+    )
+
+    // ===================================
+    // S3 -- the EARLIER of the two targets wins (George's case 2: a deposit pulls the block forward)
+    // ===================================
+    val _ = property("a deposit wakeup earlier than the forced-major target wins") = run(
+      resource = defaultResource,
+      testM = for {
+          env <- ask
+          made <- mkBlockWeaverActorWithEvents(Carol.headPeerNumber)
+          weaver = made._1
+          config = env.multiNodeConfig.nodeConfigs(Carol.headPeerNumber)
+          brief1 <- mkDummyBlockBrief1(config.headConfig)
+          _ <- lift((weaver ! brief1) >> env.system.waitForIdle())
+          _ <- settle(env.jointLedgerMock.startBlockNums.get == Vector(BlockNumber(1)))
+          // The forced-major target is minutes out; only the deposit target can explain a
+          // completion inside this test's settle window.
+          confirmed <- mkConfirmedWithWakeups(
+            BlockNumber(1),
+            config.headConfig,
+            forcedMajorIn = NeverInThisTest,
+            depositWakeupIn = Some(2.seconds)
+          )
+          _ <- lift((weaver ! confirmed) >> env.system.waitForIdle())
+          _ <- settle(env.jointLedgerMock.startBlockNums.get.contains(BlockNumber(2)))
+          starts <- lift(IO(env.jointLedgerMock.startBlockNums.get))
+          _ <- assertWith(
+            starts.contains(BlockNumber(2)),
+            s"the deposit target should have pulled block 2 forward, but StartBlocks were $starts"
+          )
+      } yield true
+    )
+
+    // ===================================
+    // The control for both tests above. Without it, "block 2 completed" could be satisfied by a
+    // weaver that completes blocks for some entirely unrelated reason, and neither test would know.
+    // ===================================
+    val _ = property("control: with both targets far out, nothing completes on its own") = run(
+      resource = defaultResource,
+      testM = for {
+          env <- ask
+          made <- mkBlockWeaverActorWithEvents(Carol.headPeerNumber)
+          weaver = made._1
+          config = env.multiNodeConfig.nodeConfigs(Carol.headPeerNumber)
+          brief1 <- mkDummyBlockBrief1(config.headConfig)
+          _ <- lift((weaver ! brief1) >> env.system.waitForIdle())
+          _ <- settle(env.jointLedgerMock.startBlockNums.get == Vector(BlockNumber(1)))
+          confirmed <- mkConfirmedWithWakeups(
+            BlockNumber(1),
+            config.headConfig,
+            forcedMajorIn = NeverInThisTest,
+            depositWakeupIn = None
+          )
+          _ <- lift((weaver ! confirmed) >> env.system.waitForIdle())
+          _ <- lift(IO.sleep(4.seconds))
+          starts <- lift(IO(env.jointLedgerMock.startBlockNums.get))
+          _ <- assertWith(
+            starts == Vector(BlockNumber(1)),
+            s"no wakeup was due, so block 2 must not start, but StartBlocks were $starts"
+          )
+      } yield true
+    )
+
+    // ===================================
+    // L2 -- GUM-111: a target already in the past must fire immediately, not never
+    // ===================================
+    val _ = property("a wakeup target already in the past fires immediately") = run(
+      resource = defaultResource,
+      testM = for {
+          env <- ask
+          made <- mkBlockWeaverActorWithEvents(Carol.headPeerNumber)
+          weaver = made._1
+          seen = made._2
+          config = env.multiNodeConfig.nodeConfigs(Carol.headPeerNumber)
+          brief1 <- mkDummyBlockBrief1(config.headConfig)
+          _ <- lift((weaver ! brief1) >> env.system.waitForIdle())
+          _ <- settle(env.jointLedgerMock.startBlockNums.get == Vector(BlockNumber(1)))
+          // Observed for real on the stage4 20-peer head: virtual time advanced past a
+          // deposit-driven target during cross-peer ack collection, leaving a negative sleep.
+          confirmed <- mkConfirmedWithWakeups(
+            BlockNumber(1),
+            config.headConfig,
+            forcedMajorIn = NeverInThisTest,
+            depositWakeupIn = Some(-30.seconds)
+          )
+          _ <- lift((weaver ! confirmed) >> env.system.waitForIdle())
+          _ <- settle(env.jointLedgerMock.startBlockNums.get.contains(BlockNumber(2)))
+          starts <- lift(IO(env.jointLedgerMock.startBlockNums.get))
+          evs <- lift(IO(events(seen)))
+          _ <- assertWith(
+            starts.contains(BlockNumber(2)),
+            s"a past-due target must fire at once, but StartBlocks were $starts"
+          )
+          _ <- assertWith(
+            evs.contains(BlockWeaverEvent.NonPositiveWakeupDelay(BlockNumber(2))),
+            s"expected the non-positive-delay path to be taken; events were $evs"
+          )
+      } yield true
+    )
+
+    // ===================================
+    // S1 -- the guard. This is the property `e6ca939e` added, and the reason cancellation is safe
+    // to have back: a cancel that loses its race delivers a superseded Wakeup, and the guard is
+    // what refuses it.
+    // ===================================
+    val _ = property("a Wakeup for any other block is ignored; the current one is honoured") = run(
+      resource = defaultResource,
+      testM = for {
+          env <- ask
+          made <- mkBlockWeaverActorWithEvents(Carol.headPeerNumber)
+          weaver = made._1
+          seen = made._2
+          config = env.multiNodeConfig.nodeConfigs(Carol.headPeerNumber)
+          brief1 <- mkDummyBlockBrief1(config.headConfig)
+          _ <- lift((weaver ! brief1) >> env.system.waitForIdle())
+          _ <- settle(env.jointLedgerMock.startBlockNums.get == Vector(BlockNumber(1)))
+          confirmed <- mkConfirmedWithWakeups(
+            BlockNumber(1),
+            config.headConfig,
+            forcedMajorIn = NeverInThisTest,
+            depositWakeupIn = None
+          )
+          _ <- lift((weaver ! confirmed) >> env.system.waitForIdle())
+          // Stale (a wakeup armed for an already-superseded block) and future (impossible today,
+          // but the handler distinguishes them and the distinction is worth pinning).
+          _ <- lift((weaver ! BlockWeaver.Wakeup(BlockNumber(1))) >> env.system.waitForIdle())
+          _ <- lift((weaver ! BlockWeaver.Wakeup(BlockNumber(9))) >> env.system.waitForIdle())
+          startsAfterBogus <- lift(IO(env.jointLedgerMock.startBlockNums.get))
+          _ <- assertWith(
+            startsAfterBogus == Vector(BlockNumber(1)),
+            s"a Wakeup for another block must not complete anything, but StartBlocks were $startsAfterBogus"
+          )
+          evs <- lift(IO(events(seen)))
+          _ <- assertWith(
+            evs.contains(
+              BlockWeaverEvent.WakeupIgnored(BlockNumber(1), BlockNumber(2), isFuture = false)
+            ) && evs.contains(
+              BlockWeaverEvent.WakeupIgnored(BlockNumber(9), BlockNumber(2), isFuture = true)
+            ),
+            s"expected both wakeups ignored, with past/future distinguished; events were $evs"
+          )
+          // ...and the same message for the CURRENT block does complete it, so the assertion above
+          // is about the block number and not about wakeups being inert in this state.
+          _ <- lift((weaver ! BlockWeaver.Wakeup(BlockNumber(2))) >> env.system.waitForIdle())
+          _ <- settle(env.jointLedgerMock.startBlockNums.get.contains(BlockNumber(2)))
+          finalStarts <- lift(IO(env.jointLedgerMock.startBlockNums.get))
+          _ <- assertWith(
+            finalStarts == Vector(BlockNumber(1), BlockNumber(2)),
+            s"the current block's Wakeup must complete block 2, but StartBlocks were $finalStarts"
+          )
+      } yield true
+    )
+
+    // ===================================
+    // R3 -- ⛔ the discriminator for cancellation, and the reason this suite exists.
+    //
+    // Arm a wakeup due in ~2s, then complete its block with a request well before it is due. WITH
+    // cancellation the fiber is collected at completion and its Wakeup never arrives. WITHOUT it
+    // the fiber sleeps out its term and delivers, and the guard quietly absorbs the message --
+    // exactly the old behaviour, and invisible unless you go looking for the absorbed message. So
+    // "zero ignored and zero dropped" is what separates a cancellation that works from a guard
+    // covering for one that does not.
+    //
+    // ⚠️ This test is why the cancellation is at block completion and not only cancel-on-replace.
+    // Written against cancel-on-replace alone it FAILED with `WakeupDropped(2)`: leadership
+    // rotates, so after completing block 2 this peer became a FOLLOWER for block 3 and never armed
+    // another wakeup, leaving the old fiber to sleep out its term. Bounded to one stale fiber, but
+    // one sleeping for hours per role change is still wrong.
+    //
+    // It fails loudly in the other direction too: if cancellation ever ate a LIVE wakeup, the
+    // forced-major and deposit properties above would stop completing their blocks.
+    // ===================================
+    val _ = property("a superseded wakeup fiber is cancelled, not merely ignored on arrival") = run(
+      resource = defaultResource,
+      testM = for {
+          env <- ask
+          anyRequest <- pick(genUserRequest)
+          made <- mkBlockWeaverActorWithEvents(Carol.headPeerNumber)
+          weaver = made._1
+          seen = made._2
+          config = env.multiNodeConfig.nodeConfigs(Carol.headPeerNumber)
+          brief1 <- mkDummyBlockBrief1(config.headConfig)
+          _ <- lift((weaver ! brief1) >> env.system.waitForIdle())
+          _ <- settle(env.jointLedgerMock.startBlockNums.get == Vector(BlockNumber(1)))
+          // Arms a wakeup for block 2, due in ~2s.
+          confirmed1 <- mkConfirmedWithWakeups(
+            BlockNumber(1),
+            config.headConfig,
+            forcedMajorIn = 2.seconds,
+            depositWakeupIn = None
+          )
+          _ <- lift((weaver ! confirmed1) >> env.system.waitForIdle())
+          // Supersede it well before it is due: the request completes block 2, which is where the
+          // wakeup armed for block 2 stops being wanted.
+          _ <- lift((weaver ! anyRequest) >> env.system.waitForIdle())
+          _ <- settle(env.jointLedgerMock.startBlockNums.get.contains(BlockNumber(2)))
+          // Sleep past when the cancelled fiber would have fired.
+          _ <- lift(IO.sleep(4.seconds))
+          evs <- lift(IO(events(seen)))
+          stragglers = evs.collect {
+              case e: BlockWeaverEvent.WakeupIgnored => e
+              case e: BlockWeaverEvent.WakeupDropped => e
+          }
+          _ <- assertWith(
+            stragglers.isEmpty,
+            "the superseded wakeup fiber was not cancelled -- it slept out its term and delivered, " +
+                s"and only the block-number guard hid it: $stragglers. Full trace: $evs"
+          )
+          starts <- lift(IO(env.jointLedgerMock.startBlockNums.get))
+          _ <- assertWith(
+            starts == Vector(BlockNumber(1), BlockNumber(2)),
+            s"nothing should start block 3 here; StartBlocks were $starts"
+          )
+      } yield true
+    )
+}

--- a/src/test/scala/hydrozoa/multisig/consensus/FiberLifecycleTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/FiberLifecycleTest.scala
@@ -1,0 +1,69 @@
+package hydrozoa.multisig.consensus
+
+import cats.effect.unsafe.implicits.global
+import cats.effect.{Deferred, FiberIO, IO, Ref}
+import java.nio.file.{Files, Path}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import scala.concurrent.duration.*
+import scala.jdk.CollectionConverters.*
+
+/** Guards a fiber-lifecycle bug class this codebase keeps reproducing: a long-running fiber stored
+  * with `Ref.set`, which drops whatever the slot already held WITHOUT cancelling it. The orphan
+  * outlives its purpose — in the `PeerLiaison*` actors it is a `foreverM` that resends for the life
+  * of the process.
+  *
+  * Cancel-on-replace has to be local to the store site. It cannot rest on the actor's own teardown:
+  * cats-actors runs `preRestart` (which calls `postStop`) on a restart, but `faultRecreate` SKIPS
+  * `preRestart` entirely when the actor is `FailedFatally`, so that ordering is not guaranteed.
+  *
+  * The first test pins the behaviour the fix depends on, with a control that fails without it. The
+  * second is a source guard: this bug is cheap to reintroduce and nearly invisible in review, so
+  * the codebase itself is what is worth asserting on.
+  */
+class FiberLifecycleTest extends AnyFunSuite with Matchers:
+
+    test("Ref.set orphans a previously stored fiber; getAndSet + cancel does not"):
+        // `survived` can only be observed if the FIRST fiber outlives replacement -- i.e. only if
+        // the buggy pattern leaked it. Without this control the test would assert nothing.
+        def scenario(cancelPrevious: Boolean): IO[Boolean] = for {
+            slot <- Ref.of[IO, Option[FiberIO[Unit]]](None)
+            ticked <- Deferred[IO, Unit]
+            first <- (IO.sleep(100.millis) >> ticked.complete(()).attempt.void).foreverM.void.start
+            _ <- slot.set(Some(first))
+            second <- IO.never[Unit].start
+            _ <-
+                if cancelPrevious then
+                    slot.getAndSet(Some(second)).flatMap(_.fold(IO.unit)(_.cancel))
+                else slot.set(Some(second))
+            _ <- ticked.tryGet // drain any pre-replacement tick
+            survived <- IO.sleep(400.millis) >> ticked.tryGet.map(_.isDefined)
+            _ <- second.cancel >> first.cancel
+        } yield survived
+
+        val buggy = scenario(cancelPrevious = false).unsafeRunSync()
+        val fixed = scenario(cancelPrevious = true).unsafeRunSync()
+        withClue("control: `set` must leave the old fiber running, else this test proves nothing"):
+            val _ = buggy shouldBe true
+        withClue("fix: replacing via getAndSet must cancel the previous fiber"):
+            fixed shouldBe false
+
+    test("no long-running fiber is stored with Ref.set outside teardown"):
+        // `<something>Fiber.set(Some(...))` is the exact shape of the bug. Teardown paths use
+        // `getAndSet(None)`, which this deliberately does not match.
+        val root = Path.of("src", "main", "scala")
+        val offenders = Files
+            .walk(root)
+            .iterator
+            .asScala
+            .filter(p => p.toString.endsWith(".scala"))
+            .flatMap { p =>
+                Files
+                    .readAllLines(p)
+                    .asScala
+                    .filter(l => l.matches(""".*[Ff]iber\.set\(Some.*"""))
+                    .map(l => s"$p: ${l.trim}")
+            }
+            .toList
+        withClue(s"stored without cancelling the previous fiber: ${offenders.mkString("; ")}"):
+            offenders shouldBe empty

--- a/src/test/scala/hydrozoa/multisig/consensus/limiter/LimiterSpacingTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/limiter/LimiterSpacingTest.scala
@@ -1,0 +1,337 @@
+package hydrozoa.multisig.consensus.limiter
+
+import cats.effect.unsafe.implicits.global
+import cats.effect.{IO, Ref}
+import cats.implicits.*
+import com.suprnation.actor.Actor.{Actor, Receive}
+import com.suprnation.actor.ActorRef.ActorRef
+import com.suprnation.actor.ActorSystem
+import hydrozoa.config.node.operation.multisig.RateLimits
+import hydrozoa.lib.logging.ContraTracer
+import io.circe.parser.decode
+import java.time.Instant
+import org.scalatest.funsuite.AnyFunSuite
+import scala.concurrent.duration.{DurationInt, DurationLong, FiniteDuration}
+
+/** Every message on the test lane carries the SAME, ancient timestamp.
+  *
+  * That is the production defect in its strongest form. The block lane's `limiterTimestamp` is a
+  * block's end time, quantized to a one-second Cardano slot, so every block produced inside one
+  * second really did share a single gate — and the old limiter, which computed its gate as
+  * `limiterTimestamp + minPeriod`, let all but the first through with no hold at all. Fixing that
+  * timestamp to `EPOCH` here means the gate can only come from the limiter's memory of its own last
+  * release. A limiter that consults the message cannot pass these tests.
+  */
+private sealed trait LaneMsg extends LimiterTimestamp:
+    def id: Int
+    override def limiterTimestamp: Instant = Instant.EPOCH
+    override def minPeriod(using cfg: RateLimits.Section): FiniteDuration = cfg.softBlockMinPeriod
+
+private final case class Paced(id: Int) extends LaneMsg
+
+private final case class Exempt(id: Int) extends LaneMsg:
+    override def limiterExempt: Boolean = true
+
+/** Records what reached the downstream, and when, on the same monotonic clock the limiter uses. */
+private final case class Recorder(seen: Ref[IO, Vector[(Int, Long)]]) extends Actor[IO, LaneMsg]:
+    override def receive: Receive[IO, LaneMsg] = PartialFunction.fromFunction { m =>
+        IO.monotonic.map(_.toMillis).flatMap(t => seen.update(_ :+ (m.id -> t)))
+    }
+
+/** The block lane's 100 ms period was inert in production: the head produced 30 blocks/s against a
+  * 10 Hz config, and at low load exactly 1.00 requests per block — one block per request, which is
+  * the degenerate case the shaper exists to prevent.
+  *
+  * Two defects caused it, and gating on the limiter's own last release fixes both at once. These
+  * tests pin the fixed behaviour, and each rate assertion is paired with a control that must NOT
+  * space, so a suite that silently stopped measuring anything would fail rather than pass.
+  */
+class LimiterSpacingTest extends AnyFunSuite:
+
+    private val PeriodMs = 200L
+
+    private def limits(
+        softBlockMinPeriod: FiniteDuration = PeriodMs.millis,
+        hardStackMinPeriod: FiniteDuration = 30.seconds
+    ): RateLimits =
+        RateLimits.default.copy(
+          softBlockMinPeriod = softBlockMinPeriod,
+          hardStackMinPeriod = hardStackMinPeriod
+        )
+
+    // ---- the spacing gate ---------------------------------------------------------------------
+
+    test("messages sharing one timestamp are still released a full period apart") {
+        val seen = runLane(limits(), gate = None, settle = 1500.millis) { lim =>
+            (0 until 5).toList.traverse_(i => (lim ! Paced(i)) >> IO.sleep(10.millis))
+        }
+        val _ = assert(seen.size == 5, s"expected all 5 messages through, got ${seen.size}: $seen")
+        assertSpacing(seen, atLeastMs = (PeriodMs * 0.8).toLong)
+        assertOrdered(seen)
+    }
+
+    // Control for the test above. Same injection, same assertions machinery, but a period short
+    // enough that spacing cannot show up -- so if the limiter ever stopped holding anything, the
+    // test above would fail while this one still passes. Without this pair, "gaps are >= 160ms"
+    // could be satisfied by a limiter that simply delivered slowly for some unrelated reason.
+    test("control: with a negligible period the same injection is NOT spaced") {
+        val seen = runLane(limits(softBlockMinPeriod = 1.milli), gate = None, settle = 500.millis) {
+            lim => (0 until 5).toList.traverse_(i => (lim ! Paced(i)) >> IO.sleep(10.millis))
+        }
+        val _ = assert(seen.size == 5, s"expected all 5 through, got $seen")
+        val span = seen.last._2 - seen.head._2
+        assert(span < 150L, s"expected no spacing with a 1ms period, but the span was ${span}ms")
+    }
+
+    // ⛔ The regression that matters most for the shared implementation. The stack lane uses the
+    // same Limiter class with NO gate, and nothing ever sends it a drain signal. If the gate's
+    // counting were unconditional rather than opt-in, its residual would climb forever and stretch
+    // hardStackMinPeriod without bound -- silently, and only in integration. Here the period must
+    // stay put across many releases with no drain signal ever sent.
+    test("a lane with no gate holds its exact period and never stretches") {
+        val seen = runLane(limits(), gate = None, settle = 2500.millis) { lim =>
+            (0 until 8).toList.traverse_(i => lim ! Paced(i))
+        }
+        val _ = assert(seen.size == 8, s"expected 8 through, got ${seen.size}")
+        assertSpacing(seen, atLeastMs = (PeriodMs * 0.8).toLong)
+        assertNoStretch(seen, atMostMs = (PeriodMs * 1.6).toLong)
+    }
+
+    test("a gated lane does not stretch either until a drain signal arrives") {
+        val gate = Some(tightGate)
+        val seen = runLane(limits(), gate = gate, settle = 2500.millis) { lim =>
+            (0 until 8).toList.traverse_(i => lim ! Paced(i))
+        }
+        val _ = assert(seen.size == 8, s"expected 8 through, got ${seen.size}")
+        // The multiplier is re-derived only on a drain signal, so with none sent it stays 1.0 even
+        // though the backlog is well past this gate's hard limit. That constancy between signals is
+        // what stops the controller sawtoothing at the downstream cadence.
+        assertNoStretch(seen, atMostMs = (PeriodMs * 1.6).toLong)
+    }
+
+    // ---- the backlog gate ---------------------------------------------------------------------
+
+    test("a drain signal carrying a large backlog stretches the period") {
+        val seen = runLane(limits(), gate = Some(tightGate), settle = 3000.millis) { lim =>
+            for {
+                // Three releases with this gate's hard limit at 3 puts the filtered residual at the
+                // bottom of the ramp, so the multiplier lands on the floor.
+                _ <- (0 until 3).toList.traverse_(i =>
+                    (lim ! Paced(i)) >> IO.sleep(PeriodMs.millis)
+                )
+                _ <- lim ! LimiterControl.DownstreamDrained
+                _ <- lim ! Paced(100)
+                _ <- lim ! Paced(101)
+            } yield ()
+        }
+        val tail = seen.filter(_._1 >= 100)
+        val _ = assert(tail.size == 2, s"expected both post-drain messages, got $seen")
+        val gap = tail(1)._2 - tail(0)._2
+        // floor 0.25 => the period is stretched 4x.
+        val expected = (PeriodMs * 4 * 0.8).toLong
+        assert(
+          gap >= expected,
+          s"expected the gate to stretch the period to >=${expected}ms, got ${gap}ms"
+        )
+    }
+
+    // ---- exemption ----------------------------------------------------------------------------
+
+    test("an exempt message passes straight through and does not restart the spacing clock") {
+        val seen =
+            runLane(limits(softBlockMinPeriod = 500.millis), gate = None, settle = 2.seconds) {
+                lim => (lim ! Paced(0)) >> (lim ! Exempt(1)) >> (lim ! Paced(2))
+            }
+        val at = seen.toMap
+        val _ = assert(at.keySet == Set(0, 1, 2), s"expected all three through, got $seen")
+        val _ = assert(
+          at(1) - at(0) < 100L,
+          s"the exempt message was held for ${at(1) - at(0)}ms; it must not be paced"
+        )
+        // If the exempt release had reset `lastReleaseMs`, this gap would be measured from the
+        // exempt message instead and the schedule would drift by one message every time.
+        assert(
+          at(2) - at(0) >= 400L,
+          s"expected the paced message to stay 500ms behind its predecessor, got ${at(2) - at(0)}ms"
+        )
+    }
+
+    // ---- failing loudly ------------------------------------------------------------------------
+
+    // ⛔ Do not make the limiter "fail open" by overriding `preRestart` to forward whatever it is
+    // holding. `MultisigRegimeManagerBase` maps every supervisor directive to `Escalate` ("normally
+    // `Restart` but our actors can't do that yet"), so this actor never restarts and such an
+    // override is unreachable — it would claim a safety property the system does not have.
+    //
+    // What protects the lane is the property below: a failure must NOT be absorbed. The lane is
+    // self-clocked, so a limiter that swallowed an exception and carried on with a message stuck in
+    // its queue would leave upstream waiting forever for a release that is never coming — a wedge
+    // with nothing in the log. Escalating turns that into a loud crash that systemd restarts and
+    // that recovers from persistence. If someone ever wraps this actor's body in `.attempt`, this
+    // test is what should fail.
+    test("a failure inside the limiter is escalated, not swallowed and carried on from") {
+        val period = 500.millis
+        val seen = ActorSystem[IO]("limiter-failure")
+            .use(system =>
+                for {
+                    got <- Ref.of[IO, Vector[(Int, Long)]](Vector.empty)
+                    sink <- system.actorOf(Recorder(got))
+                    lim <- system.actorOf(
+                      Limiter[LaneMsg](sink, limits(softBlockMinPeriod = period), throwOnHold)
+                    )
+                    _ <- lim ! Paced(0) // released immediately; nothing is held yet
+                    _ <- lim ! Paced(1) // held -> the injected failure fires
+                    _ <- IO.sleep(300.millis)
+                    _ <- (lim ! Paced(2)).attempt // must not be served by a limiter that carried on
+                    _ <- IO.sleep(1500.millis)
+                    r <- got.get
+                } yield r
+            )
+            .attempt
+            .unsafeRunSync()
+            .getOrElse(Vector.empty)
+        val delivered = seen.map(_._1).toSet
+        val _ = assert(
+          delivered.contains(0),
+          s"the pre-failure message should have been delivered: $seen"
+        )
+        assert(
+          !delivered.contains(2),
+          s"the limiter kept serving the lane after failing; the failure was swallowed: $seen"
+        )
+    }
+
+    // ---- the gate's arithmetic (no actor system) ----------------------------------------------
+
+    private val curve = LimiterGate(
+      backlogSoftLimit = 0,
+      backlogHardLimit = 1000,
+      floor = 0.01,
+      smoothing = 0.5,
+      slice = 150.millis
+    )
+
+    test(
+      "the multiplier is 1 at or below the soft limit and the floor at or above the hard limit"
+    ) {
+        val _ = assert(curve.multiplier(0.0) === 1.0)
+        val _ = assert(curve.multiplier(-5.0) === 1.0)
+        val _ = assert(curve.multiplier(1000.0) === curve.floor)
+        assert(curve.multiplier(5000.0) === curve.floor)
+    }
+
+    test("the multiplier decreases monotonically across the ramp") {
+        val ms = (0 to 1000 by 50).map(b => curve.multiplier(b.toDouble))
+        assert(
+          ms.sliding(2).forall(w => w(0) >= w(1)),
+          s"multiplier is not monotonically decreasing: $ms"
+        )
+    }
+
+    // The design decision this pins: gain belongs where the backlog is dangerous, not where the
+    // system is fine. The loop's dead time is a whole stack cycle plus confirmation latency, and
+    // high gain across a long dead time is how a controller ends up in a limit cycle. The obvious
+    // alternative curve, h^2, has exactly the opposite curvature and would fail this test.
+    test("the ramp is flat where healthy and steepens as headroom runs out") {
+        val early = curve.multiplier(250.0) - curve.multiplier(500.0)
+        val late = curve.multiplier(500.0) - curve.multiplier(750.0)
+        assert(late > early, s"expected the ramp to steepen; early drop $early, late drop $late")
+    }
+
+    test("a drain signal folds the cycle's count into the filter and resets the live count") {
+        import LimiterGate.observeDrain
+        val one = curve.observeDrain(LimiterGate.Open.copy(released = 100L))
+        val _ = assert(
+          one.residual === 50.0,
+          s"expected a half-weighted first sample, got ${one.residual}"
+        )
+        val _ = assert(one.released == 0L, "the live count must reset on a drain signal")
+        val _ = assert(one.drains == 1L)
+        val two = curve.observeDrain(one.copy(released = 100L))
+        assert(two.residual === 75.0, s"expected the filter to converge, got ${two.residual}")
+    }
+
+    // ---- config ------------------------------------------------------------------------------
+
+    // A node whose config fails to decode does not start at all, and every private.json already
+    // deployed predates the gate fields. This is what makes the deploy a binary swap with no
+    // config edit.
+    test("a rateLimits block written before the gate existed still decodes, with gate defaults") {
+        val legacy = """{"softBlockMinPeriod":100,"hardStackMinPeriod":30000}"""
+        decode[RateLimits](legacy) match {
+            case Left(e) => fail(s"a pre-gate rateLimits block must still decode: $e")
+            case Right(r) =>
+                val _ = assert(r.softBlockMinPeriod == 100.millis)
+                val _ = assert(r.hardStackMinPeriod == 30.seconds)
+                val _ = assert(r.blockBacklogSoftLimit == RateLimits.defaultBlockBacklogSoftLimit)
+                val _ = assert(r.blockBacklogHardLimit == RateLimits.defaultBlockBacklogHardLimit)
+                assert(r.blockGateFloor == RateLimits.defaultBlockGateFloor)
+        }
+    }
+
+    // ---- harness -----------------------------------------------------------------------------
+
+    /** Fails the limiter from inside a hold, and only from there, so the crash lands at the one
+      * moment it is holding a message. `preRestart`'s own trace is deliberately `attempt`ed in the
+      * limiter, so a tracer this hostile still cannot stop the flush.
+      */
+    private def throwOnHold: ContraTracer[IO, LimiterEvent] =
+        ContraTracer[IO, LimiterEvent] {
+            case _: LimiterEvent.HoldingMsg =>
+                IO.raiseError(new RuntimeException("injected failure inside the hold"))
+            case _ => IO.unit
+        }
+
+    /** A gate small enough to reach its floor after a handful of releases, so the dynamics are
+      * testable in seconds rather than in a 30-second stack cycle. `smoothing = 1.0` takes the
+      * newest cycle unfiltered, which makes the arithmetic exact.
+      */
+    private def tightGate: LimiterGate = LimiterGate(
+      backlogSoftLimit = 1,
+      backlogHardLimit = 3,
+      floor = 0.25,
+      smoothing = 1.0,
+      slice = 50.millis
+    )
+
+    private def runLane(
+        rateLimits: RateLimits,
+        gate: Option[LimiterGate],
+        settle: FiniteDuration
+    )(send: ActorRef[IO, LaneMsg | LimiterControl] => IO[Unit]): Vector[(Int, Long)] =
+        ActorSystem[IO]("limiter-test")
+            .use(system =>
+                for {
+                    seen <- Ref.of[IO, Vector[(Int, Long)]](Vector.empty)
+                    sink <- system.actorOf(Recorder(seen))
+                    lim <- system.actorOf(
+                      Limiter[LaneMsg](
+                        sink,
+                        rateLimits,
+                        ContraTracer.nullTracer[IO, LimiterEvent],
+                        gate
+                      )
+                    )
+                    _ <- send(lim)
+                    _ <- IO.sleep(settle)
+                    r <- seen.get
+                } yield r
+            )
+            .unsafeRunSync()
+
+    private def assertSpacing(seen: Vector[(Int, Long)], atLeastMs: Long): Unit =
+        val gaps = seen.map(_._2).sliding(2).map(w => w(1) - w(0)).toList
+        val _ = assert(
+          gaps.forall(_ >= atLeastMs),
+          s"expected every gap >= ${atLeastMs}ms, got $gaps"
+        )
+
+    private def assertNoStretch(seen: Vector[(Int, Long)], atMostMs: Long): Unit =
+        val gaps = seen.map(_._2).sliding(2).map(w => w(1) - w(0)).toList
+        val _ = assert(
+          gaps.forall(_ <= atMostMs),
+          s"a gap exceeded ${atMostMs}ms, so the period is stretching: $gaps"
+        )
+
+    private def assertOrdered(seen: Vector[(Int, Long)]): Unit =
+        val _ = assert(seen.map(_._1) == seen.map(_._1).sorted, s"messages were reordered: $seen")

--- a/src/test/scala/hydrozoa/multisig/metrics/PrometheusFormatTest.scala
+++ b/src/test/scala/hydrozoa/multisig/metrics/PrometheusFormatTest.scala
@@ -66,6 +66,13 @@ class PrometheusFormatTest extends AnyFunSuite:
         heapCommittedBytes = 536870912,
         // -1 is the "platform does not report this" sentinel, and it must survive rendering.
         openFileDescriptors = -1
+      ),
+      blockGate = BlockGateStats(
+        multiplier = 0.25,
+        backlog = 917,
+        residual = 903.5,
+        holds = 288347,
+        drains = 313
       )
     )
 
@@ -125,3 +132,17 @@ class PrometheusFormatTest extends AnyFunSuite:
         val _ = assert(out.contains("hydrozoa_timers_executed_total 98765"))
         val _ = assert(out.contains("# TYPE hydrozoa_timers_executed_total counter"))
         assert(out.contains("hydrozoa_open_file_descriptors -1"))
+
+    // The gate is what tells an operator whether the shaper is live and whether it is binding, and
+    // the node runs at WARN so the limiter's own traces are invisible. If these stop being rendered
+    // the deploy becomes unverifiable from outside the process.
+    test("the block-rate gate is rendered, with the multiplier as a plain decimal"):
+        val out = PrometheusFormat.render(sample)
+        assert(
+          out.contains("# TYPE hydrozoa_block_gate_multiplier gauge") &&
+              out.contains("hydrozoa_block_gate_multiplier 0.25") &&
+              out.contains("hydrozoa_block_gate_backlog 917") &&
+              out.contains("# TYPE hydrozoa_block_gate_drains_total counter") &&
+              out.contains("hydrozoa_block_gate_drains_total 313"),
+          out
+        )

--- a/src/test/scala/hydrozoa/multisig/metrics/PrometheusFormatTest.scala
+++ b/src/test/scala/hydrozoa/multisig/metrics/PrometheusFormatTest.scala
@@ -51,6 +51,21 @@ class PrometheusFormatTest extends AnyFunSuite:
         secondsInPhase = 42,
         partitionsDone = 17,
         partitionsTotal = 300
+      ),
+      runtime = RuntimeStats(
+        fibersSuspended = 27428,
+        fibersQueuedLocal = 5654,
+        workerThreads = 4,
+        workersActive = 2,
+        workersSearching = 1,
+        workersBlocked = 0,
+        timersOutstanding = 12,
+        timersExecuted = 98765,
+        liveThreads = 36,
+        heapUsedBytes = 241172480,
+        heapCommittedBytes = 536870912,
+        // -1 is the "platform does not report this" sentinel, and it must survive rendering.
+        openFileDescriptors = -1
       )
     )
 
@@ -102,3 +117,11 @@ class PrometheusFormatTest extends AnyFunSuite:
               !out.contains("E-"), // no scientific notation
           out
         )
+
+    test("the runtime gauges render, including the -1 unavailable sentinel"):
+        val out = PrometheusFormat.render(sample)
+        val _ = assert(out.contains("hydrozoa_fibers_suspended 27428"))
+        val _ = assert(out.contains("hydrozoa_workers_searching 1"))
+        val _ = assert(out.contains("hydrozoa_timers_executed_total 98765"))
+        val _ = assert(out.contains("# TYPE hydrozoa_timers_executed_total counter"))
+        assert(out.contains("hydrozoa_open_file_descriptors -1"))

--- a/src/test/scala/hydrozoa/multisig/server/HeadBlocksEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/HeadBlocksEndpointsTest.scala
@@ -191,23 +191,27 @@ class HeadBlocksEndpointsTest extends AnyFunSuite:
             body <- resp.as[Json]
         } yield (resp.status, body)
 
-    test("GET /head/blocks lists block 0 plus the spine briefs, leaders round-robin") {
+    test("GET /head/blocks is not mounted — it listed the whole spine with no paging") {
+        // Same defect as GET /head/requests: every block brief into one heap List, no limit and no
+        // offset at all. Keyed lookups are unaffected, which is what the second assertion pins.
         mkMinorBrief1
             .flatMap(brief =>
                 IO(withRoutes(stubReader(brief, soft = false, hard = false)) { app =>
-                    get(app, "/head/blocks").map { (status, body) =>
-                        val _ = assert(status == Status.Ok)
-                        val rows = body.asArray.get
-                        val _ = assert(rows.size == 2)
-                        val row0 = rows(0).hcursor
-                        val _ = assert(row0.get[Int]("number") == Right(0))
-                        val _ = assert(row0.get[String]("blockType") == Right("initial"))
-                        val _ = assert(row0.downField("leader").focus.forall(_.isNull))
-                        val row1 = rows(1).hcursor
-                        val _ = assert(row1.get[Int]("number") == Right(1))
-                        val _ = assert(row1.get[String]("blockType") == Right("minor"))
+                    for {
+                        listing <- app.run(
+                          Request[IO](Method.GET, Uri.unsafeFromString("/head/blocks"))
+                        )
+                        byNum <- app.run(
+                          Request[IO](Method.GET, Uri.unsafeFromString("/head/blocks/1"))
+                        )
+                    } yield {
                         val _ = assert(
-                          row1.get[Int]("leader") == Right(1 % headConfig.nHeadPeers.convert)
+                          listing.status == Status.NotFound,
+                          s"GET /head/blocks must not be mounted, got ${listing.status}"
+                        )
+                        val _ = assert(
+                          byNum.status == Status.Ok,
+                          s"GET /head/blocks/{n} must still serve, got ${byNum.status}"
                         )
                         ()
                     }

--- a/src/test/scala/hydrozoa/multisig/server/HeadBlocksEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/HeadBlocksEndpointsTest.scala
@@ -170,7 +170,7 @@ class HeadBlocksEndpointsTest extends AnyFunSuite:
                       }
                     )
                     routes <- HydrozoaRoutes(
-                      requestSequencerStub,
+                      Some(requestSequencerStub),
                       blockWeaverStub,
                       IO.pure(NodeStatus.Active),
                       reader,

--- a/src/test/scala/hydrozoa/multisig/server/HeadEffectsEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/HeadEffectsEndpointsTest.scala
@@ -169,7 +169,7 @@ class HeadEffectsEndpointsTest extends AnyFunSuite:
                                 _ => IO.pure(())
                         })
                         routes <- HydrozoaRoutes(
-                          reqStub,
+                          Some(reqStub),
                           bwStub,
                           IO.pure(NodeStatus.Active),
                           stubReader(brief),

--- a/src/test/scala/hydrozoa/multisig/server/HeadRequestsEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/HeadRequestsEndpointsTest.scala
@@ -155,47 +155,33 @@ class HeadRequestsEndpointsTest extends AnyFunSuite:
             body <- resp.as[Json]
         } yield (resp.status, body)
 
-    test("GET /head/requests lists rows with the opaque i64 id, peer number, and type") {
-        val reader = stubReader(
-          Map(peer0 -> List(txRequest(peer0, 0), depositRequest(peer0, 1)))
-        )
-        withRoutes(reader) { app =>
-            get(app, "/head/requests").map { (status, body) =>
-                val _ = assert(status == Status.Ok)
-                val rows = body.asArray.get
-                val _ = assert(rows.size == 2)
-                val r0 = rows(0).hcursor
-                // peer 0, request 0 packs to i64 0.
-                val _ = assert(r0.get[Long]("requestId") == Right(0L))
-                val _ = assert(r0.get[Int]("peerNumber") == Right(0))
-                val _ = assert(r0.get[String]("requestType") == Right("transaction"))
-                val r1 = rows(1).hcursor
-                val _ = assert(r1.get[Long]("requestId") == Right(1L))
-                val _ = assert(r1.get[String]("requestType") == Right("deposit"))
-                ()
-            }
-        }
-    }
-
-    test("GET /head/requests?type= and ?peer_number= narrow the listing") {
-        val reader = stubReader(
-          Map(peer0 -> List(txRequest(peer0, 0), depositRequest(peer0, 1)))
-        )
-        withRoutes(reader) { app =>
+    test("GET /head/requests is not mounted — an unpaged full-CF scan is an OOM, not an API") {
+        // Keyed lookups stay mounted, so it is the second assertion that carries the test: a
+        // router that mounted nothing at all would pass the first one on its own.
+        withRoutes(stubReader(Map(peer0 -> List(txRequest(peer0, 0))))) { app =>
             for {
-                deposits <- get(app, "/head/requests?type=deposit")
-                thisPeer <- get(app, "/head/requests?peer_number=0")
-                otherPeer <- get(app, "/head/requests?peer_number=99")
-                unknownType <- get(app, "/head/requests?type=nonsense")
+                listing <- app.run(
+                  Request[IO](Method.GET, Uri.unsafeFromString("/head/requests"))
+                )
+                filtered <- app.run(
+                  Request[IO](Method.GET, Uri.unsafeFromString("/head/requests?type=deposit"))
+                )
+                byId <- app.run(Request[IO](Method.GET, Uri.unsafeFromString("/head/requests/0")))
             } yield {
-                val _ = assert(deposits._1 == Status.Ok)
-                val depRows = deposits._2.asArray.get
-                val _ = assert(depRows.size == 1)
-                val _ = assert(depRows(0).hcursor.get[String]("requestType") == Right("deposit"))
-                val _ = assert(thisPeer._2.asArray.get.size == 2)
-                // No such author peer -> empty, not an error.
-                val _ = assert(otherPeer._1 == Status.Ok && otherPeer._2.asArray.get.isEmpty)
-                val _ = assert(unknownType._2.asArray.get.isEmpty)
+                // 405 rather than 404 on a HEAD node: POST /head/requests is mounted, so the
+                // path exists and only the GET verb is gone.
+                val _ = assert(
+                  listing.status == Status.MethodNotAllowed,
+                  s"GET /head/requests must not be mounted, got ${listing.status}"
+                )
+                val _ = assert(
+                  filtered.status == Status.MethodNotAllowed,
+                  s"a filtered listing must not be mounted either, got ${filtered.status}"
+                )
+                val _ = assert(
+                  byId.status == Status.Ok,
+                  s"GET /head/requests/{id} must still serve, got ${byId.status}"
+                )
                 ()
             }
         }
@@ -386,11 +372,9 @@ class HeadRequestsEndpointsTest extends AnyFunSuite:
                 stats <- app.run(Request[IO](Method.GET, Uri.unsafeFromString("/head/stats")))
                 ready <- app.run(Request[IO](Method.GET, Uri.unsafeFromString("/ready")))
             } yield {
-                // 405, not 404: the coil still serves GET /head/requests (the listing), so the
-                // PATH exists and only the POST method is gone. That is the more accurate answer
-                // of the two, and asserting 404 here would be asserting the wrong behaviour.
+                // 404, not 405: a coil mounts neither verb, so the path does not exist there.
                 val _ = assert(
-                  submit.status == Status.MethodNotAllowed,
+                  submit.status == Status.NotFound,
                   s"POST /head/requests must not be mounted on a coil, got ${submit.status}"
                 )
                 // 404, not the 401 challenge a mounted admin route would give.

--- a/src/test/scala/hydrozoa/multisig/server/HeadRequestsEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/HeadRequestsEndpointsTest.scala
@@ -134,7 +134,7 @@ class HeadRequestsEndpointsTest extends AnyFunSuite:
                       }
                     )
                     routes <- HydrozoaRoutes(
-                      requestSequencerStub,
+                      Some(requestSequencerStub),
                       blockWeaverStub,
                       IO.pure(NodeStatus.Active),
                       reader,
@@ -336,6 +336,76 @@ class HeadRequestsEndpointsTest extends AnyFunSuite:
                 val _ = assert(missing._1 == Status.NotFound)
                 val _ = assert(malformed.status.code >= 400 && malformed.status.code < 500)
                 val _ = assert(outOfRange.status.code >= 400 && outOfRange.status.code < 500)
+                ()
+            }
+        }
+    }
+
+    /** Build the routes the way a **coil** peer gets them — `requestSequencer = None`, because a
+      * follower accepts no user requests — and run `check`.
+      */
+    private def withCoilRoutes(check: HttpApp[IO] => IO[Unit]): Unit =
+        ActorSystem[IO]("HeadRequestsEndpointsTest-coil")
+            .use { system =>
+                for {
+                    blockWeaverStub <- system.actorOf(
+                      new Actor[IO, BlockWeaver.Request] {
+                          override def receive: Receive[IO, BlockWeaver.Request] = _ => IO.pure(())
+                      }
+                    )
+                    routes <- HydrozoaRoutes(
+                      None,
+                      blockWeaverStub,
+                      IO.pure(NodeStatus.Active),
+                      stubReader(Map.empty),
+                      None,
+                      headConfig,
+                      HydrozoaServer.Config(adminUsername = "admin", adminPassword = "admin"),
+                      PeerMetrics.create(0L, Vector.empty),
+                      ContraTracer[IO, HydrozoaHttpEvent](_ => IO.unit)
+                    )
+                    _ <- check(routes.routes.orNotFound)
+                } yield ()
+            }
+            .unsafeRunSync()
+
+    test(
+      "on a coil peer (no request sequencer) the mutating routes are absent, reads still serve"
+    ) {
+        // The coil exists to be observable: its read surface must answer, or the whole point of
+        // giving it a server is lost. So this asserts both halves — the mutations are gone AND a
+        // read still works. Without the second assertion a totally unmounted router would pass.
+        withCoilRoutes { app =>
+            for {
+                submit <- app.run(
+                  Request[IO](Method.POST, Uri.unsafeFromString("/head/requests"))
+                )
+                finalize <- app.run(
+                  Request[IO](Method.POST, Uri.unsafeFromString("/api/admin/finalize"))
+                )
+                stats <- app.run(Request[IO](Method.GET, Uri.unsafeFromString("/head/stats")))
+                ready <- app.run(Request[IO](Method.GET, Uri.unsafeFromString("/ready")))
+            } yield {
+                // 405, not 404: the coil still serves GET /head/requests (the listing), so the
+                // PATH exists and only the POST method is gone. That is the more accurate answer
+                // of the two, and asserting 404 here would be asserting the wrong behaviour.
+                val _ = assert(
+                  submit.status == Status.MethodNotAllowed,
+                  s"POST /head/requests must not be mounted on a coil, got ${submit.status}"
+                )
+                // 404, not the 401 challenge a mounted admin route would give.
+                val _ = assert(
+                  finalize.status == Status.NotFound,
+                  s"POST /api/admin/finalize must not be mounted on a coil, got ${finalize.status}"
+                )
+                val _ = assert(
+                  stats.status == Status.Ok,
+                  s"GET /head/stats must serve on a coil, got ${stats.status}"
+                )
+                val _ = assert(
+                  ready.status == Status.Ok,
+                  s"GET /ready must serve on a coil, got ${ready.status}"
+                )
                 ()
             }
         }

--- a/src/test/scala/hydrozoa/multisig/server/L2QueryEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/L2QueryEndpointsTest.scala
@@ -89,7 +89,7 @@ class L2QueryEndpointsTest extends AnyFunSuite:
                       }
                     )
                     routes <- HydrozoaRoutes(
-                      requestSequencerStub,
+                      Some(requestSequencerStub),
                       blockWeaverStub,
                       IO.pure(NodeStatus.Active),
                       ConsensusStoreReader.empty,
@@ -123,7 +123,7 @@ class L2QueryEndpointsTest extends AnyFunSuite:
                       }
                     )
                     routes <- HydrozoaRoutes(
-                      requestSequencerStub,
+                      Some(requestSequencerStub),
                       blockWeaverStub,
                       IO.pure(NodeStatus.Active),
                       ConsensusStoreReader.empty,

--- a/src/test/scala/hydrozoa/multisig/server/OpenApiSchemaTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/OpenApiSchemaTest.scala
@@ -54,7 +54,7 @@ class OpenApiSchemaTest extends AnyFunSuite:
                       }
                     )
                     routes <- HydrozoaRoutes(
-                      requestSequencerStub,
+                      Some(requestSequencerStub),
                       blockWeaverStub,
                       IO.pure(NodeStatus.Active),
                       ConsensusStoreReader.empty,

--- a/src/test/scala/hydrozoa/multisig/server/ReadyEndpointTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/ReadyEndpointTest.scala
@@ -48,7 +48,7 @@ class ReadyEndpointTest extends AnyFunSuite:
                       }
                     )
                     routes <- HydrozoaRoutes(
-                      requestSequencerStub,
+                      Some(requestSequencerStub),
                       blockWeaverStub,
                       IO.pure(status),
                       ConsensusStoreReader.empty,


### PR DESCRIPTION
One branch that brings the whole stack to `main` in a single merge, built on the current tip so nothing needs rebasing afterwards.

## What it contains

```
origin/main (75d21098)
  + merge peter/rulebased-tick-fiber-idempotent   #682
  + merge peter/bytestring-hex-hygiene            #683  (carries #681's commit)
  + cherry-pick 0a26aa7e                          #698  serve the read-only HTTP surface on coil peers
  + cherry-pick 399df6c2                          #699  drop the two unpaged listing endpoints
  + cherry-pick 5ceba919                          #700  stop orphaning long-running fibers
  + cherry-pick f1eba724                          #703  whole-process resource gauges
  + cherry-pick 980f4b0a                          #704  block-rate spacing gate
```

**#702 is not in it at all** — not added and reverted, simply never picked. It was closed on its own merits: it reused a recovery-time invariant at runtime. `SlowConsensusActor` persists `Cf.HardConfirmation` before sending `Stack.HardConfirmed`, and the send is held for `hardStackMinPeriod`, so the marker leads the message; reconciliation read that lead as "the message was lost". `State.recover` reads the same marker when nothing can be in flight and cross-checks it against the peer's own hard-ack journal. Live reconciliation had neither property.

#682 and #683 are **merged**, not cherry-picked, so their head commits become ancestors of `main` and GitHub can mark them merged. Our five are cherry-picked because their PRs are already marked merged against their stack bases; only their content is needed here.

## Verification

- Clean compile of both roots (`clean; integration/clean; Test/compile; integration/Test/compile`) — **zero compiler diagnostics**, the criterion for `-Werror` under CI.
- Full unit suite: **573 passed, 0 failed, 0 errors**, 10 canceled (the Blockfrost tests, no API key) and 3 ignored.
- `reconcileHardConfirmedFromPersistence` and `HardConfirmationReconciled`: **0 occurrences** in the tree.

## Before merging

1. **Retarget #683's base to `main`** (it currently points at `peter/supervision-effectful-logfailure`). GitHub marks a PR merged when its head becomes reachable from *its own* base, so without this #683 stays open.
2. **Reopen #681 and retarget it to `main`** if you want it marked too — its commit `076463fe` is reachable here, but a closed PR never flips to merged.

## ⛔ Merge with "Create a merge commit"

Squash or rebase rewrites the SHAs, which would stop `ed9a6f43` (#682), `359f38a0` (#683) and `076463fe` (#681) from becoming ancestors of `main` — and none of them would be marked merged.