### PR TITLE
chore(release): bump to 0.1.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -472,7 +472,7 @@ inThisBuild(
   List(
     // Release version — drives the Docker image tag, `hydrozoa.BuildInfo.version`, and `GET
     // /version`. Bump here for a release (see RELEASE.md), then tag `v<version>`.
-    version := "0.1.12",
+    version := "0.1.13",
     scalaVersion := "3.3.7",
     semanticdbEnabled := true,
     semanticdbVersion := scalafixSemanticdb.revision

--- a/docs/user-guide/DEPLOYMENT.md
+++ b/docs/user-guide/DEPLOYMENT.md
@@ -124,13 +124,13 @@ under it. Then load the CLI alias and check you are on the version you expect:
 source ./hydrozoa.sh   # sets the `hydrozoa` alias + HYDROZOA_HOME (this folder, an absolute path)
 
 hydrozoa version       # verify the image you are running
-#   hydrozoa 0.1.12
-#   git:   v0.1.12
+#   hydrozoa 0.1.13
+#   git:   v0.1.13
 #   built: 2026-07-28 14:00:37.834-0600
 ```
 
-(The `git:` line is `git describe` provenance; a published image built from the `v0.1.12` tag reads a
-clean `v0.1.12`. A locally built image between releases shows the distance from the newest tag, e.g.
+(The `git:` line is `git describe` provenance; a published image built from the `v0.1.13` tag reads a
+clean `v0.1.13`. A locally built image between releases shows the distance from the newest tag, e.g.
 `v0.1.0-10-gaa9d7c69`.)
 
 Need a version that isn't in the registry? Build it from this repo — see §3.
@@ -425,8 +425,8 @@ finalization) appears in the same section as the head progresses.
 build (§3) is already tagged `…:latest`, so it is picked up without either:
 
 ```bash
-HYDROZOA_VERSION=0.1.12 just head-up                          # a specific published release
-HYDROZOA_IMAGE=cardano-hydrozoa/hydrozoa:0.1.12 just head-up  # a specific/other image name
+HYDROZOA_VERSION=0.1.13 just head-up                          # a specific published release
+HYDROZOA_IMAGE=cardano-hydrozoa/hydrozoa:0.1.13 just head-up  # a specific/other image name
 ```
 
 **Another head** — each head directory carries its own `docker-compose.yml`, so switch heads by

--- a/src/main/resources/scaffold/hydrozoa.sh
+++ b/src/main/resources/scaffold/hydrozoa.sh
@@ -13,7 +13,7 @@
 # scaffolded workspace — resolved to an absolute path, so the alias mounts correctly no matter which
 # directory you run it from. Override HYDROZOA_HOME (to an absolute path) or HYDROZOA_VERSION before
 # sourcing, or edit the defaults below.
-: "${HYDROZOA_VERSION:=0.1.12}"   # published image tag (ghcr.io/cardano-hydrozoa/hydrozoa)
+: "${HYDROZOA_VERSION:=0.1.13}"   # published image tag (ghcr.io/cardano-hydrozoa/hydrozoa)
 : "${HYDROZOA_HOME:=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)}"   # head directory (absolute)
 export HYDROZOA_VERSION HYDROZOA_HOME
 


### PR DESCRIPTION
Version bump for `v0.1.13` — [RELEASE.md](RELEASE.md) step 1 only. Tag and push follow from the
merged commit.

## The bump

All eight occurrences of the previous version, none left behind:

| file | what |
| ---- | ---- |
| `build.sbt:475` | `inThisBuild` release version — the image tag, `BuildInfo.version`, `GET /version` |
| `src/main/resources/scaffold/hydrozoa.sh:16` | `HYDROZOA_VERSION` default |
| `docs/user-guide/DEPLOYMENT.md:127-133` | `hydrozoa version` sample output + the `git describe` paragraph |
| `docs/user-guide/DEPLOYMENT.md:428-429` | `HYDROZOA_VERSION=` / `HYDROZOA_IMAGE=` run examples |

`scaffold/docker-compose.yml` needs no edit — it follows `hydrozoa.sh`. `HydrozoaRoutes.apiVersion`
and `docs/openapi*.yaml` are the API-contract version and stay put. `build.sbt:117` is petri's own
`0.1.0-SNAPSHOT` and is unrelated.

## Steps 2 and 3 are no-ops this time

- **Baked reference-script UTxOs stay valid.** `git diff v0.1.12..main` touches neither
  `cardano-onchain/` nor `src/main/resources/hydrozoa/scripts/`, and `scalusVersion` is unchanged —
  so the compiled UPLC is identical and `src/main/resources/scaffold/ref-utxos/` needs no
  redeployment.
- **Shipped logger levels unchanged.** `src/main/resources/logback-docker.xml` has no diff since
  `v0.1.12`.

## ⚠️ Two things that need to reach the release notes

Not in this PR — flagging them for whoever writes the notes, because both change what an operator
has to do and one of them stops every existing deployment.

**1. Credentials move out of `private.json` (breaking).** `79db7186` takes the peer signing key,
the rule-based signing key, the Blockfrost project id and the admin password from the environment
instead. A credential *still present* in `private.json` is a refusal, not a warning, so **every
deployed node fails to start until its config is migrated**, exiting 2.

```
HYDROZOA_SIGNING_KEY             HYDROZOA_BLOCKFROST_API_KEY
HYDROZOA_RULE_BASED_SIGNING_KEY  HYDROZOA_ADMIN_PASSWORD
```

Read from a `private.env` beside `private.json` (override the path with `HYDROZOA_PRIVATE_ENV`);
the real environment wins over the file. `keygen` now writes both halves. There is deliberately no
fallback to the old shape.

⛔ **`docs/user-guide/DEPLOYMENT.md` still documents the old shape.** `79db7186` touched only source
and tests, so the user guide currently tells an operator to put these four in `private.json` —
which is now exactly what makes the node refuse to start. That wants fixing before the tag, or the
release ships a guide that cannot be followed.

**2. A protocol-parameter mismatch now refuses the boot.** A head whose config asserts parameters
the chain has moved past will not start, fleet-wide, and stays refused. On `mainnet`/`preprod`/
`preview` these are not a config field — they come from Scalus's `CardanoInfo` — so the remedy is a
Scalus upgrade and redeploy, not a config edit.

Smaller, also operator-visible: a deliberate refusal now exits **2** (pair with
`RestartPreventExitStatus=2`); a node that cannot reach Cardano or its L2 ledger now waits
indefinitely instead of exiting; `transplantStackNumber` is a new optional field in
`nodeOperationMultisigConfig`, absent-decodes-to-`None`, so existing configs are unaffected by that
one.

## Verification

`sbt show core/version` reports `0.1.13`. No code changes, so no test run beyond CI.
