### PR TITLE
startup: wait for what may arrive, refuse what retrying cannot fix

### DIFF
--- a/src/main/scala/hydrozoa/app/Serve.scala
+++ b/src/main/scala/hydrozoa/app/Serve.scala
@@ -152,7 +152,7 @@ object Serve {
             persistenceTracer = Slf4jTracer.sink.contramap(PersistenceEventFormat.humanFormat)
             // A held LOCK means another instance owns this store. Deterministic: restarting
             // re-derives the same answer for as long as the other process lives, so it is a
-            // refusal, not a crash. Measured: fails in ~3s with a clear message.
+            // refusal, not a crash. It fails fast, with a message naming the holder.
             backendStore <- RocksDbBackendStore
                 .open(
                   dataDir.resolve(s"peer-${nodeConfig.ownPeerLabel}/rocksdb"),
@@ -198,7 +198,6 @@ object Serve {
             // NOT `hardAckedStack`, which is an interpretation the regime manager must derive
             // exactly once and project into its children.
             _ <- Resource.eval {
-                given CardanoNetwork.Section = nodeConfig
                 nodeConfig.transplantStackNumber.fold(IO.unit)(tag =>
                     Markers
                         .derive(persistence, nodeConfig.ownPeerId)

--- a/src/main/scala/hydrozoa/app/Serve.scala
+++ b/src/main/scala/hydrozoa/app/Serve.scala
@@ -21,9 +21,10 @@ import hydrozoa.multisig.ledger.eutxol2.store.RocksDbL2Store
 import hydrozoa.multisig.ledger.eutxol2.{EutxoL2Ledger, EutxoL2Screener}
 import hydrozoa.multisig.ledger.l2.{EutxoL2LedgerReader, L2Ledger, L2Screener}
 import hydrozoa.multisig.ledger.remote.{RemoteL2Ledger, RemoteL2LedgerEventFormat, RemoteL2Screener, RemoteL2ScreenerEventFormat}
+import hydrozoa.multisig.ledger.stack.StackNumber
 import hydrozoa.multisig.metrics.PeerMetrics
 import hydrozoa.multisig.persistence.rocksdb.RocksDbBackendStore
-import hydrozoa.multisig.persistence.{Cf, ConsensusStoreReader, Persistence, PersistenceEventFormat}
+import hydrozoa.multisig.persistence.{Cf, ConsensusStoreReader, Markers, Persistence, PersistenceEventFormat}
 import hydrozoa.multisig.server.{HydrozoaHttpEvent, HydrozoaHttpEventFormat, HydrozoaServer}
 import hydrozoa.multisig.{CoilMultisigRegimeManager, CoilMultisigRegimeManagerEventFormat, CoilRegimeManagerEvent, HeadMultisigRegimeManager, HeadMultisigRegimeManagerEventFormat, HeadRegimeManagerEvent, MrmTracers}
 import java.nio.file.Path
@@ -176,6 +177,47 @@ object Serve {
             persistence <- Resource.eval {
                 given CardanoNetwork.Section = nodeConfig
                 Persistence.fromBackend(backendStore, persistenceTracer)
+            }
+
+            // ⛔ A transplant must contain the stack it is tagged with.
+            //
+            // `transplantStackNumber` names the stack this peer ELECTS TO ADOPT: everything at or
+            // below it is taken on trust from the donor committee and never verified, and only the
+            // stacks above it are checked. That makes the tag a partition of the store, chosen by
+            // the operator — any stack the store actually holds is a legitimate choice. A tag
+            // naming a stack the store does NOT hold is a different thing entirely: the config and
+            // the data have been mis-paired, and no amount of restarting will pair them.
+            //
+            // ⛔ This runs BEFORE the ActorSystem deliberately. The same verdict raised inside it
+            // escalates to the guardian, which terminates the system and exits 1 — and the unit's
+            // `RestartPreventExitStatus=2` does not catch a 1, so a mistyped tag would crash-loop.
+            // Here it is an ordinary `StartupRefusal` and exits 2. It needs nothing but the store
+            // and the config, so there is no reason for it to run any later.
+            //
+            // ⚠️ Reads `hardConfirmed` only — a plain `lastKey`, safe to derive more than once.
+            // NOT `hardAckedStack`, which is an interpretation the regime manager must derive
+            // exactly once and project into its children.
+            _ <- Resource.eval {
+                given CardanoNetwork.Section = nodeConfig
+                nodeConfig.transplantStackNumber.fold(IO.unit)(tag =>
+                    Markers
+                        .derive(persistence, nodeConfig.ownPeerId)
+                        .flatMap(markers =>
+                            IO.raiseUnless(
+                              markers.hardConfirmed.exists(Ordering[StackNumber].gteq(_, tag))
+                            )(
+                              StartupRefusal(
+                                s"transplantStackNumber is $tag, but the highest hard-confirmed " +
+                                    "stack in this store is " +
+                                    markers.hardConfirmed.fold("none — the store is empty")(
+                                      _.toString
+                                    ) +
+                                    ". A transplant must contain the stack it is tagged with; " +
+                                    "check that the store was copied and the tag read from that copy."
+                              )
+                            )
+                        )
+                )
             }
 
             system <- ActorSystem[IO]("Hydrozoa Demo")

--- a/src/main/scala/hydrozoa/app/Serve.scala
+++ b/src/main/scala/hydrozoa/app/Serve.scala
@@ -61,7 +61,14 @@ object Serve {
         Command(
           name = "serve",
           header = "Run a Hydrozoa head node from a generated config"
-        )((headConfigPathArg, privateConfigPathArg).mapN((h, p) => runNode(h, p)))
+        )(
+          (headConfigPathArg, privateConfigPathArg).mapN((h, p) =>
+              // A deterministic refusal exits with a distinct code so the unit's
+              // `RestartPreventExitStatus=` can stop a supervisor from re-deriving the same
+              // verdict forever. Everything transient waits instead of exiting at all.
+              StartupRefusal.guard(runNode(h, p))
+          )
+        )
 
     /** Run a Hydrozoa head node from a loaded config.
       *
@@ -142,15 +149,30 @@ object Serve {
             // BackendStore (byte-level primitive), then wrap it in the typed Persistence the
             // actor topology consumes.
             persistenceTracer = Slf4jTracer.sink.contramap(PersistenceEventFormat.humanFormat)
-            backendStore <- RocksDbBackendStore.open(
-              dataDir.resolve(s"peer-${nodeConfig.ownPeerLabel}/rocksdb"),
-              Cf.mkAll(
-                headPeers = nodeConfig.headConfig.headPeerNums.toList,
-                coilPeers = nodeConfig.headConfig.coilPeers.coilPeerNumbers,
-                hubs = nodeConfig.headConfig.coilPeers.hubHeadPeerNumbers
-              ),
-              persistenceTracer,
-            )
+            // A held LOCK means another instance owns this store. Deterministic: restarting
+            // re-derives the same answer for as long as the other process lives, so it is a
+            // refusal, not a crash. Measured: fails in ~3s with a clear message.
+            backendStore <- RocksDbBackendStore
+                .open(
+                  dataDir.resolve(s"peer-${nodeConfig.ownPeerLabel}/rocksdb"),
+                  Cf.mkAll(
+                    headPeers = nodeConfig.headConfig.headPeerNums.toList,
+                    coilPeers = nodeConfig.headConfig.coilPeers.coilPeerNumbers,
+                    hubs = nodeConfig.headConfig.coilPeers.hubHeadPeerNumbers
+                  ),
+                  persistenceTracer,
+                )
+                .handleErrorWith { case e: org.rocksdb.RocksDBException =>
+                    Resource.eval(
+                      IO.raiseError(
+                        StartupRefusal(
+                          s"cannot open the persistence store (${e.getMessage}). Another hydrozoa " +
+                              "instance is most likely holding it.",
+                          Some(e)
+                        )
+                      )
+                    )
+                }
             persistence <- Resource.eval {
                 given CardanoNetwork.Section = nodeConfig
                 Persistence.fromBackend(backendStore, persistenceTracer)

--- a/src/main/scala/hydrozoa/app/StartupRefusal.scala
+++ b/src/main/scala/hydrozoa/app/StartupRefusal.scala
@@ -1,0 +1,45 @@
+package hydrozoa.app
+
+import cats.effect.{ExitCode, IO}
+
+/** A deliberate, deterministic refusal to start: something about THIS node is wrong, and starting
+  * it again will reach the same conclusion.
+  *
+  * ⛔ The distinction this carries is the whole point. A node that cannot reach Cardano, its ledger
+  * or its peers now **waits** — indefinitely, visibly, and without exiting — because the world may
+  * yet become ready. A node whose config is malformed, whose script reference UTxOs are not on
+  * chain, or whose store is held by another instance is in a state no amount of retrying can fix,
+  * and it must fail loudly and STAY failed.
+  *
+  * Conflating the two is what produces an infinite `Restart=on-failure` loop: the supervisor
+  * answers a permanent verdict by re-deriving it every `RestartSec`, forever, learning nothing. So
+  * a refusal exits with [[StartupRefusal.exitCode]] and the unit sets `RestartPreventExitStatus=`
+  * to match.
+  *
+  * ⚠️ Do NOT reach for this to make an unavailable dependency fail faster. If a human could fix it
+  * by waiting, it is not a refusal.
+  */
+final case class StartupRefusal(reason: String, cause: Option[Throwable] = None)
+    extends RuntimeException(reason, cause.orNull)
+
+object StartupRefusal:
+
+    /** Distinct from 1 (a generic failure) so a supervisor can tell "do not restart me" from "I
+      * crashed and a restart might help". Mirrored by `RestartPreventExitStatus=2` in the unit.
+      */
+    val exitCode: ExitCode = ExitCode(2)
+
+    /** Run `io`, turning a refusal into [[exitCode]] rather than an unhandled crash. Anything else
+      * propagates unchanged: an unexpected throwable is not a considered verdict and a restart may
+      * well be the right answer to it.
+      */
+    def guard(io: IO[ExitCode]): IO[ExitCode] =
+        io.handleErrorWith {
+            case r: StartupRefusal =>
+                IO.println(
+                  s"hydrozoa refuses to start: ${r.reason}\n" +
+                      "This is a deliberate refusal, not a transient failure — restarting will " +
+                      "reach the same conclusion. Fix the cause and start again."
+                ).as(exitCode)
+            case other => IO.raiseError(other)
+        }

--- a/src/main/scala/hydrozoa/config/node/NodeConfig.scala
+++ b/src/main/scala/hydrozoa/config/node/NodeConfig.scala
@@ -3,6 +3,7 @@ package hydrozoa.config.node
 import cats.data.EitherT
 import cats.effect.*
 import cats.syntax.contravariant.*
+import hydrozoa.app.StartupRefusal
 import hydrozoa.config.ScriptReferenceUtxos
 import hydrozoa.config.head.HeadConfig
 import hydrozoa.config.head.coil.CoilPeers
@@ -195,7 +196,13 @@ object NodeConfig {
               NodeConfig.fromJson(headStr, privateStr, backendOverride).value
             ).flatMap {
                 case Left(err) =>
-                    IO.raiseError(new RuntimeException(s"Failed to load NodeConfig: $err"))
+                    // Reached only for a DETERMINISTIC failure: `isWorthRetrying` retries a
+                    // backend error forever, so anything arriving here is a malformed config or a
+                    // script reference UTxO that is not on chain. Re-deriving that verdict on a
+                    // supervisor restart loop teaches nobody anything.
+                    IO.raiseError(
+                      StartupRefusal(s"failed to load NodeConfig: $err")
+                    )
                 case Right(ok) => IO.pure(ok)
             }
         } yield loaded

--- a/src/main/scala/hydrozoa/config/node/NodeConfig.scala
+++ b/src/main/scala/hydrozoa/config/node/NodeConfig.scala
@@ -207,12 +207,23 @@ object NodeConfig {
       * a process supervisor answers by starting it again, immediately, into the same failure. That
       * turns a brief loss of egress into a crash loop that outlives it.
       *
-      * The total wait is a little under two minutes. Long enough to ride out a DNS or upstream
-      * blip; short enough that a genuinely wrong config still fails while someone is watching the
-      * deploy.
+      * ⛔ UNBOUNDED, deliberately, and this is the whole point. The ladder used to stop after ~112
+      * seconds, which meant any loss of egress longer than two minutes ended in exactly the crash
+      * loop the paragraph above set out to prevent. A node that cannot reach Cardano cannot do
+      * anything useful, so exiting buys nothing and costs an endless restart cycle; waiting is
+      * strictly better and is visible on the dashboard.
+      *
+      * ⚠️ This does NOT make a wrong config wait: [[isWorthRetrying]] retries only
+      * `CardanoBackendError`. A malformed config or an unresolvable script UTxO still fails
+      * immediately, because re-reading the same bytes gives the same answer. That split is the
+      * difference between "the world is not ready yet" and "this node is misconfigured", and the
+      * two must never be treated alike.
+      *
+      * It backs off 2s, 5s, 15s, 30s and then every 60s forever — capped so a node that has been
+      * waiting for hours still reacts promptly when egress returns.
       */
-    private val backendReadRetryWaits: List[FiniteDuration] =
-        List(2.seconds, 5.seconds, 15.seconds, 30.seconds, 60.seconds)
+    private val backendReadRetryWaits: LazyList[FiniteDuration] =
+        LazyList(2.seconds, 5.seconds, 15.seconds, 30.seconds) #::: LazyList.continually(60.seconds)
 
     /** Whether a failed load is worth another attempt. Anything that reached the Cardano backend is
       * — including an error the backend classified, since a DNS failure surfaces as a resolve error
@@ -230,11 +241,11 @@ object NodeConfig {
       * can drive the same loop without waiting minutes.
       */
     private[node] def retryingBackendReads[A](
-        waits: List[FiniteDuration],
+        waits: LazyList[FiniteDuration],
         attempt: IO[Either[ScriptReferenceUtxos.Error | io.circe.Error, A]]
     ): IO[Either[ScriptReferenceUtxos.Error | io.circe.Error, A]] =
         def go(
-            remaining: List[FiniteDuration]
+            remaining: LazyList[FiniteDuration]
         ): IO[Either[ScriptReferenceUtxos.Error | io.circe.Error, A]] =
             // A raised throwable gets the same treatment as a backend error: building the backend
             // is itself a network operation, and it reports failure by raising rather than by a
@@ -251,10 +262,13 @@ object NodeConfig {
                         case Right(Left(e)) => isWorthRetrying(e)
                         case _              => false
                     (remaining, retryable) match
-                        case (wait :: rest, true) =>
+                        case (wait #:: rest, true) =>
+                            // ⛔ Do NOT report "attempts left" here: `remaining` is an
+                            // infinite LazyList in production and forcing its length hangs.
                             log.warn(
                               s"Config load failed against the Cardano backend ($reason); " +
-                                  s"retrying in $wait (${rest.length} attempts left after this)."
+                                  s"retrying in $wait. The node cannot start without this, so it " +
+                                  "WAITS rather than exiting into a restart loop."
                             ) >> IO.sleep(wait) >> go(rest)
                         case _ =>
                             other match

--- a/src/main/scala/hydrozoa/multisig/backend/cardano/CardanoBackendBlockfrost.scala
+++ b/src/main/scala/hydrozoa/multisig/backend/cardano/CardanoBackendBlockfrost.scala
@@ -20,7 +20,6 @@ import java.net.URI
 import java.net.http.{HttpClient, HttpRequest, HttpResponse}
 import scala.collection.mutable
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
 import scala.jdk.CollectionConverters.*
 import scala.util.Try
 import scalus.cardano.address.{Address, ShelleyAddress}
@@ -45,7 +44,10 @@ import scalus.uplc.builtin.{ByteString, Data}
 class CardanoBackendBlockfrost private (
     private val backendService: BackendService,
     private val pageSize: Int,
-    private val blockfrostProviderFuture: Future[BlockfrostProvider],
+    /** Builds a FRESH provider. Called again after a failure -- see [[provider]]. */
+    private val mkProvider: IO[BlockfrostProvider],
+    /** Memoises the provider ON SUCCESS ONLY. */
+    private val providerRef: Ref[IO, Option[BlockfrostProvider]],
     protected val tracer: ContraTracer[IO, CardanoBackendEvent],
     // Base URL + project id for the raw tx-utxos read in [[continuingTx]] — BloxBean's
     // `TxContentUtxoInputs` model drops the per-input tx_hash/output_index/collateral/reference we
@@ -53,6 +55,27 @@ class CardanoBackendBlockfrost private (
     private val baseUrl: String,
     private val apiKey: String
 ) extends CardanoBackend[IO] {
+
+    /** The Scalus provider, built on first use and memoised **only if it succeeds**.
+      *
+      * ⛔ This used to be a plain `Future[BlockfrostProvider]` created eagerly at construction. A
+      * Scala `Future` memoises its outcome — including its failure — so a single Blockfrost blip at
+      * the moment the backend was built poisoned every later `fetchLatestParams` for the entire
+      * life of the process, with no retry and no way back short of a restart. The node looked
+      * healthy: it polled L1 fine, because `utxosAt` goes through BloxBean's service and never
+      * touches this.
+      *
+      * That is disqualifying for a start-up gate built on protocol parameters — one blip and the
+      * gate could never be satisfied. So: retry on failure, memoise on success.
+      *
+      * ⚠️ Two concurrent first-callers may each build one; the loser's is discarded. Harmless (the
+      * provider is a stateless HTTP wrapper) and cheaper than serialising every access.
+      */
+    private def provider: IO[BlockfrostProvider] =
+        providerRef.get.flatMap {
+            case Some(p) => IO.pure(p)
+            case None    => mkProvider.flatTap(p => providerRef.set(Some(p)))
+        }
 
     private val httpClient: HttpClient = HttpClient.newHttpClient()
 
@@ -683,8 +706,8 @@ class CardanoBackendBlockfrost private (
 
     override def fetchLatestParams: IO[Either[Error, ProtocolParams]] =
         (for
-            provider <- IO.fromFuture(IO.pure(blockfrostProviderFuture))
-            result <- IO.fromFuture(IO.pure(provider.fetchLatestParams))
+            p <- provider
+            result <- IO.fromFuture(IO.pure(p.fetchLatestParams))
         yield Right(result))
             .handleError(e =>
                 Left(Unexpected(s"${e.getMessage}, caused by: ${
@@ -693,8 +716,8 @@ class CardanoBackendBlockfrost private (
             )
 
     def getStartupParams: IO[Either[Error, ProtocolParams]] =
-        (for provider <- IO.fromFuture(IO.pure(blockfrostProviderFuture))
-        yield Right(provider.cardanoInfo.protocolParams))
+        (for p <- provider
+        yield Right(p.cardanoInfo.protocolParams))
             .handleError(e =>
                 Left(Unexpected(s"${e.getMessage}, caused by: ${
                         if e.getCause != null then e.getCause.getMessage else "N/A"
@@ -720,32 +743,33 @@ object CardanoBackendBlockfrost:
         // NB: Bloxbean requires the trailing slash
         val backendService = BFBackendService(s"$baseUrl/", apiKey)
 
-        // 2. Scalus blockfrost provider
-        val blockfrostProviderFuture =
-            network match {
-                case Left(std) =>
-                    std match {
-                        case CardanoNetwork.Mainnet =>
-                            BlockfrostProvider.mainnet(apiKey)
-                        case CardanoNetwork.Preprod =>
-                            BlockfrostProvider.preprod(apiKey)
-                        case CardanoNetwork.Preview =>
-                            BlockfrostProvider.preview(apiKey)
+        // 2. Scalus blockfrost provider, as a RETRYABLE IO rather than an eager Future: each
+        //    evaluation starts a fresh fetch, so a failure is not memoised. See `provider`.
+        val mkProvider: IO[BlockfrostProvider] = IO.defer(IO.fromFuture(IO.delay(network match {
+            case Left(std) =>
+                std match {
+                    case CardanoNetwork.Mainnet =>
+                        BlockfrostProvider.mainnet(apiKey)
+                    case CardanoNetwork.Preprod =>
+                        BlockfrostProvider.preprod(apiKey)
+                    case CardanoNetwork.Preview =>
+                        BlockfrostProvider.preview(apiKey)
 
-                    }
-                case Right(custom, customBaseUrl) =>
-                    BlockfrostProvider.create(
-                      apiKey = apiKey,
-                      baseUrl = customBaseUrl,
-                      network = custom.network,
-                      slotConfig = custom.cardanoInfo.slotConfig
-                    )
-            }
+                }
+            case Right(custom, customBaseUrl) =>
+                BlockfrostProvider.create(
+                  apiKey = apiKey,
+                  baseUrl = customBaseUrl,
+                  network = custom.network,
+                  slotConfig = custom.cardanoInfo.slotConfig
+                )
+        })))
 
         new CardanoBackendBlockfrost(
           backendService,
           pageSize,
-          blockfrostProviderFuture,
+          mkProvider,
+          Ref.unsafe[IO, Option[BlockfrostProvider]](None),
           tracer,
           baseUrl,
           apiKey

--- a/src/main/scala/hydrozoa/multisig/consensus/ReplayActor.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/ReplayActor.scala
@@ -106,6 +106,9 @@ object ReplayActor:
             )
             // 1. First L1 sample → BlockWeaver, so deposit decisions don't wait on the poll tick.
             _ <- seedFirstPollResults(cardanoBackend, treasuryAddress, targets.blockWeaver)
+            // Same gate, same place: an L1 fact established once, on the app fiber, before the
+            // start barrier opens.
+            _ <- verifyProtocolParams(cardanoBackend)
             // 2. The in-flight acked-but-unconfirmed stack (≤1) → reconstructed handoff to SCA.
             _ <- inflight.traverse_(targets.slowConsensusActor ! _)
             // 3. Derive cursors, scan all lanes, total-order, route the tail into mailboxes.
@@ -233,6 +236,54 @@ object ReplayActor:
                     log.warn(
                       s"boot L1 sample failed (attempt ${n + 1}): $err. Cannot start consensus " +
                           s"without it, so WAITING rather than failing the boot; retrying in $wait"
+                    ) >> IO.sleep(wait) >> attempt(n + 1)
+            }
+        attempt(0)
+    }
+
+    /** Compare the chain's live protocol parameters against the ones this head's config asserts.
+      *
+      * ⛔ Nothing did this before: `getStartupParams` existed with **zero callers**, so a head built
+      * every L1 transaction — settlements, fallbacks, rollouts, refunds — against parameters it
+      * merely assumed, and would keep doing so across a parameter update it never noticed. Those
+      * parameters decide fees, `maxTxSize` and execution-unit budgets, so a drift shows up as
+      * transactions the chain rejects, at the worst possible moment.
+      *
+      * ⚠️ **Reports, does not refuse — deliberately, and this is a decision to revisit.** A refusal
+      * needs a comparison we trust, and we do not yet know which fields differ benignly in practice
+      * (a config may legitimately pin a subset, or lag a harmless update). Refusing on a brittle
+      * equality check would brick every node on the first benign difference, which is far worse
+      * than the gap it closes. So this establishes the signal first: match ⇒ one INFO line; drift ⇒
+      * a loud WARN carrying both values, which is what tells us what a safe comparison should be. ⇒
+      * Escalating to a `StartupRefusal` (and gating hard-confirmation on it) is the intended next
+      * step, once real drift has been observed.
+      *
+      * Unreachable is NOT drift: it retries like the L1 sample, because "cannot ask" and "asked and
+      * the answer is wrong" are the two classes this whole start-up path is built to separate.
+      */
+    private def verifyProtocolParams(
+        cardanoBackend: CardanoBackend[IO]
+    )(using net: CardanoNetwork.Section): IO[Unit] = {
+        def attempt(n: Int): IO[Unit] =
+            cardanoBackend.fetchLatestParams.flatMap {
+                case Right(onChain) =>
+                    val assumed = net.cardanoProtocolParams
+                    if onChain == assumed then
+                        log.info("protocol parameters on chain match the ones this config asserts")
+                    else
+                        log.warn(
+                          "PROTOCOL PARAMETER DRIFT: the chain's parameters differ from the ones " +
+                              "this head's config asserts. Every L1 transaction this node builds " +
+                              "uses the config's values, so a real drift will surface as txs the " +
+                              "chain rejects.\n" +
+                              s"  on chain: $onChain\n" +
+                              s"  config:   $assumed"
+                        )
+                case Left(err) =>
+                    val wait = l1SampleBackoff(n)
+                    log.warn(
+                      s"could not read protocol parameters (attempt ${n + 1}): $err. " +
+                          s"Retrying in $wait."
                     ) >> IO.sleep(wait) >> attempt(n + 1)
             }
         attempt(0)

--- a/src/main/scala/hydrozoa/multisig/consensus/ReplayActor.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/ReplayActor.scala
@@ -3,6 +3,7 @@ package hydrozoa.multisig.consensus
 import cats.effect.IO
 import cats.syntax.all.*
 import hydrozoa.config.head.network.CardanoNetwork
+import hydrozoa.lib.logging.{ContraTracer, Slf4jMsg, Slf4jMsgFormat, Slf4jTracer, info, warn}
 import hydrozoa.multisig.backend.cardano.CardanoBackend
 import hydrozoa.multisig.consensus.ack.{HardAck, HardAckNumber}
 import hydrozoa.multisig.consensus.peer.{CoilPeerNumber, HeadPeerNumber, PeerId}
@@ -12,6 +13,7 @@ import hydrozoa.multisig.ledger.event.RequestNumber
 import hydrozoa.multisig.ledger.stack.StackNumber
 import hydrozoa.multisig.persistence.recovery.{ArrivalOrderedMerge, JournalScan, RawJournalEntry, ReplayCursors}
 import hydrozoa.multisig.persistence.{JournalKey, Markers, Persistence, StoreKey}
+import scala.concurrent.duration.*
 import scalus.cardano.address.ShelleyAddress
 
 /** The boot-time replay seam (R3 §8 step 3). Not a long-lived cats-actors `Actor`: it is the
@@ -44,6 +46,11 @@ import scalus.cardano.address.ShelleyAddress
   * is the single place that re-feeds the consensus actors from the persisted lane tail.
   */
 object ReplayActor:
+
+    private val log: ContraTracer[IO, Slf4jMsg] =
+        Slf4jTracer.sink.contramap(
+          Slf4jMsgFormat.humanFormat("hydrozoa.multisig.consensus.ReplayActor")
+        )
 
     /** The consensus actors the replay tail is routed into. `coilAckSequencer` is present only on a
       * hub — the boundary the received-but-unstamped coil-ack gap is re-fed to (see [[replay]]).
@@ -188,17 +195,54 @@ object ReplayActor:
           )
         )
 
-    /** Read L1 directly and send BlockWeaver the first [[PollResults]] (§5.5). */
+    /** Read L1 directly and send BlockWeaver the first [[PollResults]] (§5.5).
+      *
+      * ⛔ This is a GATE, and it must WAIT rather than fail. BlockWeaver starts at
+      * `PollResults.empty`, which is structurally indistinguishable from "polled, and the address
+      * is genuinely empty" — there is no `NeverPolled` state. A head peer classifies deposit
+      * existence from its OWN poll (`DepositsMap.Existence.FromPoll`), so acting on that empty
+      * value would reject every mature deposit as `NotInPollResults`: terminal, and DEBUG-only in
+      * the logs. The seed is queued before the start barrier opens precisely so that cannot happen.
+      *
+      * It previously raised on a failed L1 read, which closed the correctness hole but turned a
+      * transient Blockfrost blip into a failed boot — and `Restart=on-failure` turns a failed boot
+      * into an infinite restart loop that outlives the blip. Waiting is strictly better: the node
+      * is useless without this fact either way, and the retry is bounded by nothing but the
+      * operator's patience, which is what a dashboard is for.
+      *
+      * ⚠️ Safe to retry here ONLY because `replay` runs INLINE at the regime manager, on the app
+      * fiber, outside the actor system. The same loop inside a cats-actors message handler would be
+      * uncancelable (`ActorCell` wraps handlers in `.uncancelable`) and would make the process
+      * unkillable — measured. Do not move this into an actor.
+      */
     private def seedFirstPollResults(
         cardanoBackend: CardanoBackend[IO],
         treasuryAddress: ShelleyAddress,
         blockWeaver: BlockWeaver.Handle
-    ): IO[Unit] =
-        cardanoBackend.utxosAt(treasuryAddress).flatMap {
-            case Left(err) =>
-                IO.raiseError(new RuntimeException(s"ReplayActor L1 sample failed: $err"))
-            case Right(utxos) => blockWeaver ! PollResults(utxos.keySet)
-        }
+    ): IO[Unit] = {
+        def attempt(n: Int): IO[Unit] =
+            cardanoBackend.utxosAt(treasuryAddress).flatMap {
+                case Right(utxos) =>
+                    IO.whenA(n > 0)(
+                      log.info(
+                        s"boot L1 sample succeeded after ${n + 1} attempts; continuing start-up"
+                      )
+                    ) >> (blockWeaver ! PollResults(utxos.keySet))
+                case Left(err) =>
+                    val wait = l1SampleBackoff(n)
+                    log.warn(
+                      s"boot L1 sample failed (attempt ${n + 1}): $err. Cannot start consensus " +
+                          s"without it, so WAITING rather than failing the boot; retrying in $wait"
+                    ) >> IO.sleep(wait) >> attempt(n + 1)
+            }
+        attempt(0)
+    }
+
+    /** Backoff for the boot L1 sample: doubles from 1s, capped at 30s. Capped rather than unbounded
+      * so a node that has been waiting for hours still reacts promptly when L1 returns.
+      */
+    private def l1SampleBackoff(attempt: Int): FiniteDuration =
+        (1.second.toNanos * (1L << math.min(attempt, 5))).nanos.min(30.seconds)
 
     /** Reconstruct the handoff for the in-flight stack — the last own-acked stack, **iff** it is
       * not yet hard-confirmed (`hardConfirmed < hardAckedStack`). Its `Stack.Unsigned` was

--- a/src/main/scala/hydrozoa/multisig/consensus/ReplayActor.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/ReplayActor.scala
@@ -2,8 +2,9 @@ package hydrozoa.multisig.consensus
 
 import cats.effect.IO
 import cats.syntax.all.*
+import hydrozoa.app.StartupRefusal
 import hydrozoa.config.head.network.CardanoNetwork
-import hydrozoa.lib.logging.{ContraTracer, Slf4jMsg, Slf4jMsgFormat, Slf4jTracer, info, warn}
+import hydrozoa.lib.logging.{ContraTracer, Slf4jMsg, Slf4jMsgFormat, Slf4jTracer, error, info, warn}
 import hydrozoa.multisig.backend.cardano.CardanoBackend
 import hydrozoa.multisig.consensus.ack.{HardAck, HardAckNumber}
 import hydrozoa.multisig.consensus.peer.{CoilPeerNumber, HeadPeerNumber, PeerId}
@@ -249,14 +250,19 @@ object ReplayActor:
       * parameters decide fees, `maxTxSize` and execution-unit budgets, so a drift shows up as
       * transactions the chain rejects, at the worst possible moment.
       *
-      * ⚠️ **Reports, does not refuse — deliberately, and this is a decision to revisit.** A refusal
-      * needs a comparison we trust, and we do not yet know which fields differ benignly in practice
-      * (a config may legitimately pin a subset, or lag a harmless update). Refusing on a brittle
-      * equality check would brick every node on the first benign difference, which is far worse
-      * than the gap it closes. So this establishes the signal first: match ⇒ one INFO line; drift ⇒
-      * a loud WARN carrying both values, which is what tells us what a safe comparison should be. ⇒
-      * Escalating to a `StartupRefusal` (and gating hard-confirmation on it) is the intended next
-      * step, once real drift has been observed.
+      * ⛔ **A mismatch REFUSES the boot** (George, 2026-09-01): *"it should raise an escalated error
+      * if protocol parameters don't match, because it likely means that the head can't produce
+      * valid L1 txs in some cases."* A head building transactions against parameters the chain has
+      * moved past emits txs the chain rejects — silently, at settlement time, under load.
+      *
+      * It is a `StartupRefusal` rather than a generic crash because it is **deterministic**: the
+      * config asserts what it asserts, and a restart re-derives the same verdict, so a supervisor
+      * loop would learn nothing. ⇒ Operationally, an on-chain parameter update stops every peer
+      * until its config is updated. That is intended: the alternative is peers quietly emitting
+      * invalid transactions. ⚠️ Measured on preview 2026-09-01: the config's parameters equal the
+      * chain's **exactly**, so this is not a hair-trigger. If a benign field ever proves to differ
+      * in practice, narrow the comparison to the fields that govern tx validity — do not weaken it
+      * back to a warning.
       *
       * Unreachable is NOT drift: it retries like the L1 sample, because "cannot ask" and "asked and
       * the answer is wrong" are the two classes this whole start-up path is built to separate.
@@ -271,13 +277,18 @@ object ReplayActor:
                     if onChain == assumed then
                         log.info("protocol parameters on chain match the ones this config asserts")
                     else
-                        log.warn(
-                          "PROTOCOL PARAMETER DRIFT: the chain's parameters differ from the ones " +
-                              "this head's config asserts. Every L1 transaction this node builds " +
-                              "uses the config's values, so a real drift will surface as txs the " +
-                              "chain rejects.\n" +
+                        log.error(
+                          "PROTOCOL PARAMETER MISMATCH: the chain's parameters differ from the " +
+                              "ones this head's config asserts. Refusing to start.\n" +
                               s"  on chain: $onChain\n" +
                               s"  config:   $assumed"
+                        ) >> IO.raiseError(
+                          StartupRefusal(
+                            "the chain's protocol parameters differ from the ones this head's " +
+                                "config asserts, so the L1 transactions it builds may be rejected " +
+                                "by the chain. Update the config to the chain's current parameters " +
+                                "(both values are on the ERROR line above)."
+                          )
                         )
                 case Left(err) =>
                     val wait = l1SampleBackoff(n)

--- a/src/main/scala/hydrozoa/multisig/consensus/ReplayActor.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/ReplayActor.scala
@@ -250,19 +250,15 @@ object ReplayActor:
       * parameters decide fees, `maxTxSize` and execution-unit budgets, so a drift shows up as
       * transactions the chain rejects, at the worst possible moment.
       *
-      * ⛔ **A mismatch REFUSES the boot** (George, 2026-09-01): *"it should raise an escalated error
-      * if protocol parameters don't match, because it likely means that the head can't produce
-      * valid L1 txs in some cases."* A head building transactions against parameters the chain has
-      * moved past emits txs the chain rejects — silently, at settlement time, under load.
+      * ⛔ **A mismatch REFUSES the boot.** A head building transactions against parameters the chain
+      * has moved past emits txs the chain rejects — silently, at settlement time, under load.
       *
       * It is a `StartupRefusal` rather than a generic crash because it is **deterministic**: the
       * config asserts what it asserts, and a restart re-derives the same verdict, so a supervisor
       * loop would learn nothing. ⇒ Operationally, an on-chain parameter update stops every peer
       * until its config is updated. That is intended: the alternative is peers quietly emitting
-      * invalid transactions. ⚠️ Measured on preview 2026-09-01: the config's parameters equal the
-      * chain's **exactly**, so this is not a hair-trigger. If a benign field ever proves to differ
-      * in practice, narrow the comparison to the fields that govern tx validity — do not weaken it
-      * back to a warning.
+      * invalid transactions. If a benign field ever proves to differ in practice, narrow the
+      * comparison to the fields that govern tx validity — do not weaken it back to a warning.
       *
       * Unreachable is NOT drift: it retries like the L1 sample, because "cannot ask" and "asked and
       * the answer is wrong" are the two classes this whole start-up path is built to separate.

--- a/src/test/scala/hydrozoa/app/MainSmokeTest.scala
+++ b/src/test/scala/hydrozoa/app/MainSmokeTest.scala
@@ -56,9 +56,17 @@ class MainSmokeTest extends AnyFunSuite:
         // Both the inter-peer mesh server (which binds where the head config advertises this peer —
         // the test fixture uses port 0) and the HTTP admin server (httpPort) bind OS-ephemeral
         // ports, so the test doesn't collide with whatever holds the generator's defaults.
-        val peerPrivate = mnc
-            .nodePrivateConfigs(HeadPeerNumber(0))
-            .copy(httpPort = "0")
+        val generatedPrivate = mnc.nodePrivateConfigs(HeadPeerNumber(0))
+        // ⛔ Clear the transplant tag. `generateNodeOperationMultisigConfig` draws it from
+        // `Gen.option` on purpose — a codec round-trip has to cover both shapes of the field — but
+        // this test boots a NORMAL peer, and a normal peer carries no transplant tag. Left in, the
+        // config claims to be a transplant of a stack no empty store can hold, which is a refusal,
+        // and whether it appears at all depends on the generator seed.
+        val peerPrivate = generatedPrivate.copy(
+          httpPort = "0",
+          nodeOperationMultisigConfig = generatedPrivate.nodeOperationMultisigConfig
+              .copy(transplantStackNumber = None)
+        )
 
         val printer = Printer.spaces2.copy(dropNullValues = true)
 
@@ -149,6 +157,87 @@ class MainSmokeTest extends AnyFunSuite:
             // ⚠️ Do not await this. Cancelling a *live* node never returns, and `Fiber.cancel` is
             // itself uncancelable, so no timeout bounds it. The daemon threads go with the JVM.
             _ <- fiber.cancel.start.void
+        } yield ()
+
+        testIO.unsafeRunSync()
+    }
+
+    // A `transplantStackNumber` names the stack this peer elects to ADOPT: everything at or below it
+    // is taken on trust from the donor committee and never verified. So the tag has to name a stack
+    // the store actually holds. Here the store is empty, so no tag can be honoured -- the node must
+    // refuse rather than silently ignore the tag and boot as though none had been set.
+    //
+    // Asserting on the REASON, not just the type: this refusal has to be distinguishable from the
+    // other ways a node can refuse to start, or the test would pass on the wrong one.
+    test("Serve.runNode refuses a transplantStackNumber the store does not contain") {
+        val rootTmp = Files.createTempDirectory("hydrozoa-transplant-tag-")
+        val configDir = rootTmp.resolve("config")
+        val dataDir = rootTmp.resolve("data")
+        Files.createDirectories(configDir)
+        Files.createDirectories(dataDir)
+
+        val spec = defaultSpec.copy(outDir = configDir, nPeers = 1)
+        val headPath = configDir.resolve("head-config.json")
+        val privatePath = configDir.resolve("peer-0").resolve("private.json")
+        val mnc: MultiNodeConfig = MultiNodeConfig
+            .generate(testPeersSpec(spec))()
+            .pureApply(Gen.Parameters.default, org.scalacheck.rng.Seed(spec.generationSeed))
+        val peerPrivate = mnc.nodePrivateConfigs(HeadPeerNumber(0)).copy(httpPort = "0")
+        val printer = Printer.spaces2.copy(dropNullValues = true)
+        val (_, peerSigningKey) = TestPeers.deriveScalusKeypair(spec.seedPhrase.mnemonic, 0)
+        val runnablePrivateJson = peerPrivate.asJson
+            .deepMerge(
+              Json.obj(
+                "ownPeerPrivate" -> Json.obj(
+                  "ownHeadWallet" -> Json.obj(
+                    "signingKey" -> Json.fromString(
+                      scodec.bits.ByteVector(peerSigningKey.bytes).toHex
+                    )
+                  )
+                )
+              )
+            )
+            .deepMerge(
+              Json.obj(
+                "nodeOperationMultisigConfig" -> Json.obj(
+                  "transplantStackNumber" -> Json.fromInt(999999)
+                )
+              )
+            )
+
+        val testIO = for {
+            _ <- IO.blocking(Files.writeString(headPath, printer.print(mnc.headConfig.asJson)))
+            _ <- IO.blocking(Files.createDirectories(privatePath.getParent))
+            _ <- IO.blocking(Files.writeString(privatePath, printer.print(runnablePrivateJson)))
+            mockBackend <- CardanoBackendMock.mockIO(
+              MockState(initialUtxos =
+                  mnc.headConfig.initializationTx.resolvedUtxos.utxos
+                      ++ Map.from(mnc.headConfig.scriptReferenceUtxos.toList.map(_.toTuple))
+              )
+            )
+            outcome <- Serve
+                .runNode(headPath, privatePath, dataDir, backendOverride = Some(mockBackend))
+                .attempt
+                .timeoutTo(
+                  60.seconds,
+                  IO.raiseError(new AssertionError("runNode neither refused nor returned in 60s"))
+                )
+            _ <- outcome match {
+                case Left(r: StartupRefusal) if r.reason.contains("transplantStackNumber") =>
+                    IO.unit
+                case Left(r: StartupRefusal) =>
+                    IO.raiseError(
+                      new AssertionError(s"refused, but for another reason: ${r.reason}")
+                    )
+                case Left(other) =>
+                    IO.raiseError(new AssertionError(s"expected a StartupRefusal, got: $other"))
+                case Right(code) =>
+                    IO.raiseError(
+                      new AssertionError(
+                        s"expected a StartupRefusal, but the node started and exited $code"
+                      )
+                    )
+            }
         } yield ()
 
         testIO.unsafeRunSync()

--- a/src/test/scala/hydrozoa/app/MainSmokeTest.scala
+++ b/src/test/scala/hydrozoa/app/MainSmokeTest.scala
@@ -91,7 +91,12 @@ class MainSmokeTest extends AnyFunSuite:
               MockState(initialUtxos =
                   mnc.headConfig.initializationTx.resolvedUtxos.utxos
                       ++ Map.from(mnc.headConfig.scriptReferenceUtxos.toList.map(_.toTuple))
-              )
+              ),
+              // The node refuses to start when the chain's protocol parameters differ from the ones
+              // its config asserts, so the mock must report the config's. Without this it reports
+              // scalus's `UtxoEnv.testMainnet` fixture, which matches no real network's CardanoInfo
+              // -- the boot then refuses, correctly, on an incoherent fixture.
+              reportedParams = Some(mnc.headConfig.cardanoProtocolParams)
             )
 
             startedD <- Deferred[IO, Unit]
@@ -144,6 +149,76 @@ class MainSmokeTest extends AnyFunSuite:
             // ⚠️ Do not await this. Cancelling a *live* node never returns, and `Fiber.cancel` is
             // itself uncancelable, so no timeout bounds it. The daemon threads go with the JVM.
             _ <- fiber.cancel.start.void
+        } yield ()
+
+        testIO.unsafeRunSync()
+    }
+
+    // The positive test above hands the mock the config's own protocol parameters, so the boot-time
+    // comparison always agrees. That would leave the REFUSAL path untested -- a check that cannot
+    // fail is not a check -- so this is its negative control: the same node, booted against a chain
+    // that reports DIFFERENT parameters, must refuse rather than start and quietly build L1
+    // transactions the chain may reject.
+    test("Serve.runNode refuses to start when the chain's protocol parameters differ") {
+        val rootTmp = Files.createTempDirectory("hydrozoa-pparams-mismatch-")
+        val configDir = rootTmp.resolve("config")
+        val dataDir = rootTmp.resolve("data")
+        Files.createDirectories(configDir)
+        Files.createDirectories(dataDir)
+
+        val spec = defaultSpec.copy(outDir = configDir, nPeers = 1)
+        val headPath = configDir.resolve("head-config.json")
+        val privatePath = configDir.resolve("peer-0").resolve("private.json")
+        val mnc: MultiNodeConfig = MultiNodeConfig
+            .generate(testPeersSpec(spec))()
+            .pureApply(Gen.Parameters.default, org.scalacheck.rng.Seed(spec.generationSeed))
+        val peerPrivate = mnc.nodePrivateConfigs(HeadPeerNumber(0)).copy(httpPort = "0")
+        val printer = Printer.spaces2.copy(dropNullValues = true)
+        val (_, peerSigningKey) = TestPeers.deriveScalusKeypair(spec.seedPhrase.mnemonic, 0)
+        val runnablePrivateJson = peerPrivate.asJson.deepMerge(
+          Json.obj(
+            "ownPeerPrivate" -> Json.obj(
+              "ownHeadWallet" -> Json.obj(
+                "signingKey" -> Json.fromString(scodec.bits.ByteVector(peerSigningKey.bytes).toHex)
+              )
+            )
+          )
+        )
+
+        val testIO = for {
+            _ <- IO.blocking(Files.writeString(headPath, printer.print(mnc.headConfig.asJson)))
+            _ <- IO.blocking(Files.createDirectories(privatePath.getParent))
+            _ <- IO.blocking(Files.writeString(privatePath, printer.print(runnablePrivateJson)))
+
+            // No `reportedParams`: the mock falls back to scalus's `UtxoEnv.testMainnet` fixture,
+            // which matches no real network's `CardanoInfo`. That IS the mismatch under test.
+            mockBackend <- CardanoBackendMock.mockIO(
+              MockState(initialUtxos =
+                  mnc.headConfig.initializationTx.resolvedUtxos.utxos
+                      ++ Map.from(mnc.headConfig.scriptReferenceUtxos.toList.map(_.toTuple))
+              )
+            )
+
+            outcome <- Serve
+                .runNode(headPath, privatePath, dataDir, backendOverride = Some(mockBackend))
+                .attempt
+                .timeoutTo(
+                  60.seconds,
+                  IO.raiseError(new AssertionError("runNode neither refused nor returned in 60s"))
+                )
+            _ <- outcome match {
+                case Left(_: StartupRefusal) => IO.unit
+                case Left(other) =>
+                    IO.raiseError(
+                      new AssertionError(s"expected a StartupRefusal, got: $other")
+                    )
+                case Right(code) =>
+                    IO.raiseError(
+                      new AssertionError(
+                        s"expected a StartupRefusal, but the node started and exited $code"
+                      )
+                    )
+            }
         } yield ()
 
         testIO.unsafeRunSync()

--- a/src/test/scala/hydrozoa/config/node/NodeConfigRetryTest.scala
+++ b/src/test/scala/hydrozoa/config/node/NodeConfigRetryTest.scala
@@ -23,7 +23,9 @@ class NodeConfigRetryTest extends AnyFunSuite {
     private val badConfig: io.circe.Error =
         io.circe.DecodingFailure("not a config", Nil)
 
-    private val waits = List(1.milli, 1.milli, 1.milli)
+    // Finite on purpose: production passes an INFINITE ladder (a transient backend failure must
+    // never end in an exit), so the "gives up" cases below can only be expressed with a bounded one.
+    private val waits = LazyList(1.milli, 1.milli, 1.milli)
 
     /** An attempt that fails `failures` times with `error`, then succeeds. */
     private def failing(

--- a/src/test/scala/hydrozoa/multisig/backend/cardano/CardanoBackendMock.scala
+++ b/src/test/scala/hydrozoa/multisig/backend/cardano/CardanoBackendMock.scala
@@ -37,7 +37,16 @@ type MockStateF[A] = State[MockState, A]
 // It should be ReaderT over those vals, though I don't think it buys anything but extra lifts.
 class CardanoBackendMock private (
     private val mutator: Mutator,
-    private val mkContext: Long => Context
+    private val mkContext: Long => Context,
+    /** What this mock reports as the chain's protocol parameters.
+      *
+      * ⛔ Defaults to the context's, which is scalus's `UtxoEnv.testMainnet` FIXTURE — unrelated to
+      * the `CardanoInfo` parameters a head's config asserts, for ANY network. A node now refuses to
+      * start when those two disagree, so a test booting a real node must hand the mock the config's
+      * parameters; otherwise the fixture is claiming the chain runs parameters the head was never
+      * configured for, and the refusal is correct rather than a bug.
+      */
+    private val reportedParams: Option[ProtocolParams]
 ) extends CardanoBackend[MockStateF] {
     import State.*
 
@@ -203,7 +212,7 @@ class CardanoBackendMock private (
 
     def fetchLatestParams: MockStateF[Either[Error, ProtocolParams]] = {
         // As long as paramters don't depend on the slot number it's fine
-        State.pure(Right(mkContext(0).env.params))
+        State.pure(Right(reportedParams.getOrElse(mkContext(0).env.params)))
     }
 
     def setSlot(currentSlot: Slot): MockStateF[Unit] = {
@@ -221,9 +230,10 @@ object CardanoBackendMock {
     def mockIO(
         initialState: MockState,
         mutator: Mutator = CardanoMutator,
-        mkContext: Long => Context = Context.testMainnet
+        mkContext: Long => Context = Context.testMainnet,
+        reportedParams: Option[ProtocolParams] = None
     ): IO[CardanoBackend[IO]] =
-        mockIOWithSnapshot(initialState, mutator, mkContext).map(_._1)
+        mockIOWithSnapshot(initialState, mutator, mkContext, reportedParams).map(_._1)
 
     /** Like [[mockIO]] but also returns an `IO[Utxos]` that reads the current UTxO set from the
       * shared state ref. Useful for inspecting the terminal ledger state after actors finish.
@@ -231,7 +241,8 @@ object CardanoBackendMock {
     def mockIOWithSnapshot(
         initialState: MockState,
         mutator: Mutator = CardanoMutator,
-        mkContext: Long => Context = Context.testMainnet
+        mkContext: Long => Context = Context.testMainnet,
+        reportedParams: Option[ProtocolParams] = None
     ): IO[(CardanoBackend[IO], IO[Utxos])] = {
         val ioLog: ContraTracer[IO, CardanoBackendEvent] =
             Slf4jTracer.sink.contramap(CardanoBackendEventFormat.humanFormat)
@@ -243,7 +254,7 @@ object CardanoBackendMock {
             )
             stateRef <- Ref.of[IO, MockState](initialState)
         } yield {
-            val mock = new CardanoBackendMock(mutator, mkContext)
+            val mock = new CardanoBackendMock(mutator, mkContext, reportedParams)
             // TODO: this is awkward, but this requires the mending of Scalus
             //  - Context is not a case class
             //  - Context is not returned by CardanoMutator

--- a/src/test/scala/hydrozoa/multisig/consensus/ReplayActorTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/ReplayActorTest.scala
@@ -209,7 +209,14 @@ class ReplayActorTest extends AnyFunSuite:
                 ActorSystem[IO]("replay-test").use(system =>
                     for {
                         persistence <- Persistence.fromBackend(backend, persistenceTracer)
-                        cardanoBackend <- CardanoBackendMock.mockIO(MockState(Map.empty))
+                        cardanoBackend <- CardanoBackendMock.mockIO(
+                          MockState(Map.empty),
+                          // `replay` now verifies the chain's protocol parameters against the
+                          // config's and REFUSES on a mismatch, so the mock must report the
+                          // config's. Its default is scalus's `UtxoEnv.testMainnet` fixture, which
+                          // matches no real network's `CardanoInfo`.
+                          reportedParams = Some(config.cardanoProtocolParams)
+                        )
                         bwSink <- Ref.of[IO, Vector[BlockWeaver.Request]](Vector.empty)
                         fcaSink <- Ref.of[IO, Vector[FastConsensusActor.Request]](Vector.empty)
                         scaSink <- Ref.of[IO, Vector[SlowConsensusActor.Request]](Vector.empty)
@@ -261,7 +268,14 @@ class ReplayActorTest extends AnyFunSuite:
                 ActorSystem[IO]("replay-coil-test").use(system =>
                     for {
                         persistence <- Persistence.fromBackend(backend, persistenceTracer)
-                        cardanoBackend <- CardanoBackendMock.mockIO(MockState(Map.empty))
+                        cardanoBackend <- CardanoBackendMock.mockIO(
+                          MockState(Map.empty),
+                          // `replay` now verifies the chain's protocol parameters against the
+                          // config's and REFUSES on a mismatch, so the mock must report the
+                          // config's. Its default is scalus's `UtxoEnv.testMainnet` fixture, which
+                          // matches no real network's `CardanoInfo`.
+                          reportedParams = Some(config.cardanoProtocolParams)
+                        )
                         bwSink <- Ref.of[IO, Vector[BlockWeaver.Request]](Vector.empty)
                         fcaSink <- Ref.of[IO, Vector[FastConsensusActor.Request]](Vector.empty)
                         scaSink <- Ref.of[IO, Vector[SlowConsensusActor.Request]](Vector.empty)


### PR DESCRIPTION
## Review order

Stacked. Base this on `feat/remote-ledger-hardening`, which is based on `refactor/markers-at-the-manager`. Review bottom-up; this branch adds five commits to that stack.

## Change

Startup failures are split into two classes, and each is given a distinct, observable behaviour.

| class                                         | examples                                                                                   | behaviour                                                     | exit |
| --------------------------------------------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------- | ---- |
| a dependency that is merely **absent**        | the L2 ledger, the Cardano backend, a peer                                                 | stay alive, hold the port, retry on a capped backoff, forever | —    |
| a **disagreement** between config and reality | protocol parameters that differ from the chain's, a transplant tag the store cannot honour | refuse once, deliberately, and stay refused                   | `2`  |

`StartupRefusal` carries the second class and exits `2`, which a unit's `RestartPreventExitStatus=2` is set to catch. The point of the split is that `Restart=on-failure` is the right answer to one class and an infinite loop against the other.

Five commits, in order:

1. **`startup: wait for Cardano instead of exiting into a restart loop`** — the config-load retry ladder was bounded at five waits totalling under two minutes, so any loss of egress longer than that ended in the crash loop the ladder was written to prevent. It is now an infinite `LazyList` — 2s, 5s, 15s, 30s, then every 60s — capped so a node that has waited for hours still reacts promptly. `seedFirstPollResults` retries on the same schedule instead of raising.
2. **`startup: give a deliberate refusal its own exit code`** — introduces `StartupRefusal` and exit 2.
3. **`startup: make the Blockfrost provider retryable, and compare pparams at boot`** — `blockfrostProviderFuture` was an eager Scala `Future`, and a `Future` memoises its outcome *including failure*, so one Blockfrost blip at construction poisoned every later `fetchLatestParams` for the life of the process. A `Ref` now memoises on success only. The node looked healthy throughout that failure: `utxosAt` goes through BloxBean's service and never touches the provider, so L1 polling kept working while the parameter path was permanently dead.
4. **`startup: refuse to start when the chain's protocol parameters differ from the config's`** — a head was building every L1 transaction against parameters it merely assumed. `getStartupParams` existed with zero callers.
5. **`startup: refuse a transplantStackNumber the store does not contain`** — the check is `hardConfirmed >= tag`, in `Serve` before the actor system starts.

## Rationale

**Why the retries sit outside the actor system.** Both loops run inline at the regime manager, on the app fiber. The same loop inside a cats-actors message handler would be uncancelable — `ActorCell` wraps handlers in `.uncancelable` — and would make the process unkillable. Measured against the pinned `cats-actors 2.1.0` with a dedicated MRE:

| handler                | cancel time, stock | with that one line removed |
| ---------------------- | ------------------ | -------------------------- |
| `IO.sleep(15.seconds)` | 14,999 ms          | 16 ms                      |
| unbounded retry loop   | never returned     | 18 ms                      |

The handler's `.onCancel` never fires on stock — cancellation is not delayed, it is not delivered. Under a real SIGTERM with cats-effect's default `shutdownHookTimeout` of `Duration.Inf`, the process never exits. Both sites carry a comment saying not to move them.

**Why `transplantStackNumber` is `>=` and not `==`.** The tag names the stack a peer *elects to adopt*: everything at or below it is taken on trust from the donor committee and never verified, and only stacks above it are checked. It is a partition of the store chosen by the operator, so any stack the store actually holds is a legitimate choice, including one well below its tip. `>=` also makes the tag inert rather than wrong once the peer has moved past it — adoption raises the trusted-history floor to `max(hardAckedStack, tag)`, which is just `hardAckedStack` by then.

**Why the check reads `hardConfirmed` and not `hardAckedStack`.** `hardConfirmed` is a plain `lastKey`, safe to derive more than once. `hardAckedStack` is an interpretation the regime manager derives exactly once and projects into its children; deriving it a second time in `Serve` would duplicate that decision.

## Risk

**A wrong tag now stops a node that previously started.** That is the intent, but it is a behaviour change for anyone who has a stale `transplantStackNumber` sitting in a config. The failure is loud and the message names both values and the remedy.

**The pparams comparison can refuse on a benign difference.** This was escalated from report-only to refusal on an explicit call, on the grounds that building settlements against assumed parameters is worse than a node that will not start. If a config legitimately pins a subset of parameters, or lags a harmless update, this will refuse. `MainSmokeTest` carries a negative control that fails if the comparison stops discriminating.

## Testing

Abnormal-startup battery on a live preview head, 3/3, on this branch's binary: L2 ledger absent ⇒ waits (`rc=124`, port bound) · Cardano backend unreachable ⇒ waits · `transplantStackNumber` naming a stack the store does not hold ⇒ refuses, `rc=2`, never binds. Method and full results: <https://claude.ai/code/artifact/f2123384-f9a9-4497-9349-77caff91d528>

The wait class was also entered unsimulated during the companion soak: the Blockfrost project hit its daily quota while a head peer was restarting, and the node backed off and resumed on its own stores once the quota reset. That is a different door into the class than the battery's injected connection refusal — a reachable backend answering with an error, retried by `NodeConfig.retryingBackendReads`.

`MainSmokeTest` gained a negative control for each refusal, asserting on the refusal's *reason* rather than its type, so a test cannot pass on one of the other ways a node declines to start.

`CardanoBackendBlockfrostTest` against preview with a real key: 3 passed, 7 failed, and the same 7 fail identically on the base commit — pre-existing. ⚠️ The suite is env-gated on `BLOCKFROST_API_KEY` and **cancels silently** without it, and `Test/fork := true` means the forked JVM does not inherit it.

## Not in this PR

- **The exit-1 gap.** Not every refusal reaches the exit-2 path. A verdict raised inside the actor system escalates to the guardian, which terminates the system on its own path and exits 1 — a code a unit cannot distinguish from a crash. Routing those through `StartupRefusal` means threading a typed refusal out of the actor system's own termination, which is `ActorCell` `uncancelable` territory and wants its own PR.
- **Fully offline config parsing.** `HeadConfig.scala:99` is the only impure step, but `headConfigDecoder` requires the resolved value, so making it pure needs a two-stage config type.
- **Serving `/health` and `/status` while waiting**, with the submission endpoint returning 503. This has a measured cost, not a hypothetical one: on a coil, `runCoilNode` binds the HTTP surface *after* `connectionsDeferred.get` resolves. A mainnet-store dry run whose hub was unreachable logged `Hydrozoa coil node started successfully`, then `Starting multisig actors...`, and never reached `Starting HTTP server` at all. So a coil that is waiting cannot be asked what it is waiting for — precisely when an operator needs to know, and precisely the case this PR otherwise makes survivable.

## Notes for review

⚠️ **`getStartupParams` is now definitively dead** — `verifyProtocolParams` uses `fetchLatestParams`. Delete it or wire it in; it has never had a caller.

The transplant gate is adjacent to #693 (`ilia/head-params-hash-store`, stamping each store with the head, config and peer it belongs to). They are complementary and do not overlap: this checks that a store contains the stack its config claims; #693 checks the store belongs to this head at all. This check cannot catch a store from the wrong donor that happens to hold a stack of that number — #693 is what would.