### PR TITLE
transport: bound the WebSocket handshake, not the connection behind it

### DIFF
--- a/src/main/scala/hydrozoa/multisig/consensus/transport/CoilPeerWsTransport.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/transport/CoilPeerWsTransport.scala
@@ -1,7 +1,7 @@
 package hydrozoa.multisig.consensus.transport
 
 import cats.effect.std.Queue
-import cats.effect.{IO, Ref, Resource}
+import cats.effect.{Deferred, FiberIO, IO, Ref, Resource}
 import cats.syntax.all.*
 import hydrozoa.config.head.network.CardanoNetwork
 import hydrozoa.lib.QuietRelease
@@ -71,9 +71,10 @@ final class CoilPeerWsTransport private (
             case Left(err)                     => tracer.traceWith(DecodeError(err))
         }
 
-    /** How long one dial attempt may sit in the WebSocket handshake before it is abandoned. Long
-      * enough not to give up on an ordinarily slow hub, short enough that a stalled one does not
-      * stop this peer reconnecting.
+    /** How long one dial attempt may sit in the WebSocket **handshake** before it is abandoned.
+      * Long enough not to give up on an ordinarily slow hub, short enough that a stalled one does
+      * not stop this peer reconnecting. Bounds the handshake alone: an established connection is
+      * unbounded, and [[WsDuplex.defaultReadIdleTimeout]] is what catches a half-open one.
       */
     private val handshakeBudget: FiniteDuration = 30.seconds
 
@@ -85,34 +86,68 @@ final class CoilPeerWsTransport private (
 
         // Low-level `connect`, not `connectHighLevel`: the dialer needs to see the hub's keep-alive
         // Ping to know the link is alive (see WsDuplex).
-        def once: IO[Unit] =
+        // `handshook` arbitrates between this attempt and the loop's budget: whoever completes it
+        // first decides whether the socket is used or dropped. `complete` has exactly one winner,
+        // so a handshake landing on the deadline cannot leave both a live connection and a redial.
+        def once(handshook: Deferred[IO, Unit]): IO[Unit] =
             QuietRelease(client.connect(request)).use { conn =>
                 val helloLine = CoilFrame.encode(CoilFrame.Hello(ownCoilNum.convert))
-                tracer.traceWith(DialerConnected(hubUri)) >>
-                    conn.send(WSFrame.Text(helloLine)) >>
-                    WsDuplex.run(conn, outbox, onLine)
+                handshook.complete(()).flatMap {
+                    case true =>
+                        tracer.traceWith(DialerConnected(hubUri)) >>
+                            conn.send(WSFrame.Text(helloLine)) >>
+                            WsDuplex.run(conn, outbox, onLine)
+                    // Lost the claim: the budget expired and the loop has already redialed. Return
+                    // instead, so `use` closes this socket rather than leaving a second live
+                    // connection draining the shared outbox.
+                    case false => tracer.traceWith(DialerHandshakeLate(hubUri))
+                }
             }
 
-        val attempt: IO[Unit] =
-            (once >> tracer.traceWith(DialerDisconnected(hubUri)))
+        def attempt(handshook: Deferred[IO, Unit]): IO[Unit] =
+            (once(handshook) >> tracer.traceWith(DialerDisconnected(hubUri)))
                 .handleErrorWith(e => tracer.traceWith(DialerFailed(e)))
 
-        // Bound each attempt and ABANDON a stalled one rather than awaiting it. `JdkWSClient`
-        // builds its socket inside `Resource.make`'s acquire, which is uncancelable, and
-        // `fromCompletableFuture` is cooperative-only — so a hub that accepts the TCP connection and
-        // never answers the handshake blocks `once` forever. Without this the loop never iterates
-        // and the peer stops reconnecting entirely: not slow to recover, never retrying.
+        // Wait out a connection this loop owns. `onCancel` is what keeps teardown closing the
+        // socket: the attempt runs on its own fiber, so cancelling this loop cancels the JOIN and
+        // not the attempt behind it, and a live `WsDuplex.run` would otherwise outlive
+        // `startDialer`'s release with its connection still open. Safe to cancel here and only
+        // here — past the claim the uncancelable acquire is long finished.
+        def own(f: FiberIO[Unit]): IO[Unit] = f.join.void.onCancel(f.cancel)
+
+        // Bound the HANDSHAKE, and only the handshake. `JdkWSClient` builds its socket inside
+        // `Resource.make`'s acquire, which is uncancelable, and `fromCompletableFuture` is
+        // cooperative-only — so a hub that accepts the TCP connection and never answers the
+        // handshake blocks the attempt forever, the loop never iterates, and the peer stops
+        // reconnecting entirely: not slow to recover, never retrying.
         //
-        // `race` cancels the losing `join`, not the attempt behind it, which is exactly what is
-        // wanted here — the stalled fiber is left to finish or not, and the loop moves on.
+        // What must NOT be bounded is what comes after. `WsDuplex.run` occupies the attempt for the
+        // whole life of a healthy link — the hub pings well inside the read deadline, so it never
+        // returns on its own — and timing the attempt as a whole therefore abandons a *working*
+        // connection every `handshakeBudget` and dials a second one on top of it.
+        //
+        // A stalled attempt is abandoned, not cancelled: the acquire it is stuck in cannot be
+        // interrupted. It disowns itself through `handshook` if it ever does complete.
         val bounded: IO[Unit] =
-            attempt.start.flatMap(f =>
-                IO.race(f.join, IO.sleep(handshakeBudget)).flatMap {
-                    case Left(_) => IO.unit
+            for {
+                handshook <- Deferred[IO, Unit]
+                f <- attempt(handshook).start
+                _ <- IO.race(IO.race(handshook.get, f.join), IO.sleep(handshakeBudget)).flatMap {
+                    // Connected inside the budget: this attempt owns the dialer until the link
+                    // ends, and waiting on it is the point.
+                    case Left(Left(_)) => own(f)
+                    // Ended before it ever connected — refused, DNS, TLS. Redial.
+                    case Left(Right(_)) => IO.unit
                     case Right(_) =>
-                        tracer.traceWith(DialerHandshakeStalled(hubUri, handshakeBudget))
+                        handshook.complete(()).flatMap {
+                            case true =>
+                                tracer.traceWith(DialerHandshakeStalled(hubUri, handshakeBudget))
+                            // It handshook on the deadline and claimed first after all, so it owns
+                            // the link and there is nothing to redial.
+                            case false => own(f)
+                        }
                 }
-            )
+            } yield ()
 
         (bounded >> IO.sleep(1.second)).foreverM
     }

--- a/src/main/scala/hydrozoa/multisig/consensus/transport/CoilPeerWsTransportEvent.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/transport/CoilPeerWsTransportEvent.scala
@@ -46,6 +46,15 @@ object CoilPeerWsTransportEvent:
     final case class DialerHandshakeStalled(uri: Uri, after: FiniteDuration)
         extends CoilPeerWsTransportEvent
 
+    /** An abandoned dial attempt completed its handshake after the loop had given up on it, and
+      * dropped the socket instead of using it.
+      *
+      * The pair to [[DialerHandshakeStalled]]: seeing both for one attempt means the hub is merely
+      * slower than `handshakeBudget`, not black-holing, and the budget is the thing to raise.
+      * Seeing the stall alone means the handshake never landed at all.
+      */
+    final case class DialerHandshakeLate(uri: Uri) extends CoilPeerWsTransportEvent
+
     /** The connection to the hub ended without error — the peer closed cleanly, or the receive side
       * reached end of stream. A read-deadline expiry is an **error** and surfaces as
       * [[DialerFailed]], not here.

--- a/src/main/scala/hydrozoa/multisig/consensus/transport/CoilPeerWsTransportEventFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/transport/CoilPeerWsTransportEventFormat.scala
@@ -35,6 +35,11 @@ object CoilPeerWsTransportEventFormat:
                   s"dialer: handshake to hub at $uri stalled past $after and was abandoned; " +
                       "the hub accepted the connection but never completed it — redialing"
                 )
+            case DialerHandshakeLate(uri) =>
+                warn(
+                  s"dialer: handshake to hub at $uri completed after it was abandoned; " +
+                      "dropping the socket"
+                )
             case DialerDisconnected(uri) =>
                 warn(s"dialer: disconnected from hub at $uri; redialing")
         }

--- a/src/main/scala/hydrozoa/multisig/consensus/transport/PeerTransport.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/transport/PeerTransport.scala
@@ -1,7 +1,7 @@
 package hydrozoa.multisig.consensus.transport
 
 import cats.effect.std.Queue
-import cats.effect.{IO, Ref, Resource}
+import cats.effect.{Deferred, FiberIO, IO, Ref, Resource}
 import cats.syntax.all.*
 import fs2.Stream
 import hydrozoa.config.head.network.CardanoNetwork
@@ -115,30 +115,54 @@ final class WsPeerTransport private (
 
         // Low-level `connect`, not `connectHighLevel`: the dialer needs to see the remote's
         // keep-alive Ping to know the link is alive (see WsDuplex).
-        def once: IO[Unit] =
+        // `handshook` arbitrates between this attempt and the loop's budget — see the coil dialer
+        // in `CoilPeerWsTransport` for the full rationale; the shape here is identical.
+        def once(handshook: Deferred[IO, Unit]): IO[Unit] =
             QuietRelease(client.connect(request)).use { conn =>
                 val helloLine = HeadFrame.encode(HeadFrame.Hello(ownPeerId.peerNum))
-                tracer.traceWith(DialerConnected(remote, uri)) >>
-                    conn.send(WSFrame.Text(helloLine)) >>
-                    WsDuplex.run(conn, outboxes(remote), onLine(remote))
+                handshook.complete(()).flatMap {
+                    case true =>
+                        tracer.traceWith(DialerConnected(remote, uri)) >>
+                            conn.send(WSFrame.Text(helloLine)) >>
+                            WsDuplex.run(conn, outboxes(remote), onLine(remote))
+                    // Lost the claim: the budget expired and the loop has already redialed. Return
+                    // instead, so `use` closes this socket rather than leaving a second live
+                    // connection draining this remote's outbox.
+                    case false => tracer.traceWith(DialerHandshakeLate(remote, uri))
+                }
             }
 
-        val attempt: IO[Unit] =
-            (once >> tracer.traceWith(DialerDisconnected(remote, uri)))
+        def attempt(handshook: Deferred[IO, Unit]): IO[Unit] =
+            (once(handshook) >> tracer.traceWith(DialerDisconnected(remote, uri)))
                 .handleErrorWith(e => tracer.traceWith(DialerFailed(remote, e)))
 
-        // Same bound as the coil dialer: `JdkWSClient` builds its socket in an uncancelable acquire,
-        // so a remote that accepts the connection and never answers the handshake blocks `once`
-        // forever and this loop stops retrying altogether. `race` cancels the losing join, not the
-        // attempt, so the stalled fiber is abandoned and the dialer moves on.
+        // `onCancel` is what keeps teardown closing the socket: the attempt runs on its own fiber,
+        // so cancelling this loop cancels the JOIN and not the attempt behind it. Safe past the
+        // claim and only there — by then the uncancelable acquire has finished.
+        def own(f: FiberIO[Unit]): IO[Unit] = f.join.void.onCancel(f.cancel)
+
+        // Same bound as the coil dialer, and bounding the same thing: the HANDSHAKE only.
+        // `JdkWSClient` builds its socket in an uncancelable acquire, so a remote that accepts the
+        // connection and never answers blocks the attempt forever and this loop stops retrying
+        // altogether. But `WsDuplex.run` holds the attempt for the whole life of a healthy link, so
+        // bounding the attempt as a whole abandons working connections on a timer instead.
         val bounded: IO[Unit] =
-            attempt.start.flatMap(f =>
-                IO.race(f.join, IO.sleep(handshakeBudget)).flatMap {
-                    case Left(_) => IO.unit
+            for {
+                handshook <- Deferred[IO, Unit]
+                f <- attempt(handshook).start
+                _ <- IO.race(IO.race(handshook.get, f.join), IO.sleep(handshakeBudget)).flatMap {
+                    case Left(Left(_))  => own(f)
+                    case Left(Right(_)) => IO.unit
                     case Right(_) =>
-                        tracer.traceWith(DialerHandshakeStalled(remote, uri, handshakeBudget))
+                        handshook.complete(()).flatMap {
+                            case true =>
+                                tracer.traceWith(
+                                  DialerHandshakeStalled(remote, uri, handshakeBudget)
+                                )
+                            case false => own(f)
+                        }
                 }
-            )
+            } yield ()
 
         (bounded >> IO.sleep(1.second)).foreverM
     }

--- a/src/main/scala/hydrozoa/multisig/consensus/transport/PeerTransportEvent.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/transport/PeerTransportEvent.scala
@@ -49,6 +49,12 @@ object PeerTransportEvent:
     final case class DialerHandshakeStalled(remote: HeadPeerId, uri: Uri, after: FiniteDuration)
         extends PeerTransportEvent
 
+    /** An abandoned dial attempt completed its handshake after the loop had given up on it, and
+      * dropped the socket instead of using it. The pair to [[DialerHandshakeStalled]]: both for one
+      * attempt means the remote is merely slower than `handshakeBudget`, not black-holing.
+      */
+    final case class DialerHandshakeLate(remote: HeadPeerId, uri: Uri) extends PeerTransportEvent
+
     /** A frame received on an active dialer connection could not be decoded. */
     final case class ClientDecodeError(remote: HeadPeerId, cause: Throwable)
         extends PeerTransportEvent

--- a/src/main/scala/hydrozoa/multisig/consensus/transport/PeerTransportEventFormat.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/transport/PeerTransportEventFormat.scala
@@ -37,6 +37,11 @@ object PeerTransportEventFormat:
                       s"$after and was abandoned; the remote accepted the connection but never " +
                       "completed it — redialing"
                 )
+            case DialerHandshakeLate(remote, uri) =>
+                warn(
+                  s"dialer: handshake to remote=${remote.peerNum: Int} at $uri completed after " +
+                      "it was abandoned; dropping the socket"
+                )
             case ClientDecodeError(remote, cause) =>
                 warn(
                   s"failed to decode frame from remote=${remote.peerNum: Int}: ${cause.getMessage}"

--- a/src/test/scala/hydrozoa/multisig/consensus/transport/CoilDialerBudgetTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/transport/CoilDialerBudgetTest.scala
@@ -1,0 +1,117 @@
+package hydrozoa.multisig.consensus.transport
+
+import cats.effect.testkit.TestControl
+import cats.effect.{IO, Ref, Resource}
+import hydrozoa.config.head.network.CardanoNetwork
+import hydrozoa.lib.logging.ContraTracer
+import hydrozoa.multisig.consensus.peer.CoilPeerNumber
+import hydrozoa.multisig.consensus.transport.CoilPeerWsTransportEvent.*
+import org.http4s.Uri
+import org.http4s.client.websocket.{WSClient, WSConnection, WSFrame, WSRequest}
+import org.scalatest.funsuite.AnyFunSuite
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
+
+/** What the dialer's handshake budget may and may not cut short, on a virtual clock.
+  *
+  * The budget exists because `JdkWSClient` builds its socket inside an uncancelable acquire, so a
+  * hub that accepts the TCP connection and never answers can only be abandoned, never cancelled. It
+  * must bound the handshake and nothing past it: an established link is *supposed* to occupy the
+  * dialer for as long as it lives, so a budget that reaches beyond the handshake tears down working
+  * connections on a timer and dials a second one on top of each — every frame then goes to
+  * whichever of them the shared outbox happens to hand it to.
+  */
+class CoilDialerBudgetTest extends AnyFunSuite {
+
+    private given CardanoNetwork.Section = CardanoNetwork.Preview
+
+    private val hubUri = Uri.unsafeFromString("ws://hub.invalid:3001/ws")
+
+    /** A quiet-but-live link: a keep-alive Ping every `pingEvery`, which is what holds `WsDuplex`'s
+      * read deadline off a real idle connection (`NodeWsServer` pings every 10s).
+      *
+      * It closes after `pings` of them rather than running forever, only so `TestControl` has an
+      * end to reach: an eternal link leaves work scheduled at every future instant and `tickAll`
+      * chases it without terminating. Size it past the window under test.
+      */
+    private def pinging(pingEvery: FiniteDuration, pings: Int = 200): IO[WSConnection[IO]] =
+        Ref.of[IO, Int](pings).map { left =>
+            new WSConnection[IO] {
+                override def send(wsf: WSFrame): IO[Unit] = IO.unit
+                override def sendMany[G[_]: cats.Foldable, A <: WSFrame](wsfs: G[A]): IO[Unit] =
+                    IO.unit
+                override def receive: IO[Option[WSFrame]] =
+                    IO.sleep(pingEvery) >> left.modify(n => (n - 1, n)).map {
+                        case n if n > 0 => Some(WSFrame.Ping(scodec.bits.ByteVector.empty))
+                        // End of stream: the peer closed its receiving side.
+                        case _ => None
+                    }
+                override def subprotocol: Option[String] = None
+            }
+        }
+
+    /** Run the real dialer against `connect` for `forHowLong` of virtual time, and report how many
+      * dial attempts it made and what it traced.
+      */
+    private def dial(
+        connect: Resource[IO, WSConnection[IO]],
+        forHowLong: FiniteDuration
+    ): (Int, Vector[CoilPeerWsTransportEvent]) = {
+        val prog = for {
+            attempts <- Ref.of[IO, Int](0)
+            seen <- Ref.of[IO, Vector[CoilPeerWsTransportEvent]](Vector.empty)
+            tracer = ContraTracer[IO, CoilPeerWsTransportEvent](e => seen.update(_ :+ e))
+            transport <- CoilPeerWsTransport.create(CoilPeerNumber(0), tracer)
+            client = WSClient[IO](respondToPings = false) { (_: WSRequest) =>
+                Resource.eval(attempts.update(_ + 1)).flatMap(_ => connect)
+            }
+            _ <- transport.startDialer(client, hubUri).surround(IO.sleep(forHowLong))
+            n <- attempts.get
+            events <- seen.get
+        } yield (n, events)
+        TestControl.executeEmbed(prog).unsafeRunSync()(using cats.effect.unsafe.implicits.global)
+    }
+
+    private def stalls(events: Vector[CoilPeerWsTransportEvent]): Int =
+        events.count(_.isInstanceOf[DialerHandshakeStalled])
+
+    test("a live link holds the dialer: no redial and no stall for as long as it stays up") {
+        // Ten minutes is twenty budgets. The link is quiet but not silent, exactly as a real one is
+        // between blocks, so nothing about it should ever look like a stalled handshake.
+        val (attempts, events) = dial(Resource.eval(pinging(10.seconds)), 10.minutes)
+        assert(
+          (attempts, stalls(events)) == (1, 0),
+          s"the link never dropped, so the dialer must neither redial nor report a stall; " +
+              s"dialed $attempts times, traced $events"
+        )
+    }
+
+    test("a handshake that never completes is abandoned, and the dialer keeps redialing") {
+        // 30s budget + the 1s inter-attempt delay, so 65s covers three attempts and two expiries.
+        val (attempts, events) = dial(Resource.eval(IO.never[WSConnection[IO]]), 65.seconds)
+        assert(
+          (attempts, stalls(events)) == (3, 2),
+          s"expected a redial per expired budget, each announced; " +
+              s"dialed $attempts times, traced $events"
+        )
+    }
+
+    test(
+      "a handshake landing after the budget drops its socket rather than opening a second link"
+    ) {
+        // The deadline case the `handshook` claim exists for: the hub answers at 35s, five seconds
+        // after the loop gave up and one attempt into the redial. Exactly one of the two may win,
+        // so the late attempt must disown itself and never reach `DialerConnected`.
+        val late = Resource.eval(IO.sleep(35.seconds) >> pinging(10.seconds, pings = 2))
+        val (attempts, events) = dial(late, 40.seconds)
+        assert(
+          (
+            attempts,
+            stalls(events),
+            events.count(_.isInstanceOf[DialerHandshakeLate]),
+            events.count(_.isInstanceOf[DialerConnected])
+          ) == (2, 1, 1, 0),
+          s"the budget expired once and the late handshake disowned itself; " +
+              s"dialed $attempts times, traced $events"
+        )
+    }
+}

--- a/src/test/scala/hydrozoa/multisig/consensus/transport/CoilDialerBudgetTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/transport/CoilDialerBudgetTest.scala
@@ -80,7 +80,7 @@ class CoilDialerBudgetTest extends AnyFunSuite {
         val (attempts, events) = dial(Resource.eval(pinging(10.seconds)), 10.minutes)
         assert(
           (attempts, stalls(events)) == (1, 0),
-          s"the link never dropped, so the dialer must neither redial nor report a stall; " +
+          "the link never dropped, so the dialer must neither redial nor report a stall; " +
               s"dialed $attempts times, traced $events"
         )
     }
@@ -90,7 +90,7 @@ class CoilDialerBudgetTest extends AnyFunSuite {
         val (attempts, events) = dial(Resource.eval(IO.never[WSConnection[IO]]), 65.seconds)
         assert(
           (attempts, stalls(events)) == (3, 2),
-          s"expected a redial per expired budget, each announced; " +
+          "expected a redial per expired budget, each announced; " +
               s"dialed $attempts times, traced $events"
         )
     }
@@ -110,7 +110,7 @@ class CoilDialerBudgetTest extends AnyFunSuite {
             events.count(_.isInstanceOf[DialerHandshakeLate]),
             events.count(_.isInstanceOf[DialerConnected])
           ) == (2, 1, 1, 0),
-          s"the budget expired once and the late handshake disowned itself; " +
+          "the budget expired once and the late handshake disowned itself; " +
               s"dialed $attempts times, traced $events"
         )
     }

--- a/src/test/scala/hydrozoa/multisig/consensus/transport/HeadDialerBudgetTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/transport/HeadDialerBudgetTest.scala
@@ -1,0 +1,109 @@
+package hydrozoa.multisig.consensus.transport
+
+import cats.effect.testkit.TestControl
+import cats.effect.{IO, Ref, Resource}
+import hydrozoa.config.head.network.CardanoNetwork
+import hydrozoa.lib.logging.ContraTracer
+import hydrozoa.lib.number.PositiveInt
+import hydrozoa.multisig.consensus.peer.{HeadPeerId, HeadPeerNumber}
+import hydrozoa.multisig.consensus.transport.PeerTransportEvent.*
+import org.http4s.Uri
+import org.http4s.client.websocket.{WSClient, WSConnection, WSFrame, WSRequest}
+import org.scalatest.funsuite.AnyFunSuite
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
+
+/** The head-mesh mirror of [[CoilDialerBudgetTest]].
+  *
+  * `WsPeerTransport.dialerLoop` and `CoilPeerWsTransport.dialerLoop` are the same code twice over,
+  * and the budget defect was in both — so the fix needs a witness on both. Everything the coil
+  * suite pins is pinned here against `WsPeerTransport` instead: a live link must occupy the dialer
+  * for as long as it lives, a handshake that never lands must be abandoned and redialed, and one
+  * that lands after the budget must drop its socket rather than leave a second connection draining
+  * this remote's outbox.
+  */
+class HeadDialerBudgetTest extends AnyFunSuite {
+
+    private given CardanoNetwork.Section = CardanoNetwork.Preview
+
+    private val nPeers = PositiveInt.unsafeApply(2)
+    private val ownId = HeadPeerId(HeadPeerNumber(0), nPeers)
+    // Lower peerNum dials higher, so peer 0 is the dialer and peer 1 the remote.
+    private val remoteId = HeadPeerId(HeadPeerNumber(1), nPeers)
+    private val remoteUri = Uri.unsafeFromString("ws://peer1.invalid:3001/head")
+
+    /** A quiet-but-live link: a keep-alive Ping every `pingEvery`, which is what holds `WsDuplex`'s
+      * read deadline off a real idle connection. Ends after `pings` so `TestControl` has an end to
+      * reach.
+      */
+    private def pinging(pingEvery: FiniteDuration, pings: Int = 200): IO[WSConnection[IO]] =
+        Ref.of[IO, Int](pings).map { left =>
+            new WSConnection[IO] {
+                override def send(wsf: WSFrame): IO[Unit] = IO.unit
+                override def sendMany[G[_]: cats.Foldable, A <: WSFrame](wsfs: G[A]): IO[Unit] =
+                    IO.unit
+                override def receive: IO[Option[WSFrame]] =
+                    IO.sleep(pingEvery) >> left.modify(n => (n - 1, n)).map {
+                        case n if n > 0 => Some(WSFrame.Ping(scodec.bits.ByteVector.empty))
+                        case _          => None
+                    }
+                override def subprotocol: Option[String] = None
+            }
+        }
+
+    private def dial(
+        connect: Resource[IO, WSConnection[IO]],
+        forHowLong: FiniteDuration
+    ): (Int, Vector[PeerTransportEvent]) = {
+        val prog = for {
+            attempts <- Ref.of[IO, Int](0)
+            seen <- Ref.of[IO, Vector[PeerTransportEvent]](Vector.empty)
+            tracer = ContraTracer[IO, PeerTransportEvent](e => seen.update(_ :+ e))
+            transport <- WsPeerTransport.create(ownId, List(remoteId), tracer)
+            client = WSClient[IO](respondToPings = false) { (_: WSRequest) =>
+                Resource.eval(attempts.update(_ + 1)).flatMap(_ => connect)
+            }
+            _ <- transport
+                .startDialers(client, Map(remoteId -> remoteUri))
+                .surround(IO.sleep(forHowLong))
+            n <- attempts.get
+            events <- seen.get
+        } yield (n, events)
+        TestControl.executeEmbed(prog).unsafeRunSync()(using cats.effect.unsafe.implicits.global)
+    }
+
+    private def stalls(events: Vector[PeerTransportEvent]): Int =
+        events.count(_.isInstanceOf[DialerHandshakeStalled])
+
+    test("a live link holds the head dialer: no redial and no stall for as long as it stays up") {
+        val (attempts, events) = dial(Resource.eval(pinging(10.seconds)), 10.minutes)
+        assert(
+          (attempts, stalls(events)) == (1, 0),
+          "the link never dropped, so the dialer must neither redial nor report a stall; " +
+              s"dialed $attempts times, traced $events"
+        )
+    }
+
+    test("a head handshake that never completes is abandoned, and the dialer keeps redialing") {
+        val (attempts, events) = dial(Resource.eval(IO.never[WSConnection[IO]]), 65.seconds)
+        assert(
+          (attempts, stalls(events)) == (3, 2),
+          "expected a redial per expired budget, each announced; " +
+              s"dialed $attempts times, traced $events"
+        )
+    }
+
+    test("a head handshake landing after the budget drops its socket rather than opening a link") {
+        val late = Resource.eval(IO.sleep(35.seconds) >> pinging(10.seconds, pings = 2))
+        val (attempts, events) = dial(late, 40.seconds)
+        assert(
+          (
+            attempts,
+            stalls(events),
+            events.count(_.isInstanceOf[DialerHandshakeLate]),
+            events.count(_.isInstanceOf[DialerConnected])
+          ) == (2, 1, 1, 0),
+          "the budget expired once and the late handshake disowned itself; " +
+              s"dialed $attempts times, traced $events"
+        )
+    }
+}


### PR DESCRIPTION
## Review order

Stacked on `refactor/markers-at-the-manager` (#718), whose transport commit `41ddf732` this
corrects. #719 rewrites the same two `once` bodies to wrap them in `QuietRelease`, so whichever
of the two lands second needs a rebase — the wrapped expression here is untouched.

## What was wrong

`41ddf732` bounded a dial attempt at 30 seconds. But the attempt *is* the connection:

```scala
def once = client.connect(request).use { conn => hello >> WsDuplex.run(conn, outbox, onLine) }
val attempt = (once >> trace(DialerDisconnected)).handleErrorWith(...)
IO.race(attempt.start.flatMap(_.join), IO.sleep(handshakeBudget))
```

`WsDuplex.run` holds the attempt for the whole life of an established link, and the remote's 10 s
keep-alive keeps it inside the 30 s read deadline, so it never returns on its own. The race
therefore expired on **every healthy connection**, not only stalled ones. Each expiry logged a
stall that had not happened, abandoned a working socket — deliberately never cancelled — and
dialed a second link on top, with both draining the same outbox.

Measured against the real transport on a virtual clock, ten minutes on a link that never dropped:

|                     | before             | after |
| ------------------- | ------------------ | ----- |
| dial attempts       | **20**             | 1     |
| `DialerConnected`   | **20**             | 1     |
| `HandshakeStalled`  | **19**             | 0     |

## The commits

- **route `DialerHandshakeStalled` on the head mesh too.** `41ddf732` added the variant to the
  sealed `PeerTransportEvent` and gave the coil formatter its case, but not
  `PeerTransportEventFormat`. The match is non-exhaustive, which `-Werror` turns into a build
  error — this is why #718 and #719 are both red — and a head-mesh stall would `MatchError`
  inside the tracer.

- **bound the handshake, and only the handshake.** A `handshook` `Deferred` is claimed the moment
  `connect` yields a socket; past the claim the loop waits on the link with no timer. `complete`
  picks exactly one winner, so a handshake landing *on* the deadline cannot both take the link and
  leave the loop redialing — the loser returns so `use` closes its socket, and says so
  (`DialerHandshakeLate`).

  The same commit restores something `attempt.start` had silently removed: cancelling the loop
  cancels `f.join`, not `f`, so a live connection outlived `startDialer`'s release with its socket
  still open. `own(f) = f.join.void.onCancel(f.cancel)` closes it, and is safe only past the claim
  — by then the uncancelable acquire has finished.

## Verification

`CoilDialerBudgetTest` drives the real `CoilPeerWsTransport` against a fake `WSClient` under
`TestControl`, and pins three cases: a live link produces one dial and no stall; a handshake that
never completes is abandoned and redialed on schedule; a handshake landing after the budget drops
its socket rather than opening a second link. Reverting the `bounded` block to its `41ddf732`
shape fails the first and third — the table above is that run.

`scalafmtCheckAll`, `Test/compile` and `integration/Test/compile` are clean, with zero warnings
across the branch. `testOnly *transport.*` is 40 passed, 0 failed.

⚠️ The budget's *value* is unchanged and so is the abandonment strategy — an attempt stuck in the
uncancelable acquire still cannot be cancelled, only left to finish or not. What changes is which
attempts get abandoned.
