### PR TITLE
fix(consensus): derive block zero's soft-confirmation and header timings

### DIFF
--- a/docs/spec/head-params-hash.md
+++ b/docs/spec/head-params-hash.md
@@ -204,12 +204,11 @@ chain and moves with hard forks, so it is not something peers agree on.
 reaches the treasury value; the split decides who is paid what at finalization and is otherwise
 unpinned.
 
-The block-zero timing fields matter unevenly and are all included for that reason. `endTime`
-reaches the initialization transaction's validity end; `fallbackTxStartTime`,
-`forcedMajorBlockWakeupTime`, and `mDepositDecisionWakeupTime` reach no transaction at all, so
-the digest is the only thing that pins them. `startTime` repeats `endTime` — block zero has no
-creation window, so it is derived rather than configured — and stays in the preimage because
-removing a term would mean a new domain tag for nothing.
+The block-zero timing fields are five terms over one value. `endTime` reaches the initialization
+transaction's validity end and fixes the whole header: `startTime` repeats it because block zero
+has no creation window, and `fallbackTxStartTime`, `forcedMajorBlockWakeupTime`, and
+`mDepositDecisionWakeupTime` follow from it through the tx timing this preimage already covers.
+All five stay in because dropping a term would mean a new domain tag for nothing.
 
 `hubHeadPeerNumber` decides which head peer relays a coil peer's hard acknowledgement and how
 many `HubHardAck` journals a recovering coil peer must read. It is not in the native script.

--- a/docs/spec/head-params-hash.md
+++ b/docs/spec/head-params-hash.md
@@ -204,10 +204,12 @@ chain and moves with hard forks, so it is not something peers agree on.
 reaches the treasury value; the split decides who is paid what at finalization and is otherwise
 unpinned.
 
-The block-zero timing fields matter unevenly and are all included for that reason.
-`startTime` and `endTime` reach the initialization transaction's validity end, but
-`fallbackTxStartTime`, `forcedMajorBlockWakeupTime`, and `mDepositDecisionWakeupTime` reach no
-transaction at all.
+The block-zero timing fields matter unevenly and are all included for that reason. `endTime`
+reaches the initialization transaction's validity end; `fallbackTxStartTime`,
+`forcedMajorBlockWakeupTime`, and `mDepositDecisionWakeupTime` reach no transaction at all, so
+the digest is the only thing that pins them. `startTime` repeats `endTime` — block zero has no
+creation window, so it is derived rather than configured — and stays in the preimage because
+removing a term would mean a new domain tag for nothing.
 
 `hubHeadPeerNumber` decides which head peer relays a coil peer's hard acknowledgement and how
 many `HubHardAck` journals a recovering coil peer must read. It is not in the native script.

--- a/src/main/scala/hydrozoa/app/Serve.scala
+++ b/src/main/scala/hydrozoa/app/Serve.scala
@@ -312,9 +312,10 @@ object Serve {
                     )
             }
             // Read-only consensus-store view behind the /head/blocks queries.
-            consensusReader = ConsensusStoreReader.fromPersistence(persistence)(using
-              nodeConfig.headConfig
-            )
+            consensusReader = ConsensusStoreReader.fromPersistence(
+              persistence,
+              nodeConfig.headConfig.initialBlock.blockBrief.endTime
+            )(using nodeConfig.headConfig)
         } yield (nodeConfig, system, nodeRun, consensusReader, metrics)
 
         resource.use { case (nodeConfig, system, nodeRun, consensusReader, metrics) =>

--- a/src/main/scala/hydrozoa/bootstrap/Bootstrap.scala
+++ b/src/main/scala/hydrozoa/bootstrap/Bootstrap.scala
@@ -13,7 +13,7 @@ import hydrozoa.config.head.multisig.fallback.FallbackContingency
 import hydrozoa.config.head.multisig.fallback.FallbackContingency.mkFallbackContingencyWithDefaults
 import hydrozoa.config.head.multisig.settlement.SettlementConfig
 import hydrozoa.config.head.multisig.timing.TxTiming
-import hydrozoa.config.head.multisig.timing.TxTiming.BlockTimes.{BlockCreationEndTime, BlockCreationStartTime}
+import hydrozoa.config.head.multisig.timing.TxTiming.BlockTimes.BlockCreationEndTime
 import hydrozoa.config.head.network.{CardanoNetwork, StandardCardanoNetwork}
 import hydrozoa.config.head.parameters.{HeadParameters, L2LedgerKind}
 import hydrozoa.config.head.peers.{HeadPeerData, HeadPeers}
@@ -21,7 +21,6 @@ import hydrozoa.config.head.rulebased.dispute.DisputeResolutionConfig
 import hydrozoa.config.head.{HeadConfig, HeadParamsHash}
 import hydrozoa.config.node.{NodeConfig, PrivateSecrets}
 import hydrozoa.lib.cardano.cip116.JsonCodecs.CIP0116.Conway.given
-import hydrozoa.lib.cardano.scalus.QuantizedTime.QuantizedInstant.realTimeQuantizedInstant
 import hydrozoa.lib.cardano.scalus.QuantizedTime.quantize
 import hydrozoa.lib.cardano.scalus.VerificationKeyExtra.shelleyAddress
 import hydrozoa.lib.logging.{ContraTracer, Slf4jMsg, Slf4jMsgFormat, Slf4jTracer, error, info, warn}
@@ -173,16 +172,15 @@ object Bootstrap:
 
     /** Assembly-time defaults (`defaults.json`): everything the head needs that is neither peer
       * topology (the roster), script references, nor the opening L2 state — the L1 network, the
-      * head protocol parameters, the per-peer equity contributions, and (optionally) the block-zero
-      * timing anchors. [[InitBootstrapFiles]] writes these with demo defaults for the operators to
-      * adjust before [[BuildHeadConfig]]. Block-zero timing is optional: omit it and
-      * [[BuildHeadConfig]] anchors the initial block to wall-clock at build time.
+      * head protocol parameters, the per-peer equity contributions, and (optionally) block zero's
+      * end time. [[InitBootstrapFiles]] writes these with demo defaults for the operators to adjust
+      * before [[BuildHeadConfig]]. `blockZeroEndTime` is optional: omit it and [[BuildHeadConfig]]
+      * anchors the initial block to wall-clock at build time.
       */
     final case class BootstrapDefaults(
         cardanoNetwork: CardanoNetwork,
         headParams: BootstrapHeadParams,
         initialEquityContributions: Map[HeadPeerNumber, Coin],
-        blockZeroStartTime: Option[BlockCreationStartTime],
         blockZeroEndTime: Option[BlockCreationEndTime]
     )
 
@@ -241,7 +239,6 @@ object Bootstrap:
         scriptReferenceUtxos: ScriptReferenceUtxos.Unresolved,
         initialL2State: List[L2Output],
         initialEquityContributions: Map[HeadPeerNumber, Coin],
-        blockZeroStartTime: Option[BlockCreationStartTime],
         blockZeroEndTime: Option[BlockCreationEndTime]
     )
 
@@ -292,7 +289,6 @@ object Bootstrap:
           scriptReferenceUtxos = refUtxos,
           initialL2State = l2State,
           initialEquityContributions = defaults.initialEquityContributions,
-          blockZeroStartTime = defaults.blockZeroStartTime,
           blockZeroEndTime = defaults.blockZeroEndTime
         )
     }
@@ -337,9 +333,12 @@ object Bootstrap:
         l2Ledger: L2LedgerKind,
         mbInitialEvacuationMap: Option[EvacuationMap]
     ): IO[HeadConfig] = for {
-        blockCreationStartTime <- bootstrapConfig.blockZeroStartTime.fold(
-          realTimeQuantizedInstant(cardanoNetwork.slotConfig).map(BlockCreationStartTime(_))
-        )(IO.pure)
+        // Equity comes from the config (per head peer). Its total is what the treasury backs beyond
+        // the L2 value; the per-peer split is recorded but the init tx consumes only the sum.
+        initialEquityContributions <- IO.fromOption(
+          NonEmptyMap.fromMap(SortedMap.from(bootstrapConfig.initialEquityContributions))
+        )(RuntimeException("initialEquityContributions must be non-empty"))
+        totalEquity = initialEquityContributions.toSortedMap.values.foldLeft(Coin.zero)(_ + _)
 
         bhp = bootstrapConfig.headParams
         headParams = HeadParameters(
@@ -374,13 +373,6 @@ object Bootstrap:
         initialL2Value = mbInitialEvacuationMap.fold(
           Value.combine(bootstrapConfig.initialL2State.map(_.value))
         )(_.totalValue)
-
-        // Equity comes from the config (per head peer). Its total is what the treasury backs beyond
-        // the L2 value; the per-peer split is recorded but the init tx consumes only the sum.
-        initialEquityContributions <- IO.fromOption(
-          NonEmptyMap.fromMap(SortedMap.from(bootstrapConfig.initialEquityContributions))
-        )(RuntimeException("initialEquityContributions must be non-empty"))
-        totalEquity = initialEquityContributions.toSortedMap.values.foldLeft(Coin.zero)(_ + _)
 
         headPeers <- IO.fromOption(
           HeadPeers(
@@ -541,18 +533,10 @@ object Bootstrap:
 
         // Block zero's header is built before the transactions, not read back off them: the init
         // tx's treasury datum carries `headParamsHash`, and the header is part of that digest's
-        // preimage. Every field here is derived from the config and `blockCreationEndTime`, which
-        // is exactly what `InitializationTxSeq.Build` derives the fallback's start time from.
-        fallbackTxStartTime = headParams.txTiming.newFallbackStartTime(blockCreationEndTime)
-        forcedMajorBlockWakeupTime = headParams.txTiming.forcedMajorBlockWakeupTime(
-          fallbackTxStartTime
-        )
-        initialBlockHeader = BlockHeader.Initial(
-          startTime = blockCreationStartTime,
-          endTime = blockCreationEndTime,
-          fallbackTxStartTime = fallbackTxStartTime,
-          forcedMajorBlockWakeupTime = forcedMajorBlockWakeupTime,
-          mDepositDecisionWakeupTime = None,
+        // preimage. Every field follows from `blockCreationEndTime`, which is exactly what
+        // `InitializationTxSeq.Build` derives the fallback's start time from.
+        initialBlockHeader = BlockHeader.Initial.derive(blockCreationEndTime)(using
+          headParams.txTiming
         )
         headParamsHash = HeadParamsHash(bootstrap, initialBlockHeader)
 
@@ -1282,8 +1266,7 @@ end BuildHeadConfig
   * contributions — with demo defaults) and an `l2-cardano-eutxo.json` template (a min-ada
   * placeholder per head peer's L1 address, which the operators edit into the opening distribution).
   * Block-zero timing is left out of the defaults, so [[BuildHeadConfig]] anchors the initial block
-  * to wall-clock at build time; operators who want to pin it add `blockZeroStartTime` /
-  * `blockZeroEndTime` (epoch millis).
+  * to wall-clock at build time; operators who want to pin it add `blockZeroEndTime` (epoch millis).
   *
   * Usage:
   * {{{
@@ -1355,7 +1338,7 @@ object InitBootstrapFiles:
             equity = roster.headPeers.indices
                 .map(i => HeadPeerNumber(i) -> (if i == 0 then Coin.ada(100) else Coin.zero))
                 .toMap
-            defaults = Bootstrap.BootstrapDefaults(network, headParams, equity, None, None)
+            defaults = Bootstrap.BootstrapDefaults(network, headParams, equity, None)
             defaultsJson = {
                 given CardanoNetwork.Section = network
                 defaults.asJson.deepDropNullValues

--- a/src/main/scala/hydrozoa/bootstrap/Bootstrap.scala
+++ b/src/main/scala/hydrozoa/bootstrap/Bootstrap.scala
@@ -535,9 +535,7 @@ object Bootstrap:
         // tx's treasury datum carries `headParamsHash`, and the header is part of that digest's
         // preimage. Every field follows from `blockCreationEndTime`, which is exactly what
         // `InitializationTxSeq.Build` derives the fallback's start time from.
-        initialBlockHeader = BlockHeader.Initial.derive(blockCreationEndTime)(using
-          headParams.txTiming
-        )
+        initialBlockHeader = BlockHeader.Initial(blockCreationEndTime)(using headParams.txTiming)
         headParamsHash = HeadParamsHash(bootstrap, initialBlockHeader)
 
         initTxSeq <- InitializationTxSeq

--- a/src/main/scala/hydrozoa/config/head/HeadConfig.scala
+++ b/src/main/scala/hydrozoa/config/head/HeadConfig.scala
@@ -12,6 +12,7 @@ import hydrozoa.config.head.HeadConfig.Bootstrap.HeadConfigBootstrapError
 import hydrozoa.config.head.coil.CoilPeers
 import hydrozoa.config.head.coil.CoilPeers.coilPeersDecoder
 import hydrozoa.config.head.initialization.{InitialBlock, InitializationParameters}
+import hydrozoa.config.head.multisig.timing.TxTiming
 import hydrozoa.config.head.network.CardanoNetwork.{Custom, cardanoNetworkDecoder}
 import hydrozoa.config.head.network.{CardanoNetwork, StandardCardanoNetwork}
 import hydrozoa.config.head.parameters.HeadParameters
@@ -24,7 +25,7 @@ import hydrozoa.lib.cardano.scalus.codecs.json.Codecs.given
 import hydrozoa.lib.logging.Slf4jTracer
 import hydrozoa.multisig.backend.cardano.{CardanoBackend, CardanoBackendBlockfrost, CardanoBackendEventFormat}
 import hydrozoa.multisig.consensus.peer.{CoilPeerNumber, HeadPeerNumber}
-import hydrozoa.multisig.ledger.block.{Block, BlockBrief, BlockEffects, BlockHeader}
+import hydrozoa.multisig.ledger.block.{Block, BlockBrief, BlockEffects}
 import hydrozoa.multisig.ledger.joint.EvacuationMap
 import hydrozoa.multisig.ledger.l1.script.multisig.HeadMultisigScript
 import hydrozoa.multisig.ledger.l1.tx.{FallbackTx, InitializationTx}
@@ -141,9 +142,14 @@ object HeadConfig {
                 hc <- {
                     given CardanoNetwork = network
                     for {
-                        brief <- c
-                            .downField("blockBrief")
-                            .as[BlockBrief.Initial]
+                        hcBootstrap <- c.as[HeadConfig.Bootstrap]
+
+                        // Block zero's brief carries its end time and nothing else; the head
+                        // params' tx timing rebuilds the rest of the header.
+                        brief <- {
+                            given TxTiming = hcBootstrap.txTiming
+                            c.downField("blockBrief").as[BlockBrief.Initial]
+                        }
                         initTx <- c
                             .downField("initializationTx")
                             .as[Transaction]
@@ -151,28 +157,6 @@ object HeadConfig {
                             .downField("resolvedUtxos")
                             .as[Utxos]
                             .map(ResolvedUtxos(_))
-                        hcBootstrap <- c.as[HeadConfig.Bootstrap]
-
-                        // Block zero's header is fully determined by its end time, which the
-                        // initialization transaction pins through its validity end. Rebuild it and
-                        // reject a config whose stored header disagrees, rather than running on
-                        // timings a hand edit could have moved out from under the transaction.
-                        _ <- {
-                            val derived =
-                                BlockHeader.Initial.derive(brief.endTime)(using
-                                  hcBootstrap.txTiming
-                                )
-                            Either.cond(
-                              brief.header == derived,
-                              (),
-                              io.circe.DecodingFailure(
-                                "Block zero's header does not match the one its end time " +
-                                    s"${brief.endTime.convert.instant} determines: stored " +
-                                    s"${brief.header}, derived $derived",
-                                c.history
-                              )
-                            )
-                        }
 
                         // Parse the stored init tx (honouring its bytes) rather than re-building it.
                         // The fallback is protocol-derived, so we build it from the parsed init tx.

--- a/src/main/scala/hydrozoa/config/head/HeadConfig.scala
+++ b/src/main/scala/hydrozoa/config/head/HeadConfig.scala
@@ -24,7 +24,7 @@ import hydrozoa.lib.cardano.scalus.codecs.json.Codecs.given
 import hydrozoa.lib.logging.Slf4jTracer
 import hydrozoa.multisig.backend.cardano.{CardanoBackend, CardanoBackendBlockfrost, CardanoBackendEventFormat}
 import hydrozoa.multisig.consensus.peer.{CoilPeerNumber, HeadPeerNumber}
-import hydrozoa.multisig.ledger.block.{Block, BlockBrief, BlockEffects}
+import hydrozoa.multisig.ledger.block.{Block, BlockBrief, BlockEffects, BlockHeader}
 import hydrozoa.multisig.ledger.joint.EvacuationMap
 import hydrozoa.multisig.ledger.l1.script.multisig.HeadMultisigScript
 import hydrozoa.multisig.ledger.l1.tx.{FallbackTx, InitializationTx}
@@ -152,6 +152,27 @@ object HeadConfig {
                             .as[Utxos]
                             .map(ResolvedUtxos(_))
                         hcBootstrap <- c.as[HeadConfig.Bootstrap]
+
+                        // Block zero's header is fully determined by its end time, which the
+                        // initialization transaction pins through its validity end. Rebuild it and
+                        // reject a config whose stored header disagrees, rather than running on
+                        // timings a hand edit could have moved out from under the transaction.
+                        _ <- {
+                            val derived =
+                                BlockHeader.Initial.derive(brief.endTime)(using
+                                  hcBootstrap.txTiming
+                                )
+                            Either.cond(
+                              brief.header == derived,
+                              (),
+                              io.circe.DecodingFailure(
+                                "Block zero's header does not match the one its end time " +
+                                    s"${brief.endTime.convert.instant} determines: stored " +
+                                    s"${brief.header}, derived $derived",
+                                c.history
+                              )
+                            )
+                        }
 
                         // Parse the stored init tx (honouring its bytes) rather than re-building it.
                         // The fallback is protocol-derived, so we build it from the parsed init tx.

--- a/src/main/scala/hydrozoa/config/head/HeadConfig.scala
+++ b/src/main/scala/hydrozoa/config/head/HeadConfig.scala
@@ -111,8 +111,7 @@ object HeadConfig {
     }
 
     given headConfigEncoder: Encoder[HeadConfig] with {
-        override def apply(hc: HeadConfig): Json = {
-            given HeadConfig.Section = hc
+        override def apply(hc: HeadConfig): Json =
             Json.obj(
               "cardanoNetwork" -> hc.cardanoNetwork.asJson,
               "headParams" -> hc.headParameters.asJson,
@@ -130,7 +129,6 @@ object HeadConfig {
               "initializationTx" -> hc.initializationTx.asJson,
               "resolvedUtxos" -> hc.initializationTx.resolvedUtxos.utxos.asJson
             )
-        }
     }
 
     given headConfigDecoder(using resolved: ScriptReferenceUtxos): Decoder[HeadConfig] =

--- a/src/main/scala/hydrozoa/config/head/HeadParamsHash.scala
+++ b/src/main/scala/hydrozoa/config/head/HeadParamsHash.scala
@@ -131,9 +131,10 @@ object HeadParamsHash {
         out.scriptHash(HydrozoaBlueprint.disputeScriptHash)
         out.transactionInput(config.setupLadderAnchor)
 
-        // -- initialBlockTiming. Only `endTime` reaches a transaction — the initialization tx's
-        // validity end. `startTime` repeats it (block zero has no creation window) and the other
-        // three reach no transaction at all, so the digest is what pins them.
+        // -- initialBlockTiming. `endTime` carries the whole header: it reaches the initialization
+        // tx's validity end, and the other four terms are derived from it and the tx timing
+        // already hashed above. They stay in the preimage because dropping a term would mean a new
+        // domain tag for nothing.
         val header = initialBlockHeader
         out.instant(header.startTime.convert)
         out.instant(header.endTime.convert)

--- a/src/main/scala/hydrozoa/config/head/HeadParamsHash.scala
+++ b/src/main/scala/hydrozoa/config/head/HeadParamsHash.scala
@@ -131,8 +131,9 @@ object HeadParamsHash {
         out.scriptHash(HydrozoaBlueprint.disputeScriptHash)
         out.transactionInput(config.setupLadderAnchor)
 
-        // -- initialBlockTiming. Only `startTime` and `endTime` reach the initialization
-        // transaction's validity end; the other three reach no transaction at all.
+        // -- initialBlockTiming. Only `endTime` reaches a transaction — the initialization tx's
+        // validity end. `startTime` repeats it (block zero has no creation window) and the other
+        // three reach no transaction at all, so the digest is what pins them.
         val header = initialBlockHeader
         out.instant(header.startTime.convert)
         out.instant(header.endTime.convert)

--- a/src/main/scala/hydrozoa/multisig/ledger/block/BlockBrief.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/block/BlockBrief.scala
@@ -22,8 +22,7 @@ object BlockBrief {
     // does not carry — so its encoder and decoder are given separately.
     given (using CardanoNetwork.Section): Encoder[BlockBrief] = deriveEncoder[BlockBrief]
     given (using CardanoNetwork.Section, TxTiming): Decoder[BlockBrief] = deriveDecoder[BlockBrief]
-    given (using CardanoNetwork.Section): Encoder[BlockBrief.Initial] =
-        deriveEncoder[BlockBrief.Initial]
+    given Encoder[BlockBrief.Initial] = deriveEncoder[BlockBrief.Initial]
     given (using CardanoNetwork.Section, TxTiming): Decoder[BlockBrief.Initial] =
         deriveDecoder[BlockBrief.Initial]
     given bbMinorCodec(using CardanoNetwork.Section): Codec[BlockBrief.Minor] =

--- a/src/main/scala/hydrozoa/multisig/ledger/block/BlockBrief.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/block/BlockBrief.scala
@@ -1,5 +1,6 @@
 package hydrozoa.multisig.ledger.block
 
+import hydrozoa.config.head.multisig.timing.TxTiming
 import hydrozoa.config.head.multisig.timing.TxTiming.BlockTimes.{BlockCreationEndTime, BlockCreationStartTime}
 import hydrozoa.config.head.network.CardanoNetwork
 import io.circe.*
@@ -16,11 +17,15 @@ sealed trait BlockBrief extends BlockBrief.Section {
 }
 
 object BlockBrief {
-    // N.B.: technically we only need the cardano network for the decoder.
-    given (using cardanoNetwork: CardanoNetwork.Section): Codec[BlockBrief] =
-        deriveCodec[BlockBrief]
-    given (using cardanoNetwork: CardanoNetwork.Section): Codec[BlockBrief.Initial] =
-        deriveCodec[BlockBrief.Initial]
+    // N.B.: technically we only need the cardano network for the decoder. Block zero's brief is
+    // the exception that also needs the tx timing, to rebuild the derived header fields its JSON
+    // does not carry — so its encoder and decoder are given separately.
+    given (using CardanoNetwork.Section): Encoder[BlockBrief] = deriveEncoder[BlockBrief]
+    given (using CardanoNetwork.Section, TxTiming): Decoder[BlockBrief] = deriveDecoder[BlockBrief]
+    given (using CardanoNetwork.Section): Encoder[BlockBrief.Initial] =
+        deriveEncoder[BlockBrief.Initial]
+    given (using CardanoNetwork.Section, TxTiming): Decoder[BlockBrief.Initial] =
+        deriveDecoder[BlockBrief.Initial]
     given bbMinorCodec(using CardanoNetwork.Section): Codec[BlockBrief.Minor] =
         deriveCodec[BlockBrief.Minor]
     given bbMajorCodec(using CardanoNetwork.Section): Codec[BlockBrief.Major] =

--- a/src/main/scala/hydrozoa/multisig/ledger/block/BlockHeader.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/block/BlockHeader.scala
@@ -23,10 +23,9 @@ sealed trait BlockHeader extends BlockHeader.Section {
 object BlockHeader {
 
     final case class Initial(
-        // Creation start time: when did the peers start negotiating the head config, moderated by peer 0.
-        override val startTime: BlockCreationStartTime,
-        // Creation end time: when did the moderator (peer 0) receive all the information
-        // to create the head config and broadcast it to the peers.
+        /** Creation end time: when the moderator (head peer 0) received all the information to
+          * create the head config and broadcast it to the peers.
+          */
         override val endTime: BlockCreationEndTime,
         override val fallbackTxStartTime: FallbackTxStartTime,
         override val forcedMajorBlockWakeupTime: ForcedMajorBlockWakeupTime,
@@ -37,6 +36,11 @@ object BlockHeader {
         override transparent inline def blockNum: BlockNumber = Initial.blockNum
         override transparent inline def blockVersion: BlockVersion.Full = Initial.blockVersion
         override transparent inline def header: BlockHeader.Initial = this
+
+        /** Block zero has no creation window: it skips the fast cycle entirely, so there is no
+          * moment at which its weaving started. The start time is the end time.
+          */
+        override def startTime: BlockCreationStartTime = BlockCreationStartTime(endTime.convert)
     }
 
     given (using CardanoNetwork.Section): Codec[BlockHeader.Minor] = deriveCodec[BlockHeader.Minor]
@@ -286,6 +290,25 @@ object BlockHeader {
         final transparent inline def blockNum: BlockNumber = BlockNumber.zero
         final transparent inline def blockVersion: BlockVersion.Full = BlockVersion.Full.zero
 
+        /** Block zero's header, derived in full from its end time.
+          *
+          * Every field is fixed: the initialization transaction pins `endTime` through its validity
+          * end, `fallbackTxStartTime` and `forcedMajorBlockWakeupTime` follow from it through
+          * [[TxTiming]], and `mDepositDecisionWakeupTime` is absent because block zero absorbs no
+          * deposits. Bootstrap builds the header with this, and `HeadConfig`'s decoder rebuilds it
+          * to check the one it was handed.
+          */
+        def derive(
+            endTime: BlockCreationEndTime
+        )(using txTiming: TxTiming): BlockHeader.Initial =
+            val fallbackTxStartTime = txTiming.newFallbackStartTime(endTime)
+            BlockHeader.Initial(
+              endTime = endTime,
+              fallbackTxStartTime = fallbackTxStartTime,
+              forcedMajorBlockWakeupTime = txTiming.forcedMajorBlockWakeupTime(fallbackTxStartTime),
+              mDepositDecisionWakeupTime = None
+            )
+
         given blockHeaderInitialEncoder: Encoder[BlockHeader.Initial] with {
             def helper(f: BlockHeader.Initial => QuantizedInstant)(using
                 bh: BlockHeader.Initial
@@ -296,7 +319,6 @@ object BlockHeader {
                 given BlockHeader.Initial = initBH
 
                 Json.obj(
-                  "startTime" -> helper(_.startTime),
                   "endTime" -> helper(_.endTime),
                   "fallbackTxStartTime" -> helper(_.fallbackTxStartTime),
                   "forcedMajorBlockWakeupTime" -> helper(_.forcedMajorBlockWakeupTime),
@@ -325,7 +347,6 @@ object BlockHeader {
                     } yield res
 
                 for {
-                    startTime <- helper("startTime")
                     endTime <- helper("endTime")
                     fbtx <- helper("fallbackTxStartTime")
                     fmbt <- c.downField("forcedMajorBlockWakeupTime").as[ForcedMajorBlockWakeupTime]
@@ -333,7 +354,6 @@ object BlockHeader {
                         .downField("depositDecisionWakeupTime")
                         .as[Option[DepositDecisionWakeupTime]]
                 } yield BlockHeader.Initial(
-                  BlockCreationStartTime(startTime),
                   BlockCreationEndTime(endTime),
                   FallbackTxStartTime(fbtx),
                   fmbt,

--- a/src/main/scala/hydrozoa/multisig/ledger/block/BlockHeader.scala
+++ b/src/main/scala/hydrozoa/multisig/ledger/block/BlockHeader.scala
@@ -12,6 +12,7 @@ import hydrozoa.lib.logging.ContraTracer
 import io.circe.*
 import io.circe.generic.semiauto.*
 import io.circe.syntax.*
+import java.time.Instant
 
 sealed trait BlockHeader extends BlockHeader.Section {
     def asUnsigned: this.type & BlockStatus.Unsigned =
@@ -22,15 +23,22 @@ sealed trait BlockHeader extends BlockHeader.Section {
 
 object BlockHeader {
 
+    /** Block zero's header, fixed in full by its creation end time.
+      *
+      * The initialization transaction pins `endTime` through its validity end and the rest follows:
+      * `fallbackTxStartTime` and `forcedMajorBlockWakeupTime` through [[TxTiming]], `startTime`
+      * because block zero has no creation window, and `mDepositDecisionWakeupTime` because block
+      * zero absorbs no deposits. `endTime` is the whole representation — it is all the header holds
+      * and all its JSON carries.
+      *
+      * @param endTime
+      *   creation end time: when the moderator (head peer 0) received all the information to create
+      *   the head config and broadcast it to the peers.
+      */
     final case class Initial(
-        /** Creation end time: when the moderator (head peer 0) received all the information to
-          * create the head config and broadcast it to the peers.
-          */
-        override val endTime: BlockCreationEndTime,
-        override val fallbackTxStartTime: FallbackTxStartTime,
-        override val forcedMajorBlockWakeupTime: ForcedMajorBlockWakeupTime,
-        override val mDepositDecisionWakeupTime: Option[DepositDecisionWakeupTime],
-    ) extends BlockHeader,
+        override val endTime: BlockCreationEndTime
+    )(using txTiming: TxTiming)
+        extends BlockHeader,
           BlockType.Initial,
           NonFinal.Section {
         override transparent inline def blockNum: BlockNumber = Initial.blockNum
@@ -41,6 +49,15 @@ object BlockHeader {
           * moment at which its weaving started. The start time is the end time.
           */
         override def startTime: BlockCreationStartTime = BlockCreationStartTime(endTime.convert)
+
+        override val fallbackTxStartTime: FallbackTxStartTime =
+            txTiming.newFallbackStartTime(endTime)
+
+        override val forcedMajorBlockWakeupTime: ForcedMajorBlockWakeupTime =
+            txTiming.forcedMajorBlockWakeupTime(fallbackTxStartTime)
+
+        /** Block zero absorbs no deposits, so it never wakes up to decide on one. */
+        override val mDepositDecisionWakeupTime: Option[DepositDecisionWakeupTime] = None
     }
 
     given (using CardanoNetwork.Section): Codec[BlockHeader.Minor] = deriveCodec[BlockHeader.Minor]
@@ -290,75 +307,23 @@ object BlockHeader {
         final transparent inline def blockNum: BlockNumber = BlockNumber.zero
         final transparent inline def blockVersion: BlockVersion.Full = BlockVersion.Full.zero
 
-        /** Block zero's header, derived in full from its end time.
-          *
-          * Every field is fixed: the initialization transaction pins `endTime` through its validity
-          * end, `fallbackTxStartTime` and `forcedMajorBlockWakeupTime` follow from it through
-          * [[TxTiming]], and `mDepositDecisionWakeupTime` is absent because block zero absorbs no
-          * deposits. Bootstrap builds the header with this, and `HeadConfig`'s decoder rebuilds it
-          * to check the one it was handed.
+        /** Block zero's header travels as its end time alone; the reader rebuilds the rest from the
+          * same [[TxTiming]] the writer used.
           */
-        def derive(
-            endTime: BlockCreationEndTime
-        )(using txTiming: TxTiming): BlockHeader.Initial =
-            val fallbackTxStartTime = txTiming.newFallbackStartTime(endTime)
-            BlockHeader.Initial(
-              endTime = endTime,
-              fallbackTxStartTime = fallbackTxStartTime,
-              forcedMajorBlockWakeupTime = txTiming.forcedMajorBlockWakeupTime(fallbackTxStartTime),
-              mDepositDecisionWakeupTime = None
-            )
-
         given blockHeaderInitialEncoder: Encoder[BlockHeader.Initial] with {
-            def helper(f: BlockHeader.Initial => QuantizedInstant)(using
-                bh: BlockHeader.Initial
-            ): Json =
-                f(bh).instant.toEpochMilli.asJson
-
-            override def apply(initBH: BlockHeader.Initial): Json = {
-                given BlockHeader.Initial = initBH
-
-                Json.obj(
-                  "endTime" -> helper(_.endTime),
-                  "fallbackTxStartTime" -> helper(_.fallbackTxStartTime),
-                  "forcedMajorBlockWakeupTime" -> helper(_.forcedMajorBlockWakeupTime),
-                  "depositDecisionWakeupTime" -> initBH.mDepositDecisionWakeupTime.fold(Json.Null)(
-                    t => t.convert.instant.toEpochMilli.asJson
-                  ),
-                )
-            }
+            override def apply(initBH: BlockHeader.Initial): Json =
+                Json.obj("endTime" -> initBH.endTime.instant.toEpochMilli.asJson)
         }
 
         given blockHeaderInitialDecoder(using
-            config: CardanoNetwork.Section
+            config: CardanoNetwork.Section,
+            txTiming: TxTiming
         ): Decoder[BlockHeader.Initial] =
             Decoder.instance { c =>
-                given HCursor = c
-
-                def helper(fieldName: String)(using
-                    c: HCursor
-                ): Either[DecodingFailure, QuantizedInstant] =
-                    for {
-                        instant <- c
-                            .downField(fieldName)
-                            .as[Long]
-                            .map(java.time.Instant.ofEpochMilli)
-                        res = QuantizedInstant(config.slotConfig, instant)
-                    } yield res
-
                 for {
-                    endTime <- helper("endTime")
-                    fbtx <- helper("fallbackTxStartTime")
-                    fmbt <- c.downField("forcedMajorBlockWakeupTime").as[ForcedMajorBlockWakeupTime]
-                    mDdwt <- c
-                        .downField("depositDecisionWakeupTime")
-                        .as[Option[DepositDecisionWakeupTime]]
-                } yield BlockHeader.Initial(
-                  BlockCreationEndTime(endTime),
-                  FallbackTxStartTime(fbtx),
-                  fmbt,
-                  mDdwt,
-                )
+                    millis <- c.downField("endTime").as[Long]
+                    endTime = QuantizedInstant(config.slotConfig, Instant.ofEpochMilli(millis))
+                } yield BlockHeader.Initial(BlockCreationEndTime(endTime))
             }
     }
 

--- a/src/main/scala/hydrozoa/multisig/persistence/ConsensusStoreReader.scala
+++ b/src/main/scala/hydrozoa/multisig/persistence/ConsensusStoreReader.scala
@@ -1,10 +1,12 @@
 package hydrozoa.multisig.persistence
 
 import cats.effect.IO
+import cats.syntax.all.*
+import hydrozoa.config.head.multisig.timing.TxTiming.BlockTimes.BlockCreationEndTime
 import hydrozoa.config.head.network.CardanoNetwork
 import hydrozoa.multisig.consensus.UserRequestWithId
 import hydrozoa.multisig.consensus.peer.HeadPeerNumber
-import hydrozoa.multisig.ledger.block.{Block, BlockBrief, BlockNumber}
+import hydrozoa.multisig.ledger.block.{BlockBrief, BlockNumber}
 import hydrozoa.multisig.ledger.event.{RequestId, RequestNumber}
 import hydrozoa.multisig.ledger.stack.{StackBrief, StackEffects, StackNumber}
 import hydrozoa.multisig.persistence.recovery.CursorScan
@@ -28,10 +30,16 @@ trait ConsensusStoreReader[F[_]]:
     /** One block's brief, if persisted. */
     def blockBrief(num: BlockNumber): F[Option[BlockBrief.Next]]
 
-    /** This node's soft-confirmation record for a block: the aggregate plus the local confirmation
-      * stamp.
+    /** This node's soft-confirmation moment for a block, present exactly when the node holds that
+      * block's confirmation.
+      *
+      * Block zero is derived rather than read. It skips the fast cycle entirely (`Initial` is not a
+      * `BlockType.Next`), so no `SoftConfirmation(0)` is ever written and a stored read would
+      * report a hard-confirmed block as unconfirmed. Its moment is its creation end time, which the
+      * config already fixes — so this is the accessor every caller uses, and the record itself is
+      * not exposed.
       */
-    def softConfirmation(num: BlockNumber): F[Option[Timestamped[Block.SoftConfirmed.Next]]]
+    def softConfirmedAt(num: BlockNumber): F[Option[Instant]]
 
     /** The stack that hard-confirmed a block, if any. */
     def stackOf(num: BlockNumber): F[Option[StackNumber]]
@@ -80,9 +88,12 @@ trait ConsensusStoreReader[F[_]]:
 
 object ConsensusStoreReader:
 
-    /** The reader over a live [[Persistence]] instance. */
+    /** The reader over a live [[Persistence]] instance. `blockZeroEndTime` is block zero's creation
+      * end time, which is also its derived soft-confirmation moment.
+      */
     def fromPersistence(
-        persistence: Persistence[IO]
+        persistence: Persistence[IO],
+        blockZeroEndTime: BlockCreationEndTime
     )(using CardanoNetwork.Section): ConsensusStoreReader[IO] =
         new ConsensusStoreReader[IO]:
             def blockBriefs: IO[List[BlockBrief.Next]] =
@@ -96,10 +107,12 @@ object ConsensusStoreReader:
             def blockBrief(num: BlockNumber): IO[Option[BlockBrief.Next]] =
                 persistence.get(JournalKey.Block(num)).map(_.map(_.payload))
 
-            def softConfirmation(
-                num: BlockNumber
-            ): IO[Option[Timestamped[Block.SoftConfirmed.Next]]] =
-                persistence.get(StoreKey.SoftConfirmation(num))
+            def softConfirmedAt(num: BlockNumber): IO[Option[Instant]] =
+                if num == BlockNumber.zero then IO.pure(Some(blockZeroEndTime.convert.instant))
+                else
+                    persistence
+                        .get(StoreKey.SoftConfirmation(num))
+                        .flatMap(_.traverse(t => persistence.wallClockOf(t.stamp)))
 
             def stackOf(num: BlockNumber): IO[Option[StackNumber]] =
                 persistence.get(StoreKey.BlockStackIndex(num))
@@ -163,9 +176,7 @@ object ConsensusStoreReader:
         new ConsensusStoreReader[IO]:
             def blockBriefs: IO[List[BlockBrief.Next]] = IO.pure(Nil)
             def blockBrief(num: BlockNumber): IO[Option[BlockBrief.Next]] = IO.pure(None)
-            def softConfirmation(
-                num: BlockNumber
-            ): IO[Option[Timestamped[Block.SoftConfirmed.Next]]] = IO.pure(None)
+            def softConfirmedAt(num: BlockNumber): IO[Option[Instant]] = IO.pure(None)
             def stackOf(num: BlockNumber): IO[Option[StackNumber]] = IO.pure(None)
             def hardConfirmation(
                 num: StackNumber

--- a/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
+++ b/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
@@ -817,6 +817,12 @@ class HydrozoaRoutes(
       * from the records' arrival stamps: the soft-confirmation record, and — through the block →
       * stack index — the hard-confirmation record. Each moment is present exactly when this peer
       * holds that record (`wallClockOf` is total), so it also serves as the rung discriminant.
+      *
+      * Block zero is the exception. It skips the fast cycle entirely (`Initial` is not a
+      * `BlockType.Next`), so no `SoftConfirmation(0)` is ever written and a stored read would land
+      * on `(None, Some(hard))` for a block that is in fact hard-confirmed. Its soft-confirmation
+      * moment is its creation end time and is derived here rather than persisted — there is no
+      * reason to store a value the config already fixes.
       */
     private def confirmationTimes(num: BlockNumber): IO[(Option[Instant], Option[Instant])] =
         for {
@@ -826,9 +832,15 @@ class HydrozoaRoutes(
                 case None    => IO.pure(None)
                 case Some(s) => consensusReader.hardConfirmation(s)
             }
-            softAt <- soft.traverse(t => consensusReader.wallClockOf(t.stamp))
+            storedSoftAt <- soft.traverse(t => consensusReader.wallClockOf(t.stamp))
+            softAt =
+                if num == BlockNumber.zero then Some(initialBlockEndTime) else storedSoftAt
             hardAt <- hard.traverse(t => consensusReader.wallClockOf(t.stamp))
         } yield (softAt, hardAt)
+
+    /** Block zero's creation end time, which is also its derived soft-confirmation moment. */
+    private def initialBlockEndTime: Instant =
+        headConfig.initialBlock.blockBrief.header.endTime.convert.instant
 
     /** The request-details body for a request id, or a 404 when the head has assigned no such id.
       * The lifecycle status resolves through the request → block index and the block's confirmation

--- a/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
+++ b/src/main/scala/hydrozoa/multisig/server/HydrozoaRoutes.scala
@@ -813,34 +813,22 @@ class HydrozoaRoutes(
     private def blockConfirmation(num: BlockNumber): IO[BlockConfirmationView] =
         confirmationTimes(num).map((soft, hard) => ApiDto.mkBlockConfirmationView(soft, hard))
 
-    /** This node's `(soft, hard)` confirmation moments for a block, as wall-clock instants derived
-      * from the records' arrival stamps: the soft-confirmation record, and — through the block →
-      * stack index — the hard-confirmation record. Each moment is present exactly when this peer
-      * holds that record (`wallClockOf` is total), so it also serves as the rung discriminant.
-      *
-      * Block zero is the exception. It skips the fast cycle entirely (`Initial` is not a
-      * `BlockType.Next`), so no `SoftConfirmation(0)` is ever written and a stored read would land
-      * on `(None, Some(hard))` for a block that is in fact hard-confirmed. Its soft-confirmation
-      * moment is its creation end time and is derived here rather than persisted — there is no
-      * reason to store a value the config already fixes.
+    /** This node's `(soft, hard)` confirmation moments for a block, as wall-clock instants: the
+      * soft-confirmation moment the reader resolves (derived for block zero, which never writes a
+      * `SoftConfirmation` record), and — through the block → stack index — the hard-confirmation
+      * record's. Each is present exactly when this peer holds that confirmation, so the pair also
+      * serves as the rung discriminant.
       */
     private def confirmationTimes(num: BlockNumber): IO[(Option[Instant], Option[Instant])] =
         for {
-            soft <- consensusReader.softConfirmation(num)
+            softAt <- consensusReader.softConfirmedAt(num)
             stack <- consensusReader.stackOf(num)
             hard <- stack match {
                 case None    => IO.pure(None)
                 case Some(s) => consensusReader.hardConfirmation(s)
             }
-            storedSoftAt <- soft.traverse(t => consensusReader.wallClockOf(t.stamp))
-            softAt =
-                if num == BlockNumber.zero then Some(initialBlockEndTime) else storedSoftAt
             hardAt <- hard.traverse(t => consensusReader.wallClockOf(t.stamp))
         } yield (softAt, hardAt)
-
-    /** Block zero's creation end time, which is also its derived soft-confirmation moment. */
-    private def initialBlockEndTime: Instant =
-        headConfig.initialBlock.blockBrief.header.endTime.convert.instant
 
     /** The request-details body for a request id, or a 404 when the head has assigned no such id.
       * The lifecycle status resolves through the request → block index and the block's confirmation

--- a/src/test/scala/hydrozoa/bootstrap/BootstrapMembershipTest.scala
+++ b/src/test/scala/hydrozoa/bootstrap/BootstrapMembershipTest.scala
@@ -79,8 +79,21 @@ class BootstrapMembershipTest extends AnyFunSuite {
           decoded.cardanoNetwork == network &&
               decoded.headParams.coilQuorum == 2 &&
               decoded.initialEquityContributions.size == 2 &&
-              decoded.blockZeroStartTime.isEmpty
+              decoded.blockZeroEndTime.isEmpty
         )
+    }
+
+    test("a defaults.json carrying blockZeroStartTime still decodes; the field is ignored") {
+        // Block zero's start time is its end time now, so `defaults.json` no longer offers it.
+        // A bootstrap directory written before that must still assemble.
+        val network = CardanoNetwork.Preview
+        given CardanoNetwork.Section = network
+        val stale = Json.obj("blockZeroStartTime" -> 1_767_225_600_000L.asJson)
+        val withStartTime = mkPreviewDefaults(coilQuorum = 2).asJson.deepMerge(stale)
+        val decoded = withStartTime
+            .as[Bootstrap.BootstrapDefaults]
+            .fold(e => fail(s"decode failed: $e"), identity)
+        assert(decoded.cardanoNetwork == network && decoded.blockZeroEndTime.isEmpty)
     }
 
     test(
@@ -125,7 +138,7 @@ class BootstrapMembershipTest extends AnyFunSuite {
               config.headPeers.size == 1 &&
               config.initialEquityContributions.get(HeadPeerNumber(0)).contains(Coin.ada(100)) &&
               config.initialL2State.isEmpty &&
-              config.blockZeroStartTime.isEmpty
+              config.blockZeroEndTime.isEmpty
         )
     }
 
@@ -156,7 +169,6 @@ class BootstrapMembershipTest extends AnyFunSuite {
           headParams = headParams,
           initialEquityContributions =
               Map(HeadPeerNumber(0) -> Coin.ada(100), HeadPeerNumber(1) -> Coin.zero),
-          blockZeroStartTime = None,
           blockZeroEndTime = None
         )
     }

--- a/src/test/scala/hydrozoa/config/head/initialization/InitialBlockGen.scala
+++ b/src/test/scala/hydrozoa/config/head/initialization/InitialBlockGen.scala
@@ -4,13 +4,12 @@ import cats.data.ReaderT
 import hydrozoa.bootstrap.InitializationFunding
 import hydrozoa.config.head.initialization.BlockCreationEndTimeGen.currentTimeBlockCreationEndTime
 import hydrozoa.config.head.multisig.timing.TxTiming
-import hydrozoa.config.head.multisig.timing.TxTiming.BlockTimes.{BlockCreationEndTime, BlockCreationStartTime}
+import hydrozoa.config.head.multisig.timing.TxTiming.BlockTimes.BlockCreationEndTime
 import hydrozoa.config.head.{HeadConfig, HeadParamsHash, generateHeadConfigBootstrap}
 import hydrozoa.multisig.ledger.block.{Block, BlockBrief, BlockEffects, BlockHeader}
 import hydrozoa.multisig.ledger.l1.txseq.InitializationTxSeq
 import org.scalacheck.Test.Parameters
 import org.scalacheck.{Prop, Properties}
-import scala.concurrent.duration.DurationInt
 import test.{GenWithTestPeers, TestPeers, TestPeersSpec, given}
 
 def generateInitialBlock(
@@ -28,18 +27,8 @@ def generateInitialBlock(
 
         // The header is built before the transactions, as `Bootstrap.mkSharedHeadConfig` does:
         // `headParamsHash` covers it and the init tx's treasury datum carries that digest.
-        fallbackTxStartTime = config.headParameters.txTiming.newFallbackStartTime(
-          blockCreationEndTime
-        )
-        forcedMajorBlockWakeupTime = config.headParameters.txTiming.forcedMajorBlockWakeupTime(
-          fallbackTxStartTime
-        )
-        header = BlockHeader.Initial(
-          startTime = BlockCreationStartTime(blockCreationEndTime - 10.seconds),
-          endTime = blockCreationEndTime,
-          fallbackTxStartTime = fallbackTxStartTime,
-          forcedMajorBlockWakeupTime = forcedMajorBlockWakeupTime,
-          mDepositDecisionWakeupTime = None,
+        header = BlockHeader.Initial.derive(blockCreationEndTime)(using
+          config.headParameters.txTiming
         )
 
         initTxSeqResult = InitializationTxSeq

--- a/src/test/scala/hydrozoa/config/head/initialization/InitialBlockGen.scala
+++ b/src/test/scala/hydrozoa/config/head/initialization/InitialBlockGen.scala
@@ -27,9 +27,7 @@ def generateInitialBlock(
 
         // The header is built before the transactions, as `Bootstrap.mkSharedHeadConfig` does:
         // `headParamsHash` covers it and the init tx's treasury datum carries that digest.
-        header = BlockHeader.Initial.derive(blockCreationEndTime)(using
-          config.headParameters.txTiming
-        )
+        header = BlockHeader.Initial(blockCreationEndTime)(using config.headParameters.txTiming)
 
         initTxSeqResult = InitializationTxSeq
             .Build(config, funding)(blockCreationEndTime, HeadParamsHash(config, header))

--- a/src/test/scala/hydrozoa/multisig/ledger/block/BlockHeaderInitialTest.scala
+++ b/src/test/scala/hydrozoa/multisig/ledger/block/BlockHeaderInitialTest.scala
@@ -2,6 +2,7 @@ package hydrozoa.multisig.ledger.block
 
 import hydrozoa.config.ScriptReferenceUtxos
 import hydrozoa.config.head.HeadConfig
+import hydrozoa.config.head.multisig.timing.TxTiming
 import hydrozoa.config.head.network.CardanoNetwork
 import hydrozoa.config.node.MultiNodeConfig
 import io.circe.Json
@@ -10,12 +11,9 @@ import org.scalacheck.Gen
 import org.scalacheck.rng.Seed
 import org.scalatest.funsuite.AnyFunSuite
 
-/** Block zero's header: every field follows from its creation end time, so nothing about it is
-  * negotiable and nothing about it needs storing twice.
-  *
-  * `startTime` is derived rather than carried — block zero skips the fast cycle, so it has no
-  * creation window — and `HeadConfig`'s decoder rebuilds the whole header to check the one the
-  * config hands it.
+/** Block zero's header is its creation end time and nothing else: `startTime` repeats it, the two
+  * wakeup times follow from it through [[TxTiming]], and there is no deposit-decision wakeup. So
+  * `endTime` is all the header holds, all its JSON carries, and all a reader needs to rebuild it.
   */
 class BlockHeaderInitialTest extends AnyFunSuite:
 
@@ -26,66 +24,60 @@ class BlockHeaderInitialTest extends AnyFunSuite:
 
     private given CardanoNetwork.Section = headConfig
     private given ScriptReferenceUtxos = headConfig.scriptReferenceUtxos
+    private given TxTiming = headConfig.txTiming
 
     test("block zero's start time is its end time") {
         assert(header.startTime.convert == header.endTime.convert)
     }
 
-    test("the derived header is the one the config carries") {
-        assert(BlockHeader.Initial.derive(header.endTime)(using headConfig.txTiming) == header)
+    test("block zero's wakeup times follow the head's tx timing") {
+        val fallbackTxStartTime = headConfig.txTiming.newFallbackStartTime(header.endTime)
+        val _ = assert(header.fallbackTxStartTime == fallbackTxStartTime)
+        val _ = assert(
+          header.forcedMajorBlockWakeupTime ==
+              headConfig.txTiming.forcedMajorBlockWakeupTime(fallbackTxStartTime)
+        )
+        assert(header.mDepositDecisionWakeupTime.isEmpty)
     }
 
-    test("the encoded header carries no startTime, and round-trips") {
+    test("the encoded header carries the end time alone, and round-trips") {
         val encoded = header.asJson
-        val _ = assert(encoded.hcursor.downField("startTime").failed)
+        val _ = assert(encoded.hcursor.keys.map(_.toList) == Some(List("endTime")))
         assert(encoded.as[BlockHeader.Initial] == Right(header))
     }
-
-    /** Re-encode the head config with one field of block zero's header replaced. */
-    private def configWithHeaderField(field: String, value: Json): Json =
-        headConfig.asJson.hcursor
-            .downField("blockBrief")
-            .downField("header")
-            .downField(field)
-            .set(value)
-            .top
-            .getOrElse(fail(s"could not reach blockBrief.header.$field"))
 
     test("the config decodes as written") {
         assert(headConfig.asJson.as[HeadConfig].isRight)
     }
 
-    test("a config written with a block-zero startTime still decodes; the field is ignored") {
-        // Configs written before block zero's start time was derived carry a `startTime` that has
-        // no relation to `endTime`. Nothing reads it now, so an existing head-config.json must
-        // still decode — and the header it produces reports `startTime == endTime`.
-        val stale = (header.endTime.convert.instant.toEpochMilli - 600_000L).asJson
-        val withStartTime = headConfig.asJson.hcursor
+    test("a config carrying block zero's derived header fields still decodes; they are ignored") {
+        // Configs written before block zero's header collapsed to its end time carry the four
+        // derived fields alongside it. Nothing reads them now, so an existing head-config.json
+        // must still decode — and it must decode to the header `endTime` determines even when the
+        // stored values disagree, which is what these deliberately wrong ones prove.
+        val wrong = (header.endTime.convert.instant.toEpochMilli - 600_000L).asJson
+        val withDerivedFields = headConfig.asJson.hcursor
             .downField("blockBrief")
             .downField("header")
-            .withFocus(_.deepMerge(Json.obj("startTime" -> stale)))
+            .withFocus(
+              _.deepMerge(
+                Json.obj(
+                  "startTime" -> wrong,
+                  "fallbackTxStartTime" -> wrong,
+                  "forcedMajorBlockWakeupTime" -> wrong,
+                  "depositDecisionWakeupTime" -> wrong
+                )
+              )
+            )
             .top
             .getOrElse(fail("could not reach blockBrief.header"))
-        withStartTime.as[HeadConfig] match
-            case Left(e) => fail(s"a config carrying block zero's startTime was refused: $e")
+        withDerivedFields.as[HeadConfig] match
+            case Left(e) => fail(s"a config carrying block zero's derived header fields: $e")
             case Right(decoded) =>
                 val h = decoded.initialBlock.blockBrief.header
+                val _ = assert(h.endTime == header.endTime)
                 val _ = assert(h.startTime.convert == h.endTime.convert)
-                assert(h == header)
-    }
-
-    test("a config whose block-zero header timings were edited is refused") {
-        val moved = header.fallbackTxStartTime.convert.instant.toEpochMilli + 60_000L
-        val tampered = configWithHeaderField("fallbackTxStartTime", moved.asJson)
-        tampered.as[HeadConfig] match
-            case Right(_) => fail("a hand-edited block-zero header decoded")
-            case Left(e)  => assert(e.getMessage.contains("Block zero's header"))
-    }
-
-    test("a config whose block-zero deposit-decision wakeup was added is refused") {
-        val added = header.endTime.convert.instant.toEpochMilli
-        val tampered = configWithHeaderField("depositDecisionWakeupTime", added.asJson)
-        tampered.as[HeadConfig] match
-            case Right(_) => fail("a block-zero header with a deposit-decision wakeup decoded")
-            case Left(e)  => assert(e.getMessage.contains("Block zero's header"))
+                val _ = assert(h.fallbackTxStartTime == header.fallbackTxStartTime)
+                val _ = assert(h.forcedMajorBlockWakeupTime == header.forcedMajorBlockWakeupTime)
+                assert(h.mDepositDecisionWakeupTime.isEmpty)
     }

--- a/src/test/scala/hydrozoa/multisig/ledger/block/BlockHeaderInitialTest.scala
+++ b/src/test/scala/hydrozoa/multisig/ledger/block/BlockHeaderInitialTest.scala
@@ -1,0 +1,91 @@
+package hydrozoa.multisig.ledger.block
+
+import hydrozoa.config.ScriptReferenceUtxos
+import hydrozoa.config.head.HeadConfig
+import hydrozoa.config.head.network.CardanoNetwork
+import hydrozoa.config.node.MultiNodeConfig
+import io.circe.Json
+import io.circe.syntax.*
+import org.scalacheck.Gen
+import org.scalacheck.rng.Seed
+import org.scalatest.funsuite.AnyFunSuite
+
+/** Block zero's header: every field follows from its creation end time, so nothing about it is
+  * negotiable and nothing about it needs storing twice.
+  *
+  * `startTime` is derived rather than carried — block zero skips the fast cycle, so it has no
+  * creation window — and `HeadConfig`'s decoder rebuilds the whole header to check the one the
+  * config hands it.
+  */
+class BlockHeaderInitialTest extends AnyFunSuite:
+
+    private val multiNodeConfig: MultiNodeConfig =
+        MultiNodeConfig.generateDefault.pureApply(Gen.Parameters.default, Seed(0L))
+    private val headConfig: HeadConfig = multiNodeConfig.headConfig
+    private val header: BlockHeader.Initial = headConfig.initialBlock.blockBrief.header
+
+    private given CardanoNetwork.Section = headConfig
+    private given ScriptReferenceUtxos = headConfig.scriptReferenceUtxos
+
+    test("block zero's start time is its end time") {
+        assert(header.startTime.convert == header.endTime.convert)
+    }
+
+    test("the derived header is the one the config carries") {
+        assert(BlockHeader.Initial.derive(header.endTime)(using headConfig.txTiming) == header)
+    }
+
+    test("the encoded header carries no startTime, and round-trips") {
+        val encoded = header.asJson
+        val _ = assert(encoded.hcursor.downField("startTime").failed)
+        assert(encoded.as[BlockHeader.Initial] == Right(header))
+    }
+
+    /** Re-encode the head config with one field of block zero's header replaced. */
+    private def configWithHeaderField(field: String, value: Json): Json =
+        headConfig.asJson.hcursor
+            .downField("blockBrief")
+            .downField("header")
+            .downField(field)
+            .set(value)
+            .top
+            .getOrElse(fail(s"could not reach blockBrief.header.$field"))
+
+    test("the config decodes as written") {
+        assert(headConfig.asJson.as[HeadConfig].isRight)
+    }
+
+    test("a config written with a block-zero startTime still decodes; the field is ignored") {
+        // Configs written before block zero's start time was derived carry a `startTime` that has
+        // no relation to `endTime`. Nothing reads it now, so an existing head-config.json must
+        // still decode — and the header it produces reports `startTime == endTime`.
+        val stale = (header.endTime.convert.instant.toEpochMilli - 600_000L).asJson
+        val withStartTime = headConfig.asJson.hcursor
+            .downField("blockBrief")
+            .downField("header")
+            .withFocus(_.deepMerge(Json.obj("startTime" -> stale)))
+            .top
+            .getOrElse(fail("could not reach blockBrief.header"))
+        withStartTime.as[HeadConfig] match
+            case Left(e) => fail(s"a config carrying block zero's startTime was refused: $e")
+            case Right(decoded) =>
+                val h = decoded.initialBlock.blockBrief.header
+                val _ = assert(h.startTime.convert == h.endTime.convert)
+                assert(h == header)
+    }
+
+    test("a config whose block-zero header timings were edited is refused") {
+        val moved = header.fallbackTxStartTime.convert.instant.toEpochMilli + 60_000L
+        val tampered = configWithHeaderField("fallbackTxStartTime", moved.asJson)
+        tampered.as[HeadConfig] match
+            case Right(_) => fail("a hand-edited block-zero header decoded")
+            case Left(e)  => assert(e.getMessage.contains("Block zero's header"))
+    }
+
+    test("a config whose block-zero deposit-decision wakeup was added is refused") {
+        val added = header.endTime.convert.instant.toEpochMilli
+        val tampered = configWithHeaderField("depositDecisionWakeupTime", added.asJson)
+        tampered.as[HeadConfig] match
+            case Right(_) => fail("a block-zero header with a deposit-decision wakeup decoded")
+            case Left(e)  => assert(e.getMessage.contains("Block zero's header"))
+    }

--- a/src/test/scala/hydrozoa/multisig/persistence/ConsensusStoreReaderTest.scala
+++ b/src/test/scala/hydrozoa/multisig/persistence/ConsensusStoreReaderTest.scala
@@ -1,0 +1,94 @@
+package hydrozoa.multisig.persistence
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import cats.syntax.all.*
+import hydrozoa.config.head.HeadConfig
+import hydrozoa.config.head.multisig.timing.TxTiming.BlockTimes.{BlockCreationEndTime, BlockCreationStartTime}
+import hydrozoa.config.head.network.CardanoNetwork
+import hydrozoa.config.node.MultiNodeConfig
+import hydrozoa.lib.cardano.scalus.QuantizedTime.QuantizedInstant
+import hydrozoa.lib.cardano.scalus.QuantizedTime.QuantizedInstant.realTimeQuantizedInstant
+import hydrozoa.lib.logging.Slf4jTracer
+import hydrozoa.multisig.ledger.block.{Block, BlockBody, BlockBrief, BlockHeader, BlockNumber, BlockVersion}
+import org.scalacheck.Gen
+import org.scalacheck.rng.Seed
+import org.scalatest.funsuite.AnyFunSuite
+import scala.concurrent.duration.DurationInt
+
+/** `softConfirmedAt` is the only soft-confirmation accessor the reader offers, so every caller —
+  * present and future — gets block zero's derived moment rather than the `None` a stored read would
+  * return for a block that never runs the fast cycle.
+  */
+class ConsensusStoreReaderTest extends AnyFunSuite:
+
+    private val headConfig: HeadConfig =
+        MultiNodeConfig.generateDefault.pureApply(Gen.Parameters.default, Seed(0L)).headConfig
+    private given CardanoNetwork.Section = headConfig
+
+    private val blockZeroEndTime: BlockCreationEndTime =
+        headConfig.initialBlock.blockBrief.endTime
+
+    private val stamp: ArrivalStamp = ArrivalStamp(generation = 0, monotonicNanos = 1L)
+
+    test("block zero reports its creation end time, with nothing in the store") {
+        val softAt = withReader((_, reader) => reader.softConfirmedAt(BlockNumber.zero))
+        assert(softAt == Some(blockZeroEndTime.convert.instant))
+    }
+
+    test("a woven block with no stored record reports nothing") {
+        val softAt = withReader((_, reader) => reader.softConfirmedAt(BlockNumber(1)))
+        assert(softAt.isEmpty)
+    }
+
+    test("a woven block with a stored record reports that record’s wall clock") {
+        withReader { (persistence, reader) =>
+            for {
+                now <- realTimeQuantizedInstant(headConfig.slotConfig)
+                _ <- persistence.put(StoreKey.SoftConfirmation(BlockNumber(1)))(
+                  Timestamped(stamp, softConfirmedMinor(1, now))
+                )
+                expected <- persistence.wallClockOf(stamp)
+                softAt <- reader.softConfirmedAt(BlockNumber(1))
+            } yield assert(softAt == Some(expected))
+        }
+    }
+
+    /** Run `body` against a fresh in-memory store and the reader over it. */
+    private def withReader[A](body: (Persistence[IO], ConsensusStoreReader[IO]) => IO[A]): A =
+        val tracer = Slf4jTracer.sink.contramap(PersistenceEventFormat.humanFormat)
+        InMemoryBackendStore
+            .open(tracer)
+            .use(backend =>
+                for {
+                    persistence <- Persistence.fromBackend(backend, tracer)
+                    result <- body(
+                      persistence,
+                      ConsensusStoreReader.fromPersistence(persistence, blockZeroEndTime)
+                    )
+                } yield result
+            )
+            .unsafeRunSync()
+
+    /** A minimal soft-confirmed Minor at `blockNum` — the payload's content is immaterial here,
+      * only that a record exists to stamp.
+      */
+    private def softConfirmedMinor(blockNum: Int, now: QuantizedInstant): Block.SoftConfirmed.Next =
+        val end = BlockCreationEndTime(now + 1.second)
+        val fallback = headConfig.txTiming.newFallbackStartTime(end)
+        Block.SoftConfirmed.Minor(
+          BlockBrief.Minor(
+            BlockHeader.Minor(
+              blockNum = BlockNumber(blockNum),
+              blockVersion = BlockVersion.Full(0, 0),
+              startTime = BlockCreationStartTime(now),
+              endTime = end,
+              fallbackTxStartTime = fallback,
+              forcedMajorBlockWakeupTime = headConfig.txTiming.forcedMajorBlockWakeupTime(fallback),
+              mDepositDecisionWakeupTime = None
+            ),
+            BlockBody.Minor(requests = List.empty, depositsRejected = List.empty)
+          ),
+          headerMultiSigned = Nil,
+          finalizationRequested = false
+        )

--- a/src/test/scala/hydrozoa/multisig/server/EffectsResolverTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/EffectsResolverTest.scala
@@ -11,7 +11,7 @@ import hydrozoa.multisig.consensus.UserRequest.{DepositRequest, TransactionReque
 import hydrozoa.multisig.consensus.UserRequestBody.{DepositRequestBody, TransactionRequestBody}
 import hydrozoa.multisig.consensus.UserRequestWithId
 import hydrozoa.multisig.consensus.peer.HeadPeerNumber
-import hydrozoa.multisig.ledger.block.{Block, BlockBody, BlockBrief, BlockHeader, BlockNumber, BlockVersion}
+import hydrozoa.multisig.ledger.block.{BlockBody, BlockBrief, BlockHeader, BlockNumber, BlockVersion}
 import hydrozoa.multisig.ledger.event.RequestId.ValidityFlag
 import hydrozoa.multisig.ledger.event.{RequestId, RequestNumber}
 import hydrozoa.multisig.ledger.joint.EvacuationMap
@@ -125,9 +125,7 @@ class EffectsResolverTest extends AnyFunSuite:
             def blockBriefs: IO[List[BlockBrief.Next]] = IO.pure(List(minorBrief))
             def blockBrief(num: BlockNumber): IO[Option[BlockBrief.Next]] =
                 IO.pure(Option.when(num == BlockNumber(1))(minorBrief))
-            def softConfirmation(
-                num: BlockNumber
-            ): IO[Option[Timestamped[Block.SoftConfirmed.Next]]] = IO.pure(None)
+            def softConfirmedAt(num: BlockNumber): IO[Option[Instant]] = IO.pure(None)
             def stackOf(num: BlockNumber): IO[Option[StackNumber]] =
                 IO.pure(Option.when(num == BlockNumber(1))(StackNumber(1)))
             def hardConfirmation(

--- a/src/test/scala/hydrozoa/multisig/server/HeadBlocksEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/HeadBlocksEndpointsTest.scala
@@ -279,6 +279,27 @@ class HeadBlocksEndpointsTest extends AnyFunSuite:
             .unsafeRunSync()
     }
 
+    test("GET /head/blocks/0 reports a soft-confirmation moment even with no stored record") {
+        mkMinorBrief1
+            .flatMap(brief =>
+                IO(withRoutes(stubReader(brief, soft = false, hard = false)) { app =>
+                    get(app, "/head/blocks/0").map { (status, body) =>
+                        // Block zero never runs the fast cycle, so the store holds no
+                        // SoftConfirmation(0). The rung is derived from its creation end time
+                        // instead of reading as "proposed" for a block the head has long confirmed.
+                        val expected =
+                            headConfig.initialBlock.blockBrief.header.endTime.convert.instant
+                        val c = body.hcursor.downField("status")
+                        val _ = assert(status == Status.Ok)
+                        val _ = assert(c.get[String]("type") == Right("SOFT_CONFIRMED"))
+                        val _ = assert(c.get[String]("softConfirmedAt") == Right(expected.toString))
+                        ()
+                    }
+                })
+            )
+            .unsafeRunSync()
+    }
+
     test("GET /head/blocks/1/body returns the block's content") {
         mkMinorBrief1
             .flatMap(brief =>

--- a/src/test/scala/hydrozoa/multisig/server/HeadBlocksEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/HeadBlocksEndpointsTest.scala
@@ -10,7 +10,7 @@ import hydrozoa.lib.logging.ContraTracer
 import hydrozoa.multisig.NodeStatus
 import hydrozoa.multisig.consensus.peer.HeadPeerNumber
 import hydrozoa.multisig.consensus.{BlockWeaver, RequestSequencer, UserRequestWithId}
-import hydrozoa.multisig.ledger.block.{Block, BlockBody, BlockBrief, BlockHeader, BlockNumber, BlockVersion}
+import hydrozoa.multisig.ledger.block.{BlockBody, BlockBrief, BlockHeader, BlockNumber, BlockVersion}
 import hydrozoa.multisig.ledger.event.RequestId
 import hydrozoa.multisig.ledger.joint.EvacuationMap
 import hydrozoa.multisig.ledger.stack.{PartitionEffects, StackBrief, StackEffects, StackNumber, StandaloneEvacuationCommitment}
@@ -40,6 +40,11 @@ class HeadBlocksEndpointsTest extends AnyFunSuite:
     private val headConfig = multiNodeConfig.headConfig
 
     private val softAt = Instant.parse("2026-01-01T00:00:00Z")
+
+    /** Block zero's creation end time, which is also its derived soft-confirmation moment. */
+    private val blockZeroEndTime: Instant =
+        headConfig.initialBlock.blockBrief.endTime.convert.instant
+
     private val hardAt = Instant.parse("2026-01-01T00:05:00Z")
 
     private val nanosPerSecond = 1_000_000_000L
@@ -116,21 +121,14 @@ class HeadBlocksEndpointsTest extends AnyFunSuite:
             def blockBriefs: IO[List[BlockBrief.Next]] = IO.pure(List(brief))
             def blockBrief(num: BlockNumber): IO[Option[BlockBrief.Next]] =
                 IO.pure(Option.when(num == BlockNumber(1))(brief))
-            def softConfirmation(
-                num: BlockNumber
-            ): IO[Option[Timestamped[Block.SoftConfirmed.Next]]] =
+            // Block zero as the live reader resolves it: derived from its creation end time,
+            // because no `SoftConfirmation(0)` is ever written. `ConsensusStoreReaderTest` covers
+            // that derivation; this stub carries it so the rungs the routes render are the real
+            // ones.
+            def softConfirmedAt(num: BlockNumber): IO[Option[Instant]] =
                 IO.pure(
-                  Option.when(soft && num == BlockNumber(1))(
-                    Timestamped(
-                      stampFor(softAt),
-                      Block.SoftConfirmed
-                          .Minor(
-                            brief,
-                            headerMultiSigned = List.empty,
-                            finalizationRequested = false
-                          )
-                    )
-                  )
+                  if num == BlockNumber.zero then Some(blockZeroEndTime)
+                  else Option.when(soft && num == BlockNumber(1))(softAt)
                 )
             def stackOf(num: BlockNumber): IO[Option[StackNumber]] =
                 IO.pure(Option.when(hard && num == BlockNumber(1))(StackNumber(1)))

--- a/src/test/scala/hydrozoa/multisig/server/HeadEffectsEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/HeadEffectsEndpointsTest.scala
@@ -15,7 +15,7 @@ import hydrozoa.multisig.consensus.UserRequest.TransactionRequest
 import hydrozoa.multisig.consensus.UserRequestBody.TransactionRequestBody
 import hydrozoa.multisig.consensus.peer.HeadPeerNumber
 import hydrozoa.multisig.consensus.{BlockWeaver, RequestSequencer, UserRequestWithId}
-import hydrozoa.multisig.ledger.block.{Block, BlockBody, BlockBrief, BlockHeader, BlockNumber, BlockVersion}
+import hydrozoa.multisig.ledger.block.{BlockBody, BlockBrief, BlockHeader, BlockNumber, BlockVersion}
 import hydrozoa.multisig.ledger.event.RequestId.ValidityFlag
 import hydrozoa.multisig.ledger.event.{RequestId, RequestNumber}
 import hydrozoa.multisig.ledger.joint.EvacuationMap
@@ -111,9 +111,7 @@ class HeadEffectsEndpointsTest extends AnyFunSuite:
             def blockBriefs: IO[List[BlockBrief.Next]] = IO.pure(List(brief))
             def blockBrief(num: BlockNumber): IO[Option[BlockBrief.Next]] =
                 IO.pure(Option.when(num == BlockNumber(1))(brief))
-            def softConfirmation(
-                num: BlockNumber
-            ): IO[Option[Timestamped[Block.SoftConfirmed.Next]]] = IO.pure(None)
+            def softConfirmedAt(num: BlockNumber): IO[Option[Instant]] = IO.pure(None)
             def stackOf(num: BlockNumber): IO[Option[StackNumber]] =
                 IO.pure(Option.when(num == BlockNumber(1))(StackNumber(1)))
             def hardConfirmation(

--- a/src/test/scala/hydrozoa/multisig/server/HeadRequestsEndpointsTest.scala
+++ b/src/test/scala/hydrozoa/multisig/server/HeadRequestsEndpointsTest.scala
@@ -10,7 +10,7 @@ import hydrozoa.multisig.consensus.UserRequest.{DepositRequest, TransactionReque
 import hydrozoa.multisig.consensus.UserRequestBody.{DepositRequestBody, TransactionRequestBody}
 import hydrozoa.multisig.consensus.peer.HeadPeerNumber
 import hydrozoa.multisig.consensus.{BlockWeaver, RequestSequencer, UserRequestWithId}
-import hydrozoa.multisig.ledger.block.{Block, BlockBrief, BlockNumber}
+import hydrozoa.multisig.ledger.block.{BlockBrief, BlockNumber}
 import hydrozoa.multisig.ledger.event.RequestId.ValidityFlag
 import hydrozoa.multisig.ledger.event.{RequestId, RequestNumber}
 import hydrozoa.multisig.ledger.stack.{StackBrief, StackEffects, StackNumber}
@@ -82,12 +82,8 @@ class HeadRequestsEndpointsTest extends AnyFunSuite:
         new ConsensusStoreReader[IO]:
             def blockBriefs: IO[List[BlockBrief.Next]] = IO.pure(Nil)
             def blockBrief(num: BlockNumber): IO[Option[BlockBrief.Next]] = IO.pure(None)
-            def softConfirmation(
-                num: BlockNumber
-            ): IO[Option[Timestamped[Block.SoftConfirmed.Next]]] =
-                IO.pure(softBlock.collect {
-                    case (b, at) if b == num => Timestamped(stampFor(at), null)
-                })
+            def softConfirmedAt(num: BlockNumber): IO[Option[Instant]] =
+                IO.pure(softBlock.collect { case (b, at) if b == num => at })
             def stackOf(num: BlockNumber): IO[Option[StackNumber]] =
                 IO.pure(hardStack.collect { case (b, s, _) if b == num => s })
             def hardConfirmation(


### PR DESCRIPTION
Closes GUM-196.

Block zero skips the fast cycle entirely — `Initial` is not a `BlockType.Next` — so no `SoftConfirmation(0)` is ever written, even though block zero is hard-confirmed. Reads landed on `(soft = None, hard = Some)`.

Fixing that exposed a second problem in the same place: block zero's header was stored field by field, when its creation end time already fixes every one of them.

## What changed

**1. Block zero's soft-confirmation is derived on read, in the consensus reader.** `ConsensusStoreReader.softConfirmedAt` returns the moment and resolves block zero to its creation end time; it replaces `softConfirmation` as the only soft-confirmation accessor, so the raw record — which block zero can never have — is not reachable and a reader written tomorrow gets this for free. Nothing is persisted: a `SoftConfirmation(0)` row would store a value the config already fixes, and would cost a `Block.SoftConfirmed.Initial` variant plus a widened `StoreKey.SoftConfirmation.Value`.

That leaves the fast side exposing a moment where the slow side exposes a whole `hardConfirmation` record — block 0 has a real hard-confirmation, because stack 0 spans exactly it. The asymmetry is accidental and is tracked in GUM-335, together with George's fast-consensus-on-block-0 idea that would remove the derived branch entirely.

**2. The header is its end time and nothing else.** `BlockHeader.Initial` is now `(endTime: BlockCreationEndTime)(using TxTiming)`, and the rest are derived members: `startTime` repeats `endTime` (block zero has no creation window), `fallbackTxStartTime` and `forcedMajorBlockWakeupTime` follow through `TxTiming`, and `mDepositDecisionWakeupTime` is absent because block zero absorbs no deposits. The initialization transaction pins `endTime` through its validity end.

**3. So the JSON is `{"endTime": …}` and there is nothing left to check.** `HeadConfig`'s decoder rebuilds the header from the end time and the head params' tx timing — no stored copies, no equality check, no `DecodingFailure` for a header that disagrees with itself. `BlockBrief`'s encoder and decoder are given separately, because only reading block zero back needs the tx timing.

This is the stronger reading of GUM-196's decision 3. "Recompute and check them on parse" polices an affordance; removing the affordance is better. A field nobody can edit is not a field anyone hand-edits by mistake.

**What does not change:** `GET /head/blocks/0` still reports `fallbackTxStartTime` and both wakeups — `ApiDto.BlockHeaderView.InitialView` is built from the header, so the values are still there to read, at the endpoint where an operator should be reading them.

## Config changes

| file | field | change |
|---|---|---|
| `defaults.json` | `blockZeroStartTime` | removed (`blockZeroEndTime` unchanged) |
| `head-config.json` | `blockBrief.header.startTime` | removed |
| `head-config.json` | `blockBrief.header.fallbackTxStartTime` | removed |
| `head-config.json` | `blockBrief.header.forcedMajorBlockWakeupTime` | removed |
| `head-config.json` | `blockBrief.header.depositDecisionWakeupTime` | removed |

**Existing files of both kinds still decode.** The dropped fields are ignored by both decoders — whatever they hold. Verified end to end rather than argued:

- `BlockHeaderInitialTest`: "a config carrying block zero's derived header fields still decodes; they are ignored" — decodes a `head-config.json` whose four dropped fields all carry a value 10 minutes off from the truth, and asserts the resulting header is the one `endTime` determines.
- `BootstrapMembershipTest`: "a defaults.json carrying blockZeroStartTime still decodes; the field is ignored".

The four `head-config.json` fields sit in the block brief, not in the head params, so neither `HeadParameters` nor `BootstrapHeadParams` decodes them; `blockZeroStartTime` is the one that goes through `BootstrapHeadParams`, and its test above covers it. The removals belong in the release notes of the release that ships them.

## headParamsHash

The preimage covers block zero's header as five terms — `u64(startTime) || u64(endTime) || u64(fallbackTxStartTime) || u64(forcedMajorBlockWakeupTime)` plus the optional wakeup — and all five are unchanged bytes: they are derived now instead of parsed, from `endTime` and the tx timing the preimage already covers. Four of the five are therefore redundant, and they stay because dropping a term would mean a new domain tag and an on-chain break for nothing. `docs/spec/head-params-hash.md` and the preimage site say so.

The head-params-hash stack (#730 → #692 → #693 → #694) is merged, and this branch is rebased on it. A head initialized before this PR computes a different digest than one initialized after, because `startTime` was a configured value and is now `endTime`. Nothing is released, so there is nothing to migrate.

## Testing

`CI=1 just precommit` clean, `sbt "testOnly *"` — **474 succeeded, 0 failed**, 13 canceled (store-gated), 3 ignored, 2 pending. `integration`, `petri`, `examples`, and `benchmark` all compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016brF9poxv5ogov86qy4ZWk
