### PR TITLE
Review fixes for #686: defer ActionsDispatched, correct event docs

### DIFF
--- a/integration/src/test/scala/hydrozoa/integration/harness/RestartAfterBlocksTest.scala
+++ b/integration/src/test/scala/hydrozoa/integration/harness/RestartAfterBlocksTest.scala
@@ -36,19 +36,23 @@ import scala.concurrent.duration.*
   */
 class RestartAfterBlocksTest extends AnyFunSuite {
 
-    /** Every case here is `ignore`, not `test`, and must stay that way until finding #57 is fixed.
+    /** Every case here is `ignore`, not `test`, pending one timed run that confirms the suite
+      * finishes.
       *
-      * The scenario itself is sound and the fixes it guards are real — but it does not finish. A
-      * thread dump of a run that looked deadlocked showed 31 parked workers and one thread inside
-      * `TestControl.tickOne` -> `CardanoLiaison.runEffects` -> `State.prettyDump` -> `stripMargin`:
-      * progressing, microscopically. `runEffects` builds that whole debug dump **eagerly** as an
-      * argument to `traceWith`, formatting the entire effect index on every liaison tick whether or
-      * not the trace is emitted, so cost grows with accumulated effects. A restarted peer is the
-      * worst case, because `CardanoLiaison.State.recover` rebuilds the full index.
+      * The scenario is sound and the fixes it guards are real. What stalled it was cost, not a
+      * deadlock: a thread dump of a run that looked wedged showed 31 parked workers and one thread
+      * inside `TestControl.tickOne` -> `CardanoLiaison.runEffects` -> `State.prettyDump` ->
+      * `stripMargin`, progressing microscopically. The dump was built for every liaison tick
+      * whether or not the trace was emitted, so cost grew with accumulated effects, and a restarted
+      * peer is the worst case because `CardanoLiaison.State.recover` rebuilds the full index.
       *
-      * This module is run by `integration/testOnly *` in CI, and CI has wedged in this suite before
-      * — five times, for up to six hours each. Enabling these before the eager dump is fixed would
-      * reintroduce exactly that failure, so they stay disabled rather than merely slow.
+      * That cost is gone. The dump now rides on `CardanoLiaisonEvent.CurrentL1State`, which renders
+      * at TRACE inside the format, and this module pins `CardanoLiaison` at DEBUG
+      * (`integration/src/test/resources/logback-test.xml`), so it never runs.
+      *
+      * The reason to keep them disabled is now narrower: CI has wedged in this suite five times,
+      * for up to six hours each, and nothing has yet measured a full run with the dump gone. Time
+      * one locally, then flip these to `test` — do not flip them on the strength of the fix alone.
       */
 
     /** Virtual time the head runs before the restart, so the victim has real history to recover. */

--- a/src/main/scala/hydrozoa/multisig/consensus/CardanoLiaisonEvent.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/CardanoLiaisonEvent.scala
@@ -83,7 +83,7 @@ object CardanoLiaisonEvent:
     ) extends CardanoLiaisonEvent
 
     /** Whether the init tx is on L1, probed (step 4) when the target anchor is missing and no
-      * rule-based treasury exists. `isKnown == "not known"` triggers a full skeleton re-submission.
+      * rule-based treasury exists. `isKnown == false` triggers a full skeleton re-submission.
       */
     final case class InitTxStatus(hash: TransactionHash, isKnown: Boolean)
         extends CardanoLiaisonEvent

--- a/src/main/scala/hydrozoa/multisig/consensus/CardanoLiaisonEventFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/CardanoLiaisonEventFormat.scala
@@ -69,7 +69,7 @@ object CardanoLiaisonEventFormat:
             case RuleBasedTreasuryQueryError(err) =>
                 error(s"error when probing the rule-based treasury: $err")
             case ActionsDispatched(actions, hasFallback) =>
-                val text =
+                def text =
                     "Liaison's actions:" + actions.map(a => s"\n\t- ${actionMsg(a)}").mkString
                 if hasFallback then warn(text) else info(text)
             case FallbackToRuleBasedDispatched(txId) =>
@@ -88,7 +88,7 @@ object CardanoLiaisonEventFormat:
         import Action.*
         action match
             case FallbackToRuleBased(tx)         => s"FallbackToRuleBased (${tx.tx.id})"
-            case PushForwardMultisig(txs)        => s"PushForwardMultisig (${txs.map(_.tx.id)}"
-            case Rollout(txs)                    => s"Rollout (${txs.map(_.tx.id)}"
+            case PushForwardMultisig(txs)        => s"PushForwardMultisig (${txs.map(_.tx.id)})"
+            case Rollout(txs)                    => s"Rollout (${txs.map(_.tx.id)})"
             case sp @ SilencePeriodNoop(_, _, _) => s"$sp"
-            case InitializeHead(txs)             => s"InitializeHead (${txs.map(_.tx.id)}"
+            case InitializeHead(txs)             => s"InitializeHead (${txs.map(_.tx.id)})"

--- a/src/main/scala/hydrozoa/multisig/consensus/SlowConsensusActorEvent.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/SlowConsensusActorEvent.scala
@@ -11,7 +11,7 @@ sealed trait SlowConsensusActorEvent
 object SlowConsensusActorEvent:
 
     /** Stack handed off from StackComposer: own acks verified, cell created, own acks broadcast.
-      * `phase` is `"2-phase"` or `"sole"`.
+      * `twoPhase` distinguishes the two-phase handoff from the sole-peer one.
       */
     final case class StackHandedOff(stackNum: StackNumber, twoPhase: Boolean)
         extends SlowConsensusActorEvent

--- a/src/main/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonEvent.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonEvent.scala
@@ -9,6 +9,11 @@ import cats.Eval
   * One event type covers all three liaison kinds — they speak the same batch protocol, and the
   * per-liaison / per-remote identity comes from the wiring layer's `contramap` wrapper (e.g.
   * `HeadMultisigRegimeManagerEvent.PL`), not from separate event ADTs.
+  *
+  * [[BatchRequested]] and [[BatchReceived]] are the exception to "pure data": their `detail` is an
+  * `Eval`, which compares by reference, so those two variants have no value equality. Two of them
+  * with the same `batchNum` and identical detail text are unequal — do not assert on them by
+  * construction, and do not `distinct` or dedupe a collection of them.
   */
 sealed trait PeerLiaisonEvent
 


### PR DESCRIPTION
Addresses the six findings from the review of #686. Bases on `peter/logging-events-raw` so it can land into that PR before it merges.

## What each commit fixes

| # | File | Fix |
|---|---|---|
| 1 | `CardanoLiaisonEventFormat.scala:72` | `ActionsDispatched` built its message in a `val`, so it rendered when `humanFormat` ran rather than behind the by-name gate — the one converted event that stayed eager. `def` restores the deferral its own scaladoc claims. |
| 5 | `CardanoLiaisonEventFormat.scala:91-94` | Three unbalanced interpolations logged a dangling open paren: `PushForwardMultisig (List(abc…)`. Same for `Rollout` and `InitializeHead`. |
| 3 | `SlowConsensusActorEvent.scala:14` | Scaladoc described a `phase` String; the field is `twoPhase: Boolean`. |
| 4 | `CardanoLiaisonEvent.scala:86` | Scaladoc read `isKnown == "not known"`; the field is `Boolean`. |
| 6 | `PeerLiaisonEvent.scala` | `BatchRequested`/`BatchReceived` carry `Eval`, which compares by reference, so those two have no value equality — recorded against the ADT header's "pure data" claim. |
| 2 | `RestartAfterBlocksTest.scala:39` | The eager `State.prettyDump` the suite names as its blocker is gone: it now rides on `CurrentL1State`, renders at TRACE inside the format, and this module pins `CardanoLiaison` at DEBUG. Rationale narrowed to what is still unmeasured. |

Finding 1 is the substantive one — it is this PR's own thesis failing in a single spot.

## Verification

- `scalafmtCheckAll` clean over both source sets.
- `core/Test/compile` + `integration/Test/compile` green from a cold worktree (341 sources).
- 16 tests pass across `Slf4jTracerTest`, `ContraTracerDemo`, `PullerTest`, `SlowConsensusActorRecoveryTest`, `PeerLiaisonCoilRecoveryTest`.
- Forcing a recompile of all five touched files emits zero warnings, so `-Werror` has nothing to escalate.

## Open

1. **`peter/logging-events-raw` is stacked on a stale base.** `peter/logging-level-gate` has since been rebased onto `main` and is no longer an ancestor, so diffing the branch heads shows ~69 files against the real 21. It needs a rebase before merge; this branch will follow along.
2. **`RestartAfterBlocksTest` stays `ignore`d.** The blocker is fixed in code, but no one has yet timed a full run with the dump gone, and that suite has wedged CI five times at up to six hours each. Time one locally, then flip the two cases to `test`.