### PR TITLE
startup: move the L1 boot gates out of the actor system

### DIFF
--- a/integration/src/test/scala/hydrozoa/integration/harness/MultiPeerHeadHarness.scala
+++ b/integration/src/test/scala/hydrozoa/integration/harness/MultiPeerHeadHarness.scala
@@ -26,6 +26,7 @@ import hydrozoa.lib.cardano.scalus.QuantizedTime.{QuantizedFiniteDuration, quant
 import hydrozoa.lib.logging.{ContraTracer, LogEvent, Slf4jMsg, Slf4jMsgFormat, Slf4jTracer, info}
 import hydrozoa.multisig.backend.cardano.{CardanoBackend as L1Backend, CardanoBackendBlockfrost, CardanoBackendEvent, CardanoBackendEventFormat, CardanoBackendMock, FirewalledCardanoBackendEvent, MockState, yaciTestSauceGenesis}
 import hydrozoa.multisig.consensus.peer.{CoilPeerNumber, HeadPeerId, HeadPeerNumber, PeerId}
+import hydrozoa.multisig.consensus.pollresults.PollResults
 import hydrozoa.multisig.consensus.transport.*
 import hydrozoa.multisig.consensus.{CardanoLiaison, RequestSequencer}
 import hydrozoa.multisig.ledger.block.BlockVersion.Major.given_Conversion_Major_Int
@@ -87,6 +88,24 @@ object MultiPeerHeadHarness:
     ): IO[Option[Instant]] =
         if useTestControl then IO.pure(None)
         else IO.realTimeInstant.map(t => Some(t.plusSeconds(offset.toSeconds)))
+
+    /** The first L1 sample a regime manager boots from, read here as `Serve` reads it: before the
+      * manager starts, so `ReplayActor.replay` only has to queue it.
+      *
+      * No retry ladder, unlike production — the harness's backend is in-process and a failed read
+      * is a broken fixture, not a transient outage, so it should fail the test loudly.
+      */
+    def readFirstPollResults(
+        cardanoBackend: L1Backend[IO],
+        config: NodeConfig
+    ): IO[PollResults] =
+        cardanoBackend
+            .utxosAt(config.initializationTx.treasuryProduced.address)
+            .flatMap {
+                case Right(utxos) => IO.pure(PollResults(utxos.keySet))
+                case Left(err) =>
+                    IO.raiseError(new RuntimeException(s"harness boot L1 sample failed: $err"))
+            }
 
     /** Head initial-block-end-time generator anchored on [[mkTakeoffTime]]. When `takeoffTime` is
       * `Some`, quantize it to the peer's slot config. When `None`, generate a random Jan-1-2026 +
@@ -1571,9 +1590,13 @@ object MultiPeerHeadHarness:
                 // A real node runs the 1 Hz sampler for the whole life of the process
                 // (`Serve.scala`); without it the runtime gauges read their initial values.
                 _ <- metrics.sampler().background
+                // Read where `Serve` reads it: before the regime manager starts, so `replay` only
+                // has to queue it. See `ReplayActor.replay`.
+                firstPollResults <- Resource.eval(readFirstPollResults(cardanoBackend, nodeConfig))
                 mrm <- HeadMultisigRegimeManager.resource(
                   nodeConfig,
                   cardanoBackend,
+                  firstPollResults,
                   l2Ledger,
                   EutxoL2Screener(nodeConfig),
                   persistence,
@@ -1648,9 +1671,11 @@ object MultiPeerHeadHarness:
                 // A coil runs the 1 Hz sampler too, and for the same reason: without it the
                 // runtime gauges never leave their initial values.
                 _ <- metrics.sampler().background
+                firstPollResults <- Resource.eval(readFirstPollResults(cardanoBackend, coilConfig))
                 mrm <- CoilMultisigRegimeManager.resource(
                   coilConfig,
                   cardanoBackend,
+                  firstPollResults,
                   l2Ledger,
                   persistence,
                   metrics,

--- a/src/main/scala/hydrozoa/app/Serve.scala
+++ b/src/main/scala/hydrozoa/app/Serve.scala
@@ -506,11 +506,11 @@ object Serve {
     /** Compare the chain's live protocol parameters against the ones this head's config asserts,
       * and REFUSE to start on a mismatch.
       *
-      * ⛔ Nothing verified this at start-up before, so a head built
-      * every L1 transaction — settlements, fallbacks, rollouts, refunds — against parameters it
-      * merely assumed, and would keep doing so across a parameter update it never noticed. Those
-      * parameters decide fees, `maxTxSize` and execution-unit budgets, so a drift shows up as
-      * transactions the chain rejects, at the worst possible moment.
+      * ⛔ Nothing verified this at start-up before, so a head built every L1 transaction —
+      * settlements, fallbacks, rollouts, refunds — against parameters it merely assumed, and would
+      * keep doing so across a parameter update it never noticed. Those parameters decide fees,
+      * `maxTxSize` and execution-unit budgets, so a drift shows up as transactions the chain
+      * rejects, at the worst possible moment.
       *
       * ⚠️ Not to be confused with `CardanoBackendBlockfrost.getStartupParams`, which is alive and
       * called from `integration/…/stage1/Suite.scala` — it returns the **compiled-in** constant

--- a/src/main/scala/hydrozoa/app/Serve.scala
+++ b/src/main/scala/hydrozoa/app/Serve.scala
@@ -2,6 +2,7 @@ package hydrozoa.app
 
 import cats.Monoid
 import cats.effect.{ExitCode, IO, Resource}
+import cats.syntax.applicativeError.*
 import cats.syntax.apply.*
 import cats.syntax.contravariant.*
 import cats.syntax.semigroup.*
@@ -13,9 +14,11 @@ import hydrozoa.BuildInfo
 import hydrozoa.config.head.network.CardanoNetwork
 import hydrozoa.config.head.parameters.L2LedgerKind
 import hydrozoa.config.node.NodeConfig
-import hydrozoa.lib.logging.{ContraTracer, Slf4jMsg, Slf4jMsgFormat, Slf4jTracer, info}
+import hydrozoa.lib.StartupRefusal
+import hydrozoa.lib.logging.{ContraTracer, Slf4jMsg, Slf4jMsgFormat, Slf4jTracer, error, info, warn}
 import hydrozoa.multisig.backend.cardano.CardanoBackend
 import hydrozoa.multisig.consensus.peer.{CoilPeerNumber, HeadPeerId, HeadPeerNumber, PeerId}
+import hydrozoa.multisig.consensus.pollresults.PollResults
 import hydrozoa.multisig.consensus.transport.{CoilPeerWsTransport, CoilPeerWsTransportEventFormat, CoilTransport, HubTransport, HubWsTransport, NodeWsServer, WsPeerTransport}
 import hydrozoa.multisig.ledger.eutxol2.store.RocksDbL2Store
 import hydrozoa.multisig.ledger.eutxol2.{EutxoL2Ledger, EutxoL2Screener}
@@ -32,7 +35,9 @@ import org.http4s.Uri
 import org.http4s.ember.client.EmberClientBuilder
 import org.http4s.jdkhttpclient.JdkWSClient
 import org.http4s.server.websocket.WebSocketBuilder2
+import org.rocksdb.RocksDBException
 import scala.concurrent.duration.*
+import scalus.cardano.address.ShelleyAddress
 
 /** The head-node server: the `serve` subcommand of the `hydrozoa` CLI.
   *
@@ -163,7 +168,11 @@ object Serve {
                   ),
                   persistenceTracer,
                 )
-                .handleErrorWith { case e: org.rocksdb.RocksDBException =>
+                // `recoverWith`, not `handleErrorWith`: this handles ONE error type, and a
+                // partial function passed to `handleErrorWith` eta-expands into a total one that
+                // throws `MatchError` on everything else — losing the original cause for, say, a
+                // failure to create the directory.
+                .recoverWith { case e: RocksDBException =>
                     Resource.eval(
                       IO.raiseError(
                         StartupRefusal(
@@ -219,6 +228,33 @@ object Serve {
                 )
             }
 
+            // ⛔ BOTH L1 boot facts are established HERE, before the ActorSystem, and for the same
+            // two reasons the transplant gate above is.
+            //
+            // 1. Cancellability. `preStartLocal` is the handler for a `PreStart` message the regime
+            //    manager posts to itself (`MultisigRegimeManagerBase`), so it runs inside
+            //    `ActorCell.invoke(...).uncancelable`. An unbounded retry there cannot be
+            //    interrupted: SIGTERM does nothing and the process survives to be force-killed by
+            //    `shutdownHookTimeout`. Out here, on the app fiber, a wait is ordinary cancelable
+            //    IO and the node stops when it is asked to.
+            // 2. Exit code. A `StartupRefusal` raised inside the actor system escalates to the
+            //    guardian, which terminates on its own path and exits 1 — which
+            //    `RestartPreventExitStatus=2` does not catch, so the refusal crash-loops. Raised
+            //    here it reaches `StartupRefusal.guard` and exits 2, as intended.
+            //
+            // Neither needs anything the actor system provides: one is a UTxO read, the other a
+            // parameter comparison.
+            firstPollResults <- Resource.eval(
+              waitForFirstPollResults(
+                backend,
+                nodeConfig.initializationTx.treasuryProduced.address
+              )
+            )
+            _ <- Resource.eval {
+                given CardanoNetwork.Section = nodeConfig
+                verifyProtocolParams(backend)
+            }
+
             system <- ActorSystem[IO]("Hydrozoa Demo")
 
             // ⛔ ORDER IS LOAD-BEARING. Resource finalizers run in reverse acquisition order, so
@@ -239,6 +275,7 @@ object Serve {
                     buildHeadNode(
                       nodeConfig,
                       backend,
+                      firstPollResults,
                       l2Ledger,
                       l2Screener,
                       l2QueryReader,
@@ -259,6 +296,7 @@ object Serve {
                     buildCoilNode(
                       nodeConfig,
                       backend,
+                      firstPollResults,
                       l2Ledger,
                       persistence,
                       metrics,
@@ -422,12 +460,120 @@ object Serve {
                 )
         }
 
+    /** Backoff for the boot L1 reads: doubles from 1s, capped at 30s. Capped rather than unbounded
+      * so a node that has been waiting for hours still reacts promptly when L1 returns.
+      */
+    private def l1BootBackoff(attempt: Int): FiniteDuration =
+        (1.second.toNanos * (1L << math.min(attempt, 5))).nanos.min(30.seconds)
+
+    /** Read the treasury address on L1 and produce the first [[PollResults]], WAITING for as long
+      * as it takes.
+      *
+      * ⛔ This is a GATE. `BlockWeaver` starts at `PollResults.empty`, which is structurally
+      * indistinguishable from "polled, and the address is genuinely empty" — there is no
+      * `NeverPolled` state. A head peer classifies deposit existence from its own poll
+      * (`DepositsMap.Existence.FromPoll`), so acting on that empty value would reject every mature
+      * deposit as `NotInPollResults`: terminal, and DEBUG-only in the logs. `ReplayActor` queues
+      * this value into BlockWeaver's mailbox before the start barrier opens, precisely so that
+      * cannot happen.
+      *
+      * It waits rather than failing because a node is useless without this fact either way, and a
+      * failed boot under `Restart=on-failure` becomes a restart loop that outlives the blip.
+      *
+      * ⚠️ The waiting belongs HERE and not in `ReplayActor`, which runs inside an uncancelable
+      * actor message handler — see the call site.
+      */
+    private def waitForFirstPollResults(
+        cardanoBackend: CardanoBackend[IO],
+        treasuryAddress: ShelleyAddress
+    ): IO[PollResults] = {
+        def attempt(n: Int): IO[PollResults] =
+            cardanoBackend.utxosAt(treasuryAddress).flatMap {
+                case Right(utxos) =>
+                    IO.whenA(n > 0)(
+                      log.info(s"boot L1 sample succeeded after ${n + 1} attempts; continuing")
+                    ).as(PollResults(utxos.keySet))
+                case Left(err) =>
+                    val wait = l1BootBackoff(n)
+                    log.warn(
+                      s"boot L1 sample failed (attempt ${n + 1}): $err. Cannot start consensus " +
+                          s"without it, so WAITING rather than failing the boot; retrying in $wait"
+                    ) >> IO.sleep(wait) >> attempt(n + 1)
+            }
+        attempt(0)
+    }
+
+    /** Compare the chain's live protocol parameters against the ones this head's config asserts,
+      * and REFUSE to start on a mismatch.
+      *
+      * ⛔ Nothing did this before: `getStartupParams` existed with zero callers, so a head built
+      * every L1 transaction — settlements, fallbacks, rollouts, refunds — against parameters it
+      * merely assumed, and would keep doing so across a parameter update it never noticed. Those
+      * parameters decide fees, `maxTxSize` and execution-unit budgets, so a drift shows up as
+      * transactions the chain rejects, at the worst possible moment.
+      *
+      * It is a [[StartupRefusal]] rather than a generic crash because it is deterministic: the
+      * config asserts what it asserts, and a restart re-derives the same verdict.
+      *
+      * ⚠️ On `mainnet`, `preprod` and `preview` the comparison is against a value compiled into the
+      * binary, not a config field: the head config carries only the network NAME, and
+      * `cardanoProtocolParams` resolves through `CardanoInfo.<net>` from Scalus. Only a `custom`
+      * network reads parameters from JSON. The remedy differs accordingly, and the message says so
+      * — telling an operator to "update the config" on preview would send them looking for a field
+      * that does not exist.
+      *
+      * Unreachable is NOT drift: it retries, because "cannot ask" and "asked, and the answer is
+      * wrong" are the two classes this whole start-up path exists to separate.
+      */
+    private def verifyProtocolParams(
+        cardanoBackend: CardanoBackend[IO]
+    )(using net: CardanoNetwork.Section): IO[Unit] = {
+        val remedy = net.cardanoNetwork match {
+            case CardanoNetwork.Custom(_, _) =>
+                "Update the `custom` network's protocolParams in the head config to the chain's " +
+                    "current parameters (both values are on the ERROR line above)."
+            case _ =>
+                "These parameters are NOT a config field on a named network — they are compiled " +
+                    "in from Scalus's CardanoInfo. Upgrade Scalus to a version carrying the " +
+                    "chain's current parameters and redeploy every peer; editing the config " +
+                    "cannot fix this."
+        }
+        def attempt(n: Int): IO[Unit] =
+            cardanoBackend.fetchLatestParams.flatMap {
+                case Right(onChain) =>
+                    val assumed = net.cardanoProtocolParams
+                    if onChain == assumed then
+                        log.info("protocol parameters on chain match the ones this config asserts")
+                    else
+                        log.error(
+                          "PROTOCOL PARAMETER MISMATCH: the chain's parameters differ from the " +
+                              "ones this head's config asserts. Refusing to start.\n" +
+                              s"  on chain: $onChain\n" +
+                              s"  config:   $assumed"
+                        ) >> IO.raiseError(
+                          StartupRefusal(
+                            "the chain's protocol parameters differ from the ones this head's " +
+                                "config asserts, so the L1 transactions it builds may be rejected " +
+                                s"by the chain. $remedy"
+                          )
+                        )
+                case Left(err) =>
+                    val wait = l1BootBackoff(n)
+                    log.warn(
+                      s"could not read protocol parameters (attempt ${n + 1}): $err. " +
+                          s"Retrying in $wait."
+                    ) >> IO.sleep(wait) >> attempt(n + 1)
+            }
+        attempt(0)
+    }
+
     /** Build the head-node transports (mesh + optional hub-coil), bind one shared `NodeWsServer`,
       * start dialers, and allocate the [[HeadMultisigRegimeManager]].
       */
     private def buildHeadNode(
         nodeConfig: NodeConfig,
         backend: CardanoBackend[IO],
+        firstPollResults: PollResults,
         l2Ledger: L2Ledger[IO],
         l2Screener: L2Screener[IO],
         l2QueryReader: Option[EutxoL2LedgerReader[IO]],
@@ -518,6 +664,7 @@ object Serve {
             mrm <- HeadMultisigRegimeManager.resource(
               nodeConfig,
               backend,
+              firstPollResults,
               l2Ledger,
               l2Screener,
               persistence,
@@ -536,6 +683,7 @@ object Serve {
     private def buildCoilNode(
         nodeConfig: NodeConfig,
         backend: CardanoBackend[IO],
+        firstPollResults: PollResults,
         l2Ledger: L2Ledger[IO],
         persistence: Persistence[IO],
         metrics: PeerMetrics,
@@ -572,6 +720,7 @@ object Serve {
             mrm <- CoilMultisigRegimeManager.resource(
               nodeConfig,
               backend,
+              firstPollResults,
               l2Ledger,
               persistence,
               metrics,

--- a/src/main/scala/hydrozoa/app/Serve.scala
+++ b/src/main/scala/hydrozoa/app/Serve.scala
@@ -506,11 +506,18 @@ object Serve {
     /** Compare the chain's live protocol parameters against the ones this head's config asserts,
       * and REFUSE to start on a mismatch.
       *
-      * ⛔ Nothing did this before: `getStartupParams` existed with zero callers, so a head built
+      * ⛔ Nothing verified this at start-up before, so a head built
       * every L1 transaction — settlements, fallbacks, rollouts, refunds — against parameters it
       * merely assumed, and would keep doing so across a parameter update it never noticed. Those
       * parameters decide fees, `maxTxSize` and execution-unit budgets, so a drift shows up as
       * transactions the chain rejects, at the worst possible moment.
+      *
+      * ⚠️ Not to be confused with `CardanoBackendBlockfrost.getStartupParams`, which is alive and
+      * called from `integration/…/stage1/Suite.scala` — it returns the **compiled-in** constant
+      * (`provider.cardanoInfo.protocolParams`), where this gate reads the **chain** via
+      * `fetchLatestParams`. Different questions; do not delete it. (An earlier note here claimed it
+      * had zero callers. It was written from a search of `src/` only, and `integration` is a
+      * separate sbt project.)
       *
       * It is a [[StartupRefusal]] rather than a generic crash because it is deterministic: the
       * config asserts what it asserts, and a restart re-derives the same verdict.

--- a/src/main/scala/hydrozoa/config/node/NodeConfig.scala
+++ b/src/main/scala/hydrozoa/config/node/NodeConfig.scala
@@ -3,7 +3,6 @@ package hydrozoa.config.node
 import cats.data.EitherT
 import cats.effect.*
 import cats.syntax.contravariant.*
-import hydrozoa.lib.StartupRefusal
 import hydrozoa.config.ScriptReferenceUtxos
 import hydrozoa.config.head.HeadConfig
 import hydrozoa.config.head.coil.CoilPeers
@@ -16,6 +15,7 @@ import hydrozoa.config.node.NodePrivateConfig.given
 import hydrozoa.config.node.operation.evacuation.NodeOperationEvacuationConfig
 import hydrozoa.config.node.operation.multisig.NodeOperationMultisigConfig
 import hydrozoa.config.node.owninfo.{OwnCoilPeerPrivate, OwnHeadPeerPrivate}
+import hydrozoa.lib.StartupRefusal
 import hydrozoa.lib.logging.{ContraTracer, Slf4jMsg, Slf4jMsgFormat, Slf4jTracer, warn}
 import hydrozoa.multisig.backend.cardano.{CardanoBackend, CardanoBackendBlockfrost, CardanoBackendEventFormat}
 import hydrozoa.multisig.consensus.peer.PeerId.isCoil

--- a/src/main/scala/hydrozoa/config/node/NodeConfig.scala
+++ b/src/main/scala/hydrozoa/config/node/NodeConfig.scala
@@ -3,7 +3,7 @@ package hydrozoa.config.node
 import cats.data.EitherT
 import cats.effect.*
 import cats.syntax.contravariant.*
-import hydrozoa.app.StartupRefusal
+import hydrozoa.lib.StartupRefusal
 import hydrozoa.config.ScriptReferenceUtxos
 import hydrozoa.config.head.HeadConfig
 import hydrozoa.config.head.coil.CoilPeers

--- a/src/main/scala/hydrozoa/config/node/PrivateSecrets.scala
+++ b/src/main/scala/hydrozoa/config/node/PrivateSecrets.scala
@@ -1,7 +1,7 @@
 package hydrozoa.config.node
 
 import cats.effect.IO
-import hydrozoa.app.StartupRefusal
+import hydrozoa.lib.StartupRefusal
 import io.circe.{Json, JsonObject}
 import java.nio.file.{Files, Path}
 import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters

--- a/src/main/scala/hydrozoa/lib/StartupRefusal.scala
+++ b/src/main/scala/hydrozoa/lib/StartupRefusal.scala
@@ -1,6 +1,7 @@
-package hydrozoa.app
+package hydrozoa.lib
 
-import cats.effect.{ExitCode, IO}
+// `_root_.` because `hydrozoa.lib.cats` shadows the top-level `cats` package from here.
+import _root_.cats.effect.{ExitCode, IO}
 
 /** A deliberate, deterministic refusal to start: something about THIS node is wrong, and starting
   * it again will reach the same conclusion.

--- a/src/main/scala/hydrozoa/multisig/CoilMultisigRegimeManager.scala
+++ b/src/main/scala/hydrozoa/multisig/CoilMultisigRegimeManager.scala
@@ -75,22 +75,12 @@ trait CoilMultisigRegimeManager(
             // each child actor. Deriving per-actor let two paths interpret the same journal
             // independently, which is how a seeded store could satisfy one and not the other.
             derived <- Markers.derive(persistence, config.ownPeerId)
-            // Adopting a store seeded from another peer. The tag names the stack it was seeded at
-            // and the floor applies only while that is still this store's `hardConfirmed`, so it
-            // matches on the adopting boot and is inert ever after (`hardConfirmed` is monotonic).
-            // Applied to the ONE bundle, so the gate, the replay cursors, the in-flight handoff and
-            // the stack composer all move together — the alternative is the divergence that made
-            // this necessary.
-            // It RAISES the floor and never lowers it: a peer mid-flight has acked one stack beyond
-            // its confirmation, and clamping that down to the tag would discard the in-flight
-            // handoff `ReplayActor` rebuilds from it.
-            markers = config.transplantStackNumber
-                .filter(tag => derived.hardConfirmed.contains(tag))
-                .fold(derived)(tag =>
-                    derived.copy(hardAckedStack = Some(derived.hardAckedStack.fold(tag) { own =>
-                        if Ordering[StackNumber].gteq(own, tag) then own else tag
-                    }))
-                )
+            // Adopting a store seeded from another peer: raise the trusted-history floor to the
+            // stack the transplant was tagged with. Applied to the ONE bundle, so the gate, the
+            // replay cursors, the in-flight handoff and the stack composer all move together — the
+            // alternative is the divergence that made this necessary. See `Markers.adopt` for the
+            // comparison and why it must be the same one `Serve`'s boot gate uses.
+            markers = Markers.adopt(derived, config.transplantStackNumber)
             core <- spawnCoreActors(
               config,
               cardanoBackend,

--- a/src/main/scala/hydrozoa/multisig/CoilMultisigRegimeManager.scala
+++ b/src/main/scala/hydrozoa/multisig/CoilMultisigRegimeManager.scala
@@ -12,6 +12,7 @@ import hydrozoa.multisig.backend.cardano.CardanoBackend
 import hydrozoa.multisig.consensus.*
 import hydrozoa.multisig.consensus.peer.PeerId
 import hydrozoa.multisig.consensus.peer.PeerId.{Coil, Head}
+import hydrozoa.multisig.consensus.pollresults.PollResults
 import hydrozoa.multisig.consensus.transport.{CoilTransport, RemoteHubProxy}
 import hydrozoa.multisig.ledger.l2.L2Ledger
 import hydrozoa.multisig.ledger.stack.StackNumber
@@ -33,6 +34,10 @@ import hydrozoa.rulebased.RuleBasedRegimeManager
 trait CoilMultisigRegimeManager(
     config: NodeConfig,
     cardanoBackend: CardanoBackend[IO],
+    /** The first L1 sample, read by `Serve` before the actor system exists. See
+      * [[ReplayActor.replay]] for why the read cannot happen inside this actor.
+      */
+    firstPollResults: PollResults,
     l2Ledger: L2Ledger[IO],
     persistence: Persistence[IO],
     override protected val metrics: PeerMetrics,
@@ -135,7 +140,7 @@ trait CoilMultisigRegimeManager(
             // and drains in order once the barrier opens. Cold store ⇒ near-no-op.
             _ <- ReplayActor.replay(
               persistence,
-              cardanoBackend,
+              firstPollResults,
               ReplayActor.Targets(
                 blockWeaver = core.blockWeaver,
                 fastConsensusActor = core.consensusActor,
@@ -148,7 +153,6 @@ trait CoilMultisigRegimeManager(
               // A coil peer is never a hub, so it re-feeds no coil-ack gap (its Targets carries no
               // CoilAckSequencer either — the gap step is a no-op).
               coils = Nil,
-              treasuryAddress = config.initializationTx.treasuryProduced.address,
               leadsFastBlock = config.canLeadFast,
               markers = markers
             )(using config)
@@ -209,6 +213,7 @@ object CoilMultisigRegimeManager {
     def resource(
         config: NodeConfig,
         cardanoBackend: CardanoBackend[IO],
+        firstPollResults: PollResults,
         virtualLedger: L2Ledger[IO],
         persistence: Persistence[IO],
         metrics: PeerMetrics,
@@ -221,6 +226,7 @@ object CoilMultisigRegimeManager {
                 new CoilMultisigRegimeManager(
                   config,
                   cardanoBackend,
+                  firstPollResults,
                   virtualLedger,
                   persistence,
                   metrics,

--- a/src/main/scala/hydrozoa/multisig/CoilMultisigRegimeManager.scala
+++ b/src/main/scala/hydrozoa/multisig/CoilMultisigRegimeManager.scala
@@ -15,7 +15,6 @@ import hydrozoa.multisig.consensus.peer.PeerId.{Coil, Head}
 import hydrozoa.multisig.consensus.pollresults.PollResults
 import hydrozoa.multisig.consensus.transport.{CoilTransport, RemoteHubProxy}
 import hydrozoa.multisig.ledger.l2.L2Ledger
-import hydrozoa.multisig.ledger.stack.StackNumber
 import hydrozoa.multisig.metrics.PeerMetrics
 import hydrozoa.multisig.persistence.{Markers, Persistence}
 import hydrozoa.rulebased.RuleBasedRegimeManager

--- a/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManager.scala
+++ b/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManager.scala
@@ -58,22 +58,12 @@ trait HeadMultisigRegimeManager(
             // each child actor. Deriving per-actor let two paths interpret the same journal
             // independently, which is how a seeded store could satisfy one and not the other.
             derived <- Markers.derive(persistence, config.ownPeerId)
-            // Adopting a store seeded from another peer. The tag names the stack it was seeded at
-            // and the floor applies only while that is still this store's `hardConfirmed`, so it
-            // matches on the adopting boot and is inert ever after (`hardConfirmed` is monotonic).
-            // Applied to the ONE bundle, so the gate, the replay cursors, the in-flight handoff and
-            // the stack composer all move together — the alternative is the divergence that made
-            // this necessary.
-            // It RAISES the floor and never lowers it: a peer mid-flight has acked one stack beyond
-            // its confirmation, and clamping that down to the tag would discard the in-flight
-            // handoff `ReplayActor` rebuilds from it.
-            markers = config.transplantStackNumber
-                .filter(tag => derived.hardConfirmed.contains(tag))
-                .fold(derived)(tag =>
-                    derived.copy(hardAckedStack = Some(derived.hardAckedStack.fold(tag) { own =>
-                        if Ordering[StackNumber].gteq(own, tag) then own else tag
-                    }))
-                )
+            // Adopting a store seeded from another peer: raise the trusted-history floor to the
+            // stack the transplant was tagged with. Applied to the ONE bundle, so the gate, the
+            // replay cursors, the in-flight handoff and the stack composer all move together — the
+            // alternative is the divergence that made this necessary. See `Markers.adopt` for the
+            // comparison and why it must be the same one `Serve`'s boot gate uses.
+            markers = Markers.adopt(derived, config.transplantStackNumber)
             core <- spawnCoreActors(
               config,
               cardanoBackend,

--- a/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManager.scala
+++ b/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManager.scala
@@ -13,6 +13,7 @@ import hydrozoa.multisig.backend.cardano.CardanoBackend
 import hydrozoa.multisig.consensus.*
 import hydrozoa.multisig.consensus.limiter.{Limiter, LimiterControl}
 import hydrozoa.multisig.consensus.peer.{CoilPeerNumber, HeadPeerNumber, PeerId}
+import hydrozoa.multisig.consensus.pollresults.PollResults
 import hydrozoa.multisig.consensus.transport.{HubTransport, PeerTransport, RemoteCoilProxy, RemotePeerProxy}
 import hydrozoa.multisig.ledger.joint.JointLedger
 import hydrozoa.multisig.ledger.l2.{L2Ledger, L2Screener}
@@ -24,6 +25,10 @@ import hydrozoa.rulebased.RuleBasedRegimeManager
 trait HeadMultisigRegimeManager(
     config: NodeConfig,
     cardanoBackend: CardanoBackend[IO],
+    /** The first L1 sample, read by `Serve` before the actor system exists. See
+      * [[ReplayActor.replay]] for why the read cannot happen inside this actor.
+      */
+    firstPollResults: PollResults,
     l2Ledger: L2Ledger[IO],
     l2Screener: L2Screener[IO],
     persistence: Persistence[IO],
@@ -253,7 +258,7 @@ trait HeadMultisigRegimeManager(
             // L1 sample.
             _ <- ReplayActor.replay(
               persistence,
-              cardanoBackend,
+              firstPollResults,
               ReplayActor.Targets(
                 blockWeaver = core.blockWeaver,
                 fastConsensusActor = core.consensusActor,
@@ -265,7 +270,6 @@ trait HeadMultisigRegimeManager(
               peers = config.headPeerIds.map(_.peerNum).toList,
               hubs = config.hubHeadPeerNumbers,
               coils = hubbedCoilPeers,
-              treasuryAddress = config.initializationTx.treasuryProduced.address,
               leadsFastBlock = config.canLeadFast,
               markers = markers
             )(using config)
@@ -386,6 +390,7 @@ object HeadMultisigRegimeManager {
     def resource(
         config: NodeConfig,
         cardanoBackend: CardanoBackend[IO],
+        firstPollResults: PollResults,
         virtualLedger: L2Ledger[IO],
         l2Screener: L2Screener[IO],
         persistence: Persistence[IO],
@@ -403,6 +408,7 @@ object HeadMultisigRegimeManager {
                 new HeadMultisigRegimeManager(
                   config,
                   cardanoBackend,
+                  firstPollResults,
                   virtualLedger,
                   l2Screener,
                   persistence,

--- a/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManager.scala
+++ b/src/main/scala/hydrozoa/multisig/HeadMultisigRegimeManager.scala
@@ -17,7 +17,6 @@ import hydrozoa.multisig.consensus.pollresults.PollResults
 import hydrozoa.multisig.consensus.transport.{HubTransport, PeerTransport, RemoteCoilProxy, RemotePeerProxy}
 import hydrozoa.multisig.ledger.joint.JointLedger
 import hydrozoa.multisig.ledger.l2.{L2Ledger, L2Screener}
-import hydrozoa.multisig.ledger.stack.StackNumber
 import hydrozoa.multisig.metrics.PeerMetrics
 import hydrozoa.multisig.persistence.{Markers, Persistence}
 import hydrozoa.rulebased.RuleBasedRegimeManager

--- a/src/main/scala/hydrozoa/multisig/consensus/ReplayActor.scala
+++ b/src/main/scala/hydrozoa/multisig/consensus/ReplayActor.scala
@@ -2,10 +2,7 @@ package hydrozoa.multisig.consensus
 
 import cats.effect.IO
 import cats.syntax.all.*
-import hydrozoa.app.StartupRefusal
 import hydrozoa.config.head.network.CardanoNetwork
-import hydrozoa.lib.logging.{ContraTracer, Slf4jMsg, Slf4jMsgFormat, Slf4jTracer, error, info, warn}
-import hydrozoa.multisig.backend.cardano.CardanoBackend
 import hydrozoa.multisig.consensus.ack.{HardAck, HardAckNumber}
 import hydrozoa.multisig.consensus.peer.{CoilPeerNumber, HeadPeerNumber, PeerId}
 import hydrozoa.multisig.consensus.pollresults.PollResults
@@ -14,8 +11,6 @@ import hydrozoa.multisig.ledger.event.RequestNumber
 import hydrozoa.multisig.ledger.stack.StackNumber
 import hydrozoa.multisig.persistence.recovery.{ArrivalOrderedMerge, JournalScan, RawJournalEntry, ReplayCursors}
 import hydrozoa.multisig.persistence.{JournalKey, Markers, Persistence, StoreKey}
-import scala.concurrent.duration.*
-import scalus.cardano.address.ShelleyAddress
 
 /** The boot-time replay seam (R3 §8 step 3). Not a long-lived cats-actors `Actor`: it is the
   * one-shot routine `HeadMultisigRegimeManager` runs **inline** after spawning the consensus actors
@@ -27,9 +22,10 @@ import scalus.cardano.address.ShelleyAddress
   *
   * What it does, in order:
   *
-  *   1. Sample L1 directly (`CardanoBackend.utxosAt(treasuryAddress)`) and seed BlockWeaver's first
-  *      [[PollResults]], so deposit decisions proceed immediately rather than waiting on
-  *      CardanoLiaison's poll cadence (§5.5).
+  *   1. Seed BlockWeaver's first [[PollResults]], so deposit decisions proceed immediately rather
+  *      than waiting on CardanoLiaison's poll cadence (§5.5). The value is read from L1 by `Serve`
+  *      before the actor system exists and handed in — see [[replay]] for why the read cannot
+  *      happen here.
   *   2. Reconstruct the in-flight acked-but-unconfirmed stack — at most one (single-flight; the §9
   *      "crash mid-stack" case) — from its persisted `Stack.Unsigned` + this peer's hard-acks, and
   *      hand it to `SlowConsensusActor` so it re-forms its cell and re-aggregates. StackComposer
@@ -48,11 +44,6 @@ import scalus.cardano.address.ShelleyAddress
   */
 object ReplayActor:
 
-    private val log: ContraTracer[IO, Slf4jMsg] =
-        Slf4jTracer.sink.contramap(
-          Slf4jMsgFormat.humanFormat("hydrozoa.multisig.consensus.ReplayActor")
-        )
-
     /** The consensus actors the replay tail is routed into. `coilAckSequencer` is present only on a
       * hub — the boundary the received-but-unstamped coil-ack gap is re-fed to (see [[replay]]).
       */
@@ -64,25 +55,30 @@ object ReplayActor:
         coilAckSequencer: Option[CoilAckSequencer.Handle] = None
     )
 
-    /** Run the boot replay (see the object docstring), for either peer type. Pure over the store +
-      * a one-shot L1 read; all effects are mailbox sends to `targets`. The fast side and the slow
-      * side are now common to both peer types: the slow-side own-ack journal is the one
-      * `PeerId`-keyed `HardAck` journal, so `own: PeerId` flows straight into
-      * `JournalKey.HardAck(own, n)` with no peer-type branch (§10 Q10). `peers` is every head peer
-      * (own included on a head peer), `hubs` every hub head peer (their `HubHardAck` journals carry
-      * the coil quorum SCA aggregates, read by both peer types), `coils` the hubbed coils whose ack
-      * gap a hub re-feeds (`Nil` off a hub). `own`, `treasuryAddress` and `leadsFastBlock` — the
-      * fast-cycle leadership predicate, always false on a coil — come from the node config.
+    /** Run the boot replay (see the object docstring), for either peer type. Pure over the store;
+      * all effects are mailbox sends to `targets`. The fast side and the slow side are now common
+      * to both peer types: the slow-side own-ack journal is the one `PeerId`-keyed `HardAck`
+      * journal, so `own: PeerId` flows straight into `JournalKey.HardAck(own, n)` with no peer-type
+      * branch (§10 Q10). `peers` is every head peer (own included on a head peer), `hubs` every hub
+      * head peer (their `HubHardAck` journals carry the coil quorum SCA aggregates, read by both
+      * peer types), `coils` the hubbed coils whose ack gap a hub re-feeds (`Nil` off a hub). `own`
+      * and `leadsFastBlock` — the fast-cycle leadership predicate, always false on a coil — come
+      * from the node config.
+      *
+      * `firstPollResults` is read from L1 by the caller, NOT here. This runs inside an uncancelable
+      * actor message handler, so a read that retries would be uninterruptible; `Serve` establishes
+      * the fact on the app fiber and hands it down. Queuing it is still this function's job: it has
+      * to reach BlockWeaver's mailbox before the start barrier opens, or the weaver acts on
+      * `PollResults.empty` and rejects every mature deposit as `NotInPollResults`.
       */
     def replay(
         persistence: Persistence[IO],
-        cardanoBackend: CardanoBackend[IO],
+        firstPollResults: PollResults,
         targets: Targets,
         own: PeerId,
         peers: List[HeadPeerNumber],
         hubs: List[HeadPeerNumber],
         coils: List[CoilPeerNumber],
-        treasuryAddress: ShelleyAddress,
         leadsFastBlock: BlockNumber => Boolean,
         markers: Markers
     )(using CardanoNetwork.Section): IO[Unit] =
@@ -106,10 +102,7 @@ object ReplayActor:
               hardAckedStack
             )
             // 1. First L1 sample → BlockWeaver, so deposit decisions don't wait on the poll tick.
-            _ <- seedFirstPollResults(cardanoBackend, treasuryAddress, targets.blockWeaver)
-            // Same gate, same place: an L1 fact established once, on the app fiber, before the
-            // start barrier opens.
-            _ <- verifyProtocolParams(cardanoBackend)
+            _ <- targets.blockWeaver ! firstPollResults
             // 2. The in-flight acked-but-unconfirmed stack (≤1) → reconstructed handoff to SCA.
             _ <- inflight.traverse_(targets.slowConsensusActor ! _)
             // 3. Derive cursors, scan all lanes, total-order, route the tail into mailboxes.
@@ -198,109 +191,6 @@ object ReplayActor:
                 s"fastBlockMark=$fastBlockMark, hardAckedStack=$hardAckedStack"
           )
         )
-
-    /** Read L1 directly and send BlockWeaver the first [[PollResults]] (§5.5).
-      *
-      * ⛔ This is a GATE, and it must WAIT rather than fail. BlockWeaver starts at
-      * `PollResults.empty`, which is structurally indistinguishable from "polled, and the address
-      * is genuinely empty" — there is no `NeverPolled` state. A head peer classifies deposit
-      * existence from its OWN poll (`DepositsMap.Existence.FromPoll`), so acting on that empty
-      * value would reject every mature deposit as `NotInPollResults`: terminal, and DEBUG-only in
-      * the logs. The seed is queued before the start barrier opens precisely so that cannot happen.
-      *
-      * It previously raised on a failed L1 read, which closed the correctness hole but turned a
-      * transient Blockfrost blip into a failed boot — and `Restart=on-failure` turns a failed boot
-      * into an infinite restart loop that outlives the blip. Waiting is strictly better: the node
-      * is useless without this fact either way, and the retry is bounded by nothing but the
-      * operator's patience, which is what a dashboard is for.
-      *
-      * ⚠️ Safe to retry here ONLY because `replay` runs INLINE at the regime manager, on the app
-      * fiber, outside the actor system. The same loop inside a cats-actors message handler would be
-      * uncancelable (`ActorCell` wraps handlers in `.uncancelable`) and would make the process
-      * unkillable — measured. Do not move this into an actor.
-      */
-    private def seedFirstPollResults(
-        cardanoBackend: CardanoBackend[IO],
-        treasuryAddress: ShelleyAddress,
-        blockWeaver: BlockWeaver.Handle
-    ): IO[Unit] = {
-        def attempt(n: Int): IO[Unit] =
-            cardanoBackend.utxosAt(treasuryAddress).flatMap {
-                case Right(utxos) =>
-                    IO.whenA(n > 0)(
-                      log.info(
-                        s"boot L1 sample succeeded after ${n + 1} attempts; continuing start-up"
-                      )
-                    ) >> (blockWeaver ! PollResults(utxos.keySet))
-                case Left(err) =>
-                    val wait = l1SampleBackoff(n)
-                    log.warn(
-                      s"boot L1 sample failed (attempt ${n + 1}): $err. Cannot start consensus " +
-                          s"without it, so WAITING rather than failing the boot; retrying in $wait"
-                    ) >> IO.sleep(wait) >> attempt(n + 1)
-            }
-        attempt(0)
-    }
-
-    /** Compare the chain's live protocol parameters against the ones this head's config asserts.
-      *
-      * ⛔ Nothing did this before: `getStartupParams` existed with **zero callers**, so a head built
-      * every L1 transaction — settlements, fallbacks, rollouts, refunds — against parameters it
-      * merely assumed, and would keep doing so across a parameter update it never noticed. Those
-      * parameters decide fees, `maxTxSize` and execution-unit budgets, so a drift shows up as
-      * transactions the chain rejects, at the worst possible moment.
-      *
-      * ⛔ **A mismatch REFUSES the boot.** A head building transactions against parameters the chain
-      * has moved past emits txs the chain rejects — silently, at settlement time, under load.
-      *
-      * It is a `StartupRefusal` rather than a generic crash because it is **deterministic**: the
-      * config asserts what it asserts, and a restart re-derives the same verdict, so a supervisor
-      * loop would learn nothing. ⇒ Operationally, an on-chain parameter update stops every peer
-      * until its config is updated. That is intended: the alternative is peers quietly emitting
-      * invalid transactions. If a benign field ever proves to differ in practice, narrow the
-      * comparison to the fields that govern tx validity — do not weaken it back to a warning.
-      *
-      * Unreachable is NOT drift: it retries like the L1 sample, because "cannot ask" and "asked and
-      * the answer is wrong" are the two classes this whole start-up path is built to separate.
-      */
-    private def verifyProtocolParams(
-        cardanoBackend: CardanoBackend[IO]
-    )(using net: CardanoNetwork.Section): IO[Unit] = {
-        def attempt(n: Int): IO[Unit] =
-            cardanoBackend.fetchLatestParams.flatMap {
-                case Right(onChain) =>
-                    val assumed = net.cardanoProtocolParams
-                    if onChain == assumed then
-                        log.info("protocol parameters on chain match the ones this config asserts")
-                    else
-                        log.error(
-                          "PROTOCOL PARAMETER MISMATCH: the chain's parameters differ from the " +
-                              "ones this head's config asserts. Refusing to start.\n" +
-                              s"  on chain: $onChain\n" +
-                              s"  config:   $assumed"
-                        ) >> IO.raiseError(
-                          StartupRefusal(
-                            "the chain's protocol parameters differ from the ones this head's " +
-                                "config asserts, so the L1 transactions it builds may be rejected " +
-                                "by the chain. Update the config to the chain's current parameters " +
-                                "(both values are on the ERROR line above)."
-                          )
-                        )
-                case Left(err) =>
-                    val wait = l1SampleBackoff(n)
-                    log.warn(
-                      s"could not read protocol parameters (attempt ${n + 1}): $err. " +
-                          s"Retrying in $wait."
-                    ) >> IO.sleep(wait) >> attempt(n + 1)
-            }
-        attempt(0)
-    }
-
-    /** Backoff for the boot L1 sample: doubles from 1s, capped at 30s. Capped rather than unbounded
-      * so a node that has been waiting for hours still reacts promptly when L1 returns.
-      */
-    private def l1SampleBackoff(attempt: Int): FiniteDuration =
-        (1.second.toNanos * (1L << math.min(attempt, 5))).nanos.min(30.seconds)
 
     /** Reconstruct the handoff for the in-flight stack — the last own-acked stack, **iff** it is
       * not yet hard-confirmed (`hardConfirmed < hardAckedStack`). Its `Stack.Unsigned` was

--- a/src/main/scala/hydrozoa/multisig/persistence/Markers.scala
+++ b/src/main/scala/hydrozoa/multisig/persistence/Markers.scala
@@ -48,6 +48,35 @@ object Markers:
       */
     val cold: Markers = Markers(None, None, None, None, RequestNumber(0), None, None)
 
+    /** Apply a `transplantStackNumber` to a freshly derived marker bundle, raising this peer's
+      * trusted-history floor to the stack the transplant was tagged with.
+      *
+      * ⛔ The comparison is **`hardConfirmed >= tag`**, deliberately the same one
+      * `Serve`'s boot gate uses. It used to be exact equality here while the gate accepted `>=`, so
+      * a tag naming any stack BELOW the store's tip passed the gate and was then **silently
+      * dropped** — the operator got no adoption and no error. A tag is a partition of the store
+      * chosen by the operator, and any stack the store actually holds is a legitimate choice, so
+      * below-tip must adopt. (George's ruling, 2026-09-02.)
+      *
+      * It RAISES the floor and never lowers it: a peer mid-flight has acked one stack beyond its
+      * confirmation, and clamping that down to the tag would discard the in-flight handoff
+      * `ReplayActor` rebuilds from it. So once the peer has moved past the tag the `max` is a
+      * no-op, which is what keeps a tag left in the config after adoption harmless.
+      *
+      * Applied to the ONE bundle, so the gate, the replay cursors, the in-flight handoff and the
+      * stack composer all move together — the alternative is the divergence that made this
+      * necessary. Lives here rather than in each regime manager because it was duplicated verbatim
+      * in both, which is how the comparison came to disagree with the gate in the first place.
+      */
+    def adopt(derived: Markers, tag: Option[StackNumber]): Markers =
+        tag
+            .filter(t => derived.hardConfirmed.exists(Ordering[StackNumber].gteq(_, t)))
+            .fold(derived)(t =>
+                derived.copy(hardAckedStack = Some(derived.hardAckedStack.fold(t) { own =>
+                    if Ordering[StackNumber].gteq(own, t) then own else t
+                }))
+            )
+
     /** Read all five markers from `backend`, scoping the `hardAcked` and `nextRequestNumber`
       * derivations to `own`. With the per-author CF split each satellite CF holds exactly one
       * author's journal, so the own `hardAcked` mark is just `lastKey` of the own-author `HardAck`

--- a/src/main/scala/hydrozoa/multisig/persistence/Markers.scala
+++ b/src/main/scala/hydrozoa/multisig/persistence/Markers.scala
@@ -51,12 +51,12 @@ object Markers:
     /** Apply a `transplantStackNumber` to a freshly derived marker bundle, raising this peer's
       * trusted-history floor to the stack the transplant was tagged with.
       *
-      * ⛔ The comparison is **`hardConfirmed >= tag`**, deliberately the same one
-      * `Serve`'s boot gate uses. It used to be exact equality here while the gate accepted `>=`, so
-      * a tag naming any stack BELOW the store's tip passed the gate and was then **silently
-      * dropped** — the operator got no adoption and no error. A tag is a partition of the store
-      * chosen by the operator, and any stack the store actually holds is a legitimate choice, so
-      * below-tip must adopt. (George's ruling, 2026-09-02.)
+      * ⛔ The comparison is **`hardConfirmed >= tag`**, deliberately the same one `Serve`'s boot
+      * gate uses. It used to be exact equality here while the gate accepted `>=`, so a tag naming
+      * any stack BELOW the store's tip passed the gate and was then **silently dropped** — the
+      * operator got no adoption and no error. A tag is a partition of the store chosen by the
+      * operator, and any stack the store actually holds is a legitimate choice, so below-tip must
+      * adopt. (George's ruling, 2026-09-02.)
       *
       * It RAISES the floor and never lowers it: a peer mid-flight has acked one stack beyond its
       * confirmation, and clamping that down to the tag would discard the in-flight handoff

--- a/src/test/scala/hydrozoa/app/MainSmokeTest.scala
+++ b/src/test/scala/hydrozoa/app/MainSmokeTest.scala
@@ -6,6 +6,7 @@ import hydrozoa.config.GenerateSampleConfig.{defaultSpec, testPeersSpec}
 import hydrozoa.config.head.HeadConfig.headConfigEncoder
 import hydrozoa.config.node.NodePrivateConfig.nodePrivateConfigEncoder
 import hydrozoa.config.node.{MultiNodeConfig, PrivateSecrets}
+import hydrozoa.lib.StartupRefusal
 import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.backend.cardano.{CardanoBackendMock, MockState}
 import hydrozoa.multisig.consensus.peer.HeadPeerNumber
@@ -297,7 +298,17 @@ class MainSmokeTest extends AnyFunSuite:
         val mnc: MultiNodeConfig = MultiNodeConfig
             .generate(testPeersSpec(spec))()
             .pureApply(Gen.Parameters.default, org.scalacheck.rng.Seed(spec.generationSeed))
-        val peerPrivate = mnc.nodePrivateConfigs(HeadPeerNumber(0)).copy(httpPort = "0")
+        val generatedPrivate = mnc.nodePrivateConfigs(HeadPeerNumber(0))
+        // ⛔ Clear the transplant tag, for the same reason the positive test does — and here it is
+        // load-bearing rather than tidy. The generator draws it from `Gen.option`, this store is
+        // empty, and the transplant gate runs in `Serve` BEFORE the parameter comparison. Left in,
+        // this test would refuse for the wrong reason and pass while never exercising the gate it
+        // exists to cover.
+        val peerPrivate = generatedPrivate.copy(
+          httpPort = "0",
+          nodeOperationMultisigConfig = generatedPrivate.nodeOperationMultisigConfig
+              .copy(transplantStackNumber = None)
+        )
         val printer = Printer.spaces2.copy(dropNullValues = true)
         val (_, peerSigningKey) = TestPeers.deriveScalusKeypair(spec.seedPhrase.mnemonic, 0)
         val runnablePrivateJson = peerPrivate.asJson.deepMerge(
@@ -331,7 +342,13 @@ class MainSmokeTest extends AnyFunSuite:
                   IO.raiseError(new AssertionError("runNode neither refused nor returned in 60s"))
                 )
             _ <- outcome match {
-                case Left(_: StartupRefusal) => IO.unit
+                // On the REASON, not the type: a node has several ways to refuse, and the whole
+                // point of this control is that it fails for this one.
+                case Left(r: StartupRefusal) if r.reason.contains("protocol parameters") => IO.unit
+                case Left(r: StartupRefusal) =>
+                    IO.raiseError(
+                      new AssertionError(s"refused, but for another reason: ${r.reason}")
+                    )
                 case Left(other) =>
                     IO.raiseError(
                       new AssertionError(s"expected a StartupRefusal, got: $other")

--- a/src/test/scala/hydrozoa/multisig/consensus/ReplayActorTest.scala
+++ b/src/test/scala/hydrozoa/multisig/consensus/ReplayActorTest.scala
@@ -13,7 +13,6 @@ import hydrozoa.config.head.network.CardanoNetwork
 import hydrozoa.config.node.{MultiNodeConfig, NodeConfig}
 import hydrozoa.lib.cardano.scalus.QuantizedTime.QuantizedInstant.realTimeQuantizedInstant
 import hydrozoa.lib.logging.Slf4jTracer
-import hydrozoa.multisig.backend.cardano.{CardanoBackendMock, MockState}
 import hydrozoa.multisig.consensus.ack.{HardAck, HardAckId, HardAckNumber, HardAckWithId, HubHardAckNumber}
 import hydrozoa.multisig.consensus.peer.{CoilPeerNumber, HeadPeerNumber, PeerId}
 import hydrozoa.multisig.consensus.pollresults.PollResults
@@ -201,7 +200,6 @@ class ReplayActorTest extends AnyFunSuite:
     ): Captured =
         val own = ownNum
         val peers = config.headPeerIds.map(_.peerNum).toList
-        val treasuryAddress = config.initializationTx.treasuryProduced.address
         val persistenceTracer = Slf4jTracer.sink.contramap(PersistenceEventFormat.humanFormat)
         InMemoryBackendStore
             .open(persistenceTracer)
@@ -209,14 +207,6 @@ class ReplayActorTest extends AnyFunSuite:
                 ActorSystem[IO]("replay-test").use(system =>
                     for {
                         persistence <- Persistence.fromBackend(backend, persistenceTracer)
-                        cardanoBackend <- CardanoBackendMock.mockIO(
-                          MockState(Map.empty),
-                          // `replay` now verifies the chain's protocol parameters against the
-                          // config's and REFUSES on a mismatch, so the mock must report the
-                          // config's. Its default is scalus's `UtxoEnv.testMainnet` fixture, which
-                          // matches no real network's `CardanoInfo`.
-                          reportedParams = Some(config.cardanoProtocolParams)
-                        )
                         bwSink <- Ref.of[IO, Vector[BlockWeaver.Request]](Vector.empty)
                         fcaSink <- Ref.of[IO, Vector[FastConsensusActor.Request]](Vector.empty)
                         scaSink <- Ref.of[IO, Vector[SlowConsensusActor.Request]](Vector.empty)
@@ -232,13 +222,12 @@ class ReplayActorTest extends AnyFunSuite:
                         outcome <- ReplayActor
                             .replay(
                               persistence,
-                              cardanoBackend,
+                              PollResults.empty,
                               ReplayActor.Targets(bw, fca, sca, sc, Some(seq)),
                               PeerId.Head(own),
                               peers,
                               hubs,
                               coils,
-                              treasuryAddress,
                               leadsFastBlock = ownLeadsFastBlock,
                               markers = markers
                             )
@@ -260,7 +249,6 @@ class ReplayActorTest extends AnyFunSuite:
     private def runReplayCoil(seed: Persistence[IO] => IO[Unit]): Captured =
         val peers = config.headPeerIds.map(_.peerNum).toList
         val hubs = List(HeadPeerNumber(1))
-        val treasuryAddress = config.initializationTx.treasuryProduced.address
         val persistenceTracer = Slf4jTracer.sink.contramap(PersistenceEventFormat.humanFormat)
         InMemoryBackendStore
             .open(persistenceTracer)
@@ -268,14 +256,6 @@ class ReplayActorTest extends AnyFunSuite:
                 ActorSystem[IO]("replay-coil-test").use(system =>
                     for {
                         persistence <- Persistence.fromBackend(backend, persistenceTracer)
-                        cardanoBackend <- CardanoBackendMock.mockIO(
-                          MockState(Map.empty),
-                          // `replay` now verifies the chain's protocol parameters against the
-                          // config's and REFUSES on a mismatch, so the mock must report the
-                          // config's. Its default is scalus's `UtxoEnv.testMainnet` fixture, which
-                          // matches no real network's `CardanoInfo`.
-                          reportedParams = Some(config.cardanoProtocolParams)
-                        )
                         bwSink <- Ref.of[IO, Vector[BlockWeaver.Request]](Vector.empty)
                         fcaSink <- Ref.of[IO, Vector[FastConsensusActor.Request]](Vector.empty)
                         scaSink <- Ref.of[IO, Vector[SlowConsensusActor.Request]](Vector.empty)
@@ -289,13 +269,12 @@ class ReplayActorTest extends AnyFunSuite:
                         outcome <- ReplayActor
                             .replay(
                               persistence,
-                              cardanoBackend,
+                              PollResults.empty,
                               ReplayActor.Targets(bw, fca, sca, sc),
                               PeerId.Coil(CoilPeerNumber(0)),
                               peers,
                               hubs,
                               Nil,
-                              treasuryAddress,
                               // A coil peer never leads a fast block.
                               leadsFastBlock = _ => false,
                               markers = markers

--- a/src/test/scala/hydrozoa/multisig/persistence/MarkersAdoptTest.scala
+++ b/src/test/scala/hydrozoa/multisig/persistence/MarkersAdoptTest.scala
@@ -1,0 +1,64 @@
+package hydrozoa.multisig.persistence
+
+import hydrozoa.multisig.ledger.stack.StackNumber
+import org.scalatest.funsuite.AnyFunSuite
+
+/** What a `transplantStackNumber` does to a freshly derived marker bundle.
+  *
+  * The rule this pins is that `Markers.adopt` and `Serve`'s boot gate must use the **same**
+  * comparison. They did not: the gate accepted `hardConfirmed >= tag` while adoption required exact
+  * equality, so a tag naming a stack below the store's tip passed the gate and was then silently
+  * dropped — no adoption, no error, and an operator with no way to tell. The first test below is
+  * that case, and it fails on the old `hardConfirmed.contains(tag)`.
+  */
+class MarkersAdoptTest extends AnyFunSuite {
+
+    private def store(hardConfirmed: Int, hardAckedStack: Option[Int]): Markers =
+        Markers.cold.copy(
+          hardConfirmed = Some(StackNumber(hardConfirmed)),
+          hardAckedStack = hardAckedStack.map(StackNumber(_))
+        )
+
+    test("a tag BELOW the store's tip is adopted, not silently dropped") {
+        // The regression. The boot gate lets this through, so adoption must too — a tag is a
+        // partition of the store chosen by the operator, and any stack the store holds is a
+        // legitimate choice.
+        val adopted = Markers.adopt(store(hardConfirmed = 100, hardAckedStack = None), Some(StackNumber(42)))
+        assert(
+          adopted.hardAckedStack.contains(StackNumber(42)),
+          s"a below-tip tag must raise the floor; got ${adopted.hardAckedStack}"
+        )
+    }
+
+    test("a tag EQUAL to the store's tip is adopted") {
+        val adopted = Markers.adopt(store(hardConfirmed = 42, hardAckedStack = None), Some(StackNumber(42)))
+        assert(adopted.hardAckedStack.contains(StackNumber(42)))
+    }
+
+    test("a tag ABOVE the store's tip is not adopted — the gate refuses that boot anyway") {
+        val derived = store(hardConfirmed = 10, hardAckedStack = Some(7))
+        assert(Markers.adopt(derived, Some(StackNumber(99))) == derived)
+    }
+
+    test("no tag leaves the bundle untouched") {
+        val derived = store(hardConfirmed = 10, hardAckedStack = Some(7))
+        assert(Markers.adopt(derived, None) == derived)
+    }
+
+    test("an empty store adopts nothing, whatever the tag") {
+        assert(Markers.adopt(Markers.cold, Some(StackNumber(1))) == Markers.cold)
+    }
+
+    test("the floor is RAISED and never lowered") {
+        // A peer mid-flight has acked one stack beyond its confirmation; clamping that down to the
+        // tag would discard the in-flight handoff ReplayActor rebuilds from it.
+        val ahead = store(hardConfirmed = 100, hardAckedStack = Some(101))
+        assert(Markers.adopt(ahead, Some(StackNumber(42))).hardAckedStack.contains(StackNumber(101)))
+    }
+
+    test("adoption is idempotent — a tag left in the config after the fact changes nothing") {
+        val derived = store(hardConfirmed = 100, hardAckedStack = Some(60))
+        val once = Markers.adopt(derived, Some(StackNumber(42)))
+        assert(Markers.adopt(once, Some(StackNumber(42))) == once)
+    }
+}

--- a/src/test/scala/hydrozoa/multisig/persistence/MarkersAdoptTest.scala
+++ b/src/test/scala/hydrozoa/multisig/persistence/MarkersAdoptTest.scala
@@ -23,7 +23,8 @@ class MarkersAdoptTest extends AnyFunSuite {
         // The regression. The boot gate lets this through, so adoption must too — a tag is a
         // partition of the store chosen by the operator, and any stack the store holds is a
         // legitimate choice.
-        val adopted = Markers.adopt(store(hardConfirmed = 100, hardAckedStack = None), Some(StackNumber(42)))
+        val adopted =
+            Markers.adopt(store(hardConfirmed = 100, hardAckedStack = None), Some(StackNumber(42)))
         assert(
           adopted.hardAckedStack.contains(StackNumber(42)),
           s"a below-tip tag must raise the floor; got ${adopted.hardAckedStack}"
@@ -31,7 +32,8 @@ class MarkersAdoptTest extends AnyFunSuite {
     }
 
     test("a tag EQUAL to the store's tip is adopted") {
-        val adopted = Markers.adopt(store(hardConfirmed = 42, hardAckedStack = None), Some(StackNumber(42)))
+        val adopted =
+            Markers.adopt(store(hardConfirmed = 42, hardAckedStack = None), Some(StackNumber(42)))
         assert(adopted.hardAckedStack.contains(StackNumber(42)))
     }
 
@@ -53,7 +55,9 @@ class MarkersAdoptTest extends AnyFunSuite {
         // A peer mid-flight has acked one stack beyond its confirmation; clamping that down to the
         // tag would discard the in-flight handoff ReplayActor rebuilds from it.
         val ahead = store(hardConfirmed = 100, hardAckedStack = Some(101))
-        assert(Markers.adopt(ahead, Some(StackNumber(42))).hardAckedStack.contains(StackNumber(101)))
+        assert(
+          Markers.adopt(ahead, Some(StackNumber(42))).hardAckedStack.contains(StackNumber(101))
+        )
     }
 
     test("adoption is idempotent — a tag left in the config after the fact changes nothing") {


### PR DESCRIPTION
## Review order

Stacked on `feat/l1-boot-gate` (#720), which it corrects. Review #720 first; this branch adds
one commit on top and changes none of its five commits.

## What was wrong

#720 splits start-up failures into "wait" and "refuse", which is the right split. Both new gates
landed on the wrong side of the actor boundary, and that undoes each half of it.

`ReplayActor.replay` is called from `HeadMultisigRegimeManager.preStartLocal`. That is not app-fiber
code — `MultisigRegimeManagerBase` posts a message to itself and handles it in `receive`:

```scala
// MultisigRegimeManagerBase.scala:103
override def preStart: IO[Unit] = context.self ! PreStart
// :108
case PreStart => preStartLocal
```

`RuleBasedActor.scala:1116` states the pattern outright — "posting a PreStart message defers
initialization (`preStartLocal`) into the receive loop". So both gates ran inside
`ActorCell.invoke(...).uncancelable`:

| gate | intended | actual |
| ---- | -------- | ------ |
| boot L1 sample | waits, interruptibly | waits **uncancelably** — SIGTERM does nothing, only `shutdownHookTimeout` ends it |
| protocol parameters | refuses, exit 2 | escalates to the guardian → **exit 1**, which `RestartPreventExitStatus=2` does not catch |

The first is strictly worse than the `IO.raiseError` it replaced: that failed the boot and the
process exited. The second produces exactly the `Restart=on-failure` loop `StartupRefusal` exists
to eliminate, fleet-wide, on any parameter drift.

#720's own MRE measured this case — unbounded retry loop, cancel "never returned".

## The change

Both gates move to `Serve`, beside the transplant gate that already sits there for the same two
reasons. Neither needs anything the actor system provides: one is a UTxO read, the other a
comparison.

`replay` now takes `firstPollResults: PollResults` and only queues it — the ordering guarantee it
exists for (reach BlockWeaver's mailbox before the start barrier opens, so the weaver never acts on
`PollResults.empty`) is unchanged. Its `cardanoBackend` and `treasuryAddress` parameters are gone,
since nothing else in it used them.

The comparison itself is untouched: still full-record `==`, still a refusal. Only the message
changes, because the old one named a remedy that does not exist:

> `CardanoNetwork.scala:94-104` — for `"mainnet"`, `"preprod"` and `"preview"` the config carries
> only the network NAME. `cardanoProtocolParams` resolves through `CardanoInfo.<net>`, compiled in
> from Scalus. Only a `custom` network reads parameters from JSON.

So "Update the config to the chain's current parameters" would send an operator on preview looking
for a field that isn't there. The message now branches: edit `protocolParams` on a `custom`
network; upgrade Scalus and redeploy on a named one.

Also in the same commit:

- **`recoverWith`, not `handleErrorWith`, on the store open.** A partial function passed to
  `handleErrorWith` eta-expands into a total one that throws `MatchError` on everything else, so a
  directory-creation `IOException` lost its cause. `RocksDBException` is imported rather than
  written as an inline FQN.
- **`StartupRefusal` moves to `hydrozoa.lib`.** `hydrozoa.config.node.NodeConfig` was importing it
  from `hydrozoa.app`, i.e. config depending on the CLI entry point.

## The pparams negative control could pass on the wrong refusal

`MainSmokeTest` asserted only `case Left(_: StartupRefusal) => IO.unit` — the type, not the reason —
though the PR body says these controls assert the reason. Worse: all three tests build from the same
`defaultSpec` and `spec.generationSeed`, the positive test now explicitly clears
`transplantStackNumber` because the generator draws it from `Gen.option`, and this one did not. The
transplant gate runs strictly earlier. A seed yielding a tag makes the control vacuous and
permanently green.

Now clears the tag and asserts `reason.contains("protocol parameters")`.

## ⚠️ `getStartupParams` is not dead — do not delete it

#720's notes say it "has never had a caller" and to delete it or wire it in.
`integration/src/test/scala/hydrozoa/integration/stage1/Suite.scala:652` calls it on a concretely
constructed `CardanoBackendBlockfrost`. It is not on the `CardanoBackend` trait, which is presumably
how a search missed it.

It also answers a different question than the new gate: `getStartupParams` returns
`provider.cardanoInfo.protocolParams` — the compiled-in constant — while `verifyProtocolParams` uses
`fetchLatestParams`, which reads the chain. stage1 wants the constant. Left in place.

## Not addressed here

- **The comparison's breadth.** Full-record `==` over `ProtocolParams` covers more than the fee,
  size and execution-budget fields that govern tx validity, so an unrelated on-chain parameter
  change still stops every peer of a live head. Kept deliberately — that was an explicit call on
  #720 — but it now stops them *cleanly at exit 2* rather than crash-looping, which is the part
  that was broken. Narrowing it is a separate decision.
- **Serving `/health` while waiting.** #720 lists this as out of scope and scopes it to coils;
  `Serve.scala:621-627` (head) and `:674-678` (coil) are identical, so it applies to both. A node
  waiting for L1 still serves nothing. It is at least killable now.

## Verification

`scalafmtCheckAll` clean, `Test/compile` and `integration/Test/compile` clean with zero warnings.
`MainSmokeTest` + `ReplayActorTest`: 10 passed, 0 failed — including both refusal tests, with the
parameter one now passing on its reason rather than on any refusal at all.
