### PR TITLE
joint-ledger: issue ApplyDepositDecisions only when there are decisions

### DIFF
--- a/src/main/scala/hydrozoa/multisig/ledger/joint/JointLedger.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/joint/JointLedger.scala
@@ -549,8 +549,8 @@ final case class JointLedger(
                   rejectedDeposits = decisions.rejected.requestIds
                 )
 
-            // The command number the deposit-decisions command takes when this block issues it
-            // (regular/major only); the number is carried unchanged when no command is issued.
+            // The command number the deposit-decisions command takes when a block issues it;
+            // carried unchanged when none is issued.
             assigned = p.commandNumber.increment
 
             // Block header
@@ -581,13 +581,16 @@ final case class JointLedger(
                     } yield (newJLState, headerIntermediate, evacDiffs)
                 else {
                     for {
-                        newL2State <- applyDepositDecisionsOrPanic(
-                          p,
-                          assigned,
-                          depositRequestDecisions
-                        )
-                        evacDiffs = newL2State.diffs
-                        newJLState = p.setL2LedgerState(newL2State).incrementCommandNumber
+                        // Also reached for a block made major by a withdrawal, which has no
+                        // decisions to apply -- and applying two empty lists is a no-op that
+                        // would still consume a command number.
+                        newJLState <-
+                            if decisions.absorbed.isEmpty && decisions.rejected.isEmpty
+                            then IO.pure(p)
+                            else
+                                applyDepositDecisionsOrPanic(p, assigned, depositRequestDecisions)
+                                    .map(s => p.setL2LedgerState(s).incrementCommandNumber)
+                        evacDiffs = newJLState.l2LedgerState.diffs
 
                         headerIntermediate <- previousHeader.nextHeaderMajor(bhTracer)(
                           txTiming,


### PR DESCRIPTION
`mkBlockBriefIntermediate` used one condition — `decisions.absorbed.isEmpty && blockWithdrawnUtxos.isEmpty` — to answer two unrelated questions: is this block major, and are there deposit decisions to apply. Those diverge for a block made major by a **withdrawal** with no deposits to decide. Such a block issued `ApplyDepositDecisions` over two empty lists, which writes no events and returns no evacuation diffs, and spent an `L2CommandNumber` on it.

## How to review this

The whole change is the major arm of the branch in `JointLedger.mkBlockBriefIntermediate`. The header-selection condition is deliberately untouched: a withdrawal must still force a major block. Only the guard on `applyDepositDecisionsOrPanic` moves.

## Change

Issue the command when `decisions.absorbed.nonEmpty || decisions.rejected.nonEmpty`, independent of why the block is major. The minor arm already tested exactly this (its branch condition makes `absorbed` empty, so its `rejected.isEmpty` check is the same predicate); the major arm now asks the same question rather than assuming the answer.

## Rationale

The command exists to apply decisions. `L2Ledger.applyDepositDecisions` over two empty lists is a total no-op — the sugar-rush ledger's `handle_decisions` iterates `absorbed` and `rejected` and nothing else, so it returns no events, no evacuation diffs and no payouts.

**The no-op is not merely wasteful, it is invisible.** The block brief records `depositsAbsorbed` and `depositsRejected` and never withdrawals, so a consumer reconstructing the command stream from the brief cannot tell that a number was spent. Withdrawals live inside the encrypted L2 payload, so no brief-level rule can recover it either — the information is not in the brief at any level.

Measured over 4,195,615 mainnet blocks: exactly one block issued the command with both lists empty, and it contained exactly one withdrawal. Every consumer replaying that stream numbered every subsequent command one low.

## Risk

**This changes the command numbering for blocks produced after deployment**, so it must not ship alone. A consumer that infers the command's existence from the brief's outcome lists is correct for blocks written after this change and wrong for blocks written before it, and cannot tell which it is looking at.

The safe order is to deploy the consumer-side fix first — sugar-rush-ledger reading the head's own `L2CommandNumber` per block instead of inferring — which is correct under both behaviours and therefore across the deployment boundary. With that in place this change is a non-event for replay; without it, it introduces a second numbering shift with the same silent signature as the first.

Nothing in the ledger relies on block numbers increasing or on majors carrying the command: block numbers are recorded on events and never compared.

## Testing

`compile` under `-Werror`, `just precommit`, and `just test` all pass.

**Deliberately not covered:** there is no test asserting that a withdrawal-only major issues no command. The existing suite exercises the minor arm's equivalent guard but not this one, so the change rests on the branch being visibly the same predicate plus the mainnet measurement above. A test that builds a block with a withdrawal and no deposit decisions, and asserts the command number does not advance, would be the right addition and is not in this PR.

## Scope

One condition. It does not change when a block becomes major, what the command does when there are decisions, or anything about withdrawals themselves.