### PR TITLE
chore(release): bump to 0.1.14

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -472,7 +472,7 @@ inThisBuild(
   List(
     // Release version — drives the Docker image tag, `hydrozoa.BuildInfo.version`, and `GET
     // /version`. Bump here for a release (see RELEASE.md), then tag `v<version>`.
-    version := "0.1.13",
+    version := "0.1.14",
     scalaVersion := "3.3.7",
     semanticdbEnabled := true,
     semanticdbVersion := scalafixSemanticdb.revision

--- a/docs/user-guide/DEPLOYMENT.md
+++ b/docs/user-guide/DEPLOYMENT.md
@@ -124,13 +124,13 @@ under it. Then load the CLI alias and check you are on the version you expect:
 source ./hydrozoa.sh   # sets the `hydrozoa` alias + HYDROZOA_HOME (this folder, an absolute path)
 
 hydrozoa version       # verify the image you are running
-#   hydrozoa 0.1.13
-#   git:   v0.1.13
+#   hydrozoa 0.1.14
+#   git:   v0.1.14
 #   built: 2026-07-28 14:00:37.834-0600
 ```
 
-(The `git:` line is `git describe` provenance; a published image built from the `v0.1.13` tag reads a
-clean `v0.1.13`. A locally built image between releases shows the distance from the newest tag, e.g.
+(The `git:` line is `git describe` provenance; a published image built from the `v0.1.14` tag reads a
+clean `v0.1.14`. A locally built image between releases shows the distance from the newest tag, e.g.
 `v0.1.0-10-gaa9d7c69`.)
 
 Need a version that isn't in the registry? Build it from this repo — see §3.
@@ -425,8 +425,8 @@ finalization) appears in the same section as the head progresses.
 build (§3) is already tagged `…:latest`, so it is picked up without either:
 
 ```bash
-HYDROZOA_VERSION=0.1.13 just head-up                          # a specific published release
-HYDROZOA_IMAGE=cardano-hydrozoa/hydrozoa:0.1.13 just head-up  # a specific/other image name
+HYDROZOA_VERSION=0.1.14 just head-up                          # a specific published release
+HYDROZOA_IMAGE=cardano-hydrozoa/hydrozoa:0.1.14 just head-up  # a specific/other image name
 ```
 
 **Another head** — each head directory carries its own `docker-compose.yml`, so switch heads by

--- a/src/main/resources/scaffold/hydrozoa.sh
+++ b/src/main/resources/scaffold/hydrozoa.sh
@@ -13,7 +13,7 @@
 # scaffolded workspace — resolved to an absolute path, so the alias mounts correctly no matter which
 # directory you run it from. Override HYDROZOA_HOME (to an absolute path) or HYDROZOA_VERSION before
 # sourcing, or edit the defaults below.
-: "${HYDROZOA_VERSION:=0.1.13}"   # published image tag (ghcr.io/cardano-hydrozoa/hydrozoa)
+: "${HYDROZOA_VERSION:=0.1.14}"   # published image tag (ghcr.io/cardano-hydrozoa/hydrozoa)
 : "${HYDROZOA_HOME:=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)}"   # head directory (absolute)
 export HYDROZOA_VERSION HYDROZOA_HOME
 


### PR DESCRIPTION
Version bump for `v0.1.14` — [RELEASE.md](RELEASE.md) step 1 only. Tag and push follow from the
merged commit.

Ships one change: #727, `joint-ledger: issue ApplyDepositDecisions only when there are decisions`.

## The bump

All eight occurrences of the previous version:

| file | what |
| ---- | ---- |
| `build.sbt:475` | `inThisBuild` release version — the image tag, `BuildInfo.version`, `GET /version` |
| `src/main/resources/scaffold/hydrozoa.sh:16` | `HYDROZOA_VERSION` default |
| `docs/user-guide/DEPLOYMENT.md:127-133` | `hydrozoa version` sample output + the `git describe` paragraph |
| `docs/user-guide/DEPLOYMENT.md:428-429` | `HYDROZOA_VERSION=` / `HYDROZOA_IMAGE=` run examples |

`scaffold/docker-compose.yml` needs no edit — it follows `hydrozoa.sh`. `HydrozoaRoutes.apiVersion`
and `docs/openapi*.yaml` are the API-contract version and stay put. `build.sbt:117` is petri's own
`0.1.0-SNAPSHOT` and is unrelated.

## Steps 2 and 3 are no-ops

- **Baked reference-script UTxOs stay valid.** `git diff v0.1.13..main` touches neither
  `cardano-onchain/` nor `src/main/resources/hydrozoa/scripts/`, and `scalusVersion` is unchanged,
  so the compiled UPLC is identical and `src/main/resources/scaffold/ref-utxos/` needs no
  redeployment.
- **Shipped logger levels unchanged.** `logback-docker.xml` has no diff since `v0.1.13`.

## ⛔ Deployment order is load-bearing

#727 changes the command numbering for blocks produced after deployment. Its own risk section says
it must not ship before the consumer-side fix, and that fix is
**sugar-rush-ledger v0.1.14** (GummiwormLabs/sugar-rush-ledger#277), which reads the head's own
`L2CommandNumber` per block instead of inferring the command from the brief's outcome lists.
Reading the count is correct under both hydrozoa behaviours; inferring is correct under neither
once this ships.

sugar-rush v0.1.14 is tagged and its release is building. **Tagging hydrozoa v0.1.14 is safe; rolling
this image out to a node whose ledger is still on 0.1.13 is not.** Confirm every node's ledger is
actually running 0.1.14 before deploying — a release is not a deployment.

A consumer on the old rule meets a second numbering shift with the same silent signature as the
first: skips lower an account's nonce, the check is `account.nonce >= incoming`, and permissive
checks do not fire.

Also note that a views db built by sugar-rush ≤ 0.1.13 is off by one relative to 0.1.14 and needs
re-seeding; that is a sugar-rush-side operational step, unaffected by this bump but on the same
critical path.

## ⚠️ Still outstanding from v0.1.13: DEPLOYMENT.md documents credentials that now refuse to start

Unchanged since the last release and flagged here again because this is the second release to ship
it. `79db7186` (in v0.1.13) moved four credentials out of `private.json` into the environment, and a
credential *still present* in `private.json` is a refusal, exit `2`. `docs/user-guide/DEPLOYMENT.md`
has **zero** mentions of `HYDROZOA_SIGNING_KEY`, `HYDROZOA_RULE_BASED_SIGNING_KEY`,
`HYDROZOA_BLOCKFROST_API_KEY`, `HYDROZOA_ADMIN_PASSWORD` or `private.env`, and still instructs
operators to set `blockfrostApiKey` in the private config (`:98`, `:201`, `:239`, `:245`).

Out of scope for a version bump, and worth fixing before the next one — an operator following the
current guide produces a node that will not boot.

## Verification

`sbt show core/version` reports `0.1.14`. No code changes, so no test run beyond CI.
