### PR TITLE
Bound the remote-ledger handshake, and let a shutdown break its retry loop

### DIFF
--- a/src/main/scala/hydrozoa/app/Serve.scala
+++ b/src/main/scala/hydrozoa/app/Serve.scala
@@ -135,7 +135,7 @@ object Serve {
             // `remoteLedgerUri`. Only the EUTXO ledger is also an EutxoL2LedgerReader, so only it
             // yields a reader for the server's L2-query endpoints (a remote node hands it None).
             l2 <- mkL2Ledger(nodeConfig, dataDir)
-            (l2Ledger, l2Screener, l2QueryReader) = l2
+            (l2Ledger, l2Screener, l2QueryReader, signalL2Shutdown) = l2
 
             // Per-peer persistence store. Default path; later milestones will surface this
             // through NodeConfig (P1 skeleton; see design §7). Open the RocksDB-backed
@@ -157,6 +157,14 @@ object Serve {
             }
 
             system <- ActorSystem[IO]("Hydrozoa Demo")
+
+            // ⛔ ORDER IS LOAD-BEARING. Resource finalizers run in reverse acquisition order, so
+            // acquiring this AFTER the ActorSystem makes it release BEFORE the system is torn down.
+            // A remote L2 ledger retries transport failure forever from inside a cats-actors message
+            // handler, and `ActorCell` wraps handlers in `.uncancelable` — so the system cannot stop
+            // that actor, and without this signal SIGTERM does not shut the node down at all. Move
+            // this line above the ActorSystem and the node stops exiting cleanly.
+            _ <- Resource.onFinalize(signalL2Shutdown)
 
             wsClient <- Resource.eval(JdkWSClient.simple[IO])
 
@@ -283,7 +291,7 @@ object Serve {
     private def mkL2Ledger(
         nodeConfig: NodeConfig,
         dataDir: Path,
-    ): Resource[IO, (L2Ledger[IO], L2Screener[IO], Option[EutxoL2LedgerReader[IO]])] =
+    ): Resource[IO, (L2Ledger[IO], L2Screener[IO], Option[EutxoL2LedgerReader[IO]], IO[Unit])] =
         nodeConfig.headConfig.l2Ledger match {
             case L2LedgerKind.CardanoEutxo =>
                 for {
@@ -292,7 +300,7 @@ object Serve {
                       dataDir.resolve(s"peer-${nodeConfig.ownPeerLabel}/l2-rocksdb")
                     )
                     ledger <- Resource.eval(EutxoL2Ledger(nodeConfig, store))
-                } yield (ledger, EutxoL2Screener(nodeConfig), Some(ledger))
+                } yield (ledger, EutxoL2Screener(nodeConfig), Some(ledger), IO.unit)
             case L2LedgerKind.AnyRemote =>
                 val tracer = Slf4jTracer.sink.contramap(RemoteL2LedgerEventFormat.humanFormat)
                 val wsUri = nodeConfig.remoteLedgerUri.getOrElse(
@@ -308,7 +316,12 @@ object Serve {
                       tracer = tracer,
                     )
                     screener <- mkRemoteScreener(nodeConfig)
-                } yield (ledger, screener, Option.empty[EutxoL2LedgerReader[IO]])
+                } yield (
+                  ledger,
+                  screener,
+                  Option.empty[EutxoL2LedgerReader[IO]],
+                  ledger.signalShutdown
+                )
         }
 
     /** The screener for a remote-ledger node: the stateless check every request must pass before it

--- a/src/main/scala/hydrozoa/lib/QuietRelease.scala
+++ b/src/main/scala/hydrozoa/lib/QuietRelease.scala
@@ -1,0 +1,30 @@
+package hydrozoa.lib
+
+// `_root_.` because `hydrozoa.lib.cats` shadows the top-level `cats` package from here.
+import _root_.cats.effect.{IO, Resource}
+
+/** Make a resource's RELEASE non-throwing, leaving acquire and use untouched.
+  *
+  * ⛔ Why this exists. `JdkWSClient`'s close path hands the observed close status straight to the
+  * JDK's `WebSocket.sendClose`, which rejects the RFC 6455 reserved codes 1005 (No Status Received)
+  * and 1006 (Abnormal Closure) with `IllegalArgumentException: statusCode` — and those are exactly
+  * the codes reported for a socket that closed WITHOUT a close handshake, i.e. every peer that
+  * crashed, was killed, or vanished. Reproduced twice: once when the remote ledger was killed
+  * mid-run, once at node shutdown.
+  *
+  * The throw escapes from a finalizer, where cats-effect can only report it to `reportFailure` and
+  * drop it. That is bad in two ways: it prints a bare stack trace with no logger context (so it
+  * reads like a crash), and a finalizer that throws stops being a reliable part of an orderly
+  * teardown. Neither is acceptable on the shutdown path, which is precisely where a peer is most
+  * likely to have gone away.
+  *
+  * ⚠️ Deliberately narrow: only the release is swallowed. An acquire failure still propagates — a
+  * connection that cannot be opened is real news, and callers retry on it.
+  */
+object QuietRelease:
+    def apply[A](resource: Resource[IO, A]): Resource[IO, A] =
+        Resource.applyFull { poll =>
+            poll(resource.allocated).map { case (a, release) =>
+                (a, (_: Resource.ExitCase) => release.attempt.void)
+            }
+        }

--- a/src/main/scala/hydrozoa/multisig/consensus/transport/CoilPeerWsTransport.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/transport/CoilPeerWsTransport.scala
@@ -4,6 +4,7 @@ import cats.effect.std.Queue
 import cats.effect.{IO, Ref, Resource}
 import cats.syntax.all.*
 import hydrozoa.config.head.network.CardanoNetwork
+import hydrozoa.lib.QuietRelease
 import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.consensus.liaison.BatchMessages.{OwnHardAck, Population}
 import hydrozoa.multisig.consensus.liaison.{LiaisonProtocol, PeerLiaisonCoilToHub}
@@ -85,7 +86,7 @@ final class CoilPeerWsTransport private (
         // Low-level `connect`, not `connectHighLevel`: the dialer needs to see the hub's keep-alive
         // Ping to know the link is alive (see WsDuplex).
         def once: IO[Unit] =
-            client.connect(request).use { conn =>
+            QuietRelease(client.connect(request)).use { conn =>
                 val helloLine = CoilFrame.encode(CoilFrame.Hello(ownCoilNum.convert))
                 tracer.traceWith(DialerConnected(hubUri)) >>
                     conn.send(WSFrame.Text(helloLine)) >>

--- a/src/main/scala/hydrozoa/multisig/consensus/transport/PeerTransport.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/transport/PeerTransport.scala
@@ -5,6 +5,7 @@ import cats.effect.{IO, Ref, Resource}
 import cats.syntax.all.*
 import fs2.Stream
 import hydrozoa.config.head.network.CardanoNetwork
+import hydrozoa.lib.QuietRelease
 import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.consensus.liaison.{LiaisonProtocol, PeerLiaisonHeadToHead}
 import hydrozoa.multisig.consensus.peer.HeadPeerId
@@ -115,7 +116,7 @@ final class WsPeerTransport private (
         // Low-level `connect`, not `connectHighLevel`: the dialer needs to see the remote's
         // keep-alive Ping to know the link is alive (see WsDuplex).
         def once: IO[Unit] =
-            client.connect(request).use { conn =>
+            QuietRelease(client.connect(request)).use { conn =>
                 val helloLine = HeadFrame.encode(HeadFrame.Hello(ownPeerId.peerNum))
                 tracer.traceWith(DialerConnected(remote, uri)) >>
                     conn.send(WSFrame.Text(helloLine)) >>

--- a/src/main/scala/hydrozoa/multisig/ledger/remote/RemoteL2Ledger.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/remote/RemoteL2Ledger.scala
@@ -3,9 +3,10 @@ package hydrozoa.multisig.ledger.remote
 import cats.Monad
 import cats.data.EitherT
 import cats.effect.std.{Mutex, Queue}
-import cats.effect.{Async, FiberIO, IO, Ref, Resource}
+import cats.effect.{Async, Deferred, FiberIO, IO, Ref, Resource}
 import cats.syntax.all.*
 import hydrozoa.config.head.network.CardanoNetwork
+import hydrozoa.lib.QuietRelease
 import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.ledger.joint.EvacuationMapHash
 import hydrozoa.multisig.ledger.l2.{ApplyDepositDecisionsResponse, ApplyTransactionResponse, L2CommandNumber, L2Ledger, L2LedgerCommand, L2LedgerResponse, RegisterDepositResponse, RestoreError}
@@ -25,6 +26,16 @@ import scala.concurrent.duration.*
   * returned as a response.
   */
 final case class RemoteL2LedgerError(message: String) extends RuntimeException(message)
+
+/** Raised to break an in-flight exchange out of its retry loop when the node is shutting down.
+  *
+  * ⛔ This exists because a cats-actors message handler runs inside `ActorCell`'s `.uncancelable`
+  * region, so an actor parked in an unbounded retry CANNOT be cancelled and the actor system can
+  * never terminate — measured: SIGTERM did not shut the node down at all, and the process survived
+  * only to be force-killed by cats-effect's `shutdownHookTimeout` (whose default is `Duration.Inf`,
+  * i.e. never). The handler must therefore RETURN of its own accord, and this is how it does so.
+  */
+final case class RemoteL2LedgerShuttingDown(message: String) extends RuntimeException(message)
 
 /** A remote [[L2Ledger]] that drives a black-box ledger over one long-lived WebSocket connection,
   * one synchronous request/response at a time.
@@ -79,6 +90,8 @@ class RemoteL2Ledger private (
     restoreTimeout: FiniteDuration,
     initialBackoff: FiniteDuration,
     maxBackoff: FiniteDuration,
+    handshakeBudget: FiniteDuration,
+    stopping: Deferred[IO, Unit],
     config: RemoteL2Ledger.Config,
     tracer: ContraTracer[IO, RemoteL2LedgerEvent]
 ) extends L2Ledger[IO] {
@@ -267,7 +280,26 @@ class RemoteL2Ledger private (
                             }
                             tracer.traceWith(event) >> IO.sleep(wait) >> attempt(n + 1)
                     }
-            attempt(0)
+            // ⛔ The ESCAPE HATCH. `attempt` retries transport failure forever, by design — that is
+            // what makes a node tolerate an absent ledger. But it runs inside a cats-actors message
+            // handler, which `ActorCell` wraps in `.uncancelable`, so nothing outside can interrupt
+            // it: on SIGTERM the actor system cannot terminate and the process has to be
+            // force-killed. Racing an internal signal works where cancellation cannot, because the
+            // race is *inside* the uncancelable region rather than outside it.
+            //
+            // `stopping` is completed by a Resource acquired AFTER the ActorSystem, so its finalizer
+            // runs BEFORE the system is torn down — the loop is already unwinding by the time the
+            // system asks its actors to stop.
+            IO.race(stopping.get, attempt(0)).flatMap {
+                case Right(response) => IO.pure(response)
+                case Left(_) =>
+                    IO.raiseError(
+                      RemoteL2LedgerShuttingDown(
+                        "node is shutting down; abandoning the exchange for command " +
+                            s"${request.commandNumber}"
+                      )
+                    )
+            }
         }
     }
 
@@ -291,36 +323,75 @@ class RemoteL2Ledger private (
 
     /** Open a connection, cache it, and trace the outcome. A failure to connect propagates so
       * [[exchange]] backs off and retries.
+      *
+      * ⛔ The handshake is BOUNDED and a stalled attempt is ABANDONED rather than awaited.
+      * `JdkWSClient` builds its socket inside `Resource.make`'s acquire, which cats-effect runs
+      * uncancelable, so neither `.timeout` nor a `poll` around `allocated` can interrupt it. A
+      * remote that accepts the TCP connection and never completes the WebSocket upgrade therefore
+      * blocks the FIRST attempt forever — and because that attempt never returns, the retry ladder
+      * in [[exchange]] never engages. Measured: one connection, one log line, then silence
+      * indefinitely, while the node still serves HTTP and looks healthy. This is the same defect
+      * fixed for the peer transport in `41ddf732`, and `IO.race` cancels only the losing *join*,
+      * not the attempt behind it — which is exactly what is wanted.
       */
     private def open: IO[Conn] =
         tracer.traceWith(Connecting(wsUri)) >>
-            // Allocate-then-cache must be atomic w.r.t. cancellation: `poll` keeps the connect itself
-            // interruptible, but once `allocated` yields the (connection, release) pair, caching the
-            // release handle in `connRef` runs uninterruptibly. Otherwise a cancellation landing
-            // between the fd opening and the cache would strand the release handle and leak the
-            // connection — the exact fd leak this class exists to prevent.
-            IO.uncancelable { poll =>
-                poll(wsClient.connectHighLevel(WSRequest(wsUri)).allocated).flatMap {
-                    case (connection, release) =>
-                        for {
-                            // A per-connection queue fed by a background fiber that pulls
-                            // `receiveStream` without pause. Draining it continuously keeps the JDK
-                            // WebSocket's read-demand (`request(n)`) open, so a response is never left
-                            // unread in the socket — the receive-stall failure mode of re-pulling
-                            // `receiveStream.head` afresh per exchange.
-                            incoming <- Queue.unbounded[IO, String]
-                            receiveFiber <- connection.receiveStream
-                                .collect { case WSFrame.Text(t, _) => t }
-                                .foreach(incoming.offer)
-                                .compile
-                                .drain
-                                .start
-                            conn = Conn(connection, incoming, receiveFiber, release)
-                            _ <- connRef.set(Some(conn))
-                            _ <- tracer.traceWith(Connected(wsUri))
-                        } yield conn
-                }
-            }
+            QuietRelease(wsClient.connectHighLevel(WSRequest(wsUri))).allocated.start
+                .flatMap(f =>
+                    IO.race(f.joinWithNever, IO.sleep(handshakeBudget)).flatMap {
+                        case Left(pair) => cacheConnection(pair)
+                        case Right(_)   => abandon(f)
+                    }
+                )
+
+    /** Give up on a stalled handshake. The attempt is left running — it cannot be cancelled — so
+      * anything it eventually produces must still be closed by someone, or it is the exact fd leak
+      * this class exists to prevent. A cleanup fiber joins the abandoned attempt and releases
+      * whatever it yields; if it never yields, the fiber simply never runs.
+      */
+    private def abandon(f: FiberIO[(WSConnectionHighLevel[IO], IO[Unit])]): IO[Nothing] =
+        f.joinWithNever.flatMap((_, release) => release.attempt.void).start.void >>
+            tracer.traceWith(HandshakeStalled(wsUri, handshakeBudget)) >>
+            IO.raiseError(
+              RemoteL2LedgerError(
+                s"WebSocket handshake to $wsUri did not complete within $handshakeBudget"
+              )
+            )
+
+    /** Install a freshly-allocated connection: start its drain fiber and cache it.
+      *
+      * Uncancelable: once `allocated` has yielded the (connection, release) pair, a cancellation
+      * landing before the release handle reaches `connRef` would strand it and leak the connection.
+      */
+    private def cacheConnection(pair: (WSConnectionHighLevel[IO], IO[Unit])): IO[Conn] =
+        IO.uncancelable { _ =>
+            val (connection, release) = pair
+            for {
+                // A per-connection queue fed by a background fiber that pulls `receiveStream`
+                // without pause. Draining it continuously keeps the JDK WebSocket's read-demand
+                // (`request(n)`) open, so a response is never left unread in the socket — the
+                // receive-stall failure mode of re-pulling `receiveStream.head` afresh per exchange.
+                incoming <- Queue.unbounded[IO, String]
+                receiveFiber <- connection.receiveStream
+                    .collect { case WSFrame.Text(t, _) => t }
+                    .foreach(incoming.offer)
+                    .compile
+                    .drain
+                    .start
+                conn = Conn(connection, incoming, receiveFiber, release)
+                _ <- connRef.set(Some(conn))
+                _ <- tracer.traceWith(Connected(wsUri))
+            } yield conn
+        }
+
+    /** Tell any in-flight exchange to stop retrying and return.
+      *
+      * ⛔ Must be invoked from a `Resource` acquired **after** the `ActorSystem`, so that its
+      * finalizer runs **before** the system is torn down. Acquired earlier, it would fire after the
+      * system had already tried (and failed) to stop the actor parked in the retry loop, which is
+      * the deadlock it exists to prevent.
+      */
+    def signalShutdown: IO[Unit] = stopping.complete(()).void
 
     /** Discard a connection believed broken: clear it from the cache (if still current) and release
       * its resources, ignoring any close error.
@@ -443,17 +514,29 @@ object RemoteL2Ledger {
         config: Config,
         tracer: ContraTracer[IO, RemoteL2LedgerEvent],
         requestTimeout: FiniteDuration = 5.seconds,
-        // A remote ledger answers a Restore by replaying its **whole** event log — there is no
-        // snapshot — so this bound has to exceed a full rebuild, and a rebuild grows linearly with
-        // the head's lifetime. Measured 2026-08-20 on the production box: ~8 minutes over ~42M
-        // events, growing ~2-3 minutes per day at that traffic. The old 10-minute default was
-        // therefore about two minutes from expiring, and an expiry here is terminal: `restoreTo`
-        // is deliberately not retried (a retry restarts the rebuild), and every boot calls it, so
-        // the node simply fails to start. Raised to leave room while the log keeps growing;
-        // the real fix is a ledger snapshot, which makes the rebuild bounded instead of linear.
+        // An expiry here is terminal: `restoreTo` is deliberately not retried (a retry restarts
+        // the rebuild), and every boot calls it, so the node simply fails to start.
+        //
+        // ⚠️ This value was sized when a Restore replayed the remote's **whole** event log, which
+        // grew linearly with the head's lifetime — measured 2026-08-20 at ~8 minutes over ~42M
+        // events. That is no longer how it works: the remote now seeds from its newest snapshot
+        // and replays only the commands above it, capped by its snapshot interval (20,000 by
+        // default), so a rebuild is seconds and does not grow with the head's age. Measured
+        // 2026-09-01: 9,096 commands in 15 ms.
+        //
+        // ⇒ The bound is therefore now enormously oversized rather than marginal. It is left as-is
+        // deliberately: it costs nothing when nothing is wrong, and the failure it guards against
+        // (a boot that never completes) is worse than a boot that takes too long to give up. Do not
+        // re-derive a rebuild estimate from the old figure — that is how a stale constant in a
+        // comment produced a stale conclusion two steps away.
         restoreTimeout: FiniteDuration = 60.minutes,
         initialBackoff: FiniteDuration = 1.second,
         maxBackoff: FiniteDuration = 30.seconds,
+        // Bounds the WebSocket handshake. Generous, because a slow-but-healthy remote must not be
+        // abandoned: a ledger rebuilding from its newest snapshot answers in well under this, and
+        // the point of the bound is only to stop an attempt that will NEVER complete from parking
+        // the connect forever. See `open`.
+        handshakeBudget: FiniteDuration = 30.seconds,
     ): Resource[IO, RemoteL2Ledger] =
         for {
             uri <- Resource.eval(IO.fromEither(Uri.fromString(wsUri)))
@@ -463,6 +546,8 @@ object RemoteL2Ledger {
                 ref.get.flatMap(_.traverse_(c => c.receiveFiber.cancel >> c.release.attempt.void))
             )
             mutex <- Resource.eval(Mutex[IO])
+            // Completed by `stopOnShutdown`, which the caller must acquire AFTER the ActorSystem.
+            stopping <- Resource.eval(Deferred[IO, Unit])
         } yield new RemoteL2Ledger(
           uri,
           wsClient,
@@ -472,6 +557,8 @@ object RemoteL2Ledger {
           restoreTimeout,
           initialBackoff,
           maxBackoff,
+          handshakeBudget,
+          stopping,
           config,
           tracer
         )

--- a/src/main/scala/hydrozoa/multisig/ledger/remote/RemoteL2Ledger.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/remote/RemoteL2Ledger.scala
@@ -517,18 +517,17 @@ object RemoteL2Ledger {
         // An expiry here is terminal: `restoreTo` is deliberately not retried (a retry restarts
         // the rebuild), and every boot calls it, so the node simply fails to start.
         //
-        // ⚠️ This value was sized when a Restore replayed the remote's **whole** event log, which
-        // grew linearly with the head's lifetime — measured 2026-08-20 at ~8 minutes over ~42M
-        // events. That is no longer how it works: the remote now seeds from its newest snapshot
-        // and replays only the commands above it, capped by its snapshot interval (20,000 by
-        // default), so a rebuild is seconds and does not grow with the head's age. Measured
-        // 2026-09-01: 9,096 commands in 15 ms.
+        // ⚠️ This value was sized when a Restore replayed the remote's **whole** event log, so the
+        // rebuild grew linearly with the head's lifetime. That is no longer how it works: the remote
+        // seeds from its newest snapshot and replays only the commands above it, capped by its
+        // snapshot interval (20,000 by default), so a rebuild does not grow with the head's age.
         //
-        // ⇒ The bound is therefore now enormously oversized rather than marginal. It is left as-is
+        // ⇒ The bound is therefore enormously oversized rather than marginal. It is left as-is
         // deliberately: it costs nothing when nothing is wrong, and the failure it guards against
-        // (a boot that never completes) is worse than a boot that takes too long to give up. Do not
-        // re-derive a rebuild estimate from the old figure — that is how a stale constant in a
-        // comment produced a stale conclusion two steps away.
+        // (a boot that never completes) is worse than a boot that takes too long to give up.
+        // ⛔ Do not re-derive a rebuild estimate from any figure quoted near this constant: the
+        // rebuild cost depends on the snapshot interval and the state's size, and a number measured
+        // on one head does not transfer to another.
         restoreTimeout: FiniteDuration = 60.minutes,
         initialBackoff: FiniteDuration = 1.second,
         maxBackoff: FiniteDuration = 30.seconds,

--- a/src/main/scala/hydrozoa/multisig/ledger/remote/RemoteL2LedgerEvent.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/remote/RemoteL2LedgerEvent.scala
@@ -17,6 +17,14 @@ object RemoteL2LedgerEvent:
     /** A WebSocket connection to the remote ledger succeeded. */
     final case class Connected(uri: Uri) extends RemoteL2LedgerEvent
 
+    /** The WebSocket handshake did not complete within [[budget]], so the attempt was ABANDONED
+      * rather than awaited. A remote that accepts the TCP connection and never answers the upgrade
+      * would otherwise block the connect forever: `JdkWSClient` builds its socket inside
+      * `Resource.make`'s acquire, which is uncancelable, so neither a `timeout` nor a `poll` can
+      * interrupt it and the retry ladder never engages.
+      */
+    final case class HandshakeStalled(uri: Uri, budget: FiniteDuration) extends RemoteL2LedgerEvent
+
     /** A request errored; reconnecting after [[backoff]] on attempt [[attempt]] (zero-indexed). */
     final case class ConnectionError(attempt: Int, backoff: FiniteDuration, cause: Throwable)
         extends RemoteL2LedgerEvent

--- a/src/main/scala/hydrozoa/multisig/ledger/remote/RemoteL2LedgerEventFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/remote/RemoteL2LedgerEventFormat.scala
@@ -15,6 +15,13 @@ object RemoteL2LedgerEventFormat:
                 info(s"Connecting to WebSocket at $uri")
             case Connected(uri) =>
                 info(s"Successfully connected to $uri")
+            case HandshakeStalled(uri, budget) =>
+                LogEvent(
+                  Level.Warn,
+                  s"WebSocket handshake to $uri did not complete within $budget; " +
+                      "abandoning this attempt and retrying",
+                  routingKey = Some("RemoteL2Ledger")
+                )
             case ConnectionError(attempt, backoff, cause) =>
                 LogEvent(
                   Level.Warn,


### PR DESCRIPTION
## Review order

Stacked on `refactor/markers-at-the-manager`; review that first. This branch adds one commit. Above it: `feat/l1-boot-gate`, then `config/credentials-from-environment`.

Three defects in how a node talks to its remote L2 ledger, all found and measured on the preview rig with real binaries, and all closed with a before/after on the same arms.

## 1. A half-open ledger parked the connect forever

`RemoteL2Ledger.open` had no handshake bound. `JdkWSClient` builds its socket inside `Resource.make`'s acquire, which cats-effect runs **uncancelable**, so neither `.timeout` nor the `poll` that was already there could interrupt it. A remote that accepts the TCP connection and never completes the WebSocket upgrade blocked the **first** attempt forever — and because that attempt never returned, the retry ladder never engaged at all.

Measured, against a listener that accepts and sends nothing:

|                      | before                                | after                                                                                                                           |
| -------------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
| connections accepted | **1**, then silence indefinitely      | 3 and counting                                                                                                                  |
| hydrozoa's log       | one `Connecting…`, then nothing, ever | `handshake … did not complete within 30 seconds; abandoning this attempt and retrying`, then `attempt 1 … 1s`, `attempt 2 … 2s` |

⛔ The node **looked healthy** throughout: HTTP served, L1 polled, peers connected. Only the ledger path was silently and permanently dead.

Fixed with the same shape as `41ddf732`: run the connect on its own fiber, race it against a budget, and **abandon** a stalled attempt rather than awaiting it — `IO.race` cancels the losing *join*, not the attempt behind it. An abandoned attempt that later succeeds is released by a cleanup fiber, since nothing else would ever close it and that is exactly the fd leak this class exists to prevent.

## 2. The node could not shut down while an exchange was in flight

`exchange` retries transport failure forever, by design — that is what lets a node tolerate an absent ledger. But it runs inside a cats-actors message handler, and `ActorCell` wraps handlers in `.uncancelable`, so the actor system cannot stop it and SIGTERM did nothing.

Reproducible, and the rule is sharp — **it wedges iff an exchange is outstanding**:

| state at SIGTERM                             | before            | after            |
| -------------------------------------------- | ----------------- | ---------------- |
| no command pending                           | exits \<5s        | exits \<5s       |
| a request submitted while the ledger is down | **alive at +30s** | **exits in ~2s** |
| boot `restoreTo` in flight                   | **alive at +20s** | exits in seconds |

⚠️ It only died at all because `f499cacc` set a finite `shutdownHookTimeout`. cats-effect's default is `Duration.Inf` — so before that commit this was *"never exits"*, not *"exits after 30s"*. That commit bounded the symptom; this one addresses the cause.

The fix races an internal signal, which works where cancellation cannot because the race is *inside* the uncancelable region rather than outside it. `stopping` is completed by a `Resource` acquired **after** the `ActorSystem`, so its finalizer runs **before** the system is torn down. That ordering is load-bearing and the code says so; move the line above the ActorSystem and the node stops exiting cleanly.

## 3. An unhandled exception on the WebSocket close path

`JdkWSClient` hands the observed close status straight to the JDK's `sendClose`, which rejects the RFC 6455 reserved codes **1005/1006** with `IllegalArgumentException: statusCode` — and those are exactly the codes reported for a socket that closed without a handshake, i.e. every peer that crashed, was killed, or vanished. Reproduced twice: once when the ledger was killed mid-run, once at node shutdown.

It escapes from a **finalizer**, where cats-effect can only print it bare and drop it. `QuietRelease` makes the release non-throwing at all three WebSocket sites. Deliberately narrow: an *acquire* failure still propagates, because a connection that cannot be opened is real news and callers retry on it.

## Also

Corrects the `restoreTimeout` scaladoc. It claimed *"there is no snapshot"* and quoted ~8 minutes over ~42M events; the ledger now seeds from its newest snapshot and replays at most its snapshot interval (20,000 by default) — measured at 9,096 commands in **15ms**. The value is left alone (it costs nothing when nothing is wrong), but the stale figure had already produced a stale conclusion two steps away, so the comment now says not to re-derive from it.

## Verification

- **312 tests, 0 failures**; all five other sbt projects compile.
- Both defects re-tested on the rig after the change (the table rows above).
- ⚠️ Tests must be run as `nix develop -c sbt …`: the nix-profile `sbt` bundles a JDK 21 and every forked test JVM dies on `--sun-misc-unsafe-memory-access=allow`, reported only as an opaque `WorkerExchange.startWorker` timeout.

Two upstream issues drafted for http4s-jdk-http-client (the close-path throw, and the uncancelable acquire) — not filed yet.