### PR TITLE
chore(release): 0.1.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -472,7 +472,7 @@ inThisBuild(
   List(
     // Release version — drives the Docker image tag, `hydrozoa.BuildInfo.version`, and `GET
     // /version`. Bump here for a release (see RELEASE.md), then tag `v<version>`.
-    version := "0.1.11",
+    version := "0.1.12",
     scalaVersion := "3.3.7",
     semanticdbEnabled := true,
     semanticdbVersion := scalafixSemanticdb.revision

--- a/docs/user-guide/DEPLOYMENT.md
+++ b/docs/user-guide/DEPLOYMENT.md
@@ -124,13 +124,13 @@ under it. Then load the CLI alias and check you are on the version you expect:
 source ./hydrozoa.sh   # sets the `hydrozoa` alias + HYDROZOA_HOME (this folder, an absolute path)
 
 hydrozoa version       # verify the image you are running
-#   hydrozoa 0.1.11
-#   git:   v0.1.11
+#   hydrozoa 0.1.12
+#   git:   v0.1.12
 #   built: 2026-07-28 14:00:37.834-0600
 ```
 
-(The `git:` line is `git describe` provenance; a published image built from the `v0.1.11` tag reads a
-clean `v0.1.11`. A locally built image between releases shows the distance from the newest tag, e.g.
+(The `git:` line is `git describe` provenance; a published image built from the `v0.1.12` tag reads a
+clean `v0.1.12`. A locally built image between releases shows the distance from the newest tag, e.g.
 `v0.1.0-10-gaa9d7c69`.)
 
 Need a version that isn't in the registry? Build it from this repo — see §3.
@@ -425,8 +425,8 @@ finalization) appears in the same section as the head progresses.
 build (§3) is already tagged `…:latest`, so it is picked up without either:
 
 ```bash
-HYDROZOA_VERSION=0.1.11 just head-up                          # a specific published release
-HYDROZOA_IMAGE=cardano-hydrozoa/hydrozoa:0.1.11 just head-up  # a specific/other image name
+HYDROZOA_VERSION=0.1.12 just head-up                          # a specific published release
+HYDROZOA_IMAGE=cardano-hydrozoa/hydrozoa:0.1.12 just head-up  # a specific/other image name
 ```
 
 **Another head** — each head directory carries its own `docker-compose.yml`, so switch heads by

--- a/src/main/resources/scaffold/hydrozoa.sh
+++ b/src/main/resources/scaffold/hydrozoa.sh
@@ -13,7 +13,7 @@
 # scaffolded workspace — resolved to an absolute path, so the alias mounts correctly no matter which
 # directory you run it from. Override HYDROZOA_HOME (to an absolute path) or HYDROZOA_VERSION before
 # sourcing, or edit the defaults below.
-: "${HYDROZOA_VERSION:=0.1.11}"   # published image tag (ghcr.io/cardano-hydrozoa/hydrozoa)
+: "${HYDROZOA_VERSION:=0.1.12}"   # published image tag (ghcr.io/cardano-hydrozoa/hydrozoa)
 : "${HYDROZOA_HOME:=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)}"   # head directory (absolute)
 export HYDROZOA_VERSION HYDROZOA_HOME
 


### PR DESCRIPTION
Version bump for the 0.1.12 release. 48 commits since `v0.1.11` — the logging overhaul (#684, #685, #686, #714, #715), metrics and readiness work, and transport/liaison fixes.

Bumps the four sites RELEASE.md names: `build.sbt`'s `version`, the `HYDROZOA_VERSION` default in `scaffold/hydrozoa.sh`, and DEPLOYMENT.md's `hydrozoa version` sample, `git describe` paragraph, and `HYDROZOA_VERSION=` / `HYDROZOA_IMAGE=` run examples. `grep -rn "0\.1\.11"` is clean afterwards.

## Release prerequisites

- **On-chain scripts unchanged** since `v0.1.11` — `cardano-onchain/` and `plutus.json` untouched, Scalus not bumped — so the baked reference UTxOs in `scaffold/ref-utxos/` stay valid. RELEASE.md step 2 is a no-op this cycle.
- **Shipped logger levels reviewed** (step 3). `logback-docker.xml` gained two dialer-lifecycle routes at `info` (`CoilPeerWsTransport`, `PeerTransport`) and `Supervision` at `error`. Root stays `warn`; nothing ships at debug or trace.
- Version and tag will match: `build.sbt` `0.1.12`, tag `v0.1.12`.

Tag `v0.1.12` goes on the merge commit once this lands, which triggers `release.yml` to publish `:0.1.12`, `:0.1`, and `:latest`.