### PR TITLE
fix(test): wait out SLF4J initialization before asserting on the level gate

### DIFF
--- a/src/test/scala/hydrozoa/lib/logging/Slf4jTracerTest.scala
+++ b/src/test/scala/hydrozoa/lib/logging/Slf4jTracerTest.scala
@@ -5,6 +5,8 @@ import cats.effect.unsafe.implicits.global
 import cats.syntax.all.*
 import java.util.concurrent.atomic.AtomicInteger
 import org.scalatest.funsuite.AnyFunSuite
+import org.slf4j.LoggerFactory // scalafix:ok DisableSyntax
+import org.slf4j.helpers.SubstituteLoggerFactory // scalafix:ok DisableSyntax
 import scala.collection.mutable.ListBuffer
 
 /** The level gate: [[Slf4jTracer.sink]] forces a [[LogEvent]]'s deferred `render` — the message
@@ -13,7 +15,29 @@ import scala.collection.mutable.ListBuffer
   */
 class Slf4jTracerTest extends AnyFunSuite:
 
+    /** Block until SLF4J has finished installing the real backend.
+      *
+      * Until then `LoggerFactory` hands out substitute loggers, and a substitute reports **every**
+      * level as enabled for **every** name — so a gate decision taken in that window opens no
+      * matter what `logback-test.xml` says. Production never notices, because it reads the output
+      * and the substitute is swapped for the real logger before anything is written; these tests do
+      * notice, because they read the *decision* rather than the output.
+      *
+      * Without this the suite passes alone and fails under `parallelExecution` — another suite
+      * touching a logger first leaves this one measuring mid-initialization.
+      *
+      * `getILoggerFactory` initializes synchronously when nothing else has started; the loop covers
+      * the case where another thread is already doing it, since that call then returns the
+      * substitute factory rather than waiting.
+      */
+    private def awaitBackendReady(): Unit =
+        val deadlineNanos = System.nanoTime() + 5_000_000_000L
+        while LoggerFactory.getILoggerFactory.isInstanceOf[SubstituteLoggerFactory]
+            && System.nanoTime() < deadlineNanos
+        do Thread.sleep(1)
+
     test("a disabled level forces no rendering; an enabled level does") {
+        awaitBackendReady()
         val renders = new AtomicInteger(0)
         def event(routingKey: String): LogEvent =
             LogEvent(
@@ -34,6 +58,7 @@ class Slf4jTracerTest extends AnyFunSuite:
     }
 
     test("the gate wraps only the slf4j leg: a composed capture sink still fires") {
+        awaitBackendReady()
         val captured = ListBuffer.empty[Int]
         val capture: ContraTracer[IO, Int] = ContraTracer.emit(i => IO { val _ = captured += i })
 


### PR DESCRIPTION
`Slf4jTracerTest` passes alone and **fails under `parallelExecution`**. On `peter/logging-level-gate` as it stands:

```
$ sbt "core/testOnly *"
[info] - a disabled level forces no rendering; an enabled level does *** FAILED ***
[info]   1 did not equal 0 (Slf4jTracerTest.scala:33)
[info] Tests: succeeded 432, failed 1
```

`afterOff == 1` — the render was forced for the logger configured `level="off"`, which is the one thing the gate exists to prevent. CI has not caught it: the only run on #685 was cancelled at 8m21s.

## Cause

Until SLF4J finishes installing the backend, `LoggerFactory` hands out substitute loggers, and **a substitute reports every level as enabled for every name**. A gate decision taken in that window opens regardless of what `logback-test.xml` says.

Run alone, the suite initializes the backend itself and never sees the window. Run beside others, a different suite gets there first and leaves this one measuring mid-initialization.

Confirmed rather than inferred: adding a bare `LoggerFactory.getILoggerFactory` call to the test made it pass, because that call forces initialization synchronously. Bisected as well — no single package triggers it, and `set core/Test/parallelExecution := false` makes the same combination pass:

| run | result |
|---|---|
| `hydrozoa.lib.logging.*` alone | passes |
| `+ hydrozoa.multisig.*` (358 tests) | passes |
| `+ config` / `+ bootstrap` / `+ rulebased`, each alone | passes |
| all four together | **fails** |
| same four, `parallelExecution := false` | passes |

## Fix

A guard at the top of both tests:

```scala
private def awaitBackendReady(): Unit =
    val deadlineNanos = System.nanoTime() + 5_000_000_000L
    while LoggerFactory.getILoggerFactory.isInstanceOf[SubstituteLoggerFactory]
        && System.nanoTime() < deadlineNanos
    do Thread.sleep(1)
```

A bare `getILoggerFactory` is not enough on its own: it initializes synchronously only when nothing else has started, and returns the substitute factory rather than waiting if another thread is already doing it. Hence the loop. The 5s ceiling means a genuinely broken backend fails the test rather than hanging it.

## Two decisions worth your view

**It lives in the test, not in `Slf4jTracer`.** Production cannot observe this: it reads the *output*, and SLF4J swaps the substitute for the real logger before anything is written. Only a test that reads the *decision* can see it, so production should not carry a method only tests need. Say the word if you would rather it were a `private[logging]` helper on `Slf4jTracer` instead.

**It needs two `// scalafix:ok DisableSyntax` suppressions.** The `DisableSyntax.noDirectSlf4j` rule from #684 forbids `org.slf4j` outside `Slf4jTracer.scala`, so the natural fix for this test requires the same escape hatch the bridge lines use. `just lint-check` accepts them. Worth knowing that the rule bites here — if that is unwelcome, the `private[logging]` helper avoids it.

## Verification

- Full suite: **433 succeeded, 0 failed** (was 432 + 1 failed).
- The previously-failing combination, three consecutive runs: 72/0 each time.
- `just fmt`, `just lint-check` green.
