### PR TITLE
recovery: one set of boot markers, and a transplanted store that converges

### DIFF
--- a/integration/src/test/scala/hydrozoa/integration/harness/MultiPeerHeadHarness.scala
+++ b/integration/src/test/scala/hydrozoa/integration/harness/MultiPeerHeadHarness.scala
@@ -719,14 +719,14 @@ object MultiPeerHeadHarness:
             peerConnections <- Resource.eval(
               peerMrms.toList
                   .traverse { case (peerNum, peerMrm) =>
-                      peerMrm.mrm.connectionsDeferred.get.map(peerNum -> _)
+                      peerMrm.mrm.connectionsDeferred.get.flatMap(IO.fromEither).map(peerNum -> _)
                   }
                   .map(_.toMap)
             )
             coilConnections <- Resource.eval(
               coilMrms.toList
                   .traverse { case (coilNum, coilMrm) =>
-                      coilMrm.mrm.connectionsDeferred.get.map(coilNum -> _)
+                      coilMrm.mrm.connectionsDeferred.get.flatMap(IO.fromEither).map(coilNum -> _)
                   }
                   .map(_.toMap)
             )
@@ -805,7 +805,7 @@ object MultiPeerHeadHarness:
                         .allocated
                         .map(_._1)
                     (mrm, ref) = spawned
-                    conns <- mrm.connectionsDeferred.get
+                    conns <- mrm.connectionsDeferred.get.flatMap(IO.fromEither)
                     // Cancel the victim's previous tick (its CardanoLiaison is now stopped), then
                     // start a fresh supervised tick against the new connections.
                     _ <- headTicks.get.flatMap(_.getOrElse(peerNum, IO.unit))
@@ -849,7 +849,7 @@ object MultiPeerHeadHarness:
                         .allocated
                         .map(_._1)
                     (mrm, ref) = spawned
-                    conns <- mrm.connectionsDeferred.get
+                    conns <- mrm.connectionsDeferred.get.flatMap(IO.fromEither)
                     _ <- coilTicks.get.flatMap(_.getOrElse(coilNum, IO.unit))
                     tickFib <- tickSupervisor.supervise(
                       Ticks.tickLoop(coilPollingPeriodOf(coilNum), conns)

--- a/integration/src/test/scala/hydrozoa/integration/stage1/Suite.scala
+++ b/integration/src/test/scala/hydrozoa/integration/stage1/Suite.scala
@@ -554,7 +554,7 @@ case class Suite(
                   // Derived from this peer's own store rather than assumed cold, so the actor
                   // recovers from whatever the suite has put there — the same bundle the regime
                   // manager would hand it in production.
-                  markers <- Markers.derive(persistence, nodeConfig.ownPeerId)(using nodeConfig)
+                  markers <- Markers.derive(persistence, nodeConfig.ownPeerId)
                   jointLedger <- system.actorOf(
                     JointLedger(
                       nodeConfig,

--- a/integration/src/test/scala/hydrozoa/integration/stage1/Suite.scala
+++ b/integration/src/test/scala/hydrozoa/integration/stage1/Suite.scala
@@ -32,7 +32,7 @@ import hydrozoa.multisig.ledger.event.RequestNumber
 import hydrozoa.multisig.ledger.joint.{JointLedger, JointLedgerEventFormat}
 import hydrozoa.multisig.ledger.l1.tx.RawTx
 import hydrozoa.multisig.metrics.PeerMetrics
-import hydrozoa.multisig.persistence.{InMemoryBackendStore, Persistence, PersistenceEventFormat}
+import hydrozoa.multisig.persistence.{InMemoryBackendStore, Markers, Persistence, PersistenceEventFormat}
 import java.util.concurrent.TimeUnit
 import org.scalacheck.commands.{ModelBasedSuite, ScenarioGen}
 import org.scalacheck.util.Pretty
@@ -551,6 +551,10 @@ case class Suite(
                     headPeerLiaisons = List(),
                   )
                   l2Ledger <- InMemoryL2Store.ledger(nodeConfig)
+                  // Derived from this peer's own store rather than assumed cold, so the actor
+                  // recovers from whatever the suite has put there — the same bundle the regime
+                  // manager would hand it in production.
+                  markers <- Markers.derive(persistence, nodeConfig.ownPeerId)(using nodeConfig)
                   jointLedger <- system.actorOf(
                     JointLedger(
                       nodeConfig,
@@ -558,7 +562,8 @@ case class Suite(
                       l2Ledger,
                       Slf4jTracer.sink.contramap(JointLedgerEventFormat.humanFormat(headPeerNum)),
                       persistence,
-                      PeerMetrics.create(0L, Vector.empty)
+                      PeerMetrics.create(0L, Vector.empty),
+                      markers
                     )
                   )
                   _ <- jointLedgerD.complete(jointLedger)

--- a/src/main/scala/hydrozoa/app/Main.scala
+++ b/src/main/scala/hydrozoa/app/Main.scala
@@ -1,11 +1,13 @@
 package hydrozoa.app
 
+import cats.effect.unsafe.IORuntimeConfig
 import cats.effect.{ExitCode, IO}
 import com.monovore.decline.effect.CommandIOApp
 import com.monovore.decline.{Command, Opts}
 import hydrozoa.BuildInfo
 import hydrozoa.app.cli.{Scaffold, SubmitDeposit, SubmitL2Transaction}
 import hydrozoa.bootstrap.{BuildHeadConfig, GenerateKeyPair, InitBootstrapFiles, KeygenFleet, Migrate, PrintHeadZeroAddress}
+import scala.concurrent.duration.DurationInt
 
 /** The `hydrozoa` command-line entry point: a single dispatcher over every deployment and runtime
   * command. Each subcommand is defined next to its logic and surfaced here as a `Command` value:
@@ -31,6 +33,22 @@ object Main
       header = "Hydrozoa — multi-party state channels for Cardano",
       version = BuildInfo.version
     ):
+
+    /** Bound how long shutdown may hang after a signal.
+      *
+      * cats-effect defaults `shutdownHookTimeout` to `Duration.Inf`, so a finalizer that cannot
+      * complete makes the process ignore SIGTERM outright — it then needs SIGKILL, and anything
+      * downstream of the stuck finalizer never releases. A wedged node holding its RocksDB LOCK is
+      * the case that bit us: `docker stop -t 120` waits the full two minutes and kills it anyway.
+      *
+      * A finite bound converts that into a slower-than-usual exit. Finalizers past the deadline are
+      * skipped, which is safe for the store specifically: the OS releases the lock on process death
+      * and RocksDB recovers from its WAL, which is the same path any crash takes.
+      *
+      * This is a backstop, not a fix — a shutdown that needs it has a bug worth finding.
+      */
+    override protected def runtimeConfig: IORuntimeConfig =
+        super.runtimeConfig.copy(shutdownHookTimeout = 30.seconds)
 
     /** The `version` subcommand: print the version, git revision, and build time baked in at
       * compile time (see [[BuildInfo]]).

--- a/src/main/scala/hydrozoa/app/Serve.scala
+++ b/src/main/scala/hydrozoa/app/Serve.scala
@@ -547,7 +547,7 @@ object Serve {
 
             // The HTTP server needs the RequestSequencer, which only exists once connections
             // resolve, so wait for them before binding.
-            connections <- mrm.connectionsDeferred.get
+            connections <- mrm.connectionsDeferred.get.flatMap(IO.fromEither)
             _ <- log.info("Starting HTTP server...")
 
             // `surround`, not `start.void`: the server is bound for exactly as long as the node
@@ -598,7 +598,7 @@ object Serve {
             _ <- system.actorOf(mrm, "CoilMultisigRegimeManager")
             _ <- log.info("Hydrozoa coil node started successfully")
 
-            connections <- mrm.connectionsDeferred.get
+            connections <- mrm.connectionsDeferred.get.flatMap(IO.fromEither)
             _ <- log.info("Starting HTTP server (coil: read-only surface)...")
 
             // `surround` binds the server for the node's lifetime and releases it when the actor

--- a/src/main/scala/hydrozoa/config/node/operation/multisig/NodeOperationMultisigConfig.scala
+++ b/src/main/scala/hydrozoa/config/node/operation/multisig/NodeOperationMultisigConfig.scala
@@ -2,6 +2,8 @@ package hydrozoa.config.node.operation.multisig
 
 import hydrozoa.lib.cardano.scalus.QuantizedTime.given
 import hydrozoa.lib.number.PositiveInt
+import hydrozoa.multisig.ledger.stack.StackNumber
+import hydrozoa.multisig.ledger.stack.StackNumber.given
 import io.circe.*
 import io.circe.generic.semiauto.*
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
@@ -11,6 +13,7 @@ final case class NodeOperationMultisigConfig(
     override val peerLiaisonMaxRequestsPerBatch: PositiveInt,
     override val peerLiaisonOutboxCap: PositiveInt,
     override val peerLiaisonResendInterval: FiniteDuration,
+    override val transplantStackNumber: Option[StackNumber],
     override val rateLimits: RateLimits
 ) extends NodeOperationMultisigConfig.Section {
     override transparent inline def nodeOperationMultisigConfig: NodeOperationMultisigConfig = this
@@ -45,6 +48,30 @@ object NodeOperationMultisigConfig {
         def peerLiaisonResendInterval: FiniteDuration =
             nodeOperationMultisigConfig.peerLiaisonResendInterval
 
+        /** The stack a transplanted store was seeded at, when this peer is being seeded from
+          * another peer's store. At boot, and **only when this equals the store's own
+          * `hardConfirmed`**, recovery takes `hardConfirmed` as this peer's acked floor.
+          *
+          * A seeded peer inherits the donor's confirmed history but not its own hard-ack journal,
+          * so the two disagree by construction: `hardConfirmed` names a stack this peer never
+          * acked. Recovery then either refuses (`confirmed > acked`) or, on an empty journal, takes
+          * the stack-0 re-bootstrap path against a head long past it.
+          *
+          * Tagging it with the stack rather than making it a boolean is what keeps it one-shot
+          * without the operator having to take it back out. `hardConfirmed` is monotonic, so it
+          * passes through the tagged value exactly once: the adopting boot matches and adopts, and
+          * every later restart finds `hardConfirmed` past it and behaves as if unset. A boot that
+          * dies before acking leaves `hardConfirmed` where it was, so a retry still matches — the
+          * adoption is idempotent, not single-attempt. A stale tag can neither re-arm nor fail a
+          * restart.
+          *
+          * Node-local, like [[peerLiaisonOutboxCap]]: it moves this peer's own replay floor and
+          * changes nothing it sends, so it cannot make peers diverge. Absent is the only correct
+          * value for a peer that has always run its own store.
+          */
+        def transplantStackNumber: Option[StackNumber] =
+            nodeOperationMultisigConfig.transplantStackNumber
+
         override def rateLimits: RateLimits = nodeOperationMultisigConfig.rateLimits
     }
 
@@ -59,6 +86,7 @@ object NodeOperationMultisigConfig {
       peerLiaisonMaxRequestsPerBatch = PositiveInt.unsafeApply(500),
       peerLiaisonOutboxCap = defaultPeerLiaisonOutboxCap,
       peerLiaisonResendInterval = 5.seconds,
+      transplantStackNumber = None,
       rateLimits = RateLimits.default
     )
 
@@ -74,12 +102,14 @@ object NodeOperationMultisigConfig {
             maxRequestsPerBatch <- c.downField("peerLiaisonMaxRequestsPerBatch").as[PositiveInt]
             outboxCap <- c.downField("peerLiaisonOutboxCap").as[Option[PositiveInt]]
             resendInterval <- c.downField("peerLiaisonResendInterval").as[FiniteDuration]
+            transplantStack <- c.downField("transplantStackNumber").as[Option[StackNumber]]
             limits <- c.downField("rateLimits").as[RateLimits]
         } yield NodeOperationMultisigConfig(
           cardanoLiaisonPollingPeriod = pollingPeriod,
           peerLiaisonMaxRequestsPerBatch = maxRequestsPerBatch,
           peerLiaisonOutboxCap = outboxCap.getOrElse(defaultPeerLiaisonOutboxCap),
           peerLiaisonResendInterval = resendInterval,
+          transplantStackNumber = transplantStack,
           rateLimits = limits
         )
     )

--- a/src/main/scala/hydrozoa/multisig/CoilMultisigRegimeManager.scala
+++ b/src/main/scala/hydrozoa/multisig/CoilMultisigRegimeManager.scala
@@ -1,6 +1,6 @@
 package hydrozoa.multisig
 
-import cats.effect.{Deferred, IO, Ref, Resource}
+import cats.effect.{IO, Ref, Resource}
 import cats.syntax.all.*
 import com.suprnation.actor.ActorContext
 import com.suprnation.actor.ActorRef.NoSendActorRef
@@ -65,7 +65,6 @@ trait CoilMultisigRegimeManager(
                 .getOrElse(
                   throw new IllegalStateException(s"No hub configured for coil $ownCoilNum")
                 )
-            pendingConnections <- Deferred[IO, Connections]
 
             // Every recovery marker this peer boots from, derived ONCE here and projected into
             // each child actor. Deriving per-actor let two paths interpret the same journal
@@ -154,8 +153,8 @@ trait CoilMultisigRegimeManager(
               markers = markers
             )(using config)
 
-            _ <- pendingConnections.complete(connections)
-            _ <- connectionsDeferred.complete(connections)
+            _ <- pendingConnections.complete(Right(connections))
+            _ <- connectionsDeferred.complete(Right(connections))
 
             _ <- tracer.traceWith(WatchingActors)
 

--- a/src/main/scala/hydrozoa/multisig/CoilMultisigRegimeManager.scala
+++ b/src/main/scala/hydrozoa/multisig/CoilMultisigRegimeManager.scala
@@ -14,6 +14,7 @@ import hydrozoa.multisig.consensus.peer.PeerId
 import hydrozoa.multisig.consensus.peer.PeerId.{Coil, Head}
 import hydrozoa.multisig.consensus.transport.{CoilTransport, RemoteHubProxy}
 import hydrozoa.multisig.ledger.l2.L2Ledger
+import hydrozoa.multisig.ledger.stack.StackNumber
 import hydrozoa.multisig.metrics.PeerMetrics
 import hydrozoa.multisig.persistence.{Markers, Persistence}
 import hydrozoa.rulebased.RuleBasedRegimeManager
@@ -69,7 +70,23 @@ trait CoilMultisigRegimeManager(
             // Every recovery marker this peer boots from, derived ONCE here and projected into
             // each child actor. Deriving per-actor let two paths interpret the same journal
             // independently, which is how a seeded store could satisfy one and not the other.
-            markers <- Markers.derive(persistence, config.ownPeerId)(using config)
+            derived <- Markers.derive(persistence, config.ownPeerId)(using config)
+            // Adopting a store seeded from another peer. The tag names the stack it was seeded at
+            // and the floor applies only while that is still this store's `hardConfirmed`, so it
+            // matches on the adopting boot and is inert ever after (`hardConfirmed` is monotonic).
+            // Applied to the ONE bundle, so the gate, the replay cursors, the in-flight handoff and
+            // the stack composer all move together — the alternative is the divergence that made
+            // this necessary.
+            // It RAISES the floor and never lowers it: a peer mid-flight has acked one stack beyond
+            // its confirmation, and clamping that down to the tag would discard the in-flight
+            // handoff `ReplayActor` rebuilds from it.
+            markers = config.transplantStackNumber
+                .filter(tag => derived.hardConfirmed.contains(tag))
+                .fold(derived)(tag =>
+                    derived.copy(hardAckedStack = Some(derived.hardAckedStack.fold(tag) { own =>
+                        if Ordering[StackNumber].gteq(own, tag) then own else tag
+                    }))
+                )
             core <- spawnCoreActors(
               config,
               cardanoBackend,

--- a/src/main/scala/hydrozoa/multisig/CoilMultisigRegimeManager.scala
+++ b/src/main/scala/hydrozoa/multisig/CoilMultisigRegimeManager.scala
@@ -15,7 +15,7 @@ import hydrozoa.multisig.consensus.peer.PeerId.{Coil, Head}
 import hydrozoa.multisig.consensus.transport.{CoilTransport, RemoteHubProxy}
 import hydrozoa.multisig.ledger.l2.L2Ledger
 import hydrozoa.multisig.metrics.PeerMetrics
-import hydrozoa.multisig.persistence.Persistence
+import hydrozoa.multisig.persistence.{Markers, Persistence}
 import hydrozoa.rulebased.RuleBasedRegimeManager
 
 /** Coil-peer counterpart to [[HeadMultisigRegimeManager]]. A coil runs the same multisig-regime
@@ -66,12 +66,17 @@ trait CoilMultisigRegimeManager(
                 )
             pendingConnections <- Deferred[IO, Connections]
 
+            // Every recovery marker this peer boots from, derived ONCE here and projected into
+            // each child actor. Deriving per-actor let two paths interpret the same journal
+            // independently, which is how a seeded store could satisfy one and not the other.
+            markers <- Markers.derive(persistence, config.ownPeerId)(using config)
             core <- spawnCoreActors(
               config,
               cardanoBackend,
               l2Ledger,
               persistence,
               pendingConnections,
+              markers,
             )
 
             // Exactly one liaison, toward the hub head peer (§5.5) [doc-ref]. Register it on the
@@ -128,7 +133,8 @@ trait CoilMultisigRegimeManager(
               // CoilAckSequencer either — the gap step is a no-op).
               coils = Nil,
               treasuryAddress = config.initializationTx.treasuryProduced.address,
-              leadsFastBlock = config.canLeadFast
+              leadsFastBlock = config.canLeadFast,
+              markers = markers
             )(using config)
 
             _ <- pendingConnections.complete(connections)

--- a/src/main/scala/hydrozoa/multisig/CoilMultisigRegimeManager.scala
+++ b/src/main/scala/hydrozoa/multisig/CoilMultisigRegimeManager.scala
@@ -69,7 +69,7 @@ trait CoilMultisigRegimeManager(
             // Every recovery marker this peer boots from, derived ONCE here and projected into
             // each child actor. Deriving per-actor let two paths interpret the same journal
             // independently, which is how a seeded store could satisfy one and not the other.
-            derived <- Markers.derive(persistence, config.ownPeerId)(using config)
+            derived <- Markers.derive(persistence, config.ownPeerId)
             // Adopting a store seeded from another peer. The tag names the stack it was seeded at
             // and the floor applies only while that is still this store's `hardConfirmed`, so it
             // matches on the adopting boot and is inert ever after (`hardConfirmed` is monotonic).

--- a/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManager.scala
+++ b/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManager.scala
@@ -17,7 +17,7 @@ import hydrozoa.multisig.consensus.transport.{HubTransport, PeerTransport, Remot
 import hydrozoa.multisig.ledger.joint.JointLedger
 import hydrozoa.multisig.ledger.l2.{L2Ledger, L2Screener}
 import hydrozoa.multisig.metrics.PeerMetrics
-import hydrozoa.multisig.persistence.Persistence
+import hydrozoa.multisig.persistence.{Markers, Persistence}
 import hydrozoa.rulebased.RuleBasedRegimeManager
 
 trait HeadMultisigRegimeManager(
@@ -50,12 +50,17 @@ trait HeadMultisigRegimeManager(
 
             pendingConnections <- Deferred[IO, HeadMultisigRegimeManager.Connections]
 
+            // Every recovery marker this peer boots from, derived ONCE here and projected into
+            // each child actor. Deriving per-actor let two paths interpret the same journal
+            // independently, which is how a seeded store could satisfy one and not the other.
+            markers <- Markers.derive(persistence, config.ownPeerId)(using config)
             core <- spawnCoreActors(
               config,
               cardanoBackend,
               l2Ledger,
               persistence,
               pendingConnections,
+              markers,
             )
 
             // Throttles the FastConsensusActor → BlockWeaver soft-block-confirmation lane (see
@@ -82,7 +87,8 @@ trait HeadMultisigRegimeManager(
                 l2Screener,
                 tracers.eventSequencer,
                 persistence,
-                metrics
+                metrics,
+                markers
               )
             )
 
@@ -245,7 +251,8 @@ trait HeadMultisigRegimeManager(
               hubs = config.hubHeadPeerNumbers,
               coils = hubbedCoilPeers,
               treasuryAddress = config.initializationTx.treasuryProduced.address,
-              leadsFastBlock = config.canLeadFast
+              leadsFastBlock = config.canLeadFast,
+              markers = markers
             )(using config)
 
             _ <- pendingConnections.complete(connections)

--- a/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManager.scala
+++ b/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManager.scala
@@ -52,7 +52,7 @@ trait HeadMultisigRegimeManager(
             // Every recovery marker this peer boots from, derived ONCE here and projected into
             // each child actor. Deriving per-actor let two paths interpret the same journal
             // independently, which is how a seeded store could satisfy one and not the other.
-            derived <- Markers.derive(persistence, config.ownPeerId)(using config)
+            derived <- Markers.derive(persistence, config.ownPeerId)
             // Adopting a store seeded from another peer. The tag names the stack it was seeded at
             // and the floor applies only while that is still this store's `hardConfirmed`, so it
             // matches on the adopting boot and is inert ever after (`hardConfirmed` is monotonic).

--- a/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManager.scala
+++ b/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManager.scala
@@ -16,6 +16,7 @@ import hydrozoa.multisig.consensus.peer.{CoilPeerNumber, HeadPeerNumber, PeerId}
 import hydrozoa.multisig.consensus.transport.{HubTransport, PeerTransport, RemoteCoilProxy, RemotePeerProxy}
 import hydrozoa.multisig.ledger.joint.JointLedger
 import hydrozoa.multisig.ledger.l2.{L2Ledger, L2Screener}
+import hydrozoa.multisig.ledger.stack.StackNumber
 import hydrozoa.multisig.metrics.PeerMetrics
 import hydrozoa.multisig.persistence.{Markers, Persistence}
 import hydrozoa.rulebased.RuleBasedRegimeManager
@@ -53,7 +54,23 @@ trait HeadMultisigRegimeManager(
             // Every recovery marker this peer boots from, derived ONCE here and projected into
             // each child actor. Deriving per-actor let two paths interpret the same journal
             // independently, which is how a seeded store could satisfy one and not the other.
-            markers <- Markers.derive(persistence, config.ownPeerId)(using config)
+            derived <- Markers.derive(persistence, config.ownPeerId)(using config)
+            // Adopting a store seeded from another peer. The tag names the stack it was seeded at
+            // and the floor applies only while that is still this store's `hardConfirmed`, so it
+            // matches on the adopting boot and is inert ever after (`hardConfirmed` is monotonic).
+            // Applied to the ONE bundle, so the gate, the replay cursors, the in-flight handoff and
+            // the stack composer all move together — the alternative is the divergence that made
+            // this necessary.
+            // It RAISES the floor and never lowers it: a peer mid-flight has acked one stack beyond
+            // its confirmation, and clamping that down to the tag would discard the in-flight
+            // handoff `ReplayActor` rebuilds from it.
+            markers = config.transplantStackNumber
+                .filter(tag => derived.hardConfirmed.contains(tag))
+                .fold(derived)(tag =>
+                    derived.copy(hardAckedStack = Some(derived.hardAckedStack.fold(tag) { own =>
+                        if Ordering[StackNumber].gteq(own, tag) then own else tag
+                    }))
+                )
             core <- spawnCoreActors(
               config,
               cardanoBackend,

--- a/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManager.scala
+++ b/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManager.scala
@@ -49,8 +49,6 @@ trait HeadMultisigRegimeManager(
         for {
             _ <- tracer.traceWith(StartingActors)
 
-            pendingConnections <- Deferred[IO, HeadMultisigRegimeManager.Connections]
-
             // Every recovery marker this peer boots from, derived ONCE here and projected into
             // each child actor. Deriving per-actor let two paths interpret the same journal
             // independently, which is how a seeded store could satisfy one and not the other.
@@ -272,8 +270,8 @@ trait HeadMultisigRegimeManager(
               markers = markers
             )(using config)
 
-            _ <- pendingConnections.complete(connections)
-            _ <- connectionsDeferred.complete(connections)
+            _ <- pendingConnections.complete(Right(connections))
+            _ <- connectionsDeferred.complete(Right(connections))
 
             _ <- tracer.traceWith(WatchingActors)
 
@@ -383,7 +381,7 @@ object HeadMultisigRegimeManager {
         coilPeerLiaisons: List[liaison.PeerLiaisonHubToCoil.Handle] = Nil,
     )
 
-    type PendingConnections = Deferred[IO, Connections]
+    type PendingConnections = Deferred[IO, Either[Throwable, Connections]]
 
     def resource(
         config: NodeConfig,

--- a/src/main/scala/hydrozoa/multisig/MultisigRegimeManagerBase.scala
+++ b/src/main/scala/hydrozoa/multisig/MultisigRegimeManagerBase.scala
@@ -54,7 +54,21 @@ trait MultisigRegimeManagerBase[E >: LifecycleEvent <: RegimeManagerEvent]
     /** Completed by the subclass's [[preStartLocal]] once every actor is spawned and the
       * `Connections` slots are populated.
       */
-    val connectionsDeferred: Deferred[IO, Connections] = Deferred.unsafe[IO, Connections]
+    val connectionsDeferred: Deferred[IO, Either[Throwable, Connections]] =
+        Deferred.unsafe[IO, Either[Throwable, Connections]]
+
+    /** The inner barrier every child actor parks on until this manager has populated `Connections`.
+      *
+      * Held here rather than created inside [[preStartLocal]] so that a boot which never reaches
+      * the completion still has something to complete: a failure there used to leave both barriers
+      * empty forever, and the process could not exit. The children stayed parked inside
+      * `ActorCell.invoke(...).uncancelable`, the actor system's `Supervisor(await = true)` waited
+      * on them rather than cancelling, the store's release sat downstream of that wait, and the app
+      * fiber itself never reached `waitForTermination` — so SIGTERM had nothing to cancel and the
+      * node needed SIGKILL with its RocksDB LOCK still held.
+      */
+    val pendingConnections: HeadMultisigRegimeManager.PendingConnections =
+        Deferred.unsafe[IO, Either[Throwable, Connections]]
 
     /** Node lifecycle status backing the user-facing server's `/ready` endpoint. Advanced
       * monotonically (via [[NodeStatus.advanceTo]]) by [[CardanoLiaison]] as the L1 target state
@@ -105,7 +119,13 @@ trait MultisigRegimeManagerBase[E >: LifecycleEvent <: RegimeManagerEvent]
     override def receive: Receive[IO, Request] = PartialFunction.fromFunction(receiveTotal)
 
     private def receiveTotal(req: Request): IO[Unit] = req match {
-        case PreStart => preStartLocal
+        // A boot failure must reach both barriers, or nothing parked on them can ever unpark.
+        // `complete` is idempotent-by-outcome here: on the happy path `preStartLocal` has already
+        // filled them and these are no-ops.
+        case PreStart =>
+            preStartLocal.onError(e =>
+                (pendingConnections.complete(Left(e)) >> connectionsDeferred.complete(Left(e))).void
+            )
         case TerminatedChild(childType, _) =>
             tracer.traceWith(LifecycleEvent.TerminatedActor(childType))
         case TerminatedDependency(dependencyType, _) =>
@@ -144,7 +164,7 @@ trait MultisigRegimeManagerBase[E >: LifecycleEvent <: RegimeManagerEvent]
         cardanoBackend: CardanoBackend[IO],
         l2Ledger: L2Ledger[IO],
         persistence: Persistence[IO],
-        pendingConnections: Deferred[IO, Connections],
+        pendingConnections: HeadMultisigRegimeManager.PendingConnections,
         markers: Markers,
     ): IO[CoreActors] =
         for {

--- a/src/main/scala/hydrozoa/multisig/MultisigRegimeManagerBase.scala
+++ b/src/main/scala/hydrozoa/multisig/MultisigRegimeManagerBase.scala
@@ -16,7 +16,7 @@ import hydrozoa.multisig.consensus.*
 import hydrozoa.multisig.ledger.joint.JointLedger
 import hydrozoa.multisig.ledger.l2.L2Ledger
 import hydrozoa.multisig.metrics.PeerMetrics
-import hydrozoa.multisig.persistence.Persistence
+import hydrozoa.multisig.persistence.{Markers, Persistence}
 import scala.concurrent.duration.DurationInt
 
 /** Shared scaffolding for [[HeadMultisigRegimeManager]] and [[CoilMultisigRegimeManager]]: the
@@ -145,10 +145,18 @@ trait MultisigRegimeManagerBase[E >: LifecycleEvent <: RegimeManagerEvent]
         l2Ledger: L2Ledger[IO],
         persistence: Persistence[IO],
         pendingConnections: Deferred[IO, Connections],
+        markers: Markers,
     ): IO[CoreActors] =
         for {
             blockWeaver <- context.actorOf(
-              BlockWeaver(config, pendingConnections, tracers.blockWeaver, metrics, persistence)
+              BlockWeaver(
+                config,
+                pendingConnections,
+                tracers.blockWeaver,
+                metrics,
+                persistence,
+                markers
+              )
             )
             cardanoLiaison <- context.actorOf(
               CardanoLiaison(
@@ -181,7 +189,8 @@ trait MultisigRegimeManagerBase[E >: LifecycleEvent <: RegimeManagerEvent]
                 l2Ledger,
                 tracers.jointLedger,
                 persistence,
-                metrics
+                metrics,
+                markers
               )
             )
             stackComposer <- context.actorOf(
@@ -190,7 +199,8 @@ trait MultisigRegimeManagerBase[E >: LifecycleEvent <: RegimeManagerEvent]
                 pendingConnections,
                 tracers.stackComposer,
                 persistence,
-                metrics
+                metrics,
+                markers
               )
             )
             slowConsensusActor <- context.actorOf(
@@ -199,7 +209,8 @@ trait MultisigRegimeManagerBase[E >: LifecycleEvent <: RegimeManagerEvent]
                 pendingConnections,
                 tracers.slowConsensusActor,
                 persistence,
-                metrics
+                metrics,
+                markers
               )
             )
         } yield CoreActors(

--- a/src/main/scala/hydrozoa/multisig/consensus/BlockWeaver.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/BlockWeaver.scala
@@ -87,7 +87,7 @@ final case class BlockWeaver(
     private def initializeConnections: IO[BlockWeaver.Connections] = pendingConnections match {
         case pc: HeadMultisigRegimeManager.PendingConnections =>
             for {
-                c <- pc.get
+                c <- pc.get.flatMap(IO.fromEither)
             } yield BlockWeaver.Connections(
               blockWeaver = context.self,
               jointLedger = c.jointLedger,

--- a/src/main/scala/hydrozoa/multisig/consensus/BlockWeaver.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/BlockWeaver.scala
@@ -35,6 +35,10 @@ final case class BlockWeaver(
       * block to resume on, and whether its predecessor is confirmed — and reads it in `PreStart`.
       */
     persistence: Persistence[IO],
+    /** The boot markers, derived once by the regime manager (§5.2). This actor projects
+      * `fastBlockMark` and `softConfirmed` out of them rather than re-reading the store.
+      */
+    markers: Markers,
 ) extends Actor[IO, BlockWeaver.Request] {
     import BlockWeaver.*
 
@@ -62,9 +66,16 @@ final case class BlockWeaver(
                 // Suspends on the start barrier, so the base below is in place before any
                 // replayed journal entry is processed (§5.6, §8).
                 connections <- initializeConnections
-                // Same anchor as `JointLedger.preStartLocal`: the two step the spine in lockstep.
-                fastBlockMark <- Markers.recoverFastBlockMark(persistence.backend)
-                recovered <- State.recover(config, connections, tracer, persistence, fastBlockMark)
+                // Same anchor as `JointLedger.preStartLocal`: the two step the spine in lockstep —
+                // now guaranteed, because both project the one bundle rather than each re-reading.
+                recovered <- State.recover(
+                  config,
+                  connections,
+                  tracer,
+                  persistence,
+                  markers.fastBlockMark,
+                  markers.softConfirmed
+                )
                 // `None`: the store says this head finalized, so the weaver retires rather than
                 // opening a block, as on the live path.
                 _ <- recovered.fold(context.self.stop)(become)
@@ -247,10 +258,10 @@ object BlockWeaver {
             connections: Connections,
             tracer: ContraTracer[IO, BlockWeaverEvent],
             persistence: Persistence[IO],
-            fastBlockMark: Option[BlockNumber]
+            fastBlockMark: Option[BlockNumber],
+            softConfirmed: Option[BlockNumber]
         ): IO[Option[Reactive]] =
             for {
-                softConfirmed <- Markers.recoverSoftConfirmed(persistence.backend)
                 opening <- start(config, connections, tracer, fastBlockMark)
                 // `filter(softConfirmed.contains)` is the "confirmed everything it applied" test.
                 resumed <- fastBlockMark

--- a/src/main/scala/hydrozoa/multisig/consensus/CardanoLiaison.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/CardanoLiaison.scala
@@ -523,7 +523,7 @@ trait CardanoLiaison(
     private def initializeConnections: IO[Unit] = pendingConnections match {
         case x: HeadMultisigRegimeManager.PendingConnections =>
             for {
-                _connections <- x.get
+                _connections <- x.get.flatMap(IO.fromEither)
                 _ <- connections.set(
                   Some(CardanoLiaison.Connections(blockWeaver = _connections.blockWeaver))
                 )

--- a/src/main/scala/hydrozoa/multisig/consensus/CoilAckSequencer.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/CoilAckSequencer.scala
@@ -75,11 +75,13 @@ trait CoilAckSequencer(
 
     private def initializeConnections: IO[Unit] = pendingConnections match {
         case x: HeadMultisigRegimeManager.PendingConnections =>
-            x.get.flatMap(c =>
-                connections.set(
-                  Some(Connections(liaisons = c.headPeerLiaisons, coilRelay = c.coilRelay))
+            x.get
+                .flatMap(IO.fromEither)
+                .flatMap(c =>
+                    connections.set(
+                      Some(Connections(liaisons = c.headPeerLiaisons, coilRelay = c.coilRelay))
+                    )
                 )
-            )
         case x: CoilAckSequencer.Connections => connections.set(Some(x))
     }
 

--- a/src/main/scala/hydrozoa/multisig/consensus/CoilRelay.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/CoilRelay.scala
@@ -84,7 +84,9 @@ abstract class CoilRelay(
 
     private def resolveConnections: IO[CoilRelay.Connections] = pendingConnections match {
         case shared: HeadMultisigRegimeManager.PendingConnections =>
-            shared.get.map(s => CoilRelay.Connections(coilPeerLiaisons = s.coilPeerLiaisons))
+            shared.get
+                .flatMap(IO.fromEither)
+                .map(s => CoilRelay.Connections(coilPeerLiaisons = s.coilPeerLiaisons))
         case own: CoilRelay.Connections => IO.pure(own)
     }
 

--- a/src/main/scala/hydrozoa/multisig/consensus/FastConsensusActor.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/FastConsensusActor.scala
@@ -181,7 +181,7 @@ class FastConsensusActor(
     private def initializeConnections: IO[Unit] = pendingConnections match {
         case x: HeadMultisigRegimeManager.PendingConnections =>
             for {
-                _connections <- x.get
+                _connections <- x.get.flatMap(IO.fromEither)
                 _ <- connections.set(
                   Some(
                     FastConsensusActor.Connections(

--- a/src/main/scala/hydrozoa/multisig/consensus/ReplayActor.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/ReplayActor.scala
@@ -75,16 +75,21 @@ object ReplayActor:
         hubs: List[HeadPeerNumber],
         coils: List[CoilPeerNumber],
         treasuryAddress: ShelleyAddress,
-        leadsFastBlock: BlockNumber => Boolean
+        leadsFastBlock: BlockNumber => Boolean,
+        markers: Markers
     )(using CardanoNetwork.Section): IO[Unit] =
         val backend = persistence.backend
+        // `hardAckedStack` is a marker like the rest now, and the bundle is the manager's, derived
+        // once: `StackComposer` reads the same value, so the two cannot disagree — which is the
+        // whole point, since an adjustment applied to the bundle has to reach both.
+        val hardAckedStack = markers.hardAckedStack
         for
-            markers <- Markers.derive(backend, own)
-            // The slow-side own-ack journal is the one `PeerId`-keyed `HardAck` journal — both the
-            // acked stack (the StackComposer/aggregator floor) and the in-flight handoff's own acks
-            // come from it, for either peer type (§10 Q10).
-            ownAck <- recoverOwnAck(persistence, own, markers.hardConfirmed, markers.hardAcked)
-            (hardAckedStack, inflight) = ownAck
+            inflight <- reconstructInflightHandoff(
+              persistence,
+              own,
+              markers.hardConfirmed,
+              hardAckedStack
+            )
             // Fail-safe (CR6/CR7): refuse to start on an inconsistent store (confirmed > acked).
             _ <- validateInvariants(
               markers.softConfirmed,
@@ -154,20 +159,6 @@ object ReplayActor:
       * so this avoids re-scanning the own `HardAck` CF. The own ack journal is the one
       * `PeerId`-keyed `HardAck` journal, so `own: PeerId` works for both peer types (§10 Q10).
       */
-    private def recoverOwnAck(
-        persistence: Persistence[IO],
-        own: PeerId,
-        hardConfirmed: Option[StackNumber],
-        hardAcked: Option[HardAckNumber]
-    )(using
-        CardanoNetwork.Section
-    ): IO[(Option[StackNumber], Option[SlowConsensusActor.StackHandoff])] =
-        for
-            hardAckedStack <- hardAcked.traverse(n =>
-                persistence.getOrFail(JournalKey.HardAck(own, n)).map(_.payload.stackNum)
-            )
-            inflight <- reconstructInflightHandoff(persistence, own, hardConfirmed, hardAckedStack)
-        yield (hardAckedStack, inflight)
 
     /** Boot-time consistency fail-safe (CR6/CR7): a confirmed mark must never exceed its acked mark
       * (`confirmed ≤ acked` — we confirm only what we have acked). A violation means a torn or

--- a/src/main/scala/hydrozoa/multisig/consensus/RequestSequencer.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/RequestSequencer.scala
@@ -37,7 +37,11 @@ trait RequestSequencer(
     l2Screener: L2Screener[IO],
     tracer: ContraTracer[IO, EventSequencerEvent],
     persistence: Persistence[IO],
-    metrics: PeerMetrics
+    metrics: PeerMetrics,
+    /** The boot markers, derived once by the regime manager (§5.2); this actor projects
+      * `nextRequestNumber` rather than re-reading its own Request spine.
+      */
+    markers: Markers
 ) extends Actor[IO, Request] {
     private val connections = Ref.unsafe[IO, Option[RequestSequencer.Connections]](None)
     private val state = State()
@@ -186,7 +190,7 @@ trait RequestSequencer(
             _ <- initializeConnections
             // R3: continue the request counter from `max(own Request) + 1` (CR3, no re-issue);
             // empty store -> RequestNumber(0), the same cold value.
-            next <- Markers.recoverNextRequestNumber(persistence.backend, ownHeadPeerNum)
+            next = markers.nextRequestNumber
             _ <- state.seedNextRequestNum(next)
             // Seed the confirmed high-water from the highest already-assigned own request (next - 1).
             // Treating assigned-as-confirmed opens the backpressure window optimistically after a
@@ -253,7 +257,8 @@ object RequestSequencer {
         l2Screener: L2Screener[IO],
         tracer: ContraTracer[IO, EventSequencerEvent],
         persistence: Persistence[IO],
-        metrics: PeerMetrics
+        metrics: PeerMetrics,
+        markers: Markers
     ): IO[RequestSequencer] =
         IO(
           new RequestSequencer(
@@ -262,7 +267,8 @@ object RequestSequencer {
             l2Screener,
             tracer,
             persistence,
-            metrics
+            metrics,
+            markers
           ) {}
         )
 

--- a/src/main/scala/hydrozoa/multisig/consensus/RequestSequencer.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/RequestSequencer.scala
@@ -72,7 +72,7 @@ trait RequestSequencer(
     private def initializeConnections: IO[Unit] = pendingConnections match {
         case x: HeadMultisigRegimeManager.PendingConnections =>
             for {
-                _connections <- x.get
+                _connections <- x.get.flatMap(IO.fromEither)
                 _ <- connections.set(
                   Some(
                     Connections(

--- a/src/main/scala/hydrozoa/multisig/consensus/SlowConsensusActor.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/SlowConsensusActor.scala
@@ -61,7 +61,11 @@ final case class SlowConsensusActor(
         SlowConsensusActor.Connections,
     tracer: ContraTracer[IO, SlowConsensusActorEvent],
     persistence: Persistence[IO],
-    metrics: PeerMetrics
+    metrics: PeerMetrics,
+    /** The boot markers, derived once by the regime manager (§5.2); this actor projects
+      * `hardConfirmed` rather than re-reading the spine `StackComposer` also reads.
+      */
+    markers: Markers
 ) extends Actor[IO, SlowConsensusActor.Request] {
     import SlowConsensusActor.*
 
@@ -118,8 +122,7 @@ final case class SlowConsensusActor(
                 // than dropped — orphans `clearOrphans` never reaches, since no cell is re-created
                 // for a confirmed stack. The hard-ack journals scan from key 0, so the buffer would
                 // retain every remote ack the head ever produced, on every restart.
-                hardConfirmed <- Markers.recoverHardConfirmed(persistence.backend)
-                _ <- stateRef.update(_.withLastConfirmed(hardConfirmed))
+                _ <- stateRef.update(_.withLastConfirmed(markers.hardConfirmed))
             } yield ()
         case h: StackHandoff =>
             handleStackHandoff(h)

--- a/src/main/scala/hydrozoa/multisig/consensus/SlowConsensusActor.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/SlowConsensusActor.scala
@@ -515,7 +515,7 @@ final case class SlowConsensusActor(
     private def initializeConnections: IO[Unit] = pendingConnections match {
         case x: HeadMultisigRegimeManager.PendingConnections =>
             for {
-                c <- x.get
+                c <- x.get.flatMap(IO.fromEither)
                 _ <- connections.set(
                   Some(
                     Connections(

--- a/src/main/scala/hydrozoa/multisig/consensus/StackComposer.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/StackComposer.scala
@@ -51,7 +51,13 @@ final case class StackComposer(
     pendingConnections: HeadMultisigRegimeManager.PendingConnections | StackComposer.Connections,
     tracer: ContraTracer[IO, StackComposerEvent],
     persistence: Persistence[IO],
-    metrics: PeerMetrics
+    metrics: PeerMetrics,
+    /** The boot markers, derived once by the regime manager (§5.2). `hardAckedStack` in particular
+      * is projected, not re-derived: this actor and `ReplayActor` used to unpack it from the
+      * own-ack journal independently, so a store whose journal disagrees with its confirmations (a
+      * seeded one) could satisfy the replay gate and still anchor this actor at the wrong stack.
+      */
+    markers: Markers
 ) extends Actor[IO, StackComposer.Request] {
     import StackComposer.*
 
@@ -103,9 +109,12 @@ final case class StackComposer(
       */
     private def recoverOrBootstrap: IO[Unit] =
         for {
-            hardAcked <- Markers.recoverHardAcked(persistence.backend, config.ownPeerId)
-            hardConfirmed <- Markers.recoverHardConfirmed(persistence.backend)
-            recovered <- State.recover(persistence, hardAcked, hardConfirmed, config.ownPeerId)
+            recovered <- State.recover(
+              persistence,
+              markers.hardAcked,
+              markers.hardConfirmed,
+              markers.hardAckedStack
+            )
             _ <- recovered match {
                 case Some(recoveredState) => state.set(recoveredState)
                 case None                 => bootstrapInitialStack
@@ -1042,18 +1051,16 @@ object StackComposer {
             persistence: Persistence[IO],
             hardAcked: Option[HardAckNumber],
             hardConfirmed: Option[StackNumber],
-            own: PeerId
+            hardAckedStack: Option[StackNumber]
         )(using config: HeadConfig.Bootstrap.Section): IO[Option[State]] =
-            hardAcked match
-                case None => IO.pure(None)
-                case Some(hardAckNum) =>
+            (hardAcked, hardAckedStack) match
+                case (None, _) | (_, None) => IO.pure(None)
+                case (Some(hardAckNum), Some(hardAckedStack)) =>
                     for {
-                        // No peer-type branch: the own hard-ack lives in the one `PeerId`-keyed
-                        // `HardAck` journal, and the closing stack's `lastBlockNum` comes from the
-                        // `UnsignedStack` every peer persists on every close (atomic with the
-                        // hard-ack, so always present for a hard-acked stack).
-                        lastHardAck <- persistence.getOrFail(JournalKey.HardAck(own, hardAckNum))
-                        hardAckedStack = lastHardAck.payload.stackNum
+                        // The closing stack's `lastBlockNum` comes from the `UnsignedStack` every
+                        // peer persists on every close (atomic with the hard-ack, so always present
+                        // for a stack this peer itself acked). `hardAckedStack` is projected from
+                        // the one marker bundle, so this anchor and the replay gate cannot disagree.
                         unsignedStack <- persistence.getOrFail(
                           StoreKey.UnsignedStack(hardAckedStack)
                         )

--- a/src/main/scala/hydrozoa/multisig/consensus/StackComposer.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/StackComposer.scala
@@ -1053,9 +1053,20 @@ object StackComposer {
             hardConfirmed: Option[StackNumber],
             hardAckedStack: Option[StackNumber]
         )(using config: HeadConfig.Bootstrap.Section): IO[Option[State]] =
-            (hardAcked, hardAckedStack) match
-                case (None, _) | (_, None) => IO.pure(None)
-                case (Some(hardAckNum), Some(hardAckedStack)) =>
+            // The anchor is `hardAckedStack`; the ack NUMBER only says what to assign next. They can
+            // come apart in exactly one situation: a store seeded from another peer, where the floor
+            // supplies the stack from `hardConfirmed` while this peer's own ack journal is empty
+            // because the donor never recorded an ack from it. `Markers.derive` unpacks the stack
+            // FROM the number, so `(None, Some(_))` is unreachable by reading a store — only the
+            // transplant floor can construct it, which is why treating it as a cold ack counter
+            // cannot change normal operation.
+            //
+            // Zero is the right counter there for the same reason a coil must never be handed fewer
+            // acks than its hub recorded: the donor recorded none, so the hub's cursor for this
+            // peer's ack lane is at zero, which is exactly what it will ask for.
+            hardAckedStack match
+                case None => IO.pure(None)
+                case Some(hardAckedStack) =>
                     for {
                         // The closing stack's `lastBlockNum` comes from the `UnsignedStack` every
                         // peer persists on every close (atomic with the hard-ack, so always present
@@ -1095,7 +1106,7 @@ object StackComposer {
                           lastClosedBlockNum = lastBlockNum,
                           previousStackHardConfirmed =
                               hardConfirmed.exists(Ordering[StackNumber].gteq(_, hardAckedStack)),
-                          nextOwnHardAckNum = hardAckNum.increment,
+                          nextOwnHardAckNum = hardAcked.fold(HardAckNumber.zero)(_.increment),
                           treasury = treasury,
                           evacuationMap = evacuationMap
                         )

--- a/src/main/scala/hydrozoa/multisig/consensus/StackComposer.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/StackComposer.scala
@@ -813,7 +813,7 @@ final case class StackComposer(
     private def initializeConnections: IO[Unit] = pendingConnections match {
         case x: HeadMultisigRegimeManager.PendingConnections =>
             for {
-                c <- x.get
+                c <- x.get.flatMap(IO.fromEither)
                 _ <- connections.set(
                   Some(
                     Connections(

--- a/src/main/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonCoilToHub.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonCoilToHub.scala
@@ -55,23 +55,25 @@ abstract class PeerLiaisonCoilToHub(
     private def resolveConnections: IO[PeerLiaisonCoilToHub.Connections] =
         pendingConnections match {
             case shared: HeadMultisigRegimeManager.PendingConnections =>
-                shared.get.flatMap(s =>
-                    s.remoteHubLiaison.fold(
-                      IO.raiseError(
-                        IllegalStateException("Coil→hub liaison requires a hub liaison handle.")
-                      )
-                    )(hub =>
-                        IO.pure(
-                          PeerLiaisonCoilToHub.Connections(
-                            blockWeaver = s.blockWeaver,
-                            consensusActor = s.consensusActor,
-                            stackComposer = s.stackComposer,
-                            slowConsensusActor = s.slowConsensusActor,
-                            remote = hub
+                shared.get
+                    .flatMap(IO.fromEither)
+                    .flatMap(s =>
+                        s.remoteHubLiaison.fold(
+                          IO.raiseError(
+                            IllegalStateException("Coil→hub liaison requires a hub liaison handle.")
                           )
+                        )(hub =>
+                            IO.pure(
+                              PeerLiaisonCoilToHub.Connections(
+                                blockWeaver = s.blockWeaver,
+                                consensusActor = s.consensusActor,
+                                stackComposer = s.stackComposer,
+                                slowConsensusActor = s.slowConsensusActor,
+                                remote = hub
+                              )
+                            )
                         )
                     )
-                )
             case own: PeerLiaisonCoilToHub.Connections => IO.pure(own)
         }
 

--- a/src/main/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonHeadToHead.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonHeadToHead.scala
@@ -67,16 +67,18 @@ abstract class PeerLiaisonHeadToHead(
     private def resolveConnections: IO[PeerLiaisonHeadToHead.Connections] =
         pendingConnections match {
             case shared: HeadMultisigRegimeManager.PendingConnections =>
-                shared.get.map(s =>
-                    PeerLiaisonHeadToHead.Connections(
-                      blockWeaver = s.blockWeaver,
-                      consensusActor = s.consensusActor,
-                      stackComposer = s.stackComposer,
-                      slowConsensusActor = s.slowConsensusActor,
-                      remote = s.remoteHeadLiaisons(remoteHead.peerNum),
-                      coilRelay = s.coilRelay
+                shared.get
+                    .flatMap(IO.fromEither)
+                    .map(s =>
+                        PeerLiaisonHeadToHead.Connections(
+                          blockWeaver = s.blockWeaver,
+                          consensusActor = s.consensusActor,
+                          stackComposer = s.stackComposer,
+                          slowConsensusActor = s.slowConsensusActor,
+                          remote = s.remoteHeadLiaisons(remoteHead.peerNum),
+                          coilRelay = s.coilRelay
+                        )
                     )
-                )
             case own: PeerLiaisonHeadToHead.Connections => IO.pure(own)
         }
 

--- a/src/main/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonHubToCoil.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/liaison/PeerLiaisonHubToCoil.scala
@@ -53,21 +53,23 @@ abstract class PeerLiaisonHubToCoil(
     private def resolveConnections: IO[PeerLiaisonHubToCoil.Connections] =
         pendingConnections match {
             case shared: HeadMultisigRegimeManager.PendingConnections =>
-                shared.get.flatMap(s =>
-                    s.coilAckSequencer.fold(
-                      IO.raiseError(
-                        IllegalStateException("Hub→coil liaison requires a CoilAckSequencer.")
-                      )
-                    )(seq =>
-                        IO.pure(
-                          PeerLiaisonHubToCoil.Connections(
-                            slowConsensusActor = s.slowConsensusActor,
-                            coilAckSequencer = seq,
-                            remote = s.remoteCoilLiaisons(coil)
+                shared.get
+                    .flatMap(IO.fromEither)
+                    .flatMap(s =>
+                        s.coilAckSequencer.fold(
+                          IO.raiseError(
+                            IllegalStateException("Hub→coil liaison requires a CoilAckSequencer.")
                           )
+                        )(seq =>
+                            IO.pure(
+                              PeerLiaisonHubToCoil.Connections(
+                                slowConsensusActor = s.slowConsensusActor,
+                                coilAckSequencer = seq,
+                                remote = s.remoteCoilLiaisons(coil)
+                              )
+                            )
                         )
                     )
-                )
             case own: PeerLiaisonHubToCoil.Connections => IO.pure(own)
         }
 

--- a/src/main/scala/hydrozoa/multisig/consensus/transport/CoilPeerWsTransport.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/transport/CoilPeerWsTransport.scala
@@ -70,6 +70,15 @@ final class CoilPeerWsTransport private (
             case Left(err)                     => tracer.traceWith(DecodeError(err))
         }
 
+    /** How long one dial attempt may sit in the WebSocket handshake before it is abandoned. Long
+      * enough not to give up on an ordinarily slow hub, short enough that a stalled one does not
+      * stop this peer reconnecting.
+      */
+    private val handshakeBudget: FiniteDuration = 30.seconds
+
+    /** How long teardown waits for the dialer to acknowledge cancellation before proceeding. */
+    private val dialerCancelBudget: FiniteDuration = 5.seconds
+
     private def dialerLoop(client: WSClient[IO], hubUri: Uri): IO[Nothing] = {
         val request = WSRequest(hubUri)
 
@@ -87,14 +96,41 @@ final class CoilPeerWsTransport private (
             (once >> tracer.traceWith(DialerDisconnected(hubUri)))
                 .handleErrorWith(e => tracer.traceWith(DialerFailed(e)))
 
-        (attempt >> IO.sleep(1.second)).foreverM
+        // Bound each attempt and ABANDON a stalled one rather than awaiting it. `JdkWSClient`
+        // builds its socket inside `Resource.make`'s acquire, which is uncancelable, and
+        // `fromCompletableFuture` is cooperative-only — so a hub that accepts the TCP connection and
+        // never answers the handshake blocks `once` forever. Without this the loop never iterates
+        // and the peer stops reconnecting entirely: not slow to recover, never retrying.
+        //
+        // `race` cancels the losing `join`, not the attempt behind it, which is exactly what is
+        // wanted here — the stalled fiber is left to finish or not, and the loop moves on.
+        val bounded: IO[Unit] =
+            attempt.start.flatMap(f =>
+                IO.race(f.join, IO.sleep(handshakeBudget)).flatMap {
+                    case Left(_) => IO.unit
+                    case Right(_) =>
+                        tracer.traceWith(DialerHandshakeStalled(hubUri, handshakeBudget))
+                }
+            )
+
+        (bounded >> IO.sleep(1.second)).foreverM
     }
 
     /** Launch the hub dialer fiber; torn down when the resource is released. The hub URI is passed
       * at dial-start time so the caller can discover the hub's OS-assigned port after binding.
       */
     def startDialer(client: WSClient[IO], hubUri: Uri): Resource[IO, Unit] =
-        Resource.make(dialerLoop(client, hubUri).start)(_.cancel).void
+        Resource
+            .make(dialerLoop(client, hubUri).start)(fiber =>
+                // `cancel` waits for the fiber to finalize and is itself uncancelable, so a dialer
+                // stuck in an uncancelable handshake acquire would hang teardown — the same shape as
+                // the boot barriers. Run the cancel on its own fiber and bound the JOIN, which IS
+                // cancelable. A healthy dialer sits in `IO.sleep` and completes this immediately.
+                fiber.cancel.start
+                    .flatMap(_.join.timeoutTo(dialerCancelBudget, IO.unit))
+                    .void
+            )
+            .void
 }
 
 object CoilPeerWsTransport {

--- a/src/main/scala/hydrozoa/multisig/consensus/transport/CoilPeerWsTransportEvent.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/transport/CoilPeerWsTransportEvent.scala
@@ -2,6 +2,7 @@ package hydrozoa.multisig.consensus.transport
 
 import hydrozoa.multisig.consensus.liaison.LiaisonProtocol
 import org.http4s.Uri
+import scala.concurrent.duration.FiniteDuration
 
 /** Typed events emitted by [[CoilPeerWsTransport]]. Pure data; formatters in
   * [[CoilPeerWsTransportEventFormat]] decide how each variant is rendered to a particular sink.
@@ -34,6 +35,16 @@ object CoilPeerWsTransportEvent:
 
     /** A dialer attempt to the hub failed. */
     final case class DialerFailed(cause: Throwable) extends CoilPeerWsTransportEvent
+
+    /** A dial attempt sat in the WebSocket handshake past its budget and was abandoned.
+      *
+      * Distinct from [[DialerFailed]] because nothing failed: the hub accepted the TCP connection
+      * and then never answered. That attempt cannot be cancelled (the client builds its socket in
+      * an uncancelable acquire), so it is left running and the dialer moves on — which is the only
+      * way this peer keeps reconnecting at all.
+      */
+    final case class DialerHandshakeStalled(uri: Uri, after: FiniteDuration)
+        extends CoilPeerWsTransportEvent
 
     /** The connection to the hub ended without error — the peer closed cleanly, or the receive side
       * reached end of stream. A read-deadline expiry is an **error** and surfaces as

--- a/src/main/scala/hydrozoa/multisig/consensus/transport/CoilPeerWsTransportEventFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/transport/CoilPeerWsTransportEventFormat.scala
@@ -30,6 +30,11 @@ object CoilPeerWsTransportEventFormat:
                 // Class as well as message: getMessage is null for most connection exceptions,
                 // which made a live incident undiagnosable from the logs.
                 warn(s"dialer to hub failed: ${cause.getClass.getSimpleName}: ${cause.getMessage}")
+            case DialerHandshakeStalled(uri, after) =>
+                warn(
+                  s"dialer: handshake to hub at $uri stalled past $after and was abandoned; " +
+                      "the hub accepted the connection but never completed it — redialing"
+                )
             case DialerDisconnected(uri) =>
                 warn(s"dialer: disconnected from hub at $uri; redialing")
         }

--- a/src/main/scala/hydrozoa/multisig/consensus/transport/PeerTransport.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/transport/PeerTransport.scala
@@ -126,7 +126,20 @@ final class WsPeerTransport private (
             (once >> tracer.traceWith(DialerDisconnected(remote, uri)))
                 .handleErrorWith(e => tracer.traceWith(DialerFailed(remote, e)))
 
-        (attempt >> IO.sleep(1.second)).foreverM
+        // Same bound as the coil dialer: `JdkWSClient` builds its socket in an uncancelable acquire,
+        // so a remote that accepts the connection and never answers the handshake blocks `once`
+        // forever and this loop stops retrying altogether. `race` cancels the losing join, not the
+        // attempt, so the stalled fiber is abandoned and the dialer moves on.
+        val bounded: IO[Unit] =
+            attempt.start.flatMap(f =>
+                IO.race(f.join, IO.sleep(handshakeBudget)).flatMap {
+                    case Left(_) => IO.unit
+                    case Right(_) =>
+                        tracer.traceWith(DialerHandshakeStalled(remote, uri, handshakeBudget))
+                }
+            )
+
+        (bounded >> IO.sleep(1.second)).foreverM
     }
 
     /** Server-side handler for an incoming WS connection. The first frame must be
@@ -178,6 +191,12 @@ final class WsPeerTransport private (
             serverHandler(wsb)
         }
 
+    /** How long one dial attempt may sit in the WebSocket handshake before it is abandoned. */
+    private val handshakeBudget: FiniteDuration = 30.seconds
+
+    /** How long teardown waits for a dialer to acknowledge cancellation before proceeding. */
+    private val dialerCancelBudget: FiniteDuration = 5.seconds
+
     /** Launch a dialer fiber for each remote with peerNum greater than ours (lower dials higher).
       * The fibers are torn down when the resource is released. URIs are passed at dial-start time
       * so the caller can bind on an OS-assigned ephemeral port and only build the URI map after
@@ -192,7 +211,13 @@ final class WsPeerTransport private (
             .traverse_ { case (rid, uri) =>
                 Resource
                     .make(dialerLoop(client, rid, uri).start)(fiber =>
-                        tracer.traceWith(DialerStopped(rid, uri)) >> fiber.cancel
+                        // Bounded for the same reason as the coil side: `cancel` waits for the
+                        // fiber to finalize and is itself uncancelable, so a dialer stuck in the
+                        // handshake would hang teardown. Bound the JOIN, which is cancelable.
+                        tracer.traceWith(DialerStopped(rid, uri)) >>
+                            fiber.cancel.start
+                                .flatMap(_.join.timeoutTo(dialerCancelBudget, IO.unit))
+                                .void
                     )
                     .void
             }

--- a/src/main/scala/hydrozoa/multisig/consensus/transport/PeerTransportEvent.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/transport/PeerTransportEvent.scala
@@ -2,6 +2,7 @@ package hydrozoa.multisig.consensus.transport
 
 import hydrozoa.multisig.consensus.peer.HeadPeerId
 import org.http4s.Uri
+import scala.concurrent.duration.FiniteDuration
 
 /** Typed events emitted by [[PeerTransport]]. Pure data; formatters in [[PeerTransportEventFormat]]
   * decide how each variant is rendered to a particular sink.
@@ -39,6 +40,14 @@ object PeerTransportEvent:
 
     /** The dialer fiber for a remote peer was cancelled (resource release). */
     final case class DialerStopped(remote: HeadPeerId, uri: Uri) extends PeerTransportEvent
+
+    /** A dial attempt sat in the WebSocket handshake past its budget and was abandoned. Nothing
+      * failed: the remote accepted the TCP connection and never answered. The attempt cannot be
+      * cancelled (the client builds its socket in an uncancelable acquire), so it is left running
+      * and the dialer moves on — which is what keeps this peer reconnecting at all.
+      */
+    final case class DialerHandshakeStalled(remote: HeadPeerId, uri: Uri, after: FiniteDuration)
+        extends PeerTransportEvent
 
     /** A frame received on an active dialer connection could not be decoded. */
     final case class ClientDecodeError(remote: HeadPeerId, cause: Throwable)

--- a/src/main/scala/hydrozoa/multisig/consensus/transport/PeerTransportEventFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/transport/PeerTransportEventFormat.scala
@@ -31,6 +31,18 @@ object PeerTransportEventFormat:
                 warn(s"dialer: disconnected from remote=${remote.peerNum: Int} at $uri; redialing")
             case DialerStopped(remote, uri) =>
                 info(s"dialer: stopped for remote=${remote.peerNum: Int} at $uri")
+            case DialerHandshakeStalled(remote, uri, after) =>
+                warn(
+                  s"dialer: handshake to remote=${remote.peerNum: Int} at $uri stalled past " +
+                      s"$after and was abandoned; the remote accepted the connection but never " +
+                      "completed it — redialing"
+                )
+            case DialerHandshakeStalled(remote, uri, after) =>
+                warn(
+                  s"dialer: handshake to remote=${remote.peerNum: Int} at $uri stalled past " +
+                      s"$after and was abandoned; the remote accepted the connection but never " +
+                      "completed it — redialing"
+                )
             case ClientDecodeError(remote, cause) =>
                 warn(
                   s"failed to decode frame from remote=${remote.peerNum: Int}: ${cause.getMessage}"

--- a/src/main/scala/hydrozoa/multisig/consensus/transport/PeerTransportEventFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/transport/PeerTransportEventFormat.scala
@@ -37,12 +37,6 @@ object PeerTransportEventFormat:
                       s"$after and was abandoned; the remote accepted the connection but never " +
                       "completed it — redialing"
                 )
-            case DialerHandshakeStalled(remote, uri, after) =>
-                warn(
-                  s"dialer: handshake to remote=${remote.peerNum: Int} at $uri stalled past " +
-                      s"$after and was abandoned; the remote accepted the connection but never " +
-                      "completed it — redialing"
-                )
             case ClientDecodeError(remote, cause) =>
                 warn(
                   s"failed to decode frame from remote=${remote.peerNum: Int}: ${cause.getMessage}"

--- a/src/main/scala/hydrozoa/multisig/ledger/joint/JointLedger.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/joint/JointLedger.scala
@@ -127,7 +127,7 @@ final case class JointLedger(
     private def initializeConnections: IO[Unit] = pendingConnections match {
         case x: HeadMultisigRegimeManager.PendingConnections =>
             for {
-                _connections <- x.get
+                _connections <- x.get.flatMap(IO.fromEither)
                 _ <- connections.set(
                   Some(
                     Connections(

--- a/src/main/scala/hydrozoa/multisig/ledger/joint/JointLedger.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/joint/JointLedger.scala
@@ -49,7 +49,11 @@ final case class JointLedger(
     l2Ledger: L2Ledger[IO],
     tracer: ContraTracer[IO, JointLedgerEvent],
     persistence: Persistence[IO],
-    metrics: PeerMetrics
+    metrics: PeerMetrics,
+    /** The boot markers, derived once by the regime manager (§5.2): this actor projects
+      * `fastBlockMark` and `evacuationMapMark` rather than re-reading the store.
+      */
+    markers: Markers
 ) extends Actor[IO, Requests.Request] {
     import config.*
 
@@ -200,12 +204,12 @@ final case class JointLedger(
             // fast anchor is `fastBlockMark = max(BlockResult)` (§6), shared by head and coil peers:
             // on a head peer it coincides with `max(own SoftAck)` (both written in the same atomic
             // per-block batch); a coil peer authors no soft-ack and anchors on it directly.
-            fastBlockMark <- Markers.recoverFastBlockMark(persistence.backend)
             recovered <- State.recover(
               persistence,
               l2Ledger,
-              fastBlockMark,
-              config.initialEvacuationMap
+              markers.fastBlockMark,
+              config.initialEvacuationMap,
+              markers.evacuationMapMark
             )
             _ <- recovered match {
                 case Some(done) =>
@@ -1078,7 +1082,8 @@ object JointLedger {
             persistence: Persistence[IO],
             l2Ledger: L2Ledger[IO],
             fastBlockMark: Option[BlockNumber],
-            initialEvacuationMap: EvacuationMap
+            initialEvacuationMap: EvacuationMap,
+            evacuationMapMark: Option[BlockNumber]
         )(using CardanoNetwork.Section): IO[Option[Done]] =
             fastBlockMark match
                 case None =>
@@ -1102,7 +1107,12 @@ object JointLedger {
                             .restoreTo(done.commandNumber)
                             .value
                             .flatMap(IO.fromEither)
-                        expected <- evacuationMapAt(persistence, blockNum, initialEvacuationMap)
+                        expected <- evacuationMapAt(
+                          persistence,
+                          blockNum,
+                          initialEvacuationMap,
+                          evacuationMapMark
+                        )
                         _ <- IO.raiseUnless(actual == expected.digest)(
                           RestoreError.EvacuationMapMismatch(
                             expected = expected.digest,
@@ -1128,10 +1138,10 @@ object JointLedger {
         private def evacuationMapAt(
             persistence: Persistence[IO],
             blockNum: BlockNumber,
-            initialEvacuationMap: EvacuationMap
+            initialEvacuationMap: EvacuationMap,
+            mapMark: Option[BlockNumber]
         ): IO[EvacuationMap] =
             for {
-                mapMark <- Markers.recoverEvacuationMapMark(persistence.backend)
                 base <- mapMark.fold(IO.pure(BlockNumber.zero -> initialEvacuationMap))(mark =>
                     persistence.getOrFail(StoreKey.EvacuationMap(mark)).map(mark -> _)
                 )

--- a/src/main/scala/hydrozoa/multisig/persistence/Markers.scala
+++ b/src/main/scala/hydrozoa/multisig/persistence/Markers.scala
@@ -2,6 +2,8 @@ package hydrozoa.multisig.persistence
 
 import cats.effect.IO
 import cats.syntax.parallel.*
+import cats.syntax.traverse.*
+import hydrozoa.config.head.network.CardanoNetwork
 import hydrozoa.multisig.consensus.ack.HardAckNumber
 import hydrozoa.multisig.consensus.peer.{HeadPeerNumber, PeerId}
 import hydrozoa.multisig.ledger.block.BlockNumber
@@ -30,10 +32,23 @@ final case class Markers(
     fastBlockMark: Option[BlockNumber],
     hardConfirmed: Option[StackNumber],
     hardAcked: Option[HardAckNumber],
-    nextRequestNumber: RequestNumber
+    nextRequestNumber: RequestNumber,
+    evacuationMapMark: Option[BlockNumber],
+    /** The stack this peer's last own hard-ack covers — `hardAcked` dereferenced into the journal
+      * and unpacked. Unlike the six marks around it this is an *interpretation*, not a `lastKey`,
+      * which is exactly why it belongs here: derived twice it can be adjusted once and disagree
+      * everywhere. `None` on an empty own-ack journal.
+      */
+    hardAckedStack: Option[StackNumber]
 )
 
 object Markers:
+    /** The marker set of an empty store: every anchor absent, the request counter at zero. What
+      * [[derive]] returns for a cold store, spelled out so a caller that has no store to derive
+      * from (a test wiring an actor against an empty backend) need not fabricate one.
+      */
+    val cold: Markers = Markers(None, None, None, None, RequestNumber(0), None, None)
+
     /** Read all five markers from `backend`, scoping the `hardAcked` and `nextRequestNumber`
       * derivations to `own`. With the per-author CF split each satellite CF holds exactly one
       * author's journal, so the own `hardAcked` mark is just `lastKey` of the own-author `HardAck`
@@ -41,17 +56,29 @@ object Markers:
       * covers both peer types, and `nextRequestNumber` is `RequestNumber(0)` on a coil peer (the
       * user-request surface is head-only).
       */
-    def derive(backend: BackendStore[IO], own: PeerId): IO[Markers] =
+    def derive(persistence: Persistence[IO], own: PeerId)(using
+        CardanoNetwork.Section
+    ): IO[Markers] =
+        val backend = persistence.backend
         val nextRequest = own match
             case PeerId.Head(n) => recoverNextRequestNumber(backend, n)
             case PeerId.Coil(_) => IO.pure(RequestNumber(0))
-        (
-          backend.lastKey(Cf.SoftConfirmation).map(_.map(decodeBlockNum)),
-          recoverFastBlockMark(backend),
-          backend.lastKey(Cf.HardConfirmation).map(_.map(decodeStackNum)),
-          backend.lastKey(Cf.HardAck(own)).map(_.map(decodeSatelliteNumHard)),
-          nextRequest
-        ).parMapN(Markers.apply)
+        for {
+            base <- (
+              backend.lastKey(Cf.SoftConfirmation).map(_.map(decodeBlockNum)),
+              recoverFastBlockMark(backend),
+              backend.lastKey(Cf.HardConfirmation).map(_.map(decodeStackNum)),
+              backend.lastKey(Cf.HardAck(own)).map(_.map(decodeSatelliteNumHard)),
+              nextRequest,
+              recoverEvacuationMapMark(backend)
+            ).parTupled
+            (soft, fast, hardConf, hardAck, nextReq, evacMark) = base
+            // Sequenced after the parallel block: it is keyed BY `hardAcked`, so it cannot be read
+            // alongside the mark it depends on.
+            ackedStack <- hardAck.traverse(n =>
+                persistence.getOrFail(JournalKey.HardAck(own, n)).map(_.payload.stackNum)
+            )
+        } yield Markers(soft, fast, hardConf, hardAck, nextReq, evacMark, ackedStack)
 
     /** The next request number this peer will assign after recovery: `max(own Request) + 1`, or
       * `RequestNumber(0)` for an empty store — the last key of the own-author `Request` CF (an

--- a/src/main/scala/hydrozoa/multisig/persistence/Markers.scala
+++ b/src/main/scala/hydrozoa/multisig/persistence/Markers.scala
@@ -3,7 +3,6 @@ package hydrozoa.multisig.persistence
 import cats.effect.IO
 import cats.syntax.parallel.*
 import cats.syntax.traverse.*
-import hydrozoa.config.head.network.CardanoNetwork
 import hydrozoa.multisig.consensus.ack.HardAckNumber
 import hydrozoa.multisig.consensus.peer.{HeadPeerNumber, PeerId}
 import hydrozoa.multisig.ledger.block.BlockNumber
@@ -56,9 +55,7 @@ object Markers:
       * covers both peer types, and `nextRequestNumber` is `RequestNumber(0)` on a coil peer (the
       * user-request surface is head-only).
       */
-    def derive(persistence: Persistence[IO], own: PeerId)(using
-        CardanoNetwork.Section
-    ): IO[Markers] =
+    def derive(persistence: Persistence[IO], own: PeerId): IO[Markers] =
         val backend = persistence.backend
         val nextRequest = own match
             case PeerId.Head(n) => recoverNextRequestNumber(backend, n)

--- a/src/main/scala/hydrozoa/rulebased/RuleBasedActor.scala
+++ b/src/main/scala/hydrozoa/rulebased/RuleBasedActor.scala
@@ -300,7 +300,7 @@ final case class RuleBasedActor(
         versionMajor: BigInt
     ): IO[List[StandaloneEvacuationCommitment.MultiSigned]] =
         for {
-            markers <- Markers.derive(persistence.backend, config.ownPeerId)
+            markers <- Markers.derive(persistence, config.ownPeerId)
             latest <- markers.hardConfirmed.liftTo[IO](
               MissingState("no hard-confirmed stack on disk")
             )
@@ -337,7 +337,7 @@ final case class RuleBasedActor(
       */
     private[rulebased] def loadEvacuationInputs(versionMajor: BigInt): IO[EvacuationInputs] =
         for {
-            markers <- Markers.derive(persistence.backend, config.ownPeerId)
+            markers <- Markers.derive(persistence, config.ownPeerId)
             latest <- markers.hardConfirmed.liftTo[IO](
               MissingState("no hard-confirmed stack on disk")
             )
@@ -440,7 +440,7 @@ final case class RuleBasedActor(
             IO.pure(config.initialEvacuationMap.kzgCommitment -> config.initialEvacuationMap)
         else
             for {
-                markers <- Markers.derive(persistence.backend, config.ownPeerId)
+                markers <- Markers.derive(persistence, config.ownPeerId)
                 latest <- markers.hardConfirmed.liftTo[IO](
                   MissingState("no hard-confirmed stack on disk")
                 )

--- a/src/test/scala/hydrozoa/config/node/operation/multisig/NodeOperationMultisigConfigGen.scala
+++ b/src/test/scala/hydrozoa/config/node/operation/multisig/NodeOperationMultisigConfigGen.scala
@@ -1,6 +1,7 @@
 package hydrozoa.config.node.operation.multisig
 
 import hydrozoa.lib.number.PositiveInt
+import hydrozoa.multisig.ledger.stack.StackNumber
 import org.scalacheck.Gen
 import scala.concurrent.duration.{DurationInt, DurationLong, FiniteDuration}
 
@@ -21,10 +22,13 @@ def generateNodeOperationMultisigConfig(
         maxRequestsPerBatch <- Gen.choose(1, 100)
         outboxCap <- Gen.choose(1, 4096)
         millis <- Gen.choose(1L, maxPollingPeriod.toMillis)
+        // Present and absent, so a codec round-trip covers both shapes of the field.
+        transplantStack <- Gen.option(Gen.choose(0, 100000).map(StackNumber.apply))
     } yield NodeOperationMultisigConfig(
       cardanoLiaisonPollingPeriod = millis.millis,
       peerLiaisonMaxRequestsPerBatch = PositiveInt(maxRequestsPerBatch).get,
       peerLiaisonOutboxCap = PositiveInt(outboxCap).get,
       peerLiaisonResendInterval = 5.seconds,
+      transplantStackNumber = transplantStack,
       rateLimits = rateLimits
     )

--- a/src/test/scala/hydrozoa/multisig/consensus/BlockWeaverTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/BlockWeaverTest.scala
@@ -26,12 +26,7 @@ import hydrozoa.multisig.ledger.event.RequestId.ValidityFlag
 import hydrozoa.multisig.ledger.joint.JointLedger
 import hydrozoa.multisig.ledger.joint.JointLedger.Requests.{CompleteBlockFinal, CompleteBlockRegular, StartBlock}
 import hydrozoa.multisig.metrics.PeerMetrics
-import hydrozoa.multisig.persistence.{
-  InMemoryBackendStore,
-  Markers,
-  Persistence,
-  PersistenceEventFormat
-}
+import hydrozoa.multisig.persistence.{InMemoryBackendStore, Markers, Persistence, PersistenceEventFormat}
 import java.time.Instant
 import java.util.concurrent.atomic.AtomicReference
 import org.scalacheck.{Gen, Properties, PropertyM, Test}

--- a/src/test/scala/hydrozoa/multisig/consensus/BlockWeaverTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/BlockWeaverTest.scala
@@ -26,7 +26,12 @@ import hydrozoa.multisig.ledger.event.RequestId.ValidityFlag
 import hydrozoa.multisig.ledger.joint.JointLedger
 import hydrozoa.multisig.ledger.joint.JointLedger.Requests.{CompleteBlockFinal, CompleteBlockRegular, StartBlock}
 import hydrozoa.multisig.metrics.PeerMetrics
-import hydrozoa.multisig.persistence.{InMemoryBackendStore, Persistence, PersistenceEventFormat}
+import hydrozoa.multisig.persistence.{
+  InMemoryBackendStore,
+  Markers,
+  Persistence,
+  PersistenceEventFormat
+}
 import java.time.Instant
 import java.util.concurrent.atomic.AtomicReference
 import org.scalacheck.{Gen, Properties, PropertyM, Test}
@@ -128,7 +133,9 @@ object BlockWeaverTestHelpers {
             backend <- lift(InMemoryBackendStore.open(persistenceTracer).allocated.map(_._1))
             persistence <- lift(Persistence.fromBackend(backend, persistenceTracer)(using config))
             actor <- lift(
-              env.system.actorOf(BlockWeaver(config, connections, tracer, metrics, persistence))
+              env.system.actorOf(
+                BlockWeaver(config, connections, tracer, metrics, persistence, Markers.cold)
+              )
             )
         } yield (actor, seen)
 
@@ -187,7 +194,9 @@ object BlockWeaverTestHelpers {
             backend <- lift(InMemoryBackendStore.open(persistenceTracer).allocated.map(_._1))
             persistence <- lift(Persistence.fromBackend(backend, persistenceTracer)(using config))
             actor <- lift(
-              env.system.actorOf(BlockWeaver(config, connections, tracer, metrics, persistence))
+              env.system.actorOf(
+                BlockWeaver(config, connections, tracer, metrics, persistence, Markers.cold)
+              )
             )
         } yield actor
 

--- a/src/test/scala/hydrozoa/multisig/consensus/CoilLiaisonTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/CoilLiaisonTest.scala
@@ -164,7 +164,10 @@ object CoilLiaisonTest extends Properties("Coil liaison plumbing") {
                 Persistence.fromBackend(backend, persistenceTracer).flatMap { persistence =>
                     ActorSystem[IO]("coil-liaison-test").use { system =>
                         for {
-                            headPending <- Deferred[IO, Either[Throwable, HeadMultisigRegimeManager.Connections]]
+                            headPending <- Deferred[IO, Either[
+                              Throwable,
+                              HeadMultisigRegimeManager.Connections
+                            ]]
                             hubSeen <- Ref[IO].of(Vector.empty[HardAck])
                             hubSlowConsensus <- system.actorOf(new HardAckRecorder(hubSeen))
                             sequencer <- system.actorOf(
@@ -181,7 +184,10 @@ object CoilLiaisonTest extends Properties("Coil liaison plumbing") {
                                         )
                                 }
                                 for {
-                                    pending <- Deferred[IO, Either[Throwable, HeadMultisigRegimeManager.Connections]]
+                                    pending <- Deferred[IO, Either[
+                                      Throwable,
+                                      HeadMultisigRegimeManager.Connections
+                                    ]]
                                     coilSeen <- Ref[IO].of(Vector.empty[HardAck])
                                     coilSlowConsensus <- system.actorOf(
                                       new HardAckRecorder(coilSeen)

--- a/src/test/scala/hydrozoa/multisig/consensus/CoilLiaisonTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/CoilLiaisonTest.scala
@@ -138,7 +138,7 @@ object CoilLiaisonTest extends Properties("Coil liaison plumbing") {
     /** Per-coil actors + the Ref recording what its slow-consensus slot receives. */
     private final case class CoilParts(
         coilNum: CoilPeerNumber,
-        pending: Deferred[IO, HeadMultisigRegimeManager.Connections],
+        pending: HeadMultisigRegimeManager.PendingConnections,
         coilSeen: Ref[IO, Vector[HardAck]],
         coilSlowConsensus: SlowConsensusActor.Handle,
         coilLiaison: PeerLiaisonCoilToHub.Handle,
@@ -164,7 +164,7 @@ object CoilLiaisonTest extends Properties("Coil liaison plumbing") {
                 Persistence.fromBackend(backend, persistenceTracer).flatMap { persistence =>
                     ActorSystem[IO]("coil-liaison-test").use { system =>
                         for {
-                            headPending <- Deferred[IO, HeadMultisigRegimeManager.Connections]
+                            headPending <- Deferred[IO, Either[Throwable, HeadMultisigRegimeManager.Connections]]
                             hubSeen <- Ref[IO].of(Vector.empty[HardAck])
                             hubSlowConsensus <- system.actorOf(new HardAckRecorder(hubSeen))
                             sequencer <- system.actorOf(
@@ -181,7 +181,7 @@ object CoilLiaisonTest extends Properties("Coil liaison plumbing") {
                                         )
                                 }
                                 for {
-                                    pending <- Deferred[IO, HeadMultisigRegimeManager.Connections]
+                                    pending <- Deferred[IO, Either[Throwable, HeadMultisigRegimeManager.Connections]]
                                     coilSeen <- Ref[IO].of(Vector.empty[HardAck])
                                     coilSlowConsensus <- system.actorOf(
                                       new HardAckRecorder(coilSeen)
@@ -238,7 +238,7 @@ object CoilLiaisonTest extends Properties("Coil liaison plumbing") {
                                         coilPeers.map(c => c.coilNum -> c.coilLiaison).toMap,
                                   )
                                 )
-                            _ <- headPending.complete(headConnections)
+                            _ <- headPending.complete(Right(headConnections))
                             _ <- coilPeers.traverse_ { c =>
                                 baseConnections(system, slowConsensus = c.coilSlowConsensus)
                                     .map(
@@ -247,7 +247,7 @@ object CoilLiaisonTest extends Properties("Coil liaison plumbing") {
                                         remoteHubLiaison = Some(c.hubLiaison),
                                       )
                                     )
-                                    .flatMap(c.pending.complete)
+                                    .flatMap(conns => c.pending.complete(Right(conns)))
                             }
 
                             // Let the initial population/own-hard-ack handshakes settle, then

--- a/src/test/scala/hydrozoa/multisig/consensus/ReplayActorTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/ReplayActorTest.scala
@@ -21,7 +21,17 @@ import hydrozoa.multisig.ledger.block.{BlockBody, BlockBrief, BlockHeader, Block
 import hydrozoa.multisig.ledger.event.RequestNumber
 import hydrozoa.multisig.ledger.l1.tx.TxSignature
 import hydrozoa.multisig.ledger.stack.{PartitionEffects, Stack, StackBrief, StackEffects, StackNumber, StandaloneEvacuationCommitment}
-import hydrozoa.multisig.persistence.{ArrivalStamp, Cf, InMemoryBackendStore, JournalKey, JournalValue, Persistence, PersistenceEventFormat, StoreKey}
+import hydrozoa.multisig.persistence.{
+  ArrivalStamp,
+  Cf,
+  InMemoryBackendStore,
+  JournalKey,
+  JournalValue,
+  Markers,
+  Persistence,
+  PersistenceEventFormat,
+  StoreKey
+}
 import org.scalacheck.Gen
 import org.scalatest.funsuite.AnyFunSuite
 import scala.concurrent.duration.DurationInt
@@ -221,6 +231,7 @@ class ReplayActorTest extends AnyFunSuite:
                         seqSink <- Ref.of[IO, Vector[CoilAckSequencer.Request]](Vector.empty)
                         seq <- system.actorOf(Recorder[CoilAckSequencer.Request](seqSink))
                         _ <- seed(persistence)
+                        markers <- Markers.derive(persistence, PeerId.Head(own))
                         outcome <- ReplayActor
                             .replay(
                               persistence,
@@ -231,7 +242,8 @@ class ReplayActorTest extends AnyFunSuite:
                               hubs,
                               coils,
                               treasuryAddress,
-                              leadsFastBlock = ownLeadsFastBlock
+                              leadsFastBlock = ownLeadsFastBlock,
+                              markers = markers
                             )
                             .attempt
                         _ <- IO.sleep(1.second) // let the probe fibers drain their mailboxes
@@ -269,6 +281,7 @@ class ReplayActorTest extends AnyFunSuite:
                         sca <- system.actorOf(Recorder[SlowConsensusActor.Request](scaSink))
                         sc <- system.actorOf(Recorder[StackComposer.Request](scSink))
                         _ <- seed(persistence)
+                        markers <- Markers.derive(persistence, PeerId.Coil(CoilPeerNumber(0)))
                         outcome <- ReplayActor
                             .replay(
                               persistence,
@@ -280,7 +293,8 @@ class ReplayActorTest extends AnyFunSuite:
                               Nil,
                               treasuryAddress,
                               // A coil peer never leads a fast block.
-                              leadsFastBlock = _ => false
+                              leadsFastBlock = _ => false,
+                              markers = markers
                             )
                             .attempt
                         _ <- IO.sleep(1.second) // let the probe fibers drain their mailboxes

--- a/src/test/scala/hydrozoa/multisig/consensus/ReplayActorTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/ReplayActorTest.scala
@@ -21,17 +21,7 @@ import hydrozoa.multisig.ledger.block.{BlockBody, BlockBrief, BlockHeader, Block
 import hydrozoa.multisig.ledger.event.RequestNumber
 import hydrozoa.multisig.ledger.l1.tx.TxSignature
 import hydrozoa.multisig.ledger.stack.{PartitionEffects, Stack, StackBrief, StackEffects, StackNumber, StandaloneEvacuationCommitment}
-import hydrozoa.multisig.persistence.{
-  ArrivalStamp,
-  Cf,
-  InMemoryBackendStore,
-  JournalKey,
-  JournalValue,
-  Markers,
-  Persistence,
-  PersistenceEventFormat,
-  StoreKey
-}
+import hydrozoa.multisig.persistence.{ArrivalStamp, Cf, InMemoryBackendStore, JournalKey, JournalValue, Markers, Persistence, PersistenceEventFormat, StoreKey}
 import org.scalacheck.Gen
 import org.scalatest.funsuite.AnyFunSuite
 import scala.concurrent.duration.DurationInt

--- a/src/test/scala/hydrozoa/multisig/consensus/SlowConsensusActorRecoveryTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/SlowConsensusActorRecoveryTest.scala
@@ -14,7 +14,14 @@ import hydrozoa.multisig.consensus.peer.{HeadPeerNumber, PeerId}
 import hydrozoa.multisig.ledger.l1.tx.TxSignature
 import hydrozoa.multisig.ledger.stack.StackNumber
 import hydrozoa.multisig.metrics.PeerMetrics
-import hydrozoa.multisig.persistence.{Cf, InMemoryBackendStore, Persistence, PersistenceEventFormat, StoreKey}
+import hydrozoa.multisig.persistence.{
+  Cf,
+  InMemoryBackendStore,
+  Markers,
+  Persistence,
+  PersistenceEventFormat,
+  StoreKey
+}
 import org.scalacheck.Gen
 import org.scalatest.funsuite.AnyFunSuite
 import scala.concurrent.duration.DurationInt
@@ -68,6 +75,11 @@ class SlowConsensusActorRecoveryTest extends AnyFunSuite:
                           StoreKey.HardConfirmation(StackNumber(confirmed)).encode,
                           Array[Byte](0)
                         )
+                        // Derived from the SEEDED store, not `Markers.cold`: the fixture writes a
+                        // HardConfirmation key above, and a cold bundle would leave `lastConfirmed`
+                        // None — the surplus guard under test would never arm and the suite would
+                        // pass while asserting nothing.
+                        markers <- Markers.derive(persistence, config.ownPeerId)
                         seen <- Ref.of[IO, Vector[SlowConsensusActorEvent]](Vector.empty)
                         tracer = ContraTracer[IO, SlowConsensusActorEvent](e => seen.update(_ :+ e))
                         sc <- system.actorOf(SinkActor[StackComposer.Request]())
@@ -78,7 +90,8 @@ class SlowConsensusActorRecoveryTest extends AnyFunSuite:
                             SlowConsensusActor.Connections(sc, cl, Nil),
                             tracer,
                             persistence,
-                            PeerMetrics.create(0L, Vector.empty)
+                            PeerMetrics.create(0L, Vector.empty),
+                            markers
                           )
                         )
                         _ <- sca ! remoteAck(peer = 1, stack = ackStack)

--- a/src/test/scala/hydrozoa/multisig/consensus/SlowConsensusActorRecoveryTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/SlowConsensusActorRecoveryTest.scala
@@ -14,14 +14,7 @@ import hydrozoa.multisig.consensus.peer.{HeadPeerNumber, PeerId}
 import hydrozoa.multisig.ledger.l1.tx.TxSignature
 import hydrozoa.multisig.ledger.stack.StackNumber
 import hydrozoa.multisig.metrics.PeerMetrics
-import hydrozoa.multisig.persistence.{
-  Cf,
-  InMemoryBackendStore,
-  Markers,
-  Persistence,
-  PersistenceEventFormat,
-  StoreKey
-}
+import hydrozoa.multisig.persistence.{Cf, InMemoryBackendStore, Markers, Persistence, PersistenceEventFormat, StoreKey}
 import org.scalacheck.Gen
 import org.scalatest.funsuite.AnyFunSuite
 import scala.concurrent.duration.DurationInt

--- a/src/test/scala/hydrozoa/multisig/consensus/StackComposerRecoveryTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/StackComposerRecoveryTest.scala
@@ -20,16 +20,7 @@ import hydrozoa.multisig.ledger.l1.utxo.MultisigTreasuryUtxo
 import hydrozoa.multisig.ledger.stack.{PartitionEffects, Stack, StackBrief, StackEffects, StackNumber, StandaloneEvacuationCommitment}
 import hydrozoa.multisig.metrics.PeerMetrics
 import hydrozoa.multisig.persistence.codec.TreasuryFixture
-import hydrozoa.multisig.persistence.{
-  ArrivalStamp,
-  InMemoryBackendStore,
-  JournalKey,
-  JournalValue,
-  Markers,
-  Persistence,
-  PersistenceEventFormat,
-  StoreKey
-}
+import hydrozoa.multisig.persistence.{ArrivalStamp, InMemoryBackendStore, JournalKey, JournalValue, Markers, Persistence, PersistenceEventFormat, StoreKey}
 import org.scalacheck.Gen
 import org.scalatest.funsuite.AnyFunSuite
 import scala.concurrent.duration.DurationInt

--- a/src/test/scala/hydrozoa/multisig/consensus/StackComposerRecoveryTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/StackComposerRecoveryTest.scala
@@ -20,7 +20,16 @@ import hydrozoa.multisig.ledger.l1.utxo.MultisigTreasuryUtxo
 import hydrozoa.multisig.ledger.stack.{PartitionEffects, Stack, StackBrief, StackEffects, StackNumber, StandaloneEvacuationCommitment}
 import hydrozoa.multisig.metrics.PeerMetrics
 import hydrozoa.multisig.persistence.codec.TreasuryFixture
-import hydrozoa.multisig.persistence.{ArrivalStamp, InMemoryBackendStore, JournalKey, JournalValue, Persistence, PersistenceEventFormat, StoreKey}
+import hydrozoa.multisig.persistence.{
+  ArrivalStamp,
+  InMemoryBackendStore,
+  JournalKey,
+  JournalValue,
+  Markers,
+  Persistence,
+  PersistenceEventFormat,
+  StoreKey
+}
 import org.scalacheck.Gen
 import org.scalatest.funsuite.AnyFunSuite
 import scala.concurrent.duration.DurationInt
@@ -87,7 +96,7 @@ class StackComposerRecoveryTest extends AnyFunSuite:
                   p,
                   Some(HardAckNumber(0)),
                   None,
-                  PeerId.Head(ownNum)
+                  Some(StackNumber(1))
                 )
             } yield recovered match {
                 case Some(state) => assert(state.treasury == balancedTreasury)
@@ -105,7 +114,7 @@ class StackComposerRecoveryTest extends AnyFunSuite:
             for {
                 _ <- seedRecoverableWith(p, TreasuryFixture.sampleTreasury)
                 outcome <- StackComposer.State
-                    .recover(p, Some(HardAckNumber(0)), None, PeerId.Head(ownNum))
+                    .recover(p, Some(HardAckNumber(0)), None, Some(StackNumber(1)))
                     .attempt
             } yield outcome match {
                 case Left(e) =>
@@ -171,6 +180,9 @@ class StackComposerRecoveryTest extends AnyFunSuite:
                     for {
                         persistence <- Persistence.fromBackend(backend, persistenceTracer)
                         _ <- seed(persistence)
+                        // From the SEEDED store: this case is about recovering a real anchor, so a
+                        // cold bundle would make the actor bootstrap instead and assert nothing.
+                        markers <- Markers.derive(persistence, config.ownPeerId)
                         gotHandoff <- Deferred[IO, SlowConsensusActor.StackHandoff]
                         probe <- system.actorOf(HandoffProbe(gotHandoff))
                         jlSink <- system.actorOf(NoopSink[JointLedger.Requests.Request]())
@@ -186,7 +198,8 @@ class StackComposerRecoveryTest extends AnyFunSuite:
                             ),
                             ContraTracer.nullTracer[IO, StackComposerEvent],
                             persistence,
-                            PeerMetrics.create(0L, Vector.empty)
+                            PeerMetrics.create(0L, Vector.empty),
+                            markers
                           )
                         )
                         r <- check(gotHandoff)

--- a/src/test/scala/hydrozoa/multisig/ledger/JointLedgerTest.scala
+++ b/src/test/scala/hydrozoa/multisig/ledger/JointLedgerTest.scala
@@ -35,7 +35,12 @@ import hydrozoa.multisig.ledger.joint.{JointLedger, JointLedgerEventFormat}
 import hydrozoa.multisig.ledger.l1.deposits.map.DepositsMap
 import hydrozoa.multisig.ledger.l1.txseq.DepositRefundTxSeq
 import hydrozoa.multisig.metrics.PeerMetrics
-import hydrozoa.multisig.persistence.{InMemoryBackendStore, Persistence, PersistenceEventFormat}
+import hydrozoa.multisig.persistence.{
+  InMemoryBackendStore,
+  Markers,
+  Persistence,
+  PersistenceEventFormat
+}
 import java.util.concurrent.TimeUnit
 import monocle.Focus.focus
 import org.scalacheck.*
@@ -167,7 +172,10 @@ object JointLedgerTestHelpers {
                             JointLedgerEventFormat.humanFormat(HeadPeerNumber.zero)
                           ),
                           persistence,
-                          PeerMetrics.create(0L, Vector(HeadPeerNumber.zero: Int))
+                          PeerMetrics.create(0L, Vector(HeadPeerNumber.zero: Int)),
+                          // Nothing is seeded in this fixture, so the cold bundle is exactly what
+                          // deriving from this backend would return.
+                          Markers.cold
                         )
                       )
                     )

--- a/src/test/scala/hydrozoa/multisig/ledger/JointLedgerTest.scala
+++ b/src/test/scala/hydrozoa/multisig/ledger/JointLedgerTest.scala
@@ -35,12 +35,7 @@ import hydrozoa.multisig.ledger.joint.{JointLedger, JointLedgerEventFormat}
 import hydrozoa.multisig.ledger.l1.deposits.map.DepositsMap
 import hydrozoa.multisig.ledger.l1.txseq.DepositRefundTxSeq
 import hydrozoa.multisig.metrics.PeerMetrics
-import hydrozoa.multisig.persistence.{
-  InMemoryBackendStore,
-  Markers,
-  Persistence,
-  PersistenceEventFormat
-}
+import hydrozoa.multisig.persistence.{InMemoryBackendStore, Markers, Persistence, PersistenceEventFormat}
 import java.util.concurrent.TimeUnit
 import monocle.Focus.focus
 import org.scalacheck.*

--- a/src/test/scala/hydrozoa/multisig/persistence/recovery/JournalScanTest.scala
+++ b/src/test/scala/hydrozoa/multisig/persistence/recovery/JournalScanTest.scala
@@ -97,7 +97,10 @@ class JournalScanTest extends AnyFunSuite:
               fastBlockMark = None,
               hardConfirmed = Some(StackNumber(1)), // stack floor 2
               hardAcked = Some(HardAckNumber(4)),
-              nextRequestNumber = RequestNumber(0)
+              nextRequestNumber = RequestNumber(0),
+              // Neither is read by cursor derivation; present only to complete the bundle.
+              evacuationMapMark = None,
+              hardAckedStack = None
             )
             val highWater = Map(
               HeadPeerNumber(0) -> RequestNumber(4), // request floor 5

--- a/src/test/scala/hydrozoa/multisig/persistence/recovery/RecoverSeamsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/persistence/recovery/RecoverSeamsTest.scala
@@ -79,11 +79,13 @@ class RecoverSeamsTest extends AnyFunSuite:
             for
                 store <- InMemoryL2Store.create
                 ledger <- EutxoL2Ledger(config, store)
+                emm <- Markers.recoverEvacuationMapMark(p.backend)
                 viaRecover <- JointLedger.State.recover(
                   p,
                   ledger,
                   None,
-                  config.initialEvacuationMap
+                  config.initialEvacuationMap,
+                  emm
                 )
                 viaState <- JointLedger.State.recoverState(p, None)
             yield assert(viaRecover.isEmpty && viaState.isEmpty)
@@ -131,11 +133,13 @@ class RecoverSeamsTest extends AnyFunSuite:
                         p.put(StoreKey.BlockResult(BlockNumber(n)))(br.persisted)
                     )
                 )
+                emm <- Markers.recoverEvacuationMapMark(p.backend)
                 done <- JointLedger.State.recover(
                   p,
                   ledger,
                   Some(BlockNumber(2)),
-                  config.initialEvacuationMap
+                  config.initialEvacuationMap,
+                  emm
                 )
                 anchored <- ledger.peekState.map(_.commandNumber)
             yield assert(done.isDefined && anchored == L2CommandNumber(2L))
@@ -168,11 +172,13 @@ class RecoverSeamsTest extends AnyFunSuite:
                         p.put(StoreKey.BlockResult(BlockNumber(n)))(br.persisted)
                     )
                 )
+                emm <- Markers.recoverEvacuationMapMark(p.backend)
                 recovered <- JointLedger.State.recover(
                   p,
                   ledger,
                   Some(BlockNumber(2)),
-                  config.initialEvacuationMap
+                  config.initialEvacuationMap,
+                  emm
                 )
                 anchored <- ledger.peekState.map(_.commandNumber)
             yield assert(
@@ -188,7 +194,7 @@ class RecoverSeamsTest extends AnyFunSuite:
     test("StackComposer.recover returns None for an empty store (no own hard-ack)") {
         withStore { p =>
             StackComposer.State
-                .recover(p, None, None, PeerId.Head(HeadPeerNumber(0)))
+                .recover(p, None, None, None)
                 .map(s => assert(s.isEmpty))
         }
     }
@@ -212,18 +218,23 @@ class RecoverSeamsTest extends AnyFunSuite:
                 _ <- p.put(StoreKey.UnsignedStack(StackNumber(stackN)))(us)
                 _ <- p.put(StoreKey.Treasury)(balancedTreasury)
                 _ <- p.put(StoreKey.EvacuationMap(BlockNumber(lastBlock)))(EvacuationMap.empty)
-                markers = Markers(
-                  softConfirmed = None,
-                  fastBlockMark = None,
-                  hardConfirmed = Some(StackNumber(stackN)), // stack 2 hard-confirmed → gate armed
-                  hardAcked = Some(HardAckNumber(hardAckNum)),
-                  nextRequestNumber = RequestNumber(0)
+                // DERIVED, not hand-built: `hardAckedStack` is unpacked from the hard-ack VALUE
+                // inside `Markers.derive`, and that unpacking is what this test exists to check —
+                // passing it in by hand would assert the fixture, not the code. Only
+                // `hardConfirmed` is overridden, because no HardConfirmation is seeded and this
+                // case wants the gate armed.
+                markers <- Markers
+                    .derive(p, PeerId.Head(own))
+                    .map(_.copy(hardConfirmed = Some(StackNumber(stackN))))
+                _ = assert(
+                  markers.hardAckedStack == Some(StackNumber(stackN)),
+                  s"ack $hardAckNum must unpack to stack $stackN, got ${markers.hardAckedStack}"
                 )
                 recovered <- StackComposer.State.recover(
                   p,
                   markers.hardAcked,
                   markers.hardConfirmed,
-                  PeerId.Head(own)
+                  markers.hardAckedStack
                 )
             yield assert(
               recovered.exists { s =>
@@ -267,18 +278,16 @@ class RecoverSeamsTest extends AnyFunSuite:
                 _ <- p.put(StoreKey.BlockResult(BlockNumber(5)))(br5.persisted)
                 _ <- p.put(JournalKey.Block(BlockNumber(4)))(JournalValue(stamp, br4.brief))
                 _ <- p.put(JournalKey.Block(BlockNumber(5)))(JournalValue(stamp, br5.brief))
-                markers = Markers(
-                  softConfirmed = None,
-                  fastBlockMark = None,
-                  hardConfirmed = Some(StackNumber(0)), // below stack 1 → gate disarmed
-                  hardAcked = Some(HardAckNumber(0)),
-                  nextRequestNumber = RequestNumber(0)
-                )
+                // Derived for the same reason as above; `hardConfirmed` overridden to keep the
+                // gate disarmed, which is what this case is about.
+                markers <- Markers
+                    .derive(p, PeerId.Head(own))
+                    .map(_.copy(hardConfirmed = Some(StackNumber(0))))
                 recovered <- StackComposer.State.recover(
                   p,
                   markers.hardAcked,
                   markers.hardConfirmed,
-                  PeerId.Head(own)
+                  markers.hardAckedStack
                 )
             yield assert(
               recovered.exists { s =>
@@ -329,11 +338,16 @@ class RecoverSeamsTest extends AnyFunSuite:
                       Timestamped(stamp, softConfirmedOf(br))
                     )
                 )
+                // Derived so the acked stack comes from the seeded ack VALUE (stack 1 here, not
+                // the ack number 0); `hardConfirmed` is pinned below it to keep the gate disarmed.
+                markers <- Markers
+                    .derive(p, PeerId.Head(own))
+                    .map(_.copy(hardConfirmed = Some(StackNumber(0))))
                 recovered <- StackComposer.State.recover(
                   p,
-                  Some(HardAckNumber(0)),
-                  Some(StackNumber(0)),
-                  PeerId.Head(own)
+                  markers.hardAcked,
+                  markers.hardConfirmed,
+                  markers.hardAckedStack
                 )
             yield assert(
               recovered.exists { s =>
@@ -351,7 +365,7 @@ class RecoverSeamsTest extends AnyFunSuite:
     test("StackComposer.recover (coil) returns None for an empty store (no own coil hard-ack)") {
         withStore { p =>
             StackComposer.State
-                .recover(p, None, None, PeerId.Coil(CoilPeerNumber(0)))
+                .recover(p, None, None, None)
                 .map(r => assert(r.isEmpty))
         }
     }
@@ -406,7 +420,7 @@ class RecoverSeamsTest extends AnyFunSuite:
                   p,
                   Some(HardAckNumber(hardAckNum)),
                   Some(StackNumber(stackN)), // stack 2 hard-confirmed → gate armed
-                  PeerId.Coil(coil)
+                  Some(StackNumber(stackN))
                 )
             yield assert(
               recovered.exists { s =>
@@ -444,7 +458,7 @@ class RecoverSeamsTest extends AnyFunSuite:
                 store <- InMemoryL2Store.create
                 ledger <- EutxoL2Ledger(config, store)
                 r <- JointLedger.State
-                    .recover(p, ledger, None, config.initialEvacuationMap)
+                    .recover(p, ledger, None, config.initialEvacuationMap, None)
                     .attempt
             yield assert(r == Right(None))
         }
@@ -459,7 +473,7 @@ class RecoverSeamsTest extends AnyFunSuite:
                 // or against a different configuration of this one. Dropping one entry is enough —
                 // the check is on the digest of the whole map.
                 divergent = EvacuationMap.from(config.initialEvacuationMap.drop(1))
-                r <- JointLedger.State.recover(p, ledger, None, divergent).attempt
+                r <- JointLedger.State.recover(p, ledger, None, divergent, None).attempt
             yield assert(
               r.swap.toOption.exists {
                   case RestoreError.EvacuationMapMismatch(expected, actual) =>
@@ -493,8 +507,12 @@ class RecoverSeamsTest extends AnyFunSuite:
                 // A stack closed at block 1, so its stored map — not the config's initial one — is
                 // the base, and only block 2's diffs are folded on top.
                 _ <- p.put(StoreKey.EvacuationMap(BlockNumber(1)))(config.initialEvacuationMap)
+                // Derived: these cases seed EvacuationMap(1) so the STORED map is the fold base.
+                // A hard-coded None would restore the config's initial map instead, and the
+                // divergence these tests assert on would quietly stop being exercised.
+                emm <- Markers.recoverEvacuationMapMark(p.backend)
                 r <- JointLedger.State
-                    .recover(p, ledger, Some(BlockNumber(2)), config.initialEvacuationMap)
+                    .recover(p, ledger, Some(BlockNumber(2)), config.initialEvacuationMap, emm)
                     .attempt
             yield assert(r.map(_.isDefined) == Right(true))
         }
@@ -520,8 +538,12 @@ class RecoverSeamsTest extends AnyFunSuite:
                 // The stack-close base disagrees with what the ledger holds, and the blocks folded
                 // on top carry no diffs to reconcile it — so the anchor maps differ.
                 _ <- p.put(StoreKey.EvacuationMap(BlockNumber(1)))(EvacuationMap.empty)
+                // Derived: these cases seed EvacuationMap(1) so the STORED map is the fold base.
+                // A hard-coded None would restore the config's initial map instead, and the
+                // divergence these tests assert on would quietly stop being exercised.
+                emm <- Markers.recoverEvacuationMapMark(p.backend)
                 r <- JointLedger.State
-                    .recover(p, ledger, Some(BlockNumber(2)), config.initialEvacuationMap)
+                    .recover(p, ledger, Some(BlockNumber(2)), config.initialEvacuationMap, emm)
                     .attempt
             yield assert(
               r.swap.toOption.exists(_.isInstanceOf[RestoreError.EvacuationMapMismatch])
@@ -537,8 +559,12 @@ class RecoverSeamsTest extends AnyFunSuite:
                 _ <- p.put(JournalKey.Block(BlockNumber(2)))(JournalValue(stamp, brief))
                 _ <- p.put(StoreKey.DepositMap)(DepositsMap.empty)
                 // L2CommandNumber intentionally not written
+                // Derived: these cases seed EvacuationMap(1) so the STORED map is the fold base.
+                // A hard-coded None would restore the config's initial map instead, and the
+                // divergence these tests assert on would quietly stop being exercised.
+                emm <- Markers.recoverEvacuationMapMark(p.backend)
                 r <- JointLedger.State
-                    .recover(p, ledger, Some(BlockNumber(2)), config.initialEvacuationMap)
+                    .recover(p, ledger, Some(BlockNumber(2)), config.initialEvacuationMap, emm)
                     .attempt
             yield assert(r.swap.toOption.exists(_.isInstanceOf[IllegalStateException]))
         }
@@ -554,15 +580,18 @@ class RecoverSeamsTest extends AnyFunSuite:
                 )
                 _ <- p.put(StoreKey.UnsignedStack(StackNumber(1)))(us)
                 // Treasury intentionally not written
-                markers = Markers(
-                  None,
-                  None,
-                  Some(StackNumber(1)),
-                  Some(HardAckNumber(0)),
-                  RequestNumber(0)
-                )
+                // Derived, so the ack-value unpacking stays under test; only `hardConfirmed` is
+                // pinned, since no HardConfirmation is seeded here.
+                markers <- Markers
+                    .derive(p, PeerId.Head(own))
+                    .map(_.copy(hardConfirmed = Some(StackNumber(1))))
                 r <- StackComposer.State
-                    .recover(p, markers.hardAcked, markers.hardConfirmed, PeerId.Head(own))
+                    .recover(
+                      p,
+                      markers.hardAcked,
+                      markers.hardConfirmed,
+                      markers.hardAckedStack
+                    )
                     .attempt
             yield assert(r.swap.toOption.exists(_.isInstanceOf[IllegalStateException]))
         }

--- a/src/test/scala/hydrozoa/multisig/persistence/recovery/ReplayCursorsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/persistence/recovery/ReplayCursorsTest.scala
@@ -68,7 +68,9 @@ class ReplayCursorsTest extends AnyFunSuite:
           hardConfirmed = Some(StackNumber(3)),
           hardAcked =
               Some(HardAckNumber(4)), // the counter — derive ignores it; acked stack is a param
-          nextRequestNumber = RequestNumber(0)
+          nextRequestNumber = RequestNumber(0),
+          evacuationMapMark = None,
+          hardAckedStack = None
         )
         val hw = Map(HeadPeerNumber(0) -> RequestNumber(7), HeadPeerNumber(1) -> RequestNumber(2))
         val cursors =
@@ -139,7 +141,9 @@ class ReplayCursorsTest extends AnyFunSuite:
           fastBlockMark = Some(BlockNumber(5)),
           hardConfirmed = None,
           hardAcked = Some(HardAckNumber(5)),
-          nextRequestNumber = RequestNumber(0)
+          nextRequestNumber = RequestNumber(0),
+          evacuationMapMark = None,
+          hardAckedStack = None
         )
         val cursors =
             ReplayCursors.derive(
@@ -164,7 +168,7 @@ class ReplayCursorsTest extends AnyFunSuite:
     }
 
     test("derive: empty store (all None, no acked stack) yields index-0 floors everywhere") {
-        val markers = Markers(None, None, None, None, RequestNumber(0))
+        val markers = Markers(None, None, None, None, RequestNumber(0), None, None)
         val cursors = ReplayCursors.derive(
           markers,
           peers,
@@ -188,7 +192,7 @@ class ReplayCursorsTest extends AnyFunSuite:
     test("scanFloors enumerates exactly 2 + 3N journals (no hubs; spines collapse to confirmed)") {
         val cursors =
             ReplayCursors.derive(
-              Markers(None, None, None, None, RequestNumber(0)),
+              Markers(None, None, None, None, RequestNumber(0), None, None),
               peers,
               Nil,
               Map.empty,
@@ -205,7 +209,7 @@ class ReplayCursorsTest extends AnyFunSuite:
         val hubs = List(HeadPeerNumber(0), HeadPeerNumber(1))
         val cursors =
             ReplayCursors.derive(
-              Markers(None, None, None, None, RequestNumber(0)),
+              Markers(None, None, None, None, RequestNumber(0), None, None),
               peers,
               hubs,
               Map.empty,
@@ -227,7 +231,7 @@ class ReplayCursorsTest extends AnyFunSuite:
         val own = PeerId.Coil(CoilPeerNumber(0))
         val cursors =
             ReplayCursors.derive(
-              Markers(None, None, None, None, RequestNumber(0)),
+              Markers(None, None, None, None, RequestNumber(0), None, None),
               peers,
               hubs,
               Map.empty,


### PR DESCRIPTION
## Review order

Bottom of a four-PR stack. Above it, in order: `feat/remote-ledger-hardening`, `feat/l1-boot-gate`, `config/credentials-from-environment`. This branch has no dependencies of its own.

A coil peer joining a head with deep history cannot catch up over the wire — catch-up is one block per round trip — so it is seeded from another peer's RocksDB store. That store made the node refuse to boot, and once it booted it was inert. This is the five-commit path to a seeded coil that behaves like an ordinary one, verified on real nodes against preview.

## What was wrong

A seeded peer inherits the donor's confirmed history but not its own hard-ack journal, so `hardConfirmed` names a stack this peer never acked. Two independent readers unpacked "the stack my last ack covers" from that journal — `ReplayActor.recoverOwnAck` and `StackComposer.State.recover`. They agree on any store a peer wrote itself, because `StackComposer` writes a stack's effects and its own acks in one atomic batch. On a seeded store the pairing does not hold: the ack journal read is the donor's *receive copy* of this peer's acks, while the confirmations are the donor's own.

So the two readers disagreed, and fixing one fixed nothing:

```
Recovery refused: store inconsistency (confirmed > acked).
softConfirmed=Some(909) hardConfirmed=Some(114) fastBlockMark=Some(909), hardAckedStack=Some(0)
```

and with the gate satisfied, the composer still anchored at stack 0 and waited to compose stack 1 against a head at 124 — booted, healthy, following blocks, and contributing nothing.

## The commits

- **derive the boot markers once, at the regime manager.** Eight call sites across five actors plus ReplayActor's bundle — thirteen store reads at boot, `hardConfirmed` read twice and `fastBlockMark` twice. Now one bundle, projected. Duplicating a *derivation* was harmless; duplicating an *interpretation* was not, and `hardAckedStack` is an interpretation. It also removes a latent race: the per-actor reads happened after the start barrier, where a faster sibling could already be advancing the spine a slower one was about to read.
- **`transplantStackNumber`.** Names the stack the store was seeded at; the floor applies only while that is still this store's `hardConfirmed`. Monotonic, so it matches on the adopting boot and is inert ever after — nothing to retire by hand, and a stale tag can neither re-arm nor fail a restart. Raise-only, so an in-flight peer does not lose its handoff.
- **boot barriers carry `Either`, and the shutdown hook is bounded.** A boot failure left both barriers empty forever: children parked inside an uncancelable `invoke`, the system's `Supervisor(await = true)` waited on them, RocksDB's release sat downstream, and the app fiber never reached `waitForTermination`. The node ignored SIGTERM and needed SIGKILL with its store LOCK held — which then blocked the retry.
- **bounded WebSocket handshake and cancel-wait.** `JdkWSClient` builds its socket in an uncancelable acquire, so a remote that accepts TCP and never answers neither completes nor cancels. Worse than a shutdown hang: `once` blocks forever, `foreverM` never iterates, and the peer stops reconnecting altogether.

## Verification

All three peers seeded from one snapshot (`hardConfirmed` = 114); only the coil being adopted is tagged.

|                         |                                                                                                       |
| ----------------------- | ----------------------------------------------------------------------------------------------------- |
| all three boot          | 0 refusals                                                                                            |
| drive traffic           | head 114 → 119; the seeded coil's own `HardConfirmation` follows, ack journal matches the head's view |
| its `StackComposer`     | runs 20× — was **0**                                                                                  |
| **stop the other coil** | head advanced **119 → 123 on the seeded coil's quorum alone** (previously stalled dead at 119)        |
| restart it              | rejoins in 6 s, 0 refusals, all three converge                                                        |
| refused boot            | exits itself in ~5 s, no signal, no held lock — previously survived SIGTERM indefinitely              |

## Notes for review

- `Markers.derive` now decodes one journal value rather than reading keys only, so it can fail on a store with a malformed ack where before it could not.
- `RuleBasedActor`'s three `Markers.derive` calls are runtime, not boot, and keep re-deriving deliberately; they now also pay the dependent get.
- Recovery suites derive from their seeded stores instead of being handed literals — the test that exists to prove the stack number comes from the ack *value* would otherwise assert its own fixture.
- Supersedes `feat/adopt-transplanted-history`, which fixed the gate only.