### PR TITLE
config: read credentials from the environment, not from private.json

### DIFF
--- a/src/main/scala/hydrozoa/bootstrap/Bootstrap.scala
+++ b/src/main/scala/hydrozoa/bootstrap/Bootstrap.scala
@@ -19,7 +19,7 @@ import hydrozoa.config.head.network.{CardanoNetwork, StandardCardanoNetwork}
 import hydrozoa.config.head.parameters.{HeadParameters, L2LedgerKind}
 import hydrozoa.config.head.peers.{HeadPeerData, HeadPeers}
 import hydrozoa.config.head.rulebased.dispute.DisputeResolutionConfig
-import hydrozoa.config.node.NodeConfig
+import hydrozoa.config.node.{NodeConfig, PrivateSecrets}
 import hydrozoa.lib.cardano.cip116.JsonCodecs.CIP0116.Conway.given
 import hydrozoa.lib.cardano.scalus.QuantizedTime.QuantizedInstant.realTimeQuantizedInstant
 import hydrozoa.lib.cardano.scalus.QuantizedTime.quantize
@@ -37,8 +37,9 @@ import hydrozoa.multisig.ledger.l1.tx.RawTx
 import hydrozoa.multisig.ledger.l1.txseq.InitializationTxSeq
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import io.circe.syntax.*
-import io.circe.{Decoder, DecodingFailure, Encoder, Json, parser}
+import io.circe.{Decoder, DecodingFailure, Encoder, Json, JsonObject, parser}
 import java.nio.charset.StandardCharsets
+import java.nio.file.attribute.PosixFilePermissions
 import java.nio.file.{Files, Path}
 import java.security.SecureRandom
 import org.bouncycastle.crypto.generators.Ed25519KeyPairGenerator
@@ -817,14 +818,22 @@ object GenerateKeyPair:
     ): IO[Unit] = for {
         templateStr <- IO.blocking(Files.readString(templatePath))
         template <- IO.fromEither(parser.parse(templateStr))
-        filled <- IO.fromEither(
+        result <- IO.fromEither(
           fillPrivateConfig(template, role, vKeyHex, sKeyHex).left.map(
             new IllegalArgumentException(_)
           )
         )
+        (filled, secrets) = result
+        envPath = outPath.resolveSibling(PrivateSecrets.defaultFileName)
         _ <- IO.blocking {
             Option(outPath.getParent).foreach(Files.createDirectories(_))
             Files.writeString(outPath, filled.spaces2)
+            Files.writeString(
+              envPath,
+              secrets.map((k, v) => s"$k=$v").toList.sorted.mkString("", "\n", "\n")
+            )
+            // The config beside it is meant to be shareable; this file is the reason that is safe.
+            Files.setPosixFilePermissions(envPath, PosixFilePermissions.fromString("rw-------"))
         }
     } yield ()
 
@@ -839,24 +848,52 @@ object GenerateKeyPair:
         role: Role,
         vKeyHex: String,
         sKeyHex: String
-    ): Either[String, Json] = {
-        def mkWallet(v: String, s: String): Json = Json.obj(
-          "verificationKey" -> Json.fromString(v),
-          "signingKey" -> Json.fromString(s)
-        )
+    ): Either[String, (Json, Map[String, String])] = {
         val walletField = role match {
             case Role.Head => "ownHeadWallet"
             case Role.Coil => "ownCoilWallet"
         }
+        // The generated signing key never enters the config; only its public half does, and the
+        // node re-pairs the two at boot and refuses if they disagree.
+        val ownWallet = Json.obj("verificationKey" -> Json.fromString(vKeyHex))
+
+        /** Lift a secret the template still carries out of the config and into the env map. */
+        def lift(obj: JsonObject, field: String): (JsonObject, Option[String]) =
+            obj(field).flatMap(_.asString) match
+                case Some(v) if v.nonEmpty => (obj.remove(field), Some(v))
+                case _                     => (obj, None)
+
         for {
             obj <- template.asObject.toRight("template is not a JSON object")
-            withWallet = obj
-                .add("ownPeerPrivate", Json.obj(walletField -> mkWallet(vKeyHex, sKeyHex)))
-            filled = role match {
+            withWallet = obj.add("ownPeerPrivate", Json.obj(walletField -> ownWallet))
+            roleFixed = role match {
                 case Role.Head => withWallet
                 case Role.Coil => withWallet.remove("remoteScreenerUri")
             }
-        } yield Json.fromJsonObject(filled)
+            (noBlockfrost, bfKey) = lift(roleFixed, "blockfrostApiKey")
+            (noAdmin, adminPw) = lift(noBlockfrost, "adminPassword")
+            evac = noAdmin("nodeOperationEvacuationConfig").flatMap(_.asObject)
+            ruleBased = evac.flatMap(_.apply("ruleBasedWallet")).flatMap(_.asObject)
+            ruleKey = ruleBased
+                .flatMap(_.apply("signingKey"))
+                .flatMap(_.asString)
+                .filter(_.nonEmpty)
+            cleaned = (evac, ruleBased) match
+                case (Some(e), Some(rb)) =>
+                    noAdmin.add(
+                      "nodeOperationEvacuationConfig",
+                      Json.fromJsonObject(
+                        e.add("ruleBasedWallet", Json.fromJsonObject(rb.remove("signingKey")))
+                      )
+                    )
+                case _ => noAdmin
+            secrets = List(
+              Some("HYDROZOA_SIGNING_KEY" -> sKeyHex),
+              bfKey.map("HYDROZOA_BLOCKFROST_API_KEY" -> _),
+              adminPw.map("HYDROZOA_ADMIN_PASSWORD" -> _),
+              ruleKey.map("HYDROZOA_RULE_BASED_SIGNING_KEY" -> _)
+            ).flatten.toMap
+        } yield (Json.fromJsonObject(cleaned), secrets)
     }
 
     private def mkHex(bytes: Array[Byte]): String = bytes.map("%02x".format(_)).mkString

--- a/src/main/scala/hydrozoa/config/node/NodeConfig.scala
+++ b/src/main/scala/hydrozoa/config/node/NodeConfig.scala
@@ -190,7 +190,20 @@ object NodeConfig {
     ): IO[(NodeConfig, CardanoBackend[IO])] =
         for {
             headStr <- IO.blocking(Files.readString(headConfigPath))
-            privateStr <- IO.blocking(Files.readString(privateConfigPath))
+            privateRaw <- IO.blocking(Files.readString(privateConfigPath))
+            // Credentials come from the environment, not from the config file, so they are spliced
+            // in before decoding and the decoders below are unchanged. A missing or mismatched one
+            // is a `StartupRefusal` raised here — deliberately ahead of the backend reads, since it
+            // is a verdict about this node alone and no amount of retrying changes it.
+            privateJson <- IO.fromEither(
+              io.circe.parser
+                  .parse(privateRaw)
+                  .left
+                  .map(e =>
+                      StartupRefusal(s"$privateConfigPath is not valid JSON: ${e.getMessage}")
+                  )
+            )
+            privateStr <- PrivateSecrets.overlay(privateConfigPath, privateJson).map(_.noSpaces)
             loaded <- retryingBackendReads(
               backendReadRetryWaits,
               NodeConfig.fromJson(headStr, privateStr, backendOverride).value

--- a/src/main/scala/hydrozoa/config/node/PrivateSecrets.scala
+++ b/src/main/scala/hydrozoa/config/node/PrivateSecrets.scala
@@ -1,0 +1,257 @@
+package hydrozoa.config.node
+
+import cats.effect.IO
+import hydrozoa.app.StartupRefusal
+import io.circe.{Json, JsonObject}
+import java.nio.file.{Files, Path}
+import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters
+
+/** The credentials a node needs to run, sourced from the environment rather than from
+  * `private.json`.
+  *
+  * Splitting them out is what lets `private.json` be treated as an ordinary configuration file: it
+  * can be templated, diffed, committed to a deployment repo, and handed to an operator who is not
+  * trusted with the head's signing key. Everything secret arrives through the environment, which is
+  * how every deployment target already wants to supply one — a Kubernetes `Secret` projected as env
+  * vars, systemd's `EnvironmentFile=`, `docker run --env-file`.
+  *
+  * ⛔ A missing credential is a REFUSAL, not a wait. No amount of retrying conjures a signing key,
+  * and a node that started without one would fail much later and much more obscurely: the signing
+  * key in particular surfaces as a `BadSignature` while the node verifies its own stack-0 hard ack,
+  * deep inside consensus, with nothing pointing back at the config.
+  */
+object PrivateSecrets:
+
+    /** Where a credential comes from and where the decoder expects to find it.
+      *
+      * `path` is the JSON location the value is spliced into; the decoders are unchanged and still
+      * read the field they always read.
+      */
+    final case class Secret(
+        envName: String,
+        path: List[String],
+        describe: String,
+        /** True for an Ed25519 signing key, whose public half sits beside it in the config and must
+          * agree with it.
+          */
+        pairedWithVerificationKey: Boolean = false
+    )
+
+    /** The env file read when `HYDROZOA_PRIVATE_ENV` is unset: a sibling of `private.json`. */
+    val defaultFileName: String = "private.env"
+
+    private val ruleBasedPath: List[String] =
+        List("nodeOperationEvacuationConfig", "ruleBasedWallet", "signingKey")
+
+    /** Credentials that are not the peer's own signing key, whose JSON path does not depend on
+      * whether this node is a head or a coil peer.
+      */
+    private val fixedSecrets: List[Secret] = List(
+      Secret(
+        "HYDROZOA_RULE_BASED_SIGNING_KEY",
+        ruleBasedPath,
+        "the rule-based (dispute/evacuation) wallet's signing key",
+        pairedWithVerificationKey = true
+      ),
+      Secret("HYDROZOA_BLOCKFROST_API_KEY", List("blockfrostApiKey"), "the Blockfrost project id"),
+      Secret("HYDROZOA_ADMIN_PASSWORD", List("adminPassword"), "the admin API password")
+    )
+
+    /** Parse the `KEY=value` subset systemd's `EnvironmentFile=` and `docker --env-file` share.
+      *
+      * Blank lines and `#` comments are skipped, a leading `export ` is tolerated so the file can
+      * also be `source`d by a shell, and one layer of matching quotes is stripped. Deliberately not
+      * a shell parser: no interpolation, no continuations, no `$(…)`. A credentials file that
+      * executes anything is a credentials file that can surprise you.
+      */
+    def parseEnvFile(contents: String): Map[String, String] =
+        contents.linesIterator
+            .map(_.trim)
+            .filter(l => l.nonEmpty && !l.startsWith("#"))
+            .map(l => if l.startsWith("export ") then l.drop("export ".length).trim else l)
+            .flatMap { line =>
+                line.split("=", 2) match
+                    case Array(k, v) if k.trim.nonEmpty =>
+                        val raw = v.trim
+                        val unquoted =
+                            if raw.length >= 2 &&
+                                ((raw.startsWith("\"") && raw.endsWith("\"")) ||
+                                    (raw.startsWith("'") && raw.endsWith("'")))
+                            then raw.substring(1, raw.length - 1)
+                            else raw
+                        Some(k.trim -> unquoted)
+                    case _ => None
+            }
+            .toMap
+
+    /** The peer's own signing key lives under whichever wallet field this node's role puts it in,
+      * and that is the same field the decoder dispatches on.
+      */
+    private def ownWalletSecret(json: Json): Either[String, Secret] =
+        val cursor = json.hcursor.downField("ownPeerPrivate")
+        val field =
+            if cursor.downField("ownHeadWallet").succeeded then Some("ownHeadWallet")
+            else if cursor.downField("ownCoilWallet").succeeded then Some("ownCoilWallet")
+            else None
+        field
+            .toRight(
+              "ownPeerPrivate carries neither ownHeadWallet nor ownCoilWallet"
+            )
+            .map(f =>
+                Secret(
+                  "HYDROZOA_SIGNING_KEY",
+                  List("ownPeerPrivate", f, "signingKey"),
+                  "this peer's own signing key",
+                  pairedWithVerificationKey = true
+                )
+            )
+
+    private def at(json: Json, path: List[String]): Option[Json] =
+        path.foldLeft(Option(json))((acc, k) => acc.flatMap(_.asObject).flatMap(_.apply(k)))
+
+    /** Set `path` to `value`, creating intermediate objects as needed. */
+    private def splice(json: Json, path: List[String], value: Json): Json =
+        path match
+            case Nil => value
+            case head :: rest =>
+                val obj = json.asObject.getOrElse(JsonObject.empty)
+                val child = obj(head).getOrElse(Json.obj())
+                Json.fromJsonObject(obj.add(head, splice(child, rest, value)))
+
+    /** ⛔ An all-zeros placeholder is what the config ENCODER writes in place of a real signing key.
+      * Finding one is expected and harmless — it is overwritten. Finding anything else means a live
+      * credential is sitting in a file this split exists to make shareable.
+      */
+    private def isPlaceholder(j: Json): Boolean =
+        j.asString.exists(s => s.isEmpty || s.forall(_ == '0'))
+
+    /** Resolve every credential and splice it into `json`, ready for the ordinary decoders.
+      *
+      * Precedence is the real environment first, then the env file. That ordering is what lets a
+      * Kubernetes deployment override one value without rewriting the file the rest come from.
+      */
+    def overlay(privateConfigPath: Path, json: Json): IO[Json] =
+        for {
+            envPath <- IO.delay(
+              sys.env
+                  .get("HYDROZOA_PRIVATE_ENV")
+                  .map(Path.of(_))
+                  .getOrElse(privateConfigPath.resolveSibling(defaultFileName))
+            )
+            fromFile <- IO.blocking {
+                if Files.isReadable(envPath) then parseEnvFile(Files.readString(envPath))
+                else Map.empty[String, String]
+            }
+            provided = fromFile ++ sys.env.view.filterKeys(fromFile.keySet ++ allEnvNames).toMap
+            resolved <- IO.fromEither(
+              applySecrets(json, provided, s"$privateConfigPath (credentials from $envPath)")
+            )
+        } yield resolved
+
+    /** Every credential name this loader knows about. */
+    def allEnvNames: Set[String] =
+        (Set("HYDROZOA_SIGNING_KEY") ++ fixedSecrets.map(_.envName)).toSet
+
+    /** The pure core: check, pair and splice, given credentials from wherever.
+      *
+      * Separating it from the file and environment reads is what lets the round trip be tested
+      * directly — `GenerateKeyPair` writes the config and the credentials as a pair, and this
+      * reassembles them.
+      */
+    def applySecrets(
+        json: Json,
+        provided: Map[String, String],
+        source: String
+    ): Either[StartupRefusal, Json] =
+        ownWalletSecret(json).left
+            .map(m => StartupRefusal(s"$source: $m"))
+            .flatMap(own => resolve(own :: fixedSecrets, provided, source, json))
+
+    private def resolve(
+        secrets: List[Secret],
+        fromFile: Map[String, String],
+        source: String,
+        json: Json
+    ): Either[StartupRefusal, Json] =
+        val leaked = secrets.filter(s => at(json, s.path).exists(v => !isPlaceholder(v)))
+        if leaked.nonEmpty then
+            Left(
+              StartupRefusal(
+                s"$source still contains credentials that are now read from the environment: " +
+                    s"${leaked.map(_.path.mkString(".")).mkString(", ")}. Move each value out and " +
+                    "delete the field, so the config file carries no secrets."
+              )
+            )
+        else
+            // A signing key is required only where its public half is: a config with no rule-based
+            // wallet at all is a different (and self-reporting) problem, and demanding a key for a
+            // wallet that is not there would turn the decoder's clear message into a confusing one.
+            val applicable = secrets.filter(s =>
+                !s.pairedWithVerificationKey || at(json, s.path.init :+ "verificationKey").isDefined
+            )
+            val missing = applicable.filter(s => value(s, fromFile).isEmpty)
+            if missing.nonEmpty then
+                Left(
+                  StartupRefusal(
+                    "missing credentials: " +
+                        missing
+                            .map(s => s"${s.envName} (${s.describe})")
+                            .mkString(", ") +
+                        s". Set them in the environment, or in the private.env beside $source."
+                  )
+                )
+            else
+                val spliced = applicable.foldLeft(json)((acc, s) =>
+                    splice(acc, s.path, Json.fromString(value(s, fromFile).get))
+                )
+                pairingErrors(applicable, spliced) match
+                    case Nil => Right(spliced)
+                    case errs =>
+                        Left(
+                          StartupRefusal(
+                            "credential does not match the config it is paired with: " +
+                                errs.mkString("; ") +
+                                ". A signing key whose public half disagrees with the config is " +
+                                "not caught at load — the node signs with a key its own " +
+                                "verification key does not match, and dies verifying its own " +
+                                "stack-0 hard ack, deep in consensus."
+                          )
+                        )
+
+    /** Every signing key must agree with the `verificationKey` sitting beside it.
+      *
+      * ⛔ This is the check whose absence is expensive. The two halves are supplied from different
+      * places by design — the public half from the config file, the private half from the
+      * environment — so nothing else in the system is positioned to notice they were paired wrong.
+      */
+    private def pairingErrors(secrets: List[Secret], json: Json): List[String] =
+        secrets.filter(_.pairedWithVerificationKey).flatMap { s =>
+            val vkeyPath = s.path.init :+ "verificationKey"
+            val where = s.path.init.mkString(".")
+            (at(json, s.path).flatMap(_.asString), at(json, vkeyPath).flatMap(_.asString)) match
+                case (Some(skeyHex), Some(vkeyHex)) =>
+                    derivePublicKeyHex(skeyHex) match
+                        case Left(why) => Some(s"$where: ${s.envName} $why")
+                        case Right(derived) =>
+                            Option.when(!derived.equalsIgnoreCase(vkeyHex))(
+                              s"$where: ${s.envName} derives verification key $derived, but the " +
+                                  s"config declares $vkeyHex"
+                            )
+                case (_, None) => Some(s"$where: no verificationKey in the config to check against")
+                case (None, _) => Some(s"$where: no signing key resolved")
+        }
+
+    /** Ed25519 public half of a 32-byte signing key, as lowercase hex. */
+    private def derivePublicKeyHex(skeyHex: String): Either[String, String] =
+        val cleaned = skeyHex.trim
+        if cleaned.length != 64 || !cleaned.forall(c => "0123456789abcdefABCDEF".contains(c)) then
+            Left(s"is not 32 bytes of hex (got ${cleaned.length} characters)")
+        else
+            try
+                val bytes = cleaned.grouped(2).map(Integer.parseInt(_, 16).toByte).toArray
+                val pub = Ed25519PrivateKeyParameters(bytes, 0).generatePublicKey().getEncoded
+                Right(pub.map("%02x".format(_)).mkString)
+            catch case e: Exception => Left(s"could not be read as an Ed25519 key: ${e.getMessage}")
+
+    private def value(s: Secret, provided: Map[String, String]): Option[String] =
+        provided.get(s.envName).filter(_.nonEmpty)

--- a/src/test/scala/hydrozoa/app/MainSmokeTest.scala
+++ b/src/test/scala/hydrozoa/app/MainSmokeTest.scala
@@ -88,7 +88,7 @@ class MainSmokeTest extends AnyFunSuite:
 
         val testIO = for {
             _ <- IO.blocking(
-              Files.writeString(headPath, printer.print(mnc.headConfig.asJson))
+              Files.writeString(headPath, printer.print(mnc.headConfig.asJson)): Unit
             )
             _ <- IO.blocking(writePrivatePair(runnablePrivateJson, privatePath))
 
@@ -192,11 +192,11 @@ class MainSmokeTest extends AnyFunSuite:
         val stripped = paths.foldLeft(json)((acc, kv) => drop(acc, kv._2))
         val printer = Printer.spaces2.copy(dropNullValues = true)
         Files.createDirectories(privatePath.getParent)
-        Files.writeString(privatePath, printer.print(stripped))
+        Files.writeString(privatePath, printer.print(stripped)): Unit
         Files.writeString(
           privatePath.resolveSibling(PrivateSecrets.defaultFileName),
           found.map((k, v) => s"$k=$v").mkString("", "\n", "\n")
-        )
+        ): Unit
     }
 
     // A `transplantStackNumber` names the stack this peer elects to ADOPT: everything at or below it

--- a/src/test/scala/hydrozoa/app/MainSmokeTest.scala
+++ b/src/test/scala/hydrozoa/app/MainSmokeTest.scala
@@ -4,15 +4,15 @@ import cats.effect.unsafe.implicits.global
 import cats.effect.{Deferred, IO}
 import hydrozoa.config.GenerateSampleConfig.{defaultSpec, testPeersSpec}
 import hydrozoa.config.head.HeadConfig.headConfigEncoder
-import hydrozoa.config.node.MultiNodeConfig
 import hydrozoa.config.node.NodePrivateConfig.nodePrivateConfigEncoder
+import hydrozoa.config.node.{MultiNodeConfig, PrivateSecrets}
 import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.backend.cardano.{CardanoBackendMock, MockState}
 import hydrozoa.multisig.consensus.peer.HeadPeerNumber
 import hydrozoa.multisig.server.HydrozoaHttpEvent
 import io.circe.syntax.*
 import io.circe.{Json, Printer}
-import java.nio.file.Files
+import java.nio.file.{Files, Path}
 import org.scalacheck.Gen
 import org.scalatest.funsuite.AnyFunSuite
 import scala.concurrent.duration.DurationInt
@@ -90,10 +90,7 @@ class MainSmokeTest extends AnyFunSuite:
             _ <- IO.blocking(
               Files.writeString(headPath, printer.print(mnc.headConfig.asJson))
             )
-            _ <- IO.blocking(Files.createDirectories(privatePath.getParent))
-            _ <- IO.blocking(
-              Files.writeString(privatePath, printer.print(runnablePrivateJson))
-            )
+            _ <- IO.blocking(writePrivatePair(runnablePrivateJson, privatePath))
 
             mockBackend <- CardanoBackendMock.mockIO(
               MockState(initialUtxos =
@@ -162,6 +159,46 @@ class MainSmokeTest extends AnyFunSuite:
         testIO.unsafeRunSync()
     }
 
+    /** Split a private config into the file a node reads and the credentials beside it.
+      *
+      * Credentials no longer live in `private.json` — the node reads them from the environment or
+      * from a `private.env` sibling — so a test that writes a runnable config has to write both
+      * halves. Doing it here rather than hand-rolling per test keeps every test on the real path.
+      */
+    private def writePrivatePair(json: Json, privatePath: Path): Unit = {
+        val walletField =
+            if json.hcursor.downField("ownPeerPrivate").downField("ownHeadWallet").succeeded then
+                "ownHeadWallet"
+            else "ownCoilWallet"
+        val paths = List(
+          "HYDROZOA_SIGNING_KEY" -> List("ownPeerPrivate", walletField, "signingKey"),
+          "HYDROZOA_RULE_BASED_SIGNING_KEY" ->
+              List("nodeOperationEvacuationConfig", "ruleBasedWallet", "signingKey"),
+          "HYDROZOA_BLOCKFROST_API_KEY" -> List("blockfrostApiKey"),
+          "HYDROZOA_ADMIN_PASSWORD" -> List("adminPassword")
+        )
+        def get(j: Json, path: List[String]): Option[String] =
+            path.foldLeft(Option(j))((acc, k) => acc.flatMap(_.asObject).flatMap(_.apply(k)))
+                .flatMap(_.asString)
+        def drop(j: Json, path: List[String]): Json = path match {
+            case Nil         => j
+            case last :: Nil => j.asObject.fold(j)(o => Json.fromJsonObject(o.remove(last)))
+            case head :: rest =>
+                j.asObject.fold(j)(o =>
+                    Json.fromJsonObject(o.add(head, drop(o(head).getOrElse(Json.obj()), rest)))
+                )
+        }
+        val found = paths.flatMap((env, path) => get(json, path).map(env -> _))
+        val stripped = paths.foldLeft(json)((acc, kv) => drop(acc, kv._2))
+        val printer = Printer.spaces2.copy(dropNullValues = true)
+        Files.createDirectories(privatePath.getParent)
+        Files.writeString(privatePath, printer.print(stripped))
+        Files.writeString(
+          privatePath.resolveSibling(PrivateSecrets.defaultFileName),
+          found.map((k, v) => s"$k=$v").mkString("", "\n", "\n")
+        )
+    }
+
     // A `transplantStackNumber` names the stack this peer elects to ADOPT: everything at or below it
     // is taken on trust from the donor committee and never verified. So the tag has to name a stack
     // the store actually holds. Here the store is empty, so no tag can be honoured -- the node must
@@ -207,8 +244,7 @@ class MainSmokeTest extends AnyFunSuite:
 
         val testIO = for {
             _ <- IO.blocking(Files.writeString(headPath, printer.print(mnc.headConfig.asJson)))
-            _ <- IO.blocking(Files.createDirectories(privatePath.getParent))
-            _ <- IO.blocking(Files.writeString(privatePath, printer.print(runnablePrivateJson)))
+            _ <- IO.blocking(writePrivatePair(runnablePrivateJson, privatePath))
             mockBackend <- CardanoBackendMock.mockIO(
               MockState(initialUtxos =
                   mnc.headConfig.initializationTx.resolvedUtxos.utxos
@@ -276,8 +312,7 @@ class MainSmokeTest extends AnyFunSuite:
 
         val testIO = for {
             _ <- IO.blocking(Files.writeString(headPath, printer.print(mnc.headConfig.asJson)))
-            _ <- IO.blocking(Files.createDirectories(privatePath.getParent))
-            _ <- IO.blocking(Files.writeString(privatePath, printer.print(runnablePrivateJson)))
+            _ <- IO.blocking(writePrivatePair(runnablePrivateJson, privatePath))
 
             // No `reportedParams`: the mock falls back to scalus's `UtxoEnv.testMainnet` fixture,
             // which matches no real network's `CardanoInfo`. That IS the mismatch under test.

--- a/src/test/scala/hydrozoa/bootstrap/GenerateKeyPairOutputsTest.scala
+++ b/src/test/scala/hydrozoa/bootstrap/GenerateKeyPairOutputsTest.scala
@@ -4,12 +4,13 @@ import cats.data.NonEmptyMap
 import hydrozoa.bootstrap.GenerateKeyPair.Role
 import hydrozoa.config.head.coil.{CoilPeerData, CoilPeers}
 import hydrozoa.config.head.peers.{HeadPeerData, HeadPeers}
-import hydrozoa.config.node.NodePrivateConfig
 import hydrozoa.config.node.NodePrivateConfig.nodePrivateConfigDecoder
 import hydrozoa.config.node.owninfo.{OwnCoilPeerPrivate, OwnHeadPeerPrivate}
+import hydrozoa.config.node.{NodePrivateConfig, PrivateSecrets}
 import hydrozoa.multisig.consensus.peer.HeadPeerNumber
 import io.circe.parser
 import java.nio.file.{Files, Path}
+import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters
 import org.http4s.Uri
 import org.scalatest.funsuite.AnyFunSuite
 import scala.collection.immutable.SortedMap
@@ -25,10 +26,24 @@ import scalus.uplc.builtin.ByteString
   */
 class GenerateKeyPairOutputsTest extends AnyFunSuite {
 
+    /** A signing key: an arbitrary but valid 32-byte Ed25519 seed. */
     private def hex(digit: Char): String = digit.toString * 64
 
+    /** The verification key that ACTUALLY belongs to `hex(digit)`.
+      *
+      * Derived rather than invented, because the config loader re-derives it and refuses a pair
+      * that does not agree. A fixture pairing an arbitrary "vkey" with an unrelated "skey" builds a
+      * config no node would accept, and would test the decoder against something unreachable.
+      */
+    private def vkeyHex(digit: Char): String =
+        Ed25519PrivateKeyParameters(ByteString.fromHex(hex(digit)).bytes, 0)
+            .generatePublicKey()
+            .getEncoded
+            .map("%02x".format(_))
+            .mkString
+
     private def vkey(digit: Char): VerificationKey =
-        VerificationKey.unsafeFromByteString(ByteString.fromHex(hex(digit)))
+        VerificationKey.unsafeFromByteString(ByteString.fromHex(vkeyHex(digit)))
 
     private val wsUri: Uri = Uri.unsafeFromString("ws://head-0:4001")
 
@@ -94,12 +109,19 @@ class GenerateKeyPairOutputsTest extends AnyFunSuite {
         given HeadPeers = headPeers
         given CoilPeers = coilPeers
 
-        val filled = GenerateKeyPair
-            .fillPrivateConfig(template, Role.Head, hex('1'), hex('a'))
+        // The round trip the split creates: `fillPrivateConfig` writes the config and the
+        // credentials as a pair, and the loader reassembles them. Decoding the config alone is
+        // supposed to be impossible now, which the dedicated test below asserts.
+        val (filled, secrets) = GenerateKeyPair
+            .fillPrivateConfig(template, Role.Head, vkeyHex('1'), hex('1'))
             .fold(e => fail(s"fill failed: $e"), identity)
 
+        val reassembled = PrivateSecrets
+            .applySecrets(filled, secrets, "test")
+            .fold(e => fail(s"credentials rejected: ${e.reason}"), identity)
+
         val decoded = parser
-            .decode[NodePrivateConfig](filled.spaces2)(using nodePrivateConfigDecoder)
+            .decode[NodePrivateConfig](reassembled.spaces2)(using nodePrivateConfigDecoder)
             .fold(e => fail(s"decode failed: $e"), identity)
 
         decoded.ownPeerPrivate match {
@@ -114,11 +136,13 @@ class GenerateKeyPairOutputsTest extends AnyFunSuite {
 
     test("the screener uri survives a head fill and is dropped from a coil's") {
         val head = GenerateKeyPair
-            .fillPrivateConfig(template, Role.Head, hex('1'), hex('a'))
+            .fillPrivateConfig(template, Role.Head, vkeyHex('1'), hex('1'))
             .fold(e => fail(s"fill failed: $e"), identity)
+            ._1
         val coil = GenerateKeyPair
-            .fillPrivateConfig(template, Role.Coil, hex('3'), hex('a'))
+            .fillPrivateConfig(template, Role.Coil, vkeyHex('3'), hex('3'))
             .fold(e => fail(s"fill failed: $e"), identity)
+            ._1
 
         // The template has to carry it, or the head check passes vacuously.
         val inTemplate = template.hcursor.downField("remoteScreenerUri").succeeded
@@ -134,12 +158,16 @@ class GenerateKeyPairOutputsTest extends AnyFunSuite {
         given HeadPeers = headPeers
         given CoilPeers = coilPeers
 
-        val filled = GenerateKeyPair
-            .fillPrivateConfig(template, Role.Coil, hex('3'), hex('a'))
+        val (filled, secrets) = GenerateKeyPair
+            .fillPrivateConfig(template, Role.Coil, vkeyHex('3'), hex('3'))
             .fold(e => fail(s"fill failed: $e"), identity)
 
+        val reassembled = PrivateSecrets
+            .applySecrets(filled, secrets, "test")
+            .fold(e => fail(s"credentials rejected: ${e.reason}"), identity)
+
         val decoded = parser
-            .decode[NodePrivateConfig](filled.spaces2)(using nodePrivateConfigDecoder)
+            .decode[NodePrivateConfig](reassembled.spaces2)(using nodePrivateConfigDecoder)
             .fold(e => fail(s"decode failed: $e"), identity)
 
         decoded.ownPeerPrivate match {

--- a/src/test/scala/hydrozoa/config/node/PrivateSecretsTest.scala
+++ b/src/test/scala/hydrozoa/config/node/PrivateSecretsTest.scala
@@ -1,0 +1,166 @@
+package hydrozoa.config.node
+
+import io.circe.{Json, parser}
+import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters
+import org.scalatest.funsuite.AnyFunSuite
+
+class PrivateSecretsTest extends AnyFunSuite {
+
+    private def skey(digit: Char): String = digit.toString * 64
+
+    private def vkeyOf(skeyHex: String): String =
+        Ed25519PrivateKeyParameters(
+          skeyHex.grouped(2).map(Integer.parseInt(_, 16).toByte).toArray,
+          0
+        ).generatePublicKey().getEncoded.map("%02x".format(_)).mkString
+
+    /** A config in the shape the split produces: public halves present, secrets absent. */
+    private def config(ownVkey: String, ruleVkey: String): Json =
+        parser
+            .parse(s"""{
+              "ownPeerPrivate": { "ownHeadWallet": { "verificationKey": "$ownVkey" } },
+              "nodeOperationEvacuationConfig": {
+                "ruleBasedWallet": { "verificationKey": "$ruleVkey" }
+              },
+              "httpPort": "8080"
+            }""")
+            .fold(e => fail(s"bad fixture: $e"), identity)
+
+    private def credentials(own: String, rule: String): Map[String, String] = Map(
+      "HYDROZOA_SIGNING_KEY" -> own,
+      "HYDROZOA_RULE_BASED_SIGNING_KEY" -> rule,
+      "HYDROZOA_BLOCKFROST_API_KEY" -> "previewXXXX",
+      "HYDROZOA_ADMIN_PASSWORD" -> "hunter2"
+    )
+
+    test("a complete, matching credential set is spliced into the config") {
+        val json = config(vkeyOf(skey('1')), vkeyOf(skey('2')))
+        val out = PrivateSecrets
+            .applySecrets(json, credentials(skey('1'), skey('2')), "test")
+            .fold(e => fail(s"unexpectedly refused: ${e.reason}"), identity)
+
+        val c = out.hcursor
+        assert(
+          c.downField("ownPeerPrivate")
+              .downField("ownHeadWallet")
+              .downField("signingKey")
+              .as[String] == Right(skey('1'))
+        )
+        assert(c.downField("blockfrostApiKey").as[String] == Right("previewXXXX"))
+        assert(c.downField("adminPassword").as[String] == Right("hunter2"))
+    }
+
+    test("a missing credential is refused, and the message names it") {
+        val json = config(vkeyOf(skey('1')), vkeyOf(skey('2')))
+        val refusal = PrivateSecrets
+            .applySecrets(
+              json,
+              credentials(skey('1'), skey('2')) - "HYDROZOA_ADMIN_PASSWORD",
+              "test"
+            )
+            .swap
+            .fold(_ => fail("expected a refusal"), identity)
+        assert(refusal.reason.contains("HYDROZOA_ADMIN_PASSWORD"))
+    }
+
+    // The check that earns this module its place: the two halves of a keypair now arrive from
+    // different places, so nothing else in the system is positioned to notice they were paired
+    // wrong. Unchecked it surfaces as a BadSignature deep in consensus.
+    test("a signing key that does not match its verification key is refused") {
+        val json = config(vkeyOf(skey('1')), vkeyOf(skey('2')))
+        val refusal = PrivateSecrets
+            .applySecrets(json, credentials(skey('9'), skey('2')), "test")
+            .swap
+            .fold(_ => fail("expected a refusal"), identity)
+        assert(refusal.reason.contains("derives verification key"))
+        assert(refusal.reason.contains("ownPeerPrivate.ownHeadWallet"))
+    }
+
+    test("the rule-based wallet is paired too, not just the peer's own") {
+        val json = config(vkeyOf(skey('1')), vkeyOf(skey('2')))
+        val refusal = PrivateSecrets
+            .applySecrets(json, credentials(skey('1'), skey('9')), "test")
+            .swap
+            .fold(_ => fail("expected a refusal"), identity)
+        assert(refusal.reason.contains("ruleBasedWallet"))
+    }
+
+    // The whole point of the split is that the config file becomes shareable. A live key left in
+    // it would defeat that silently, so it is refused rather than overwritten.
+    test("a credential left behind in the config is refused") {
+        val json = config(vkeyOf(skey('1')), vkeyOf(skey('2')))
+            .deepMerge(Json.obj("blockfrostApiKey" -> Json.fromString("previewLEFTBEHIND")))
+        val refusal = PrivateSecrets
+            .applySecrets(json, credentials(skey('1'), skey('2')), "test")
+            .swap
+            .fold(_ => fail("expected a refusal"), identity)
+        assert(refusal.reason.contains("blockfrostApiKey"))
+    }
+
+    // The encoder writes an all-zeros stand-in where a signing key would go. That is not a leak
+    // and must not be treated as one -- it is simply overwritten.
+    test("the encoder's all-zeros placeholder is overwritten, not treated as a leak") {
+        val json = config(vkeyOf(skey('1')), vkeyOf(skey('2'))).deepMerge(
+          Json.obj(
+            "ownPeerPrivate" -> Json.obj(
+              "ownHeadWallet" -> Json.obj("signingKey" -> Json.fromString("0" * 64))
+            )
+          )
+        )
+        val out = PrivateSecrets
+            .applySecrets(json, credentials(skey('1'), skey('2')), "test")
+            .fold(e => fail(s"unexpectedly refused: ${e.reason}"), identity)
+        assert(
+          out.hcursor
+              .downField("ownPeerPrivate")
+              .downField("ownHeadWallet")
+              .downField("signingKey")
+              .as[String] == Right(skey('1'))
+        )
+    }
+
+    test("a config with no rule-based wallet does not demand its key") {
+        val json = parser
+            .parse(s"""{
+              "ownPeerPrivate": { "ownHeadWallet": { "verificationKey": "${vkeyOf(skey('1'))}" } }
+            }""")
+            .fold(e => fail(s"bad fixture: $e"), identity)
+        val creds = Map(
+          "HYDROZOA_SIGNING_KEY" -> skey('1'),
+          "HYDROZOA_BLOCKFROST_API_KEY" -> "previewXXXX",
+          "HYDROZOA_ADMIN_PASSWORD" -> "hunter2"
+        )
+        assert(PrivateSecrets.applySecrets(json, creds, "test").isRight)
+    }
+
+    test("a malformed signing key is refused rather than parsed into nonsense") {
+        val json = config(vkeyOf(skey('1')), vkeyOf(skey('2')))
+        val refusal = PrivateSecrets
+            .applySecrets(json, credentials("nothex", skey('2')), "test")
+            .swap
+            .fold(_ => fail("expected a refusal"), identity)
+        assert(refusal.reason.contains("32 bytes of hex"))
+    }
+
+    test("the env file parser handles comments, quotes, blanks and export") {
+        val parsed = PrivateSecrets.parseEnvFile("""
+          |# a comment
+          |
+          |HYDROZOA_SIGNING_KEY=abc123
+          |export HYDROZOA_ADMIN_PASSWORD="quoted value"
+          |HYDROZOA_BLOCKFROST_API_KEY='single'
+          |  SPACED  =  padded
+          |not a pair
+          |""".stripMargin)
+
+        assert(parsed("HYDROZOA_SIGNING_KEY") == "abc123")
+        assert(parsed("HYDROZOA_ADMIN_PASSWORD") == "quoted value")
+        assert(parsed("HYDROZOA_BLOCKFROST_API_KEY") == "single")
+        assert(parsed("SPACED") == "padded")
+        assert(!parsed.contains("not a pair"))
+    }
+
+    test("a value containing '=' survives the split") {
+        assert(PrivateSecrets.parseEnvFile("K=a=b=c")("K") == "a=b=c")
+    }
+}

--- a/src/test/scala/hydrozoa/config/node/PrivateSecretsTest.scala
+++ b/src/test/scala/hydrozoa/config/node/PrivateSecretsTest.scala
@@ -45,9 +45,9 @@ class PrivateSecretsTest extends AnyFunSuite {
               .downField("ownHeadWallet")
               .downField("signingKey")
               .as[String] == Right(skey('1'))
-        )
-        assert(c.downField("blockfrostApiKey").as[String] == Right("previewXXXX"))
-        assert(c.downField("adminPassword").as[String] == Right("hunter2"))
+        ): Unit
+        assert(c.downField("blockfrostApiKey").as[String] == Right("previewXXXX")): Unit
+        assert(c.downField("adminPassword").as[String] == Right("hunter2")): Unit
     }
 
     test("a missing credential is refused, and the message names it") {
@@ -60,7 +60,7 @@ class PrivateSecretsTest extends AnyFunSuite {
             )
             .swap
             .fold(_ => fail("expected a refusal"), identity)
-        assert(refusal.reason.contains("HYDROZOA_ADMIN_PASSWORD"))
+        assert(refusal.reason.contains("HYDROZOA_ADMIN_PASSWORD")): Unit
     }
 
     // The check that earns this module its place: the two halves of a keypair now arrive from
@@ -72,8 +72,8 @@ class PrivateSecretsTest extends AnyFunSuite {
             .applySecrets(json, credentials(skey('9'), skey('2')), "test")
             .swap
             .fold(_ => fail("expected a refusal"), identity)
-        assert(refusal.reason.contains("derives verification key"))
-        assert(refusal.reason.contains("ownPeerPrivate.ownHeadWallet"))
+        assert(refusal.reason.contains("derives verification key")): Unit
+        assert(refusal.reason.contains("ownPeerPrivate.ownHeadWallet")): Unit
     }
 
     test("the rule-based wallet is paired too, not just the peer's own") {
@@ -82,7 +82,7 @@ class PrivateSecretsTest extends AnyFunSuite {
             .applySecrets(json, credentials(skey('1'), skey('9')), "test")
             .swap
             .fold(_ => fail("expected a refusal"), identity)
-        assert(refusal.reason.contains("ruleBasedWallet"))
+        assert(refusal.reason.contains("ruleBasedWallet")): Unit
     }
 
     // The whole point of the split is that the config file becomes shareable. A live key left in
@@ -94,7 +94,7 @@ class PrivateSecretsTest extends AnyFunSuite {
             .applySecrets(json, credentials(skey('1'), skey('2')), "test")
             .swap
             .fold(_ => fail("expected a refusal"), identity)
-        assert(refusal.reason.contains("blockfrostApiKey"))
+        assert(refusal.reason.contains("blockfrostApiKey")): Unit
     }
 
     // The encoder writes an all-zeros stand-in where a signing key would go. That is not a leak
@@ -116,7 +116,7 @@ class PrivateSecretsTest extends AnyFunSuite {
               .downField("ownHeadWallet")
               .downField("signingKey")
               .as[String] == Right(skey('1'))
-        )
+        ): Unit
     }
 
     test("a config with no rule-based wallet does not demand its key") {
@@ -130,7 +130,7 @@ class PrivateSecretsTest extends AnyFunSuite {
           "HYDROZOA_BLOCKFROST_API_KEY" -> "previewXXXX",
           "HYDROZOA_ADMIN_PASSWORD" -> "hunter2"
         )
-        assert(PrivateSecrets.applySecrets(json, creds, "test").isRight)
+        assert(PrivateSecrets.applySecrets(json, creds, "test").isRight): Unit
     }
 
     test("a malformed signing key is refused rather than parsed into nonsense") {
@@ -139,7 +139,7 @@ class PrivateSecretsTest extends AnyFunSuite {
             .applySecrets(json, credentials("nothex", skey('2')), "test")
             .swap
             .fold(_ => fail("expected a refusal"), identity)
-        assert(refusal.reason.contains("32 bytes of hex"))
+        assert(refusal.reason.contains("32 bytes of hex")): Unit
     }
 
     test("the env file parser handles comments, quotes, blanks and export") {
@@ -153,14 +153,14 @@ class PrivateSecretsTest extends AnyFunSuite {
           |not a pair
           |""".stripMargin)
 
-        assert(parsed("HYDROZOA_SIGNING_KEY") == "abc123")
-        assert(parsed("HYDROZOA_ADMIN_PASSWORD") == "quoted value")
-        assert(parsed("HYDROZOA_BLOCKFROST_API_KEY") == "single")
-        assert(parsed("SPACED") == "padded")
-        assert(!parsed.contains("not a pair"))
+        assert(parsed("HYDROZOA_SIGNING_KEY") == "abc123"): Unit
+        assert(parsed("HYDROZOA_ADMIN_PASSWORD") == "quoted value"): Unit
+        assert(parsed("HYDROZOA_BLOCKFROST_API_KEY") == "single"): Unit
+        assert(parsed("SPACED") == "padded"): Unit
+        assert(!parsed.contains("not a pair")): Unit
     }
 
     test("a value containing '=' survives the split") {
-        assert(PrivateSecrets.parseEnvFile("K=a=b=c")("K") == "a=b=c")
+        assert(PrivateSecrets.parseEnvFile("K=a=b=c")("K") == "a=b=c"): Unit
     }
 }


### PR DESCRIPTION
## Review order

Stacked on `feat/l1-boot-gate`. One commit. The three branches below it are `refactor/markers-at-the-manager` → `feat/remote-ledger-hardening` → `feat/l1-boot-gate`.

## Change

Four credentials move out of `private.json` and into the environment:

| variable                          | was                                                        |
| --------------------------------- | ---------------------------------------------------------- |
| `HYDROZOA_SIGNING_KEY`            | `ownPeerPrivate.own{Head,Coil}Wallet.signingKey`           |
| `HYDROZOA_RULE_BASED_SIGNING_KEY` | `nodeOperationEvacuationConfig.ruleBasedWallet.signingKey` |
| `HYDROZOA_BLOCKFROST_API_KEY`     | `blockfrostApiKey`                                         |
| `HYDROZOA_ADMIN_PASSWORD`         | `adminPassword`                                            |

Values are read from the real environment first, then from a `private.env` sitting beside `private.json` (or wherever `HYDROZOA_PRIVATE_ENV` points). That precedence is what lets a deployment override one value without rewriting the file the rest come from. The decoders are unchanged: values are spliced into the JSON at the paths they already read.

`private.env` is the `KEY=value` subset that systemd's `EnvironmentFile=`, `docker --env-file` and a shell `source` all agree on — comments, blanks, optional `export`, one layer of quotes. Deliberately not a shell parser: no interpolation, no continuations, no `$(…)`. A credentials file that executes anything is a credentials file that can surprise you.

`GenerateKeyPair` now writes both halves as a pair — the config with the public half, and `private.env` at mode 0600.

## Rationale

The point is that `private.json` becomes an ordinary configuration file: templated, diffed, committed to a deployment repo, and handed to an operator who is not trusted with the head's signing key. Everything secret arrives the way every deployment target already wants to supply it — a Kubernetes `Secret` projected as env vars, systemd's `EnvironmentFile=`, `docker run --env-file`. This is a prerequisite for handing BlinkLabs a config pack they can fill in.

**A missing credential is a refusal, not a wait.** No amount of retrying conjures a signing key. Left to fail later it fails obscurely: the signing key in particular surfaces as a `BadSignature` while the node verifies its own stack-0 hard ack, deep inside consensus, with nothing pointing back at the config.

**The check that earns this module its place is the keypair pairing.** Each signing key is checked against the `verificationKey` sitting beside it in the config. The two halves are now supplied from different places *by design* — public half from the file, private half from the environment — so nothing else in the system is positioned to notice they were paired wrong. Unchecked, a mis-pairing means the node signs with a key its own declared verification key does not match, and dies verifying its own stack-0 hard ack.

**A credential left behind in the config is refused rather than overwritten.** The whole point of the split is that the file becomes shareable; a live key still sitting in it would defeat that silently. The one exception is the all-zeros placeholder the config *encoder* writes where a signing key would go — that is expected and is simply overwritten.

## Risk

⛔ **No backward compatibility, by explicit decision.** A config that still carries any of the four fields is refused. Every existing deployment must be migrated in the same step as the binary: write `private.env` per peer, then delete the four fields. Mainnet head-0 and coil-0 configs will be changed accordingly.

⚠️ **The pairing check makes a fake-key dry run impossible on this branch.** Confirmed in practice: a mainnet transplant dry run runs with the real *verification* key and a fabricated *signing* key, which is exactly the combination this refuses. Dry runs of that shape must use a commit below this one. That is the check working as intended, but it is a workflow consequence worth knowing before it surprises someone.

A config with no rule-based wallet at all does not demand that key — otherwise the decoder's own clear message about the missing wallet would be replaced by a confusing one about a missing credential.

## Testing

`PrivateSecretsTest`, 10 cases, against the pure core (`applySecrets`) so the file and environment reads are not in the way: a complete matching set splices · a missing credential is refused and the message names it · a signing key that does not match its verification key is refused, for both the peer's own wallet and the rule-based one · a credential left in the config is refused · the encoder's all-zeros placeholder is overwritten rather than treated as a leak · a config with no rule-based wallet does not demand its key · a malformed key is refused rather than parsed into nonsense · the env-file parser handles comments, quotes, blanks, `export`, and a value containing `=`.

`GenerateKeyPairOutputsTest` covers the round trip: the generator writes the config and the credentials as a pair, and this module reassembles them.

`MainSmokeTest` gained a `writePrivatePair` helper so every smoke case now goes through the split form.

## Not in this PR

- Reading credentials from a secrets manager directly (Vault, AWS Secrets Manager). The env-var boundary is what those all project into anyway.
- Rotating a credential without a restart.
- Migrating the deployed mainnet configs — that is an ops step, not a code change, and must land with the binary.